### PR TITLE
docs: Update resource contexts

### DIFF
--- a/ui/core/translations/resources/en-us.yaml
+++ b/ui/core/translations/resources/en-us.yaml
@@ -56,8 +56,11 @@ descriptions:
   roles: A role is a collection of capabilities granted to any Principal the Role is assigned to. A Role belongs to one and only one Scope. A Role owns zero or more Direct Grants. The lifecycle of a Role is not tied to the lifecycle of any Principal.
   grants: A grant represents a set of capabilities granted to a role. It couples a set of Actions to either a set of Resource Types or an individual Resource. A Direct Grant belongs exclusively to one and only one Role. However, equivalent Direct Grants may exist across different Roles. A Direct Grant references one or more Actions and either one or more Resource types or one specific Resource. A Direct Grant is deleted when the Role it belongs to is deleted. A Direct Grant is also deleted if it is associated with a specific Resource and that Resource itself is deleted. The lifecycle of a Direct Grant is not tied to the lifecycle of any Action or Resource Type.
   principals: A principal is any entity which can be assigned capabilities. Principal is abstract. User, Group, and Project are concrete Principals. A Principal can be assigned to zero or more Roles.
+  add-principals: TBD
   group: All Users in a Group are granted the capabilities of all Roles the Group is associated with. A Group is deleted when the Scope it belongs to is deleted.
   groups: Groups are collections of Users used only for access control purposes. A Group is owned by one and only one Scope. A Group can contain zero or more Users. A Group inherits from Principal ("is-a" Principal) allowing it to be associated with zero or more Roles. The lifecycle of a Group is not tied to the lifecycle of any User or Role.
+  group-members: TBD
+  add-group-members: TBD
   org: When an Organization is deleted, all resources owned by it are also deleted.
   orgs: An Organization is a top-level container, and owns zero to many Projects and zero to many Authentication Methods. An Organization inherits from Scope ("is-a" Scope) allowing it to own zero to many Groups, Roles, Targets, or Host Catalogs. The lifecycle of an Organization is not tied to anything else. A Role at the Organization level can grant permissions at the Project level.
   project: When a Project is deleted, all resources owned by it are also deleted. The lifecycle of a Project is not tied to any resource it contains.
@@ -70,5 +73,6 @@ descriptions:
   hosts: A host is a computing element with a network address reachable from Boundary. A Host belongs to one and only one Host Catalog. A Host can be contained by zero or more Host Sets. The lifecycle of a Host is not tied to the lifecycle of any Host Sets.
   target: Target is abstract. A Target is deleted when the Scope it belongs to is deleted.
   targets: A target is a networked service a User can connect to and interact with through Boundary. A Target does not directly contain any secrets. A Target contains a collection of Hosts. A Target belongs to one and only one Scope. A Target can contain zero or more Host Sets. The lifecycle of a Target is not tied to the lifecycle of any Host Set.
+  add-host-sets-to-target: TBD
   sessions: Sessions
   session: Session


### PR DESCRIPTION
@malnick , Pete, below screenshot shows an example role resource workflows. Few resources like users, session, etc. don't have association workflows. This should give you both a good idea on where we can add documentation value to our users.

![context](https://user-images.githubusercontent.com/111036/94176630-600ff800-fe66-11ea-8c70-8ed0ab9535e8.png)


Another example where we can provide context:
![change-password-form](https://user-images.githubusercontent.com/111036/94177398-74a0c000-fe67-11ea-9612-b3eae59ac3fc.png)

I'm happy to document all screens if it helps when updating descriptions.

Note: @randallmorey is working on updating the structure of the translation file so this PR is tagged as a draft so that our changes won't interrupt your text updates. 