### PR TITLE
chore: 🤖 Add 'yarn web' and 'yarn desktop' scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ You will need the following things properly installed on your computer.
 * `cd watchtower-ui`
 * `yarn install`
 
+Use `yarn web` to launch ui/web workspace app.
+Use `yarn desktop` to launch ui/desktop workspace app.
+
 ## Contributing
 
 ### Branching

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "ui/*"
   ],
   "scripts": {
-    "commit": "git-cz"
+    "commit": "git-cz",
+    "web": "yarn --cwd ui/web start",
+    "desktop": "yarn --cwd ui/desktop start"
   },
   "devDependencies": {
     "cz-conventional-changelog": "^3.1.0",


### PR DESCRIPTION
To allow launching workspaces in dev mode without having to navigate
into them, add yarn scripts to change workspace paths automatically.

@randallmorey , I was able to get `chore-repo-setup` up and running without issues. Yay!