### PR TITLE
Add users link to sidebar navigation

### DIFF
--- a/ui/core/app/templates/orgs/org.hbs
+++ b/ui/core/app/templates/orgs/org.hbs
@@ -11,6 +11,10 @@
     {{outlet "sidebar"}}
 
     <Rose::Nav::Sidebar @title={{t "titles.iam"}} as |nav|>
+      <nav.link @route="orgs.org.users">
+        {{t "resources.users"}}
+      </nav.link>
+
       <nav.link @route="orgs.org.groups">
         {{t "resources.groups"}}
       </nav.link>


### PR DESCRIPTION
Updated sidebar IAM content:
<img width="344" alt="sidebar" src="https://user-images.githubusercontent.com/111036/86056461-7eaf5000-ba2b-11ea-8cb5-ee5fdd0a491a.png">
