### PR TITLE
Feature more oidc modeling

### DIFF
--- a/addons/api/addon/initializers/fragment-string.js
+++ b/addons/api/addon/initializers/fragment-string.js
@@ -1,0 +1,12 @@
+// app/initializers/fragment-serializer.js
+import FragmentStringSerializer from '../serializers/fragment-string';
+
+export function initialize(application) {
+  application.register('serializer:fragment-string', FragmentStringSerializer);
+}
+
+// Fragment serializers must be manually registered
+export default {
+  name: 'fragment-string',
+  initialize: initialize,
+};

--- a/addons/api/addon/models/auth-method.js
+++ b/addons/api/addon/models/auth-method.js
@@ -7,7 +7,7 @@ import { equal } from '@ember/object/computed';
  */
 export const options = {
   oidc: {
-    signing_algorithm: [
+    signing_algorithms: [
       'RS256',
       'RS384',
       'RS512',

--- a/addons/api/addon/models/fragment-auth-method-attributes.js
+++ b/addons/api/addon/models/fragment-auth-method-attributes.js
@@ -20,4 +20,21 @@ export default class FragmentAuthMethodAttributesModel extends Fragment {
     emptyArrayIfMissing: true,
   })
   account_claim_maps;
+
+  @fragmentArray('fragment-string', {
+    emptyArrayIfMissing: true,
+  })
+  claims_scopes;
+
+  @fragmentArray('fragment-string', {
+    emptyArrayIfMissing: true,
+  })
+  signing_algorithms;
+
+  @fragmentArray('fragment-string', {
+    emptyArrayIfMissing: true,
+  })
+  allowed_audiences;
+
+  @fragmentArray('fragment-string', { emptyArrayIfMissing: true }) idp_ca_certs;
 }

--- a/addons/api/addon/serializers/fragment-string.js
+++ b/addons/api/addon/serializers/fragment-string.js
@@ -1,0 +1,24 @@
+import JSONSerializer from '@ember-data/serializer/json';
+
+export default class FragmentStringSerializer extends JSONSerializer {
+  // =methods
+
+  /**
+   * Serializes a to string.
+   * @param {Snapshot} snapshot
+   * @return {string}
+   */
+  serialize(snapshot) {
+    return snapshot.attr('value');
+  }
+
+  /**
+   * Normalizes from strings.
+   * @param {Model} typeClass
+   * @param {string} value
+   * @return {object}
+   */
+  normalize(typeClass, value) {
+    return super.normalize(typeClass, { value });
+  }
+}

--- a/addons/api/addon/serializers/host-set.js
+++ b/addons/api/addon/serializers/host-set.js
@@ -37,21 +37,4 @@ export default class HostSetSerializer extends ApplicationSerializer {
       host_ids: hostIDs,
     };
   }
-
-  /**
-   * Converts string arrays to object arrays for use with `fragment-string`.
-   * E.g. `"foo"` -> `{value: "foo"}`
-   * @override
-   * @param {Model} modelClass
-   * @param {Object} resourceHash
-   * @return {Object}
-   */
-  normalize(modelClass, resourceHash) {
-    // TODO:  can fragment string normalization be handled generically?
-    // TODO: host_ids might actually be attributes.host_ids
-    if (resourceHash.host_ids) {
-      resourceHash.host_ids = resourceHash.host_ids.map((value) => ({ value }));
-    }
-    return super.normalize(modelClass, resourceHash);
-  }
 }

--- a/addons/api/app/initializers/fragment-string.js
+++ b/addons/api/app/initializers/fragment-string.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'api/initializers/fragment-string';

--- a/addons/api/app/serializers/fragment-string.js
+++ b/addons/api/app/serializers/fragment-string.js
@@ -1,0 +1,1 @@
+export { default } from 'api/serializers/fragment-string';

