### PR TITLE
Add ability to create and assign host to a host set in one step

### DIFF
--- a/addons/api/addon/models/host-set.js
+++ b/addons/api/addon/models/host-set.js
@@ -40,6 +40,16 @@ export default class HostSetModel extends GeneratedHostSetModel {
   }
 
   /**
+   * Add a single host via the `add-hosts` method.
+   * @param {string} hostID
+   * @param {object} options
+   * @return {Promise}
+   */
+  addHost(hostID, options) {
+    return this.addHosts([hostID], options);
+  }
+
+  /**
    * Delete hosts via the `remove-hosts` method.
    * See serializer and adapter for more information.
    * @param {[string]} hostIDs

--- a/addons/api/tests/unit/models/host-set-test.js
+++ b/addons/api/tests/unit/models/host-set-test.js
@@ -1,13 +1,144 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Unit | Model | host set', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let store = this.owner.lookup('service:store');
-    let model = store.createRecord('host-set', {});
-    assert.ok(model);
+  test('it has an `addHosts` method that targets a specific POST API endpoint and serialization', async function (assert) {
+    assert.expect(1);
+    this.server.post('/v1/host-sets/123abc:add-hosts', (schema, request) => {
+      const body = JSON.parse(request.requestBody);
+      assert.deepEqual(body, {
+        host_ids: ['123_abc', 'foobar'],
+        version: 1,
+      });
+      return { id: '123abc' };
+    });
+    const store = this.owner.lookup('service:store');
+    store.push({
+      data: {
+        id: '123abc',
+        type: 'host-set',
+        attributes: {
+          name: 'Host Set',
+          description: 'Description',
+          host_ids: [
+            {value: '1'},
+            {value: '3'},
+          ],
+          version: 1,
+          scope: {
+            scope_id: 'o_1',
+            type: 'scope',
+          },
+        },
+      },
+    });
+    const model = store.peekRecord('host-set', '123abc');
+    await model.addHosts(['123_abc', 'foobar']);
+  });
+
+  test('it has an `addHost` method that adds a single host using `addHosts` method', async function (assert) {
+    assert.expect(1);
+    this.server.post('/v1/host-sets/123abc:add-hosts', (schema, request) => {
+      const body = JSON.parse(request.requestBody);
+      assert.deepEqual(body, {
+        host_ids: ['foobar'],
+        version: 1,
+      });
+      return { id: '123abc' };
+    });
+    const store = this.owner.lookup('service:store');
+    store.push({
+      data: {
+        id: '123abc',
+        type: 'host-set',
+        attributes: {
+          name: 'Host Set',
+          description: 'Description',
+          host_ids: [
+            {value: '1'},
+            {value: '3'},
+          ],
+          version: 1,
+          scope: {
+            scope_id: 'o_1',
+            type: 'scope',
+          },
+        },
+      },
+    });
+    const model = store.peekRecord('host-set', '123abc');
+    await model.addHost('foobar');
+  });
+
+  test('it has a `removeHostSets` method that targets a specific POST API endpoint and serialization', async function (assert) {
+    assert.expect(1);
+    this.server.post('/v1/host-sets/123abc:remove-hosts', (schema, request) => {
+      const body = JSON.parse(request.requestBody);
+      assert.deepEqual(body, {
+        host_ids: ['3'],
+        version: 1,
+      });
+      return { id: '123abc' };
+    });
+    const store = this.owner.lookup('service:store');
+    store.push({
+      data: {
+        id: '123abc',
+        type: 'host-set',
+        attributes: {
+          name: 'Host Set',
+          description: 'Description',
+          host_ids: [
+            {value: '1'},
+            {value: '3'},
+          ],
+          version: 1,
+          scope: {
+            scope_id: 'o_1',
+            type: 'scope',
+          },
+        },
+      },
+    });
+    const model = store.peekRecord('host-set', '123abc');
+    await model.removeHosts(['3']);
+  });
+
+  test('it has a `removeHost` method that removes a single host using `removeHosts` method', async function (assert) {
+    assert.expect(1);
+    this.server.post('/v1/host-sets/123abc:remove-hosts', (schema, request) => {
+      const body = JSON.parse(request.requestBody);
+      assert.deepEqual(body, {
+        host_ids: ['3'],
+        version: 1,
+      });
+      return { id: '123abc' };
+    });
+    const store = this.owner.lookup('service:store');
+    store.push({
+      data: {
+        id: '123abc',
+        type: 'host-set',
+        attributes: {
+          name: 'Host Set',
+          description: 'Description',
+          host_ids: [
+            {value: '1'},
+            {value: '3'},
+          ],
+          version: 1,
+          scope: {
+            scope_id: 'o_1',
+            type: 'scope',
+          },
+        },
+      },
+    });
+    const model = store.peekRecord('host-set', '123abc');
+    await model.removeHost('3');
   });
 });

--- a/ui/core/app/components/form/host-set/add-hosts/index.hbs
+++ b/ui/core/app/components/form/host-set/add-hosts/index.hbs
@@ -43,9 +43,9 @@
 
 {{#unless this.hasAvailableHosts}}
   <Rose::Layout::Centered>
-    <Rose::Message @title={{t "resources.host-set.host.messages.add.title"}} as |message|>
+    <Rose::Message @title={{t "resources.host-set.host.messages.add-none.title"}} as |message|>
       <message.description>
-        {{t "resources.host-set.host.messages.add.description"}}
+        {{t "resources.host-set.host.messages.add-none.description"}}
       </message.description>
       <message.link @route="scopes.scope.projects.project.host-catalogs.host-catalog.host-sets.host-set.hosts">
         <Rose::Icon @name="chevron-left" />

--- a/ui/core/app/components/form/host-set/create-host/index.hbs
+++ b/ui/core/app/components/form/host-set/create-host/index.hbs
@@ -1,0 +1,82 @@
+<Rose::Form
+  @onSubmit={{@submit}}
+  @cancel={{@cancel}}
+  @disabled={{@model.host.isSaving}}
+  @error={{@model.host.errors.base}}
+  as |form|
+>
+
+  <form.input
+  @value={{@model.hostSet.displayName}}
+  @label={{t "form.host_set.label"}}
+  readonly={{true}}
+  @disabled={{true}} />
+
+  <form.input
+  @value={{@model.host.type}}
+  @label={{t "form.type.label"}}
+  readonly={{true}}
+  @disabled={{true}} />
+
+  <form.input
+    @name="name"
+    @type="name"
+    @value={{@model.host.name}}
+    @label={{t "form.name.label"}}
+    @error={{@model.host.errors.name}}
+    @helperText={{t "form.name.help"}}
+    readonly={{false}}
+  as |field|>
+    {{#if @model.host.errors.name}}
+      <field.errors as |errors|>
+        {{#each @model.host.errors.name as |error|}}
+          <errors.message>{{error.message}}</errors.message>
+        {{/each}}
+      </field.errors>
+    {{/if}}
+  </form.input>
+
+  <form.textarea
+    @name="description"
+    @type="description"
+    @value={{@model.host.description}}
+    @label={{t "form.description.label"}}
+    @error={{@model.host.errors.description}}
+    @helperText={{t "form.description.help"}}
+    disabled={{@model.host.isSaving}}
+    readonly={{false}}
+  as |field|>
+    {{#if @model.host.errors.description}}
+      <field.errors as |errors|>
+        {{#each @model.host.errors.description as |error|}}
+          <errors.message>{{error.message}}</errors.message>
+        {{/each}}
+      </field.errors>
+    {{/if}}
+  </form.textarea>
+
+  <form.input
+    @name="address"
+    @type="text"
+    @value={{@model.host.attributes.address}}
+    @label={{t "form.address.label"}}
+    @error={{@model.host.errors.name}}
+    @helperText={{t "form.address.help"}}
+    readonly={{false}}
+  as |field|>
+    {{#if @model.host.errors.name}}
+      <field.errors as |errors|>
+        {{#each @model.host.errors.name as |error|}}
+          <errors.message>{{error.message}}</errors.message>
+        {{/each}}
+      </field.errors>
+    {{/if}}
+  </form.input>
+
+  <form.actions
+    @disabled={{if @model.host.cannotSave @model.host.cannotSave}}
+    @enableEditText={{t "actions.edit-form"}}
+    @submitText={{t "actions.save"}}
+    @cancelText={{t "actions.cancel"}} />
+
+</Rose::Form>

--- a/ui/core/app/controllers/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host.js
+++ b/ui/core/app/controllers/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host.js
@@ -1,0 +1,18 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default class ScopesScopeProjectsProjectHostCatalogsHostCatalogHostSetsHostSetCreateHostController extends Controller {
+  // =services
+
+  @service intl;
+
+  // =attributes
+
+  /**
+   * Translated new host set breadcrumb
+   * @type {string}
+   */
+  get breadCrumb() {
+    return this.intl.t('resources.host-set.actions.create-host');
+  }
+}

