### PR TITLE
fix: 🐛 target sessions should update on poll

### DIFF
--- a/ui/desktop/app/controllers/scopes/scope/projects/sessions/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/sessions/index.js
@@ -1,5 +1,4 @@
 import Controller from '@ember/controller';
-import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class ScopesScopeProjectsSessionsIndexController extends Controller {
@@ -15,7 +14,6 @@ export default class ScopesScopeProjectsSessionsIndexController extends Controll
    * and active/pending.
    * @type {SessionModel[]}
    */
-  @computed('model.@each.{created_time,active}', 'session.data.authenticated.user_id')
   get sorted() {
     const userId = this.session.data.authenticated.user_id;
     const sessions = this.model;

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/target/sessions.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/target/sessions.js
@@ -1,5 +1,4 @@
 import Controller from '@ember/controller';
-import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
 
@@ -9,14 +8,21 @@ export default class ScopesScopeProjectsTargetsTargetSessionsController extends 
   @service session;
 
   /**
-   * Sort and filter to active sessions of current user
+   * Sessions belonging to the target.
+   * @type {SessionModel[]}
+   */
+  get sessions() {
+    return this.model.sessions;
+  }
+
+  /**
+   * Sort and filter to active sessions of current user.
    * @param {[SessionModel]} model
    * @param {object} session
    * @type {[SessionModel]}
    */
-  @computed('model.@each.{created_time,active}', 'session.data.authenticated.user_id')
-  get selfActiveSessions() {
-    const sessions = this.model;
+  get cancelableUserSessions() {
+    const sessions = this.sessions;
     const userId = this.session.data.authenticated.user_id;
     const filteredSessions =
       sessions.filter(session =>
@@ -27,10 +33,6 @@ export default class ScopesScopeProjectsTargetsTargetSessionsController extends 
     // Sort sessions
     const sortedSessions = A(filteredSessions).sortBy('created_time').reverse();
 
-    // Move active sessions to top
-    return [
-      ...sortedSessions.filter(session => session.isActive),
-      ...sortedSessions.filter(session => !session.isActive)
-    ]
+    return sortedSessions;
   }
 }

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/target/sessions.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/target/sessions.js
@@ -4,15 +4,6 @@ import { notifySuccess, notifyError } from 'core/decorators/notify';
 
 export default class ScopesScopeProjectsTargetsTargetSessionsRoute extends Route {
 
-  // =methods
-
-  /**
-   * @return {[SessionModel]}
-   */
-  model() {
-    return this.modelFor('scopes.scope.projects.targets.target').sessions;
-  }
-
   // =actions
 
   /**
@@ -25,4 +16,5 @@ export default class ScopesScopeProjectsTargetsTargetSessionsRoute extends Route
   async cancelSession(session) {
     await session.cancelSession();
   }
+
 }

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target/sessions.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target/sessions.hbs
@@ -1,6 +1,6 @@
 <Rose::Table as |table|>
   <table.body as |body|>
-    {{this.sessions.length}} / {{this.cancelableUserSessions.length}}
+    
     {{#each this.cancelableUserSessions as |session|}}
       <body.row as |row|>
         <row.cell class="nowrap">

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target/sessions.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target/sessions.hbs
@@ -1,6 +1,7 @@
 <Rose::Table as |table|>
   <table.body as |body|>
-    {{#each this.selfActiveSessions as |session|}}
+    {{this.sessions.length}} / {{this.cancelableUserSessions.length}}
+    {{#each this.cancelableUserSessions as |session|}}
       <body.row as |row|>
         <row.cell class="nowrap">
           <Rose::Icon


### PR DESCRIPTION
This fix ensures that target/sessions as well as overall sessions are properly updated when polling.