### PR TITLE
Add code signing check for desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ yarn install
 yarn build:ui:desktop
 ```
 
+To provide a signing identify for macOS build, use `BOUNDARY_DESKTOP_SIGNING_IDENTITY`
+environment variable to set signing certificate name (e.g Developer ID Application: * (*)).
+
 Assets are saved to `ui/desktop/electron-app/out/make/`.
 DMG packaged desktop UI is available at asset location as `Boundary Desktop.dmg`.
 

--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -66,15 +66,17 @@ To run as a desktop app:
 
 Before executing a build, be sure to set any environment variables necessary
 for your target [environment](#environment-variables).  To build this UI for
-production, run the following commads from this folder:
+production, run the following commands from this folder:
 
 ```bash
 yarn install
 yarn build
 ```
 
-The static production assets are saved into the `dist/` folder.
+`BOUNDARY_DESKTOP_SIGNING_IDENTITY` environment variable must be provided
+to codesign in production.
 
+The static production assets are saved into the `dist/` folder.
 
 #### Environment Variables
 
@@ -83,7 +85,7 @@ These environment variables may be used to customized the build.
 | Variable | Default Value | Description |
 | -------- | ------------- | ----------- |
 | `APP_NAME` | Application Name | The user-facing name of the application, appearing in titles, etc. |
-| `API_HOST` | | The host of the API, if different than UI (e.g. https://example.net:1234). |
+| `BOUNDARY_DESKTOP_SIGNING_IDENTITY` | | The name of the certificate to use when signing (e.g. Developer ID Application: * (*)). |
 
 ### Running Tests
 

--- a/ui/desktop/electron-app/config/forge.config.js
+++ b/ui/desktop/electron-app/config/forge.config.js
@@ -1,0 +1,38 @@
+const process = require('process');
+
+module.exports = {
+  hooks: {
+    prePackage: (forgeConfig) => {
+      if (process.env.BOUNDARY_DESKTOP_SIGNING_IDENTITY) {
+        forgeConfig.osxSign = {
+          identity: process.env.BOUNDARY_DESKTOP_SIGNING_IDENTITY,
+          hardenedRuntime: true,
+          "gatekeeper-assess": false,
+          entitlements: "config/macos/entitlements.plist",
+          "entitlements-inherit": "config/macos/entitlements.plist",
+          "signature-flags": "library"
+        }
+      } else {
+        console.warn('Could not find signing identity. Skipping signing.');
+      }
+    }
+  },
+  packagerConfig: {
+    ignore: [
+      "/ember-test(/|$)",
+      "/tests(/|$)"
+    ],
+    name: "Boundary Desktop",
+    appBundleId: "com.electron.boundary",
+    appVersion: "0.0.1",
+    appCopyright: "Copyright © 2021 HashiCorp, Inc."
+  },
+  makers: [
+    {
+      name: "@electron-forge/maker-dmg",
+      config: {
+        name: "Boundary Desktop"
+      }
+    }
+  ]
+}

--- a/ui/desktop/electron-app/config/forge.config.js
+++ b/ui/desktop/electron-app/config/forge.config.js
@@ -2,7 +2,7 @@ const process = require('process');
 
 module.exports = {
   hooks: {
-    prePackage: (forgeConfig) => {
+    preMake: (forgeConfig) => {
       if (process.env.BOUNDARY_DESKTOP_SIGNING_IDENTITY) {
         forgeConfig.osxSign = {
           identity: process.env.BOUNDARY_DESKTOP_SIGNING_IDENTITY,

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -16,34 +16,7 @@
   },
   "keywords": [],
   "config": {
-    "forge": {
-      "packagerConfig": {
-        "ignore": [
-          "/ember-test(/|$)",
-          "/tests(/|$)"
-        ],
-        "name": "Boundary Desktop",
-        "appBundleId": "com.electron.boundary",
-        "appVersion": "0.0.1",
-        "appCopyright": "Copyright © 2021 HashiCorp, Inc.",
-        "osxSign": {
-          "identity": "Developer ID Application: Hashicorp, Inc. (D38WU7D763)",
-          "hardenedRuntime": true,
-          "gatekeeper-assess": false,
-          "entitlements": "config/macos/entitlements.plist",
-          "entitlements-inherit": "config/macos/entitlements.plist",
-          "signature-flags": "library"
-        }
-      },
-      "makers": [
-        {
-          "name": "@electron-forge/maker-dmg",
-          "config": {
-            "name": "Boundary Desktop"
-          }
-        }
-      ]
-    }
+    "forge": "config/forge.config.js"
   },
   "dependencies": {
     "axios": "^0.21.1",


### PR DESCRIPTION
Extract electron config from package.json to be able to use prePackage hook to check for code signing.
Code signing will be based on finding `BOUNDARY_DESKTOP_SIGNING_IDENTITY` in env variables.