### PR TITLE
chore: Add a catchall error template

### DIFF
--- a/ui/desktop/app/templates/error.hbs
+++ b/ui/desktop/app/templates/error.hbs
@@ -1,0 +1,7 @@
+{{page-title (t "errors.generic.title") }}
+
+<main>
+  <Rose::Layout::Centered>
+    <Error::Message />
+  </Rose::Layout::Centered>
+</main>


### PR DESCRIPTION
Shows user a common error message when errors occur. This prevents blank white screens on network errors.

<img width="701" alt="catchall-error-template" src="https://user-images.githubusercontent.com/111036/107705527-db930a00-6c8c-11eb-83ce-52c57d0a3814.png">