### PR TITLE
fix: 🐛 migrate IPC to service-based window for reliable testing

### DIFF
--- a/ui/desktop/app/services/ipc.js
+++ b/ui/desktop/app/services/ipc.js
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import { getOwner } from '@ember/application';
+import { inject as service } from '@ember/service';
 import { Promise } from 'rsvp';
 
 /**
@@ -58,7 +58,7 @@ export class IPCRequest {
     this.method = method;
     this.payload = payload;
     this.origin = window?.location?.origin;
-    this.#channel = new MessageChannel();
+    this.#channel = new window.MessageChannel();
     this.#promise = new Promise((resolve, reject) => {
       this.#channel.port1.onmessage = (event) => {
         this.close();
@@ -124,18 +124,9 @@ export class IPCRequest {
  *   }
  */
 export default class IpcService extends Service {
-  // =attributes
+  // =services
 
-  /**
-   * Looks up the window object indirectly.
-   * @type {Window}
-   */
-  get window() {
-    // The Ember way of accessing globals...
-    const document = getOwner(this).lookup('service:-document').documentElement;
-    // defaultView === window, but without using globals directly
-    return document.parentNode.defaultView;
-  }
+  @service('browser/window') window;
 
   // =methods
 

--- a/ui/desktop/tests/helpers/window-mock-ipc.js
+++ b/ui/desktop/tests/helpers/window-mock-ipc.js
@@ -1,0 +1,75 @@
+import Service from '@ember/service';
+
+class MockIPC {
+  origin = null;
+
+  invoke(method, payload) {
+    return this[method](payload);
+  }
+
+  getOrigin() {
+    return this.origin;
+  }
+
+  setOrigin(origin) {
+    this.origin = origin;
+    return this.origin;
+  }
+
+  resetOrigin() {}
+}
+
+/**
+ * Mock window service with support for simplified postMessage and
+ * MessageChannel APIs.  This mock implements just enough functionality
+ * to support the IPC mechanism.
+ *
+ * This mock is necessary to guarantee synchronous and deterministic
+ * operation.  The window's own API is evented and asychronous, which
+ * cannot be relied on for testing purposes.
+ *
+ * @todo refactor mock postMessage and MessageChannel for reusability
+ *       outside of tests
+ */
+export default class extends Service {
+  // =attributes
+
+  /**
+   *
+   */
+  mockIPC = new MockIPC();
+
+  /**
+   *
+   */
+  MessageChannel = class MessageChannel {
+    constructor() {
+      this.port1.postMessage = this.port1.postMessage.bind(this);
+      this.port2.postMessage = this.port2.postMessage.bind(this);
+    }
+    port1 = {
+      postMessage() {},
+      close() {},
+    };
+    port2 = {
+      postMessage(data) {
+        this.port1.onmessage({ data });
+      },
+      close() {},
+    };
+  };
+
+  // =methods
+
+  /**
+   *
+   */
+  postMessage(data, origin, ports) {
+    if (origin !== window.location.origin) return;
+    const { method, payload } = data;
+    if (method) {
+      const response = this.mockIPC.invoke(method, payload);
+      ports[0].postMessage(response);
+    }
+  }
+}


### PR DESCRIPTION
This resolves a longstanding issue where IPC tests rely on the real
window.postMessage and MessageChannel APIs.  These are evented and
asynchronous, resulting in nondeterministic tests.  This commit updates
tests with synchronous mocked APIs.