### PR TITLE
chore: 🤖 Update node version engines

### DIFF
--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -71,7 +71,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": ">=10 <=14"
+    "node": ">=10 <=15"
   },
   "ember": {
     "edition": "octane"

--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -71,7 +71,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": ">=10 <=14"
   },
   "ember": {
     "edition": "octane"

--- a/addons/auth/package.json
+++ b/addons/auth/package.json
@@ -65,7 +65,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": ">=10 <=14"
   },
   "ember": {
     "edition": "octane"

--- a/addons/auth/package.json
+++ b/addons/auth/package.json
@@ -65,7 +65,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": ">=10 <=14"
+    "node": ">=10 <=15"
   },
   "ember": {
     "edition": "octane"

--- a/addons/core/package.json
+++ b/addons/core/package.json
@@ -80,7 +80,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": ">=10 <=14"
+    "node": ">=10 <=15"
   },
   "ember": {
     "edition": "octane"

--- a/addons/core/package.json
+++ b/addons/core/package.json
@@ -80,7 +80,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": ">=10 <=14"
   },
   "ember": {
     "edition": "octane"

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -87,7 +87,7 @@
     "sass-lint": "^1.13.1"
   },
   "engines": {
-    "node": ">=10 <=14"
+    "node": ">=10 <=15"
   },
   "ember": {
     "edition": "octane"

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -36,8 +36,7 @@
     "ember-named-blocks-polyfill": "^0.2.4",
     "ember-radio-button": "^2.0.1",
     "ember-uuid": "^2.1.0",
-    "emberx-select": "github:adopted-ember-addons/emberx-select#bc5f774",
-    "ember-named-blocks-polyfill": "^0.2.4"
+    "emberx-select": "github:adopted-ember-addons/emberx-select#bc5f774"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -88,7 +87,7 @@
     "sass-lint": "^1.13.1"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": ">=10 <=14"
   },
   "ember": {
     "edition": "octane"

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "engines": {
+    "node": ">=10 <=15"
   }
 }

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -92,7 +92,7 @@
     "sinon": "^9.2.1"
   },
   "engines": {
-    "node": ">=10 <=14"
+    "node": ">=10 <=15"
   },
   "ember": {
     "edition": "octane"

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -92,7 +92,7 @@
     "sinon": "^9.2.1"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": ">=10 <=14"
   },
   "ember": {
     "edition": "octane"

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -99,7 +99,7 @@
     "stylelint-config-sass-guidelines": "^7.1.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": ">=10 <=14"
   },
   "ember": {
     "edition": "octane"

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -99,7 +99,7 @@
     "stylelint-config-sass-guidelines": "^7.1.0"
   },
   "engines": {
-    "node": ">=10 <=14"
+    "node": ">=10 <=15"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Update the node versions our UI's can use. These versions are specified
on the engines key in the package.json of each UI (admin and desktop).
Our UI's can run from node v10 to v14, we can not run on v15 because
ember-cli does not support it yet (info [here](https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md)).

**How to test?**
 I use [nvm](https://github.com/nvm-sh/nvm) to switch node version in my dev environment.
- Run `yarn run start` using `node` version `10`, `12` and `14`, should run no problem.
- Run `yarn run start` using `node` version `15`, should not run. You should see in the terminal a message like this `The engine "node" is incompatible with this module. Expected version ">=10 <=14". Got "15.14.0"`