### PR TITLE
fix: Connecting from a target view raises toString error

### DIFF
--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target/-actions.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target/-actions.hbs
@@ -1,3 +1,3 @@
-<Rose::Button @style="primary" {{on "click" (route-action "connect" @model)}}>
+<Rose::Button @style="primary" {{on "click" (route-action "connect" @model.target)}}>
   {{t "resources.session.actions.connect"}}
 </Rose::Button>


### PR DESCRIPTION
Issue: Using connect action in a target view raises following error:
<img width="661" alt="to-string-error" src="https://user-images.githubusercontent.com/111036/107462796-dfa71680-6b2a-11eb-8b96-1e9c3ac23cdc.png">

It's caused by mismatched target model being passed in for connect action.