### PR TITLE
Add "disconnect" escape hatch to error page in desktop

### DIFF
--- a/addons/core/tests/integration/components/error/message-test.js
+++ b/addons/core/tests/integration/components/error/message-test.js
@@ -60,7 +60,7 @@ module('Integration | Component | error/message', function (hooks) {
     );
     assert.equal(
       find('.rose-message-description').textContent.trim(),
-      'Please contact your administrator or try again later.'
+      'We\'re not sure what happened.  Please contact your administrator or try again later.'
     );
   });
 });

--- a/addons/core/translations/actions/en-us.yaml
+++ b/addons/core/translations/actions/en-us.yaml
@@ -3,6 +3,7 @@ cancel: Cancel
 delete: Delete
 remove: Remove
 discard: Discard
+disconnect: Disconnect
 dismiss: Dismiss
 save: Save
 submit: Submit

--- a/addons/core/translations/errors/en-us.yaml
+++ b/addons/core/translations/errors/en-us.yaml
@@ -12,7 +12,7 @@
   description: We ran into a problem and could not continue. You can ask your administrator or try again later.
 unknown:
   title: Something went wrong
-  description: Please contact your administrator or try again later.
+  description: We're not sure what happened.  Please contact your administrator or try again later.
 generic:
   title: Error
 authentication-failed:

--- a/ui/desktop/app/routes/application.js
+++ b/ui/desktop/app/routes/application.js
@@ -72,6 +72,16 @@ export default class ApplicationRoute extends Route.extend(
   }
 
   /**
+   * Disconnects from origin and invalidates session, thereby resetting
+   * the client and reloading to the onboarding origin screen.
+   */
+  @action
+  disconnect() {
+    this.origin.resetOrigin();
+    this.invalidateSession();
+  }
+
+  /**
    * Hooks into ember-loading to kick off loading indicator in the
    * application template.
    * @return {boolean} always returns true

--- a/ui/desktop/app/services/origin.js
+++ b/ui/desktop/app/services/origin.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import { assert } from '@ember/debug';
 import { inject as service } from '@ember/service';
+import { notifyError } from 'core/decorators/notify';
 
 export default class OriginService extends Service {
 
@@ -70,6 +71,15 @@ export default class OriginService extends Service {
       this.rendererOrigin = null;
       throw e;
     }
+  }
+
+  /**
+   * Resets the origin.
+   */
+  @notifyError(({ message }) => message, { catch: true })
+  async resetOrigin() {
+    this.rendererOrigin = null;
+    await this.ipc.invoke('resetOrigin');
   }
 
 }

--- a/ui/desktop/app/templates/error.hbs
+++ b/ui/desktop/app/templates/error.hbs
@@ -1,7 +1,15 @@
 {{page-title (t "errors.generic.title") }}
 
 <main>
+
   <Rose::Layout::Centered>
     <Error::Message />
   </Rose::Layout::Centered>
+
+  <Rose::Layout::Centered>
+    <Rose::Button @style="primary" {{on "click" (route-action "disconnect")}}>
+      {{t "actions.disconnect"}}
+    </Rose::Button>
+  </Rose::Layout::Centered>
+
 </main>

--- a/ui/desktop/electron-app/src/handlers.js
+++ b/ui/desktop/electron-app/src/handlers.js
@@ -18,6 +18,13 @@ handle('setOrigin', async (requestOrigin) => {
 });
 
 /**
+ * Resets the origin.
+ */
+handle('resetOrigin', async (requestOrigin) => {
+  origin.resetOrigin();
+});
+
+/**
  * Check for boundary cli existence
  */
 handle('cliExists', () => boundaryCli.exists());

--- a/ui/desktop/electron-app/src/origin.js
+++ b/ui/desktop/electron-app/src/origin.js
@@ -24,7 +24,7 @@ class RuntimeSettings {
   }
 
   /**
-   *
+   * Validates the origin is reachable and has a scopes endpoint.
    */
   async validateOrigin(origin) {
     // If the origin is the Electron origin, it is automatically valid.
@@ -38,6 +38,13 @@ class RuntimeSettings {
     } catch (e) {
       throw new Error(`Origin ${origin} could not be validated.`);
     }
+  }
+
+  /**
+   * Sets the origin to null.
+   */
+  async resetOrigin() {
+    this.origin = null;
   }
 
   // Quick and dirty event handler pattern to enable the application to respond


### PR DESCRIPTION
When an error occurs, it's difficult to know if it's recoverable.  The user may now choose to disconnect from their Boundary origin and reset the client.

<img width="1136" alt="Screenshot 2021-02-11 at 18 49 19" src="https://user-images.githubusercontent.com/8390120/107714660-ac37c980-6c9b-11eb-89fe-5f9d9fd5f78c.png">
