### PR TITLE
fix: Remove unused flexbox dropdown definition to fix Safari layout issue

### DIFF
--- a/addons/rose/addon/styles/rose/components/dropdown/_dropdown.scss
+++ b/addons/rose/addon/styles/rose/components/dropdown/_dropdown.scss
@@ -12,8 +12,6 @@ $xxs: sizing.rems(xxs); // 4
     @include type.type(button, semibold);
     cursor: default;
     overflow: hidden;
-    display: flex;
-    align-items: center;
     $yPadding: sizing.rems(xxs) + sizing.rems(xxxs);
     padding: $yPadding sizing.rems(m) $yPadding sizing.rems(l);
     color: var(--stark);


### PR DESCRIPTION
Safari screenshots:
<img width="501" alt="Screen Shot 2020-10-02 at 17 28 28" src="https://user-images.githubusercontent.com/111036/94971489-1f068c00-04d5-11eb-91a8-a579f4a6196e.png">

<img width="766" alt="Screen Shot 2020-10-02 at 17 28 54" src="https://user-images.githubusercontent.com/111036/94971498-22017c80-04d5-11eb-89af-48f7862eb3eb.png">

Chrome screenshots:
<img width="350" alt="Screen Shot 2020-10-02 at 17 32 49" src="https://user-images.githubusercontent.com/111036/94971606-5f660a00-04d5-11eb-8146-18d7a486c686.png">

<img width="848" alt="Screen Shot 2020-10-02 at 17 32 41" src="https://user-images.githubusercontent.com/111036/94971599-5bd28300-04d5-11eb-9e5d-75e0ba3d2e2d.png">