--- a/ui/core/app/router.js
+++ b/ui/core/app/router.js
@@ -29,6 +29,7 @@ Router.map(function () {
                   this.route('host-set', { path: ':host_set_id' }, function () {
                     this.route('hosts');
                     this.route('add-hosts');
+                    this.route('create-host');
                   });
                   this.route('new');
                 });

--- a/ui/core/app/routes/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host.js
+++ b/ui/core/app/routes/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host.js
@@ -1,0 +1,90 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { hash } from 'rsvp';
+import loading from 'ember-loading/decorator';
+import { notifySuccess, notifyError } from '../../../../../../../../../decorators/notify';
+
+export default class ScopesScopeProjectsProjectHostCatalogsHostCatalogHostSetsHostSetCreateHostRoute extends Route {
+  // =services
+
+  @service intl;
+  @service notify;
+
+  // =methods
+
+  /**
+   * Creates a new unsaved host in current host catalog scope.
+   * @return {Promise{HostSetModel,HostModel}}
+   */
+  async model() {
+    const { id: host_catalog_id } = this.modelFor(
+      'scopes.scope.projects.project.host-catalogs.host-catalog'
+    );
+
+    return hash({
+      hostSet: this.modelFor(
+        'scopes.scope.projects.project.host-catalogs.host-catalog.host-sets.host-set'
+      ),
+      host: this.store.createRecord('host', {
+        type: 'static',
+        host_catalog_id,
+      }),
+    });
+  }
+
+  /**
+   * Renders the create-host-specific header template.
+   * Empties the actions and navigation outlets and renders a custom empty header.
+   * @override
+   */
+  renderTemplate() {
+    super.renderTemplate(...arguments);
+
+    this.render(
+      'scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host/-header',
+      {
+        into: 'scopes/scope/projects/project/host-catalogs/host-catalog',
+        outlet: 'header',
+      }
+    );
+
+    this.render('-empty', {
+      into: 'scopes/scope/projects/project/host-catalogs/host-catalog',
+      outlet: 'navigation',
+    });
+
+    this.render('-empty', {
+      into: 'scopes/scope/projects/project/host-catalogs/host-catalog',
+      outlet: 'actions',
+    });
+  }
+
+  // =actions
+
+  /**
+   * Saves host and add it to current host set.
+   * @param {HostSetModel,HostModel} model
+   */
+  @action
+  @loading
+  @notifyError(({ message }) => message, { catch: true })
+  @notifySuccess('notifications.add-success')
+  async save(model) {
+    await model.host.save();
+    await model.hostSet.addHost(model.host.id);
+    await this.replaceWith(
+      'scopes.scope.projects.project.host-catalogs.host-catalog.host-sets.host-set.hosts'
+    );
+  }
+
+  /**
+   * Redirect to hosts in host set as if nothing ever happened.
+   */
+  @action
+  cancel() {
+    this.replaceWith(
+      'scopes.scope.projects.project.host-catalogs.host-catalog.host-sets.host-set.hosts'
+    );
+  }
+}

