### PR TITLE
Bundle Boundary CLI into Desktop Client

### DIFF
--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -62,6 +62,9 @@ List of available project commands.  `yarn run <command-name>`
 To run as a desktop app:
 * `yarn start:desktop`
 
+The Boundary CLI is downloaded and extracted to `electron-app/cli/` folder as part of
+build. CLI version is defined in `electron-app/config/cli.js`.
+
 ### Building for Production
 
 Before executing a build, be sure to set any environment variables necessary
@@ -77,6 +80,8 @@ yarn build
 to codesign in production.
 
 The static production assets are saved into the `dist/` folder.
+The Boundary CLI is downloaded and extracted to `electron-app/cli/` folder as part of
+packaging. CLI version is defined in `electron-app/config/cli.js`.
 
 #### Environment Variables
 

--- a/ui/desktop/app/routes/scopes/scope/projects/targets.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets.js
@@ -49,11 +49,9 @@ export default class ScopesScopeProjectsTargetsRoute extends Route {
   @action
   async connect(model) {
     try {
-      //eslint-disable-next-line no-debugger
-      debugger;
-      // Check for cli
-      const cliPath = await this.ipc.invoke('cliExists');
-      if(!cliPath) throw new Error('Cannot find boundary cli.')
+      // Check for CLI
+      const cliExists = await this.ipc.invoke('cliExists');
+      if (!cliExists) throw new Error('Cannot find Boundary CLI.');
 
       // Create target session
       const connectionDetails = await this.ipc.invoke('connect', {

--- a/ui/desktop/electron-app/.gitignore
+++ b/ui/desktop/electron-app/.gitignore
@@ -91,3 +91,6 @@ out/
 # Ember build
 ember-dist/
 ember-test/
+
+# CLI
+cli/

--- a/ui/desktop/electron-app/config/cli.js
+++ b/ui/desktop/electron-app/config/cli.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const decompress = require('decompress');
+const os = require('os');
+
+const artifactVersion = '0.1.4';
+const artifactDestination = path.resolve(__dirname, '..', 'cli');
+
+const downloadArtifact = (version) => {
+  const url = `https://releases.hashicorp.com/boundary/${version}/boundary_${version}_darwin_amd64.zip`;
+  return new Promise((resolve, reject) => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boundary-desktop-artifact-'))
+    console.log('Create tmp artifact directory: ', tmpDir);
+
+    const artifactFileName = url.split('/').pop();
+    if(!artifactFileName) reject('Could not find artifact filename in: ', url);
+
+    const artifactPath = path.resolve(tmpDir, artifactFileName);
+    console.log('Download artifact url: ', url);
+    https.get(url, (response) => {
+      const stream = response.pipe(fs.createWriteStream(artifactPath))
+      stream.on('close', () => resolve(artifactPath));
+      stream.on('error', reject);
+    });
+  });
+};
+
+const extract = (artifactPath, destination) => {
+  if (!fs.existsSync(destination)) fs.mkdirSync(destination);
+  console.log('Extract artifact to: ', destination);
+  return decompress(artifactPath, destination);
+};
+
+module.exports = {
+  setup: async () => {
+      const artifactPath = await downloadArtifact(artifactVersion);
+      await extract(artifactPath, artifactDestination);
+  }
+}

--- a/ui/desktop/electron-app/config/cli.js
+++ b/ui/desktop/electron-app/config/cli.js
@@ -4,10 +4,10 @@ const https = require('https');
 const decompress = require('decompress');
 const os = require('os');
 
-const artifactVersion = '0.1.4';
+const artifactVersion = '0.1.5';
 const artifactDestination = path.resolve(__dirname, '..', 'cli');
 
-const downloadArtifact = (version) => {
+const downloadArtifact = version => {
   const url = `https://releases.hashicorp.com/boundary/${version}/boundary_${version}_darwin_amd64.zip`;
   return new Promise((resolve, reject) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boundary-desktop-artifact-'))

--- a/ui/desktop/electron-app/config/forge.config.js
+++ b/ui/desktop/electron-app/config/forge.config.js
@@ -34,7 +34,7 @@ module.exports = {
       const artifactPath = await downloadArtifact(url);
 
       // Extract artifact content
-      const binaryPath = path.resolve(__dirname, '..', 'ember-dist', 'binary');
+      const binaryPath = path.resolve(__dirname, '..', 'src', 'binary');
       if (!fs.existsSync(binaryPath)) fs.mkdirSync(binaryPath);
       console.log('\nExtract artifact to: ', binaryPath);
       await decompress(artifactPath, binaryPath);

--- a/ui/desktop/electron-app/config/forge.config.js
+++ b/ui/desktop/electron-app/config/forge.config.js
@@ -1,7 +1,44 @@
 const process = require('process');
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const decompress = require('decompress');
+const os = require('os');
 
 module.exports = {
   hooks: {
+    prePackage: async () => {
+      const downloadArtifact = (url) => {
+        return new Promise((resolve, reject) => {
+          const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boundary-desktop-artifact-'))
+          console.log('\nCreate tmp artifact directory: ', tmpDir);
+
+          const artifactFileName = url.split('/').pop();
+          if(!artifactFileName) reject('Could not find artifact filename in: ', url);
+
+          const artifactPath = path.resolve(tmpDir, artifactFileName);
+          console.log('\nDownload artifact url: ', url);
+          https.get(url, (response) => {
+            const stream = response.pipe(fs.createWriteStream(artifactPath))
+            stream.on('close', () => resolve(artifactPath));
+            stream.on('error', reject);
+          });
+        });
+      }
+
+      // Download boundary
+      let artifactVersion = '0.1.4';
+      if (process.env.BOUNDARY_ARTIFACT_VERSION) artifactVersion = process.env.BOUNDARY_ARTIFACT_VERSION;
+
+      const url = `https://releases.hashicorp.com/boundary/${artifactVersion}/boundary_${artifactVersion}_darwin_amd64.zip`;
+      const artifactPath = await downloadArtifact(url);
+
+      // Extract artifact content
+      const binaryPath = path.resolve(__dirname, '..', 'ember-dist', 'binary');
+      if (!fs.existsSync(binaryPath)) fs.mkdirSync(binaryPath);
+      console.log('\nExtract artifact to: ', binaryPath);
+      await decompress(artifactPath, binaryPath);
+    },
     preMake: (forgeConfig) => {
       if (process.env.BOUNDARY_DESKTOP_SIGNING_IDENTITY) {
         forgeConfig.osxSign = {

--- a/ui/desktop/electron-app/config/forge.config.js
+++ b/ui/desktop/electron-app/config/forge.config.js
@@ -27,9 +27,7 @@ module.exports = {
       }
 
       // Download boundary
-      let artifactVersion = '0.1.4';
-      if (process.env.BOUNDARY_ARTIFACT_VERSION) artifactVersion = process.env.BOUNDARY_ARTIFACT_VERSION;
-
+      const artifactVersion = '0.1.4';
       const url = `https://releases.hashicorp.com/boundary/${artifactVersion}/boundary_${artifactVersion}_darwin_amd64.zip`;
       const artifactPath = await downloadArtifact(url);
 

--- a/ui/desktop/electron-app/config/forge.config.js
+++ b/ui/desktop/electron-app/config/forge.config.js
@@ -1,42 +1,7 @@
 const process = require('process');
-const fs = require('fs');
-const path = require('path');
-const https = require('https');
-const decompress = require('decompress');
-const os = require('os');
 
 module.exports = {
   hooks: {
-    prePackage: async () => {
-      const downloadArtifact = (url) => {
-        return new Promise((resolve, reject) => {
-          const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boundary-desktop-artifact-'))
-          console.log('\nCreate tmp artifact directory: ', tmpDir);
-
-          const artifactFileName = url.split('/').pop();
-          if(!artifactFileName) reject('Could not find artifact filename in: ', url);
-
-          const artifactPath = path.resolve(tmpDir, artifactFileName);
-          console.log('\nDownload artifact url: ', url);
-          https.get(url, (response) => {
-            const stream = response.pipe(fs.createWriteStream(artifactPath))
-            stream.on('close', () => resolve(artifactPath));
-            stream.on('error', reject);
-          });
-        });
-      }
-
-      // Download boundary
-      const artifactVersion = '0.1.4';
-      const url = `https://releases.hashicorp.com/boundary/${artifactVersion}/boundary_${artifactVersion}_darwin_amd64.zip`;
-      const artifactPath = await downloadArtifact(url);
-
-      // Extract artifact content
-      const binaryPath = path.resolve(__dirname, '..', 'src', 'binary');
-      if (!fs.existsSync(binaryPath)) fs.mkdirSync(binaryPath);
-      console.log('\nExtract artifact to: ', binaryPath);
-      await decompress(artifactPath, binaryPath);
-    },
     preMake: (forgeConfig) => {
       if (process.env.BOUNDARY_DESKTOP_SIGNING_IDENTITY) {
         forgeConfig.osxSign = {
@@ -48,7 +13,7 @@ module.exports = {
           "signature-flags": "library"
         }
       } else {
-        console.warn('Could not find signing identity. Skipping signing.');
+        console.warn('WARNING: Could not find signing identity. Skipping signing.');
       }
     }
   },

--- a/ui/desktop/electron-app/config/forge.config.js
+++ b/ui/desktop/electron-app/config/forge.config.js
@@ -1,4 +1,7 @@
 const process = require('process');
+const { version } = require('../src/boundary-cli.js');
+
+const formattedCLIVersion = version().formatted;
 
 module.exports = {
   hooks: {
@@ -24,7 +27,8 @@ module.exports = {
     ],
     name: "Boundary Desktop",
     appBundleId: "com.electron.boundary",
-    appVersion: "0.0.1",
+    // TODO: where should the client version number come from?
+    appVersion: `1.0.0 ${formattedCLIVersion}`,
     appCopyright: "Copyright © 2021 HashiCorp, Inc."
   },
   makers: [

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -8,8 +8,10 @@
   "author": "HashiCorp",
   "main": "src/index.js",
   "scripts": {
+    "build:cli": "node -e 'require(\"./config/cli.js\").setup()'",
     "start": "electron-forge start",
     "package": "electron-forge package",
+    "premake": "yarn build:cli",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
     "lint": "echo \"No linting configured\""

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@electron-forge/cli": "6.0.0-beta.53",
     "@electron-forge/maker-dmg": "^6.0.0-beta.54",
+    "decompress": "^4.2.1",
     "devtron": "^1.4.0",
     "electron": "10.1.5"
   }

--- a/ui/desktop/electron-app/src/boundary-cli.js
+++ b/ui/desktop/electron-app/src/boundary-cli.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const spawnPromise = require('./spawn-promise');
+const { spawnAsyncJSONPromise } = require('./spawn-promise');
 
 const cliPath = async () => path.resolve(__dirname, '..', 'cli', 'boundary');
 
@@ -18,6 +18,6 @@ module.exports = {
       '-format=json',
       '--output-json-errors'
     ];
-    return spawnPromise(command);
+    return spawnAsyncJSONPromise(command);
   }
 }

--- a/ui/desktop/electron-app/src/boundary-cli.js
+++ b/ui/desktop/electron-app/src/boundary-cli.js
@@ -1,7 +1,7 @@
-const { lookpath } = require('lookpath');
+const path = require('path');
 const spawnPromise = require('./spawn-promise');
 
-const cliPath = async () => await lookpath('boundary');
+const cliPath = async () => path.resolve(__dirname, 'binary', 'boundary');
 
 module.exports = {
   // Find boundary cli path
@@ -17,7 +17,7 @@ module.exports = {
       `-addr=${addr}`,
       '-format=json',
       '--output-json-errors'
-    ]
+    ];
     return spawnPromise(command);
   }
 }

--- a/ui/desktop/electron-app/src/boundary-cli.js
+++ b/ui/desktop/electron-app/src/boundary-cli.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { spawnAsyncJSONPromise } = require('./spawn-promise');
+const { spawnAsyncJSONPromise, spawnSync } = require('./spawn-promise');
 
 const cliPath = async () => path.resolve(__dirname, '..', 'cli', 'boundary');
 
@@ -17,5 +17,19 @@ module.exports = {
       '--output-json-errors'
     ];
     return spawnAsyncJSONPromise(command);
+  },
+  // Returns JSON-formatted version information from the CLI
+  version: () => {
+    const command = [ '-v' ];
+    const rawOutput = spawnSync(command);
+    let gitRevision = /Git Revision:\s*(?<rev>.*)\n/.exec(rawOutput);
+    let versionNumber = /Version Number:\s*(?<ver>.*)\n/.exec(rawOutput);
+    if (gitRevision) gitRevision = gitRevision.groups.rev;
+    if (versionNumber) versionNumber = versionNumber.groups.ver;
+    const formatted = versionNumber
+      ? `CLI Version ${versionNumber}; Git Rev ${gitRevision}`
+      : `CLI Git Rev ${gitRevision}`;
+    return { gitRevision, versionNumber, formatted };
+    return rawOutput;
   }
 }

--- a/ui/desktop/electron-app/src/boundary-cli.js
+++ b/ui/desktop/electron-app/src/boundary-cli.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const spawnPromise = require('./spawn-promise');
 
-const cliPath = async () => path.resolve(__dirname, 'binary', 'boundary');
+const cliPath = async () => path.resolve(__dirname, '..', 'cli', 'boundary');
 
 module.exports = {
   // Find boundary cli path

--- a/ui/desktop/electron-app/src/boundary-cli.js
+++ b/ui/desktop/electron-app/src/boundary-cli.js
@@ -4,8 +4,6 @@ const { spawnAsyncJSONPromise } = require('./spawn-promise');
 const cliPath = async () => path.resolve(__dirname, '..', 'cli', 'boundary');
 
 module.exports = {
-  // Find boundary cli path
-  path: () => cliPath(),
   // Check boundary cli existence
   exists: () => Boolean(cliPath()),
   // Initiate connection and return output

--- a/ui/desktop/electron-app/src/boundary-cli.js
+++ b/ui/desktop/electron-app/src/boundary-cli.js
@@ -27,7 +27,7 @@ module.exports = {
     if (gitRevision) gitRevision = gitRevision.groups.rev;
     if (versionNumber) versionNumber = versionNumber.groups.ver;
     const formatted = versionNumber
-      ? `CLI Version ${versionNumber}; Git Rev ${gitRevision}`
+      ? `CLI Version ${versionNumber}; CLI Git Rev ${gitRevision}`
       : `CLI Git Rev ${gitRevision}`;
     return { gitRevision, versionNumber, formatted };
     return rawOutput;

--- a/ui/desktop/electron-app/src/handlers.js
+++ b/ui/desktop/electron-app/src/handlers.js
@@ -23,11 +23,6 @@ handle('setOrigin', async (requestOrigin) => {
 handle('cliExists', () => boundaryCli.exists());
 
 /**
- * Detect boundary cli path
- */
-handle('cliPath', () => boundaryCli.path());
-
-/**
  * Establishes a boundary session and returns session details.
  */
 handle('connect', ({ target_id, token, addr }) => boundaryCli.connect(target_id, token, addr));

--- a/ui/desktop/electron-app/src/spawn-promise.js
+++ b/ui/desktop/electron-app/src/spawn-promise.js
@@ -28,8 +28,6 @@ const jsonify = (data) => {
 module.exports = function spawnPromise (command) {
   return new Promise((resolve, reject) => {
     const boundaryPath = path.resolve(__dirname, '..', 'cli', 'boundary');
-    // TODO:  remove path logging
-    console.log(boundaryPath);
     const childProcess = spawn(boundaryPath, command);
     let outputStream = '';
     let errorStream = '';

--- a/ui/desktop/electron-app/src/spawn-promise.js
+++ b/ui/desktop/electron-app/src/spawn-promise.js
@@ -25,23 +25,36 @@ const jsonify = (data) => {
 // error from the underlying exec implementation.  It's not a very
 // helpful message for users, so it's recommended to craft nice
 // POJO representation and throw it or promise->reject it.
-module.exports = function spawnPromise (command) {
-  return new Promise((resolve, reject) => {
-    const boundaryPath = path.resolve(__dirname, '..', 'cli', 'boundary');
-    const childProcess = spawn(boundaryPath, command);
-    let outputStream = '';
-    let errorStream = '';
+module.exports = {
 
-    childProcess.stdout.on('data', (data) => {
-      outputStream += data.toString();
-      const jsonData = jsonify(outputStream);
-      if(jsonData) resolve(jsonData);
-    });
+  /**
+   * Spawns an asynchronous child process that is expected to output JSON
+   * data on either stdout or stderr.  The process is allowed to continue
+   * running after the promise resolves.  This function is intended to launch
+   * the local proxy.
+   * @param {string} command
+   * @return {Promise}
+   */
+  spawnAsyncJSONPromise(command) {
+    return new Promise((resolve, reject) => {
+      const boundaryPath = path.resolve(__dirname, '..', 'cli', 'boundary');
+      const childProcess = spawn(boundaryPath, command);
+      let outputStream = '';
+      let errorStream = '';
 
-    childProcess.stderr.on('data', (data) => {
-      errorStream += data.toString();
-      const jsonData = jsonify(errorStream);
-      if(jsonData) reject(new Error(jsonData?.error));
+      childProcess.stdout.on('data', (data) => {
+        outputStream += data.toString();
+        const jsonData = jsonify(outputStream);
+        if (jsonData) resolve(jsonData);
+      });
+
+      childProcess.stderr.on('data', (data) => {
+        errorStream += data.toString();
+        const jsonData = jsonify(errorStream);
+        const error = jsonData ? jsonData.error : undefined;
+        if (jsonData) reject(new Error(error));
+      });
     });
-  });
-}
+  },
+
+};

--- a/ui/desktop/electron-app/src/spawn-promise.js
+++ b/ui/desktop/electron-app/src/spawn-promise.js
@@ -1,5 +1,7 @@
 const path = require('path');
-const { spawn } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
+
+const boundaryPath = path.resolve(__dirname, '..', 'cli', 'boundary');
 
 // Convert to json
 const jsonify = (data) => {
@@ -37,7 +39,6 @@ module.exports = {
    */
   spawnAsyncJSONPromise(command) {
     return new Promise((resolve, reject) => {
-      const boundaryPath = path.resolve(__dirname, '..', 'cli', 'boundary');
       const childProcess = spawn(boundaryPath, command);
       let outputStream = '';
       let errorStream = '';
@@ -56,5 +57,14 @@ module.exports = {
       });
     });
   },
+
+  /**
+   *
+   */
+  spawnSync(command) {
+    const childProcess = spawnSync(boundaryPath, command);
+    const rawOutput = childProcess.output.toString();
+    return rawOutput;
+  }
 
 };

--- a/ui/desktop/electron-app/src/spawn-promise.js
+++ b/ui/desktop/electron-app/src/spawn-promise.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { spawn } = require('child_process');
 
 // Convert to json
@@ -26,7 +27,10 @@ const jsonify = (data) => {
 // POJO representation and throw it or promise->reject it.
 module.exports = function spawnPromise (command) {
   return new Promise((resolve, reject) => {
-    const childProcess = spawn('boundary', command);
+    const boundaryPath = path.resolve(__dirname, 'binary', 'boundary');
+    // TODO:  remove path logging
+    console.log(boundaryPath);
+    const childProcess = spawn(boundaryPath, command);
     let outputStream = '';
     let errorStream = '';
 

--- a/ui/desktop/electron-app/src/spawn-promise.js
+++ b/ui/desktop/electron-app/src/spawn-promise.js
@@ -27,7 +27,7 @@ const jsonify = (data) => {
 // POJO representation and throw it or promise->reject it.
 module.exports = function spawnPromise (command) {
   return new Promise((resolve, reject) => {
-    const boundaryPath = path.resolve(__dirname, 'binary', 'boundary');
+    const boundaryPath = path.resolve(__dirname, '..', 'cli', 'boundary');
     // TODO:  remove path logging
     console.log(boundaryPath);
     const childProcess = spawn(boundaryPath, command);

--- a/ui/desktop/electron-app/yarn.lock
+++ b/ui/desktop/electron-app/yarn.lock
@@ -523,6 +523,14 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bl@^1.0.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.3.tgz#1e8dd80142eac80d7158c9dccc047fb620e035e7"
+  integrity sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
+
 bl@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
@@ -585,7 +593,7 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-buffer@^5.5.0:
+buffer@^5.2.1, buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -742,6 +750,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^2.8.1:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
@@ -868,6 +881,59 @@ decompress-response@^6.0.0:
   integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
   dependencies:
     mimic-response "^3.1.0"
+
+decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/decompress-tar/-/decompress-tar-4.1.1.tgz#718cbd3fcb16209716e70a26b84e7ba4592e5af1"
+  integrity sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==
+  dependencies:
+    file-type "^5.2.0"
+    is-stream "^1.1.0"
+    tar-stream "^1.5.2"
+
+decompress-tarbz2@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz#3082a5b880ea4043816349f378b56c516be1a39b"
+  integrity sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==
+  dependencies:
+    decompress-tar "^4.1.0"
+    file-type "^6.1.0"
+    is-stream "^1.1.0"
+    seek-bzip "^1.0.5"
+    unbzip2-stream "^1.0.9"
+
+decompress-targz@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/decompress-targz/-/decompress-targz-4.1.1.tgz#c09bc35c4d11f3de09f2d2da53e9de23e7ce1eee"
+  integrity sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==
+  dependencies:
+    decompress-tar "^4.1.1"
+    file-type "^5.2.0"
+    is-stream "^1.1.0"
+
+decompress-unzip@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/decompress-unzip/-/decompress-unzip-4.0.1.tgz#deaaccdfd14aeaf85578f733ae8210f9b4848f69"
+  integrity sha1-3qrM39FK6vhVePczroIQ+bSEj2k=
+  dependencies:
+    file-type "^3.8.0"
+    get-stream "^2.2.0"
+    pify "^2.3.0"
+    yauzl "^2.4.2"
+
+decompress@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.1.tgz#007f55cc6a62c055afa37c07eb6a4ee1b773f118"
+  integrity sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==
+  dependencies:
+    decompress-tar "^4.0.0"
+    decompress-tarbz2 "^4.0.0"
+    decompress-targz "^4.0.0"
+    decompress-unzip "^4.0.1"
+    graceful-fs "^4.1.10"
+    make-dir "^1.0.0"
+    pify "^2.3.0"
+    strip-dirs "^2.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1066,7 +1132,7 @@ encodeurl@^1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -1194,6 +1260,21 @@ figures@^3.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
+file-type@^3.8.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
+  integrity sha1-JXoHg4TR24CHvESdEH1SpSZyuek=
+
+file-type@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-5.2.0.tgz#2ddbea7c73ffe36368dfae49dc338c058c2b8ad6"
+  integrity sha1-LdvqfHP/42No365J3DOMBYwritY=
+
+file-type@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-6.2.0.tgz#e50cd75d356ffed4e306dc4f5bcf52a79903a919"
+  integrity sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==
+
 filename-reserved-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
@@ -1272,6 +1353,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-extra@^4.0.0:
   version "4.0.3"
@@ -1410,6 +1496,14 @@ get-stdin@^4.0.1:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
 
+get-stream@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
+  integrity sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=
+  dependencies:
+    object-assign "^4.0.1"
+    pinkie-promise "^2.0.0"
+
 get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
@@ -1527,7 +1621,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.3:
+graceful-fs@^4.1.10, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -1743,6 +1837,11 @@ is-my-json-valid@^2.20.0:
     is-my-ip-valid "^1.0.0"
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
+
+is-natural-number@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
+  integrity sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=
 
 is-property@^1.0.0, is-property@^1.0.2:
   version "1.0.2"
@@ -2006,6 +2105,13 @@ macos-alias@~0.2.5:
   integrity sha1-/u6mwTuhGYFKQ/xDxHCzHlnvcYo=
   dependencies:
     nan "^2.4.0"
+
+make-dir@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
+  integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
+  dependencies:
+    pify "^3.0.0"
 
 map-age-cleaner@^0.1.1:
   version "0.1.3"
@@ -2573,7 +2679,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-pify@^2.0.0:
+pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
@@ -2739,7 +2845,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.5, readable-stream@~2.3.6:
+readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -2910,7 +3016,7 @@ rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -2936,6 +3042,13 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+seek-bzip@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.6.tgz#35c4171f55a680916b52a07859ecf3b5857f21c4"
+  integrity sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==
+  dependencies:
+    commander "^2.8.1"
 
 semver-compare@^1.0.0:
   version "1.0.0"
@@ -3154,6 +3267,13 @@ strip-bom@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
+strip-dirs@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/strip-dirs/-/strip-dirs-2.1.0.tgz#4987736264fc344cf20f6c34aca9d13d1d4ed6c5"
+  integrity sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==
+  dependencies:
+    is-natural-number "^4.0.1"
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -3197,6 +3317,19 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+tar-stream@^1.5.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
+  integrity sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==
+  dependencies:
+    bl "^1.0.0"
+    buffer-alloc "^1.2.0"
+    end-of-stream "^1.0.0"
+    fs-constants "^1.0.0"
+    readable-stream "^2.3.0"
+    to-buffer "^1.1.1"
+    xtend "^4.0.0"
+
 tar@^4:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
@@ -3235,7 +3368,7 @@ through2@~0.2.3:
     readable-stream "~1.1.9"
     xtend "~2.1.1"
 
-through@^2.3.6:
+through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -3253,6 +3386,11 @@ tn1150@^0.1.0:
   integrity sha1-ZzUD0k1WuH3ouMd/7j/AhT1ZoY0=
   dependencies:
     unorm "^1.4.1"
+
+to-buffer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
+  integrity sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==
 
 to-readable-stream@^1.0.0:
   version "1.0.0"
@@ -3322,6 +3460,14 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+unbzip2-stream@^1.0.9:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
+  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
+  dependencies:
+    buffer "^5.2.1"
+    through "^2.3.8"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -3516,7 +3662,7 @@ yarn-or-npm@^3.0.1:
     cross-spawn "^6.0.5"
     pkg-dir "^4.2.0"
 
-yauzl@^2.10.0:
+yauzl@^2.10.0, yauzl@^2.4.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
   integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -24,6 +24,7 @@
     "format:js": "prettier --write '{app,config,stories,tests,electron-app/src}/**/*.js' *.js",
     "format:sass": "prettier --write app/**/*.scss",
     "start": "ember serve",
+    "prestart:desktop": "cd electron-app && yarn build:cli",
     "start:desktop": "ember electron",
     "clean:coverage": "rm -rf coverage_*",
     "pretest": "yarn clean:coverage",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7540,7 +7540,7 @@ debug@~4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -12357,7 +12357,7 @@ import-lazy@^4.0.0:
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
   integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -14058,11 +14058,6 @@ lodash._baseflatten@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -14071,15 +14066,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
 
 lodash._createassigner@^3.0.0:
   version "3.1.1"
@@ -14090,19 +14080,12 @@ lodash._createassigner@^3.0.0:
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
 
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -14315,7 +14298,7 @@ lodash.pick@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
   integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=

--- a/yarn.lock
+++ b/yarn.lock
@@ -5887,15 +5887,15 @@ browserslist@^3.2.6:
     electron-to-chromium "^1.3.47"
 
 browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.1:
-  version "4.16.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.1.tgz#bf757a2da376b3447b800a16f0f1c96358138766"
-  integrity sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==
+  version "4.16.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.3.tgz#340aa46940d7db878748567c5dea24a48ddf3717"
+  integrity sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==
   dependencies:
-    caniuse-lite "^1.0.30001173"
+    caniuse-lite "^1.0.30001181"
     colorette "^1.2.1"
-    electron-to-chromium "^1.3.634"
+    electron-to-chromium "^1.3.649"
     escalade "^3.1.1"
-    node-releases "^1.1.69"
+    node-releases "^1.1.70"
 
 bser@2.1.1:
   version "2.1.1"
@@ -6248,7 +6248,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001157, caniuse-lite@^1.0.30001173:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001157, caniuse-lite@^1.0.30001181:
   version "1.0.30001181"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001181.tgz#4f0e5184e1ea7c3bf2727e735cbe7ca9a451d673"
   integrity sha512-m5ul/ARCX50JB8BSNM+oiPmQrR5UmngaQ3QThTTp5HcIIQGP/nPBs82BYLE+tigzm3VW+F4BJIhUyaVtEweelQ==
@@ -7540,7 +7540,7 @@ debug@~4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@^1.0.1:
+debuglog@*, debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -8107,7 +8107,7 @@ electron-rebuild@^2.0.0:
     tar "^6.0.5"
     yargs "^16.0.0"
 
-electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.634:
+electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.649:
   version "1.3.649"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.649.tgz#3aa8be052d4d268ede45d8e98d0cd60ffefad607"
   integrity sha512-ojGDupQ3UMkvPWcTICe4JYe17+o9OLiFMPoduoR72Zp2ILt1mRVeqnxBEd6s/ptekrnsFU+0A4lStfBe/wyG/A==
@@ -9846,9 +9846,9 @@ eslint@^6.5.1:
     v8-compile-cache "^2.0.3"
 
 eslint@^7.5.0:
-  version "7.18.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.18.0.tgz#7fdcd2f3715a41fe6295a16234bd69aed2c75e67"
-  integrity sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.19.0.tgz#6719621b196b5fad72e43387981314e5d0dc3f41"
+  integrity sha512-CGlMgJY56JZ9ZSYhJuhow61lMPPjUzWmChFya71Z/jilVos7mR/jPgaEfVGgMBY5DshbKdG8Ezb8FDCHcoMEMg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@eslint/eslintrc" "^0.3.0"
@@ -12357,7 +12357,7 @@ import-lazy@^4.0.0:
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
   integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
 
-imurmurhash@^0.1.4:
+imurmurhash@*, imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -14058,6 +14058,11 @@ lodash._baseflatten@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash._baseindexof@*:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
+  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
+
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -14066,10 +14071,15 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@^3.0.0:
+lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
+
+lodash._cacheindexof@*:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
+  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
 
 lodash._createassigner@^3.0.0:
   version "3.1.1"
@@ -14080,12 +14090,19 @@ lodash._createassigner@^3.0.0:
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
 
+lodash._createcache@*:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
+  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
+  dependencies:
+    lodash._getnative "^3.0.0"
+
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@^3.0.0:
+lodash._getnative@*, lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -14298,7 +14315,7 @@ lodash.pick@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
 
-lodash.restparam@^3.0.0:
+lodash.restparam@*, lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
   integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
@@ -15537,7 +15554,7 @@ node-pre-gyp@^0.11.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.52, node-releases@^1.1.69:
+node-releases@^1.1.52, node-releases@^1.1.70:
   version "1.1.70"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.70.tgz#66e0ed0273aa65666d7fe78febe7634875426a08"
   integrity sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==
@@ -18094,9 +18111,9 @@ regjsparser@^0.1.4:
     jsesc "~0.5.0"
 
 regjsparser@^0.6.4:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.6.tgz#6d8c939d1a654f78859b08ddcc4aa777f3fa800a"
-  integrity sha512-jjyuCp+IEMIm3N1H1LLTJW1EISEJV9+5oHdEyrt43Pg9cDSb6rrLZei2cVWpl0xTjmmlpec/lEQGYgM7xfpGCQ==
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.7.tgz#c00164e1e6713c2e3ee641f1701c4b7aa0a7f86c"
+  integrity sha512-ib77G0uxsA2ovgiYbCVGx4Pv3PSttAx2vIwidqQzbL2U5S4Q+j00HdSAneSBuyVcMvEnTXMjiGgB+DlXozVhpQ==
   dependencies:
     jsesc "~0.5.0"
 
@@ -21620,9 +21637,9 @@ workerpool@^5.0.1:
   integrity sha512-Sywova24Ow2NQ24JPB68bI89EdqMDjUXo4OpofK/QMD7C2ZVMloYBgQ5J3PChcBJHj2vspsmGx1/3nBKXtUkXQ==
 
 workerpool@^6.0.3:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.0.4.tgz#f83ecf101b35c034cb20ed38cedd619dde9d722c"
-  integrity sha512-sAc9w9oAJQ2680gDArGinjw0Ygj2K3KF1ZCRfslBKUCzc9Gycwlj9ZIAbizPRBftcXxhXgoGMVPxJE0VMNnWbw==
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.0.tgz#a8e038b4c94569596852de7a8ea4228eefdeb37b"
+  integrity sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
As part of building and packaging of desktop client, download boundary artifact from releases.hashicorp.com and extract it into `cli` folder under electron app. CLI commands in Desktop Client have been updated to use this bundled cli path instead of checking PATH.