### PR TITLE
fix: 🐛 Update trim package version resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "merge": "^2.1.1",
     "xmlhttprequest-ssl": "^1.6.2",
     "underscore": "^1.12.1",
-    "hosted-git-info": "3.0.8"
+    "hosted-git-info": "3.0.8",
+    "trim": "~1.0.1"
   },
   "config": {
     "commitizen": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20565,10 +20565,10 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+trim@0.0.1, trim@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-1.0.1.tgz#68e78f6178ccab9687a610752f4f5e5a7022ee8c"
+  integrity sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w==
 
 trough@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Update the version we resolve of dependency package trim since older version has a security vulnerability.

Tests performed:
- Run all the tests suite.
- Run `yarn run build:ui:admin` and `yarn run build:ui:desktop` to make sure this does not brake anything.