### PR TITLE
Show ID of IAM resources when name isn't available

### DIFF
--- a/ui/core/app/templates/orgs/org/groups/index.hbs
+++ b/ui/core/app/templates/orgs/org/groups/index.hbs
@@ -33,7 +33,7 @@
                   @route="orgs.org.groups.group"
                   @model={{group}}
                 >
-                  {{group.name}}
+                  {{group.displayName}}
                 </LinkTo>
               </row.cell>
               <row.cell>{{group.description}}</row.cell>

--- a/ui/core/app/templates/orgs/org/users/index.hbs
+++ b/ui/core/app/templates/orgs/org/users/index.hbs
@@ -33,7 +33,7 @@
                   @route="orgs.org.users.user"
                   @model={{user}}
                 >
-                  {{user.name}}
+                  {{user.displayName}}
                 </LinkTo>
               </row.cell>
               <row.cell>{{user.description}}</row.cell>


### PR DESCRIPTION
With a user being created after authenticating, users table shows empty fields as user name isn't populated. Using helpful `model.displayName` instead of `model.name` shows model id when name isn't available.