### PR TITLE
fix: Remove global scope from header org dropdown

### DIFF
--- a/ui/desktop/app/templates/scopes/scope/-header-nav.hbs
+++ b/ui/desktop/app/templates/scopes/scope/-header-nav.hbs
@@ -1,13 +1,7 @@
 <Rose::Dropdown
   @text={{this.scopes.selectedOrg.displayName}}
-  @icon={{if this.scopes.selectedOrg.isGlobal "app-icons/global" "app-icons/org"}} as |dropdown|
+  @icon="app-icons/org" as |dropdown|
 >
-  {{!-- {{#if this.session.data.authenticated.isGlobal}} --}}
-    <dropdown.link @route="scopes.scope" @model="global">
-      {{t "titles.global"}}
-    </dropdown.link>
-    <dropdown.separator />
-  {{!-- {{/if}} --}}
   {{#each this.scopes.orgs as |scope|}}
     <dropdown.link @route="scopes.scope" @model={{scope.id}}>
       {{scope.displayName}}


### PR DESCRIPTION
As selecting 'global' scope in header after authentication loads first org by default, remove option from dropdown to avoid confusion.