### PR TITLE
chore: Remove spaces from dmg filename

### DIFF
--- a/ui/desktop/electron-app/config/forge.config.js
+++ b/ui/desktop/electron-app/config/forge.config.js
@@ -34,7 +34,8 @@ module.exports = {
     {
       name: "@electron-forge/maker-dmg",
       config: {
-        name: "Boundary Desktop"
+        name: "boundary-desktop",
+        title: "Boundary Desktop"
       }
     }
   ]


### PR DESCRIPTION
Renaming `Boundary Desktop.dmg` to `boundary-desktop.dmg` for CI pipeline.