### PR TITLE
chore: Introduce PR labling github action

### DIFF
--- a/.github/labler.yml
+++ b/.github/labler.yml
@@ -1,0 +1,23 @@
+addons:
+  - addons/**/*
+
+addons/api:
+  - addons/api/**/*
+
+addons/auth:
+  - addons/auth/**/*
+
+addons/styles:
+  - addons/rose/**/*
+
+ui:
+  - ui/**/*
+
+ui/admin:
+  - ui/core/**/*
+
+ui/admin/app:
+  - ui/core/app/**/*
+
+ui/admin/tests:
+  - ui/core/tests/**/*

--- a/.github/workflows/labler.yml
+++ b/.github/workflows/labler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
From: https://github.com/actions/labeler

Reason for mapping `rose` to `styles` and `core` to `admin` is to provide context for folks without in-depth knowledge about the repo to understand PR labels. Open for discussion. 