### PR TITLE
fix: Show project id to copy in targets list in desktop

### DIFF
--- a/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
@@ -58,11 +58,11 @@
               <row.cell>
                 <div>
                   <Copyable
-                    @text={{model.target.id}}
+                    @text={{model.project.id}}
                     @buttonText={{t "actions.copy-to-clipboard"}}
                     @acknowledgeText={{t "states.copied"}}
                   >
-                    <code>{{model.target.id}}</code>
+                    <code>{{model.project.id}}</code>
                   </Copyable>
                 </div>
                 <Rose::Badge @style='informational'>


### PR DESCRIPTION
<img width="450" alt="copyable-project-id" src="https://user-images.githubusercontent.com/111036/114448602-c3af0800-9ba1-11eb-8cb0-edf38f493b1d.png">
