### PR TITLE
Update README to use doc:toc command

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ confidence about the state of the project.
 ### Building ToC
 
 To autogenerate a ToC (table of contents) for this README,
-run `npm run build:toc`.  Please update the ToC whenever editing the structure
+run `npm run doc:toc`.  Please update the ToC whenever editing the structure
 of README.
 
 ### Committing


### PR DESCRIPTION
Update "Building Toc" section to use update doc:toc command instead of non-existent build:toc command.

Does our git workflow protect `develop` branch from direct commits? I could have made this change on `develop` directly but decided to be safe by using a PR.