### PR TITLE
Enable inline OIDC flow for admin

### DIFF
--- a/ui/admin/app/routes/scopes/scope/authenticate/method.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate/method.js
@@ -26,22 +26,16 @@ export default class ScopesScopeAuthenticateMethodRoute extends Route {
   }
 
   /**
-   *
+   * Kicks off the OIDC auth flow by opening a new window to the provider.
+   * @param {string} authenticatorName
+   * @param {object} options
    */
   async startOIDCAuthentication(authenticatorName, options) {
     const oidc = getOwner(this).lookup(authenticatorName);
     // TODO: delegate this call from the session service so that we don't have
     // to look up the authenticator directly
     const json = await oidc.startAuthentication(options);
-    await this.openExternalOIDCFlow(json.attributes.auth_url);
-  }
-
-  /**
-   * Opens the specified URL in a new tab or window.
-   * @param {string} url
-   */
-  openExternalOIDCFlow(url) {
-    this.windowManager.open(url);
+    await this.windowManager.open(json.attributes.auth_url);
   }
 
   // =actions

--- a/ui/admin/app/routes/scopes/scope/authenticate/method.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate/method.js
@@ -11,7 +11,7 @@ export default class ScopesScopeAuthenticateMethodRoute extends Route {
   @service session;
   @service notify;
   @service intl;
-  @service('browser/window') window;
+  @service windowManager;
 
   // =methods
 
@@ -41,7 +41,7 @@ export default class ScopesScopeAuthenticateMethodRoute extends Route {
    * @param {string} url
    */
   openExternalOIDCFlow(url) {
-    this.window.open(url);
+    this.windowManager.open(url);
   }
 
   // =actions

--- a/ui/admin/app/routes/scopes/scope/authenticate/method/oidc.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate/method/oidc.js
@@ -13,6 +13,7 @@ export default class ScopesScopeAuthenticateMethodOidcRoute extends Route {
   // =services
 
   @service session;
+  @service windowManager;
 
   // =attributes
 
@@ -61,10 +62,12 @@ export default class ScopesScopeAuthenticateMethodOidcRoute extends Route {
   }
 
   /**
-   * When this route is deactivated (exited), stop polling for changes.
+   * When this route is deactivated (exited), stop polling for changes and close
+   * any windows opened via the window manager service.
    */
   deactivate() {
     this.poller.cancelAll();
+    this.windowManager.closeAll();
   }
 
   /**

--- a/ui/admin/app/services/window-manager.js
+++ b/ui/admin/app/services/window-manager.js
@@ -28,7 +28,7 @@ export default class WindowManagerService extends Service {
    */
   open(url) {
     const newWindow = this.window.open(url);
-    this.add(newWindow);
+    if (newWindow) this.add(newWindow);
   }
 
   /**

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -152,6 +152,12 @@
   }
 }
 
+.rose-dialog-cover {
+  svg {
+    max-width: 20rem;
+  }
+}
+
 .copyable {
   white-space: nowrap;
 

--- a/ui/admin/app/templates/scopes/scope/authenticate/method/oidc.hbs
+++ b/ui/admin/app/templates/scopes/scope/authenticate/method/oidc.hbs
@@ -8,9 +8,9 @@
     <p>
       {{t 'resources.auth-method.questions.no-see-window'}}
       <a
-        href="{{this.authURL}}"
-        target="_blank"
-        rel="noreferrer noopener"
+        href="#"
+        aria-role="button"
+        {{on "click" (route-action "authenticate")}}
       >
         {{t 'actions.retry'}}
       </a>

--- a/ui/admin/app/templates/scopes/scope/authenticate/method/oidc.hbs
+++ b/ui/admin/app/templates/scopes/scope/authenticate/method/oidc.hbs
@@ -9,7 +9,7 @@
       {{t 'resources.auth-method.questions.no-see-window'}}
       <a
         href="#"
-        aria-role="button"
+        role="button"
         {{on "click" (route-action "authenticate")}}
       >
         {{t 'actions.retry'}}

--- a/ui/admin/config/environment.js
+++ b/ui/admin/config/environment.js
@@ -149,8 +149,9 @@ module.exports = function (environment) {
 
     // Notification timeout should be 0 for fast tests
     ENV.notifyTimeout = 0;
-    // Session polling timeout should be short
+    // Polling timeouts should be short
     ENV.sessionPollingTimeoutSeconds = 0.25;
+    ENV.oidcPollingTimeoutSeconds = 0;
     ENV.enableConfirmService = false;
   }
 


### PR DESCRIPTION
This PR improves auth UX by enabling an "inline" OIDC flow, such that users will be shifted back into the admin UI after successfully authenticating.  Previously, users would land on a success message, requiring them to manually navigate back to the admin window.

To test this PR:
- Spin up Boundary dev and then run the UI externally, pointing it to the dev instance
- Click the OIDC "authenticate" button
- Log in and observe the provider window is automatically closed.
- Repeat to test OIDC "cancel" and "retry" features of the pending authentication dialog.

https://user-images.githubusercontent.com/8390120/117494076-d539c480-af41-11eb-94fe-558e1ef0ecc3.mov

