### PR TITLE
test: Fix flaky origin test in desktop

### DIFF
--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -57,7 +57,8 @@ app.on('ready', async () => {
   // Register custom protocol
   // This file protocol is the exclusive protocol for this application.  All
   // other protocols are disabled.
-  ses.protocol.registerFileProtocol(emberAppProtocol, (request, callback) => { /* eng-disable PROTOCOL_HANDLER_JS_CHECK */
+  ses.protocol.registerFileProtocol(emberAppProtocol, (request, callback) => {
+    /* eng-disable PROTOCOL_HANDLER_JS_CHECK */
     const isDir = request.url.endsWith('/');
     const absolutePath = request.url.substr(emberAppURL.length);
     const normalizedPath = isDir
@@ -71,7 +72,8 @@ app.on('ready', async () => {
 
   // Disallow all permissions requests,
   // per Electronegativity PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK
-  ses.setPermissionRequestHandler((webContents, permission, callback) => { /* eng-disable PERMISSION_REQUEST_HANDLER_JS_CHECK */
+  ses.setPermissionRequestHandler((webContents, permission, callback) => {
+    /* eng-disable PERMISSION_REQUEST_HANDLER_JS_CHECK */
     return callback(false);
   });
 
@@ -119,7 +121,7 @@ app.on('ready', async () => {
       allowRunningInsecureContent: false,
       // The preload script establishes the message-based IPC pathway without
       // exposing new modules to the renderer.
-      preload: preloadPath, /* eng-disable PRELOAD_JS_CHECK */
+      preload: preloadPath /* eng-disable PRELOAD_JS_CHECK */,
       disableBlinkFeatures: 'Auxclick',
     },
   });
@@ -151,10 +153,12 @@ app.on('ready', async () => {
 
   // Prevent navigation outside of serve://boundary per
   // Electronegativity LIMIT_NAVIGATION_GLOBAL_CHECK
-  mainWindow.webContents.on('will-navigate', (event, url) => { /* eng-disable LIMIT_NAVIGATION_JS_CHECK */
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    /* eng-disable LIMIT_NAVIGATION_JS_CHECK */
     if (!url.startsWith('serve://boundary')) event.preventDefault();
   });
-  mainWindow.webContents.on('new-window', (event, url) => { /* eng-disable LIMIT_NAVIGATION_JS_CHECK */
+  mainWindow.webContents.on('new-window', (event, url) => {
+    /* eng-disable LIMIT_NAVIGATION_JS_CHECK */
     if (!url.startsWith('serve://boundary')) event.preventDefault();
   });
 

--- a/ui/desktop/tests/acceptance/origin-test.js
+++ b/ui/desktop/tests/acceptance/origin-test.js
@@ -157,13 +157,26 @@ module('Acceptance | origin', function (hooks) {
   });
 
   test('can set origin', async function (assert) {
-    assert.expect(2);
+    assert.expect(3);
     assert.notOk(mockIPC.origin);
     await visit(urls.origin);
     await a11yAudit();
     await fillIn('[name="host"]', window.location.origin);
     await click('[type="submit"]');
+    assert.equal(currentURL(), urls.authenticate.methods.global);
     assert.equal(mockIPC.origin, window.location.origin);
+  });
+
+  test('can reset origin before authentication', async function (assert) {
+    assert.expect(4);
+    assert.notOk(mockIPC.origin);
+    await visit(urls.origin);
+    await fillIn('[name="host"]', window.location.origin);
+    await click('[type="submit"]');
+    assert.equal(currentURL(), urls.authenticate.methods.global);
+    assert.equal(mockIPC.origin, window.location.origin);
+    await click('.change-origin a');
+    assert.equal(currentURL(), urls.origin);
   });
 
   test('captures error on origin update', async function (assert) {
@@ -175,18 +188,6 @@ module('Acceptance | origin', function (hooks) {
     await fillIn('[name="host"]', window.location.origin);
     await click('[type="submit"]');
     assert.ok(find('.rose-notification.is-error'));
-  });
-
-  test('can reset origin before authentication', async function (assert) {
-    assert.expect(4);
-    assert.notOk(mockIPC.origin);
-    await visit(urls.origin);
-    await fillIn('[name="host"]', window.location.origin);
-    await click('[type="submit"]');
-    assert.equal(mockIPC.origin, window.location.origin);
-    assert.equal(currentURL(), urls.authenticate.methods.global);
-    await click('.change-origin a');
-    assert.equal(currentURL(), urls.origin);
   });
 
   test('origin set automatically in dev mode', async function (assert) {


### PR DESCRIPTION
Clearing localstorage after each test didn't work. Moving position of 'can reset origin before authentication' in test seems to do the trick. I'm sure it's something obvious but I'm not seeing it. Could use 👀  on this. Ty!