### PR TITLE
Add static auth callback pages to admin UI for notifying success or error.

### DIFF
--- a/addons/core/translations/en-us.yaml
+++ b/addons/core/translations/en-us.yaml
@@ -2,13 +2,13 @@ auth:
   titles:
     no-scopes: No Scopes Available
     flow-success: Successful authentication
-    flow-error: Could not authenticate to provider
+    flow-error: Could not authenticate
   descriptions:
     no-scopes: No scopes were found.  To authenticate, ask your administrator to create an scope and grant you access.
     choose-org: Choose a scope to authenticate.
     authenticating-with-org: "You are authenticating with {name}."
     flow-success: You've successfully authenticated.  You may now close this window and return to the client.
-    flow-error: Something went wrong while authenticating with the provider.  Please close this window and try again.  If the problem persists, notify your administrator.
+    flow-error: Something went wrong while authenticating.  Please close this window and try again.  If the problem persists, notify your administrator.
 origin:
   connected-to: Connected to
 titles:

--- a/addons/core/translations/en-us.yaml
+++ b/addons/core/translations/en-us.yaml
@@ -1,10 +1,14 @@
 auth:
   titles:
     no-scopes: No Scopes Available
+    flow-success: Successful authentication
+    flow-error: Could not authenticate to provider
   descriptions:
     no-scopes: No scopes were found.  To authenticate, ask your administrator to create an scope and grant you access.
     choose-org: Choose a scope to authenticate.
     authenticating-with-org: "You are authenticating with {name}."
+    flow-success: You've successfully authenticated.  You may now close this window and return to the client.
+    flow-error: Something went wrong while authenticating with the provider.  Please close this window and try again.  If the problem persists, notify your administrator.
 origin:
   connected-to: Connected to
 titles:

--- a/ui/admin/app/router.js
+++ b/ui/admin/app/router.js
@@ -7,6 +7,9 @@ export default class Router extends EmberRouter {
 }
 
 Router.map(function () {
+  this.route('authentication-complete');
+  this.route('authentication-error');
+
   this.route('scopes', function () {
     this.route('scope', { path: ':scope_id' }, function () {
       this.route('authenticate', function () {

--- a/ui/admin/app/routes/authentication-complete.js
+++ b/ui/admin/app/routes/authentication-complete.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class AuthenticationCompleteRoute extends Route {}

--- a/ui/admin/app/routes/authentication-error.js
+++ b/ui/admin/app/routes/authentication-error.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class AuthenticationErrorRoute extends Route {}

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -4,6 +4,12 @@
 @import 'rose';
 @import 'notify';
 
+.rose-layout-global {
+  .rose-layout-global-body {
+    justify-content: center;
+  }
+}
+
 .rose-layout-centered {
   > .rose-layout-page {
     width: sizing.rems(l) * 18;

--- a/ui/admin/app/templates/authentication-complete.hbs
+++ b/ui/admin/app/templates/authentication-complete.hbs
@@ -1,0 +1,12 @@
+{{page-title (t 'auth.titles.flow-success')}}
+
+<main>
+  <Rose::Layout::Centered>
+    <Rose::Notification
+      @style="success"
+      @heading={{t "auth.titles.flow-success"}}
+    >
+      {{t "auth.descriptions.flow-success"}}
+    </Rose::Notification>
+  </Rose::Layout::Centered>
+</main>

--- a/ui/admin/app/templates/authentication-error.hbs
+++ b/ui/admin/app/templates/authentication-error.hbs
@@ -1,0 +1,12 @@
+{{page-title (t "auth.titles.flow-error")}}
+
+<main>
+  <Rose::Layout::Centered>
+    <Rose::Notification
+      @style="error"
+      @heading={{t "auth.titles.flow-error"}}
+    >
+      {{t "auth.descriptions.flow-error"}}
+    </Rose::Notification>
+  </Rose::Layout::Centered>
+</main>

--- a/ui/admin/tests/unit/routes/authentication-complete-test.js
+++ b/ui/admin/tests/unit/routes/authentication-complete-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | authentication-complete', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:authentication-complete');
+    assert.ok(route);
+  });
+});

--- a/ui/admin/tests/unit/routes/authentication-error-test.js
+++ b/ui/admin/tests/unit/routes/authentication-error-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | authentication-error', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:authentication-error');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
`/authentication-complete`
`/authentication-error`

<img width="1348" alt="Screenshot 2021-04-02 at 16 01 15" src="https://user-images.githubusercontent.com/8390120/113450280-9017f500-93cd-11eb-80f3-408d9a7e0e91.png">
<img width="1348" alt="Screenshot 2021-04-02 at 16 01 03" src="https://user-images.githubusercontent.com/8390120/113450285-927a4f00-93cd-11eb-8490-2afde341c842.png">
