### PR TITLE
feat: 🎸 implement configurable IPC timeout, with a 2s default

### DIFF
--- a/addons/core/translations/errors/en-us.yaml
+++ b/addons/core/translations/errors/en-us.yaml
@@ -17,3 +17,5 @@ generic:
   title: Error
 authentication-failed:
   title: Authentication Failed
+origin-verification-failed:
+  description: The controller URL could not be reached or is not a valid server.

--- a/ui/desktop/app/routes/scopes/scope/projects/targets.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets.js
@@ -2,6 +2,8 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { all } from 'rsvp';
 import { action } from '@ember/object';
+import loading from 'ember-loading/decorator';
+import { notifyError } from 'core/decorators/notify';
 
 export default class ScopesScopeProjectsTargetsRoute extends Route {
   // =services
@@ -45,14 +47,12 @@ export default class ScopesScopeProjectsTargetsRoute extends Route {
    * Establish a session to current target.
    */
   @action
+  @loading
+  @notifyError(({ message }) => message, { catch: true })
   async connect(model) {
-    try {
-      await this.ipc.invoke('connect', {
-        target_id: model.target.id,
-        auth_token: this.session.data.authenticated.token,
-      });
-    } catch(e) {
-      this.notify.error(e.toString(), { closeAfter: null });
-    }
+    await this.ipc.invoke('connect', {
+      target_id: model.target.id,
+      auth_token: this.session.data.authenticated.token,
+    });
   }
 }

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -50,6 +50,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^2.0.2",
     "ember-cli-uglify": "^3.0.0",
+    "ember-concurrency": "^1.3.0",
     "ember-electron": "https://github.com/adopted-ember-addons/ember-electron#v3.0.0-beta.4",
     "ember-exam": "^6.0.1",
     "ember-export-application-global": "^2.0.1",

--- a/ui/desktop/tests/unit/services/ipc-test.js
+++ b/ui/desktop/tests/unit/services/ipc-test.js
@@ -6,33 +6,26 @@ import sinon from 'sinon';
 module('Unit | Service | ipc', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(() => {
-    // IPC requests talk to the main process indirectly via window.postMessage
-    // proxy layer (mediated by preload.js).
-    // But we don't want to send these for real in tests.
-    sinon.stub(window, 'postMessage');
-  });
-
-  hooks.afterEach(() => {
-    sinon.restore();
-  });
-
-  test('it creates new IPCRequest objects', function (assert) {
+  test('it creates new IPCRequest objects', async function (assert) {
     assert.expect(1);
+    sinon.stub(window, 'postMessage').callsFake((request, origin, [port]) => {
+      port.postMessage({});
+    });
     const service = this.owner.lookup('service:ipc');
-    const request = service.invoke('hello', 'world', 'http://localhost:4200');
+    const request = service.invoke('hello', 'world');
     assert.equal(request.constructor, IPCRequest);
   });
 
-  test('IPCRequest objects post messages on their window objects', function (assert) {
+  test('IPCRequest objects post messages on their window objects', async function (assert) {
     assert.expect(2);
     const myWindow = {
-      postMessage(request) {
+      postMessage(request, origin, [port]) {
         assert.equal(request.method, 'hello');
         assert.equal(request.payload, 'world');
+        port.postMessage({});
       },
     };
-    new IPCRequest('hello', 'world', myWindow);
+    new IPCRequest('hello', 'world', null, myWindow);
   });
 
   test('IPCRequest objects resolve to the value posted via a response message port', async function (assert) {
@@ -46,11 +39,24 @@ module('Unit | Service | ipc', function (hooks) {
         });
       },
     };
-    const request = new IPCRequest('hello', 'world', myWindow);
+    const request = new IPCRequest('hello', 'world', null, myWindow);
     const response = await request;
     assert.deepEqual(response, {
       foo: 'bar',
       test: 42,
+    });
+  });
+
+  test('IPCRequest objects reject if a timeout duration elapses', async function (assert) {
+    assert.expect(1);
+    const myWindow = {
+      postMessage(/*request, origin, [port]*/) {
+        // ...do nothing in order to trigger a timeout
+      },
+    };
+    const request = new IPCRequest('hello', 'world', 1, myWindow);
+    request.catch(() => {
+      assert.ok(true, 'Request rejected.');
     });
   });
 });


### PR DESCRIPTION
Adds timeouts to IPC requests.  If the request does not complete within the timeout period, the request rejects with an error.  The duration is configurable per request and defaults to 2 seconds.