### PR TITLE
Fix 'missing translation for key' error in empty orgs list view.

### DIFF
--- a/ui/core/translations/en-us.yaml
+++ b/ui/core/translations/en-us.yaml
@@ -76,6 +76,7 @@ titles:
   overview: Overview
   settings: Settings
   empty-set: No Items Yet
+  orgs-welcome: Welcome to Orgs
   projects-welcome: Welcome to Projects
   host-catalogs-welcome: Welcome to Host Catalogs
   host-sets-welcome: Welcome to Host Sets
@@ -103,6 +104,7 @@ titles:
 descriptions:
   host-catalogs: Overview of collections of hosts and host sets.
   empty-set: There are no items to display yet.  You may be able to add items or try back later.
+  orgs-welcome: Create your orgs here.
   projects-welcome: Projects allow you to create and manage host catalogs. To start, create a project.
   host-catalogs-welcome: Host catalogs allow you to configure to collect and create hosts and host sets. To start, create a host catalog.
   host-sets-welcome: Configure a static host set in this host catalog.


### PR DESCRIPTION
Add empty org message attributes to translation file