### PR TITLE
update gajira-comment action, addressing security vulnerability

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -68,7 +68,7 @@ jobs:
 
     - name: Sync comment
       if: github.event.action == 'created' && steps.search.outputs.issue
-      uses: atlassian/gajira-comment@v2.0.1
+      uses: atlassian/gajira-comment@v2.0.2
       with:
         issue: ${{ steps.search.outputs.issue }}
         comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"


### PR DESCRIPTION
GitHub advised us that we were using a Jira workflow version with an interpolation-related code execution vulnerability ([GHSL-2020-207-hashicorp-boundary-ui-workflow.pdf](https://github.com/hashicorp/boundary-ui/files/5461210/GHSL-2020-207-hashicorp-boundary-ui-workflow.pdf)).

This moves to a newer version of that workflow in which the vulnerability is addressed.

