### PR TITLE
Add workflow to trigger test release manually

### DIFF
--- a/.github/workflows/test-release-trigger.yml
+++ b/.github/workflows/test-release-trigger.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Trigger Release job
         if: github.event_name == 'workflow_dispatch'
         run: |
-          echo "Triggering Test release with a TAG ${GITHUB_REF#refs/tags/}"
+          echo "Triggering Test release with a TAG ${{ github.event.inputs.branch }}"
 
           curl -u ${{ secrets.CIRCLE_TOKEN }}: -X POST --header "Content-Type: application/json" \
           -d '{ "branch": "main", "parameters": {"TAG": "'${{ github.event.inputs.branch }}'" }}' \

--- a/.github/workflows/test-release-trigger.yml
+++ b/.github/workflows/test-release-trigger.yml
@@ -1,0 +1,23 @@
+name: "Trigger Test Boundary UI release"
+
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Please use tag-like format n.n.n-someword (1.111.11-beta)
+        required: true
+
+jobs:
+  trigger-circleci-release:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Trigger Release job
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "Triggering Test release with a TAG ${GITHUB_REF#refs/tags/}"
+
+          curl -u ${{ secrets.CIRCLE_TOKEN }}: -X POST --header "Content-Type: application/json" \
+          -d '{ "branch": "main", "parameters": {"TAG": "'${{ github.event.inputs.branch }}'" }}' \
+          https://circleci.com/api/v2/project/github/hashicorp/boundary-ui-releases/pipeline

--- a/.github/workflows/test-release-trigger.yml
+++ b/.github/workflows/test-release-trigger.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Trigger Release job
         if: github.event_name == 'workflow_dispatch'
         run: |
-          echo "Triggering Test release with a TAG ${{ github.event.inputs.branch }}"
+          echo "Triggering Test release using BRANCH and TEST_TAG ${{ github.event.inputs.branch }}"
 
           curl -u ${{ secrets.CIRCLE_TOKEN }}: -X POST --header "Content-Type: application/json" \
           -d '{ "branch": "main", "parameters": {"TAG": "'${{ github.event.inputs.branch }}'" }}' \


### PR DESCRIPTION
Team has requested an option to run a test release from development branches. 
For now this will be a separate file for testing signing and notarization.
Please see trigger example:
<img width="369" alt="Screen Shot 2021-04-02 at 4 14 06 PM" src="https://user-images.githubusercontent.com/5048814/113460719-8a6edf00-93ce-11eb-94f4-7483f48caf7e.png">