--- a/addons/api/mirage/generated/factories/auth-method.js
+++ b/addons/api/mirage/generated/factories/auth-method.js
@@ -24,6 +24,11 @@ export default Factory.extend({
           client_secret_hmac: 'GY7blb4ynM5TEPNi_qnphJ9aDWhW8FpmN3D-eP_L7Zk',
           issuer: 'http://127.0.0.1:57070',
           state: 'active-public',
+          account_claim_maps: ['oid=sub', 'full_name=name'],
+          claims_scopes: ['profile', 'email'],
+          signing_algorithms: ['RS256', 'RS384'],
+          allowed_audiences: ['www.alice.com', 'www.alice.com/admin'],
+          idp_ca_certs: ['certificate-1234', 'certificate-5678'],
         };
         break;
     }

--- a/addons/api/tests/unit/initializers/fragment-string-test.js
+++ b/addons/api/tests/unit/initializers/fragment-string-test.js
@@ -1,0 +1,32 @@
+import Application from '@ember/application';
+
+import { initialize } from 'dummy/initializers/fragment-string';
+import { module, test } from 'qunit';
+import Resolver from 'ember-resolver';
+import { run } from '@ember/runloop';
+
+module('Unit | Initializer | fragment-string', function (hooks) {
+  hooks.beforeEach(function () {
+    this.TestApplication = class TestApplication extends Application {};
+    this.TestApplication.initializer({
+      name: 'initializer under test',
+      initialize,
+    });
+
+    this.application = this.TestApplication.create({
+      autoboot: false,
+      Resolver,
+    });
+  });
+
+  hooks.afterEach(function () {
+    run(this.application, 'destroy');
+  });
+
+  // TODO: Replace this with your real tests.
+  test('it works', async function (assert) {
+    await this.application.boot();
+
+    assert.ok(true);
+  });
+});

--- a/addons/api/tests/unit/serializers/auth-method-test.js
+++ b/addons/api/tests/unit/serializers/auth-method-test.js
@@ -37,6 +37,16 @@ module('Unit | Serializer | auth method', function (hooks) {
       attributes: {
         state: 'foo',
         account_claim_maps: [{ from: 'foo', to: 'bar' }],
+        claims_scopes: [{ value: 'profile' }, { value: 'email' }],
+        signing_algorithms: [{ value: 'RS256' }, { value: 'RS384' }],
+        allowed_audiences: [
+          { value: 'www.alice.com' },
+          { value: 'www.alice.com/admin' },
+        ],
+        idp_ca_certs: [
+          { value: 'certificate-1234' },
+          { value: 'certificate-5678' },
+        ],
       },
     });
 
@@ -48,6 +58,10 @@ module('Unit | Serializer | auth method', function (hooks) {
       description: null,
       attributes: {
         account_claim_maps: ['foo=bar'],
+        claims_scopes: ['profile', 'email'],
+        signing_algorithms: ['RS256', 'RS384'],
+        allowed_audiences: ['www.alice.com', 'www.alice.com/admin'],
+        idp_ca_certs: ['certificate-1234', 'certificate-5678'],
         api_url_prefix: null,
         callback_url: null,
         client_id: null,

--- a/addons/api/tests/unit/serializers/fragment-string-test.js
+++ b/addons/api/tests/unit/serializers/fragment-string-test.js
@@ -1,0 +1,49 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Serializer | fragment string', function (hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let serializer = store.serializerFor('fragment-string');
+
+    assert.ok(serializer);
+  });
+
+  test('it serializes records', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let record = store.createRecord('fragment-string', {
+      value: 'string value',
+    });
+
+    let serializedRecord = record.serialize();
+
+    assert.equal(serializedRecord, 'string value');
+  });
+
+  test('it normalizes records', function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('fragment-string');
+    const modelClass = store.createRecord('fragment-string').constructor;
+    const payload = 'string value';
+    const normalized = serializer.normalizeSingleResponse(
+      store,
+      modelClass,
+      payload
+    );
+    assert.deepEqual(normalized, {
+      included: [],
+      data: {
+        id: null,
+        type: 'fragment-string',
+        attributes: {
+          value: 'string value',
+        },
+        relationships: {},
+      },
+    });
+  });
+});


### PR DESCRIPTION
This PR completes OIDC auth method modelling with the missing string array fields.  Unlike other string array fields so far, these are updated via conventional PUT/PATCH requests, rather than via custom methods.  Thus no field-specific serialization methods are required as are found in previous serializers