### PR TITLE
Use docker mirror

### DIFF
--- a/docker-compose-embedding.yml
+++ b/docker-compose-embedding.yml
@@ -6,7 +6,7 @@ version: '3.8'
 
 services:
   node: &node
-    image: node:12
+    image: docker.mirror.hashicorp.services/node:12
     volumes:
       - './:/src'
       - 'icu_node_modules:/src/node_modules'


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. We're updating CircleCI configs, docker compose, dockerfiles, and travis configs. Github actions are excluded, as Github is handling the issue on their end. LMK if you have any q's, otherwise feel free to approve and merge on your own! 