### PR TITLE
Set breadcrumb using ember object.set to fix routing errors

### DIFF
--- a/addons/rose/addon/mixins/bread-crumb-route.js
+++ b/addons/rose/addon/mixins/bread-crumb-route.js
@@ -18,7 +18,7 @@ export default Mixin.create({
    */
   setupController(controller) {
     if (super.setupController) super.setupController(...arguments);
-    controller.breadCrumb = this.breadCrumb;
+    controller.set('breadCrumb', this.breadCrumb);
   }
 
 });


### PR DESCRIPTION
Following exception occurs in projects overview routes when attempting to update breadcrumb:

Error while processing route: orgs.org.projects.project Assertion Failed: You attempted to update (generated orgs.org.projects.project controller).breadCrumb to "Seychelles Rupee systems Oregon", but it is being tracked by a tracking context, such as a template, computed property, or observer. In order to make sure the context updates properly, you must invalidate the property when updating it. You can mark the property as `@tracked`, or use `@ember/object#set` to do this. Error: Assertion Failed: You attempted to update (generated orgs.org.projects.project controller).breadCrumb to "Seychelles Rupee systems Oregon", but it is being tracked by a tracking context, such as a template, computed property, or observer. In order to make sure the context updates properly, you must invalidate the property when updating it. You can mark the property as `@tracked`, or use `@ember/object#set` to do this.
