### PR TITLE
chore: Attach osx sign to packager config correctly

### DIFF
--- a/ui/desktop/electron-app/config/forge.config.js
+++ b/ui/desktop/electron-app/config/forge.config.js
@@ -4,7 +4,7 @@ module.exports = {
   hooks: {
     preMake: (forgeConfig) => {
       if (process.env.BOUNDARY_DESKTOP_SIGNING_IDENTITY) {
-        forgeConfig.osxSign = {
+        forgeConfig.packagerConfig.osxSign = {
           identity: process.env.BOUNDARY_DESKTOP_SIGNING_IDENTITY,
           hardenedRuntime: true,
           "gatekeeper-assess": false,


### PR DESCRIPTION
`osxSign` should be within `packagerConfig`, not the main `forgeConfig`.
Ref: https://www.electronjs.org/docs/tutorial/code-signing#electron-forge