### PR TITLE
style: Reduce doc help icon size in page header

### DIFF
--- a/ui/core/app/styles/app.scss
+++ b/ui/core/app/styles/app.scss
@@ -115,8 +115,8 @@
   }
 }
 
-.rose-layout-page-header {
-  .doc-link {
+.doc-link {
+  .large {
     svg {
       transform: scale(0.8);
     }


### PR DESCRIPTION
Before:
<img width="261" alt="Screen Shot 2020-10-07 at 11 53 36" src="https://user-images.githubusercontent.com/111036/95357847-5dfe5e00-0896-11eb-810c-f7845047ba2c.png">

After:
<img width="172" alt="Screen Shot 2020-10-07 at 12 12 14" src="https://user-images.githubusercontent.com/111036/95357854-60f94e80-0896-11eb-8e93-bbf39cdb0b1e.png">