--- a/ui/core/app/templates/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/-actions.hbs
+++ b/ui/core/app/templates/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/-actions.hbs
@@ -1,4 +1,7 @@
 <Rose::Dropdown @text="{{t 'actions.manage'}}" @dropdownRight={{true}} as |dropdown|>
+  <dropdown.link @route="scopes.scope.projects.project.host-catalogs.host-catalog.host-sets.host-set.create-host">
+    {{t 'resources.host-set.actions.create-host'}}
+  </dropdown.link>
   <dropdown.link @route="scopes.scope.projects.project.host-catalogs.host-catalog.host-sets.host-set.add-hosts">
     {{t 'resources.host-set.actions.add-hosts'}}
   </dropdown.link>

--- a/ui/core/app/templates/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host.hbs
+++ b/ui/core/app/templates/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host.hbs
@@ -1,0 +1,7 @@
+{{title (t 'resources.host-set.actions.create-host')}}
+
+<Form::HostSet::CreateHost
+  @model={{@model}}
+  @submit={{route-action "save" @model}}
+  @cancel={{route-action "cancel" @model}}
+/>

--- a/ui/core/app/templates/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host/-header.hbs
+++ b/ui/core/app/templates/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host/-header.hbs
@@ -1,0 +1,4 @@
+<h2>
+  {{t "resources.host-set.actions.create-host"}}
+  <DocLink @doc="host.new" @iconSize="large" />
+</h2>

