### PR TITLE
Specify zoom-in shortcut

### DIFF
--- a/ui/desktop/CHANGELOG.md
+++ b/ui/desktop/CHANGELOG.md
@@ -4,9 +4,9 @@ Canonical reference for changes, improvements, and bugfixes for Boundary Desktop
 
 ## Next
 
-### Changes
+### Bug Fixes
 
-- Trigger zoom-in menu option on keyboard shortcut.
+- ui: Trigger zoom-in menu option on keyboard shortcut. ([PR](https://github.com/hashicorp/boundary-ui/pull/505))
 
 ## v1.0.0-beta [CLI 0.1.8] (2021.03.10)
 

--- a/ui/desktop/CHANGELOG.md
+++ b/ui/desktop/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Canonical reference for changes, improvements, and bugfixes for Boundary Desktop.
 
+## Next
+
+### Changes
+
+- Trigger zoom-in menu option on keyboard shortcut.
 
 ## v1.0.0-beta [CLI 0.1.8] (2021.03.10)
 

--- a/ui/desktop/electron-app/src/menu.js
+++ b/ui/desktop/electron-app/src/menu.js
@@ -49,7 +49,7 @@ const generateMenuTemplate = () => {
         { role: 'reload' },
         { type: 'separator' },
         { role: 'resetZoom' },
-        { role: 'zoomIn' },
+        { role: 'zoomIn', accelerator: 'CommandOrControl+=' },
         { role: 'zoomOut' },
         { type: 'separator' },
         { role: 'togglefullscreen' },

--- a/ui/desktop/tests/acceptance/origin-test.js
+++ b/ui/desktop/tests/acceptance/origin-test.js
@@ -178,15 +178,12 @@ module('Acceptance | origin', function (hooks) {
   });
 
   test('can reset origin before authentication', async function (assert) {
-    assert.expect(3);
+    assert.expect(4);
+    assert.notOk(mockIPC.origin);
     await visit(urls.origin);
-    await a11yAudit();
     await fillIn('[name="host"]', window.location.origin);
     await click('[type="submit"]');
-    assert.equal(
-      this.owner.lookup('controller:origin').origin,
-      window.location.origin
-    );
+    assert.equal(mockIPC.origin, window.location.origin);
     assert.equal(currentURL(), urls.authenticate.methods.global);
     await click('.change-origin a');
     assert.equal(currentURL(), urls.origin);

--- a/ui/desktop/tests/acceptance/origin-test.js
+++ b/ui/desktop/tests/acceptance/origin-test.js
@@ -178,12 +178,15 @@ module('Acceptance | origin', function (hooks) {
   });
 
   test('can reset origin before authentication', async function (assert) {
-    assert.expect(4);
-    assert.notOk(mockIPC.origin);
+    assert.expect(3);
     await visit(urls.origin);
+    await a11yAudit();
     await fillIn('[name="host"]', window.location.origin);
     await click('[type="submit"]');
-    assert.equal(mockIPC.origin, window.location.origin);
+    assert.equal(
+      this.owner.lookup('controller:origin').origin,
+      window.location.origin
+    );
     assert.equal(currentURL(), urls.authenticate.methods.global);
     await click('.change-origin a');
     assert.equal(currentURL(), urls.origin);


### PR DESCRIPTION
[Bug](https://github.com/electron/electron/issues/15496) in electron forces zoom-in shortcut to be defined for keyboard shortcut to work.