### PR TITLE
fix: 🐛 desktop client should pass controller URL to CLI

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects/targets.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets.js
@@ -8,6 +8,7 @@ export default class ScopesScopeProjectsTargetsRoute extends Route {
 
   @service ipc;
   @service session;
+  @service origin;
   @service notify;
   @service confirm;
 
@@ -58,6 +59,7 @@ export default class ScopesScopeProjectsTargetsRoute extends Route {
       const connectionDetails = await this.ipc.invoke('connect', {
         target_id: model.target.id,
         token: this.session.data.authenticated.token,
+        addr: this.origin.rendererOrigin
       });
 
       // Show the user a modal with basic connection info.

--- a/ui/desktop/electron-app/src/boundary-cli.js
+++ b/ui/desktop/electron-app/src/boundary-cli.js
@@ -9,11 +9,12 @@ module.exports = {
   // Check boundary cli existence
   exists: () => Boolean(cliPath()),
   // Initiate connection and return output
-  connect: (target_id, token) => {
+  connect: (target_id, token, addr) => {
     const command = [
       'connect',
       `-target-id=${target_id}`,
       `-token=${token}`,
+      `-addr=${addr}`,
       '-format=json',
       '--output-json-errors'
     ]

--- a/ui/desktop/electron-app/src/handlers.js
+++ b/ui/desktop/electron-app/src/handlers.js
@@ -33,4 +33,4 @@ handle('cliPath', () => boundaryCli.path());
 /**
  * Establishes a boundary session and returns session details.
  */
-handle('connect', ({ target_id, token }) => boundaryCli.connect(target_id, token));
+handle('connect', ({ target_id, token, addr }) => boundaryCli.connect(target_id, token, addr));


### PR DESCRIPTION
Plumbs the controller URL specified in the desktop client through to the CLI via the `-addr` option.