--- a/ui/core/app/templates/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/hosts.hbs
+++ b/ui/core/app/templates/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/hosts.hbs
@@ -64,7 +64,10 @@
       </message.description>
       <message.link @route="scopes.scope.projects.project.host-catalogs.host-catalog.hosts.new">
         <Rose::Icon @name="plus-circle-outline" />
-        {{t "titles.new"}}
+        {{t "resources.host-set.host.messages.none.actions.new"}}
+      </message.link>
+      <message.link @route="scopes.scope.projects.project.host-catalogs.host-catalog.host-sets.host-set.add-hosts">
+        {{t "resources.host-set.actions.add-hosts"}}
       </message.link>
     </Rose::Message>
   </Rose::Layout::Centered>

--- a/ui/core/app/templates/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/hosts.hbs
+++ b/ui/core/app/templates/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/hosts.hbs
@@ -62,12 +62,9 @@
       <message.description>
         {{t "resources.host-set.host.messages.none.description"}}
       </message.description>
-      <message.link @route="scopes.scope.projects.project.host-catalogs.host-catalog.hosts.new">
+      <message.link @route="scopes.scope.projects.project.host-catalogs.host-catalog.host-sets.host-set.create-host">
         <Rose::Icon @name="plus-circle-outline" />
-        {{t "resources.host-set.host.messages.none.actions.new"}}
-      </message.link>
-      <message.link @route="scopes.scope.projects.project.host-catalogs.host-catalog.host-sets.host-set.add-hosts">
-        {{t "resources.host-set.actions.add-hosts"}}
+        {{t "resources.host-set.actions.create-host"}}
       </message.link>
     </Rose::Message>
   </Rose::Layout::Centered>

--- a/ui/core/tests/unit/controllers/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host-test.js
+++ b/ui/core/tests/unit/controllers/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host', function(hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host');
+    assert.ok(controller);
+  });
+});

--- a/ui/core/tests/unit/routes/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host-test.js
+++ b/ui/core/tests/unit/routes/scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:scopes/scope/projects/project/host-catalogs/host-catalog/host-sets/host-set/create-host');
+    assert.ok(route);
+  });
+});

--- a/ui/core/translations/form/en-us.yaml
+++ b/ui/core/translations/form/en-us.yaml
@@ -41,3 +41,5 @@ session_max_seconds:
 session_connection_limit:
   label: Maximum Connections
   help: The maximum number of connections allowed per session.  For unlimited, specify "-1".
+host_set:
+  label: Host Set

--- a/ui/core/translations/resources/en-us.yaml
+++ b/ui/core/translations/resources/en-us.yaml
@@ -67,7 +67,8 @@ host-set:
     add: Add Host Set
     create: New Host Set
     delete: Delete Host Set
-    add-hosts: Add Hosts
+    create-host: Create and Add Host
+    add-hosts: Add Existing Host
   messages:
     welcome:
       title: Welcome to Host Sets
@@ -75,12 +76,13 @@ host-set:
     messages:
       none:
         title: No Hosts
-        description: No hosts available in this host set. Create hosts in a host catalog before assigning them to this host set.
-        actions:
-          new: New Host
+        description: No hosts available in this host set.
       add:
         title: Add Hosts
         description: Select hosts that belong to this host set.
+      add-none:
+        title: No Hosts Available
+        description: No hosts available for selection.
   types:
     static: Static
 host:

--- a/ui/core/translations/resources/en-us.yaml
+++ b/ui/core/translations/resources/en-us.yaml
@@ -74,8 +74,10 @@ host-set:
   host:
     messages:
       none:
-        title: Welcome to Hosts
-        description: No hosts available in this host set.
+        title: No Hosts
+        description: No hosts available in this host set. Create hosts in a host catalog before assigning them to this host set.
+        actions:
+          new: New Host
       add:
         title: Add Hosts
         description: Select hosts that belong to this host set.


### PR DESCRIPTION
![host-create-and-assign-workflow-revised](https://user-images.githubusercontent.com/111036/96890778-faf3f600-1455-11eb-99fb-a2d14fb46238.gif)

Introduces ability to create a host and assign it to a host set automagically from within a host set. This removed the current need to navigate to a host catalog to create a host and then navigate into a host set to assign it. The current assignment of hosts in a host set workflow hasn't been changed.
