### PR TITLE
feat: 🎸 add helper text option to checkbox component

### DIFF
--- a/addons/rose/addon/components/rose/form/checkbox/index.hbs
+++ b/addons/rose/addon/components/rose/form/checkbox/index.hbs
@@ -8,7 +8,7 @@
     disabled={{@disabled}}
     @type="checkbox"
     @checked={{if @checked true false}}
-    aria-describedby="{{if @error (concat 'errors-' this.id)}}" />
+    aria-describedby="{{if @helperText (concat 'helper-text-' this.id)}} {{if @error (concat 'errors-' this.id)}}" />
 
   <label class="rose-form-checkbox-label" for={{this.id}}>
     <span class="rose-form-checkbox-label-text">{{@label}}</span>
@@ -16,6 +16,12 @@
       <p class="rose-form-checkbox-label-description">{{@description}}</p>
     {{/if}}
   </label>
+
+  {{#if @helperText}}
+    <Rose::Form::HelperText @id="helper-text-{{this.id}}" @error={{@error}}>
+      {{@helperText}}
+    </Rose::Form::HelperText>
+  {{/if}}
 
   {{yield (hash
     errors=(component 'rose/form/errors' id=(concat 'errors-' this.id))

--- a/addons/rose/addon/components/rose/form/checkbox/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/checkbox/index.stories.mdx
@@ -26,6 +26,7 @@ Renders a form input checkbox.
         @name={{name}}
         @label={{label}}
         @description={{description}}
+        @helperText={{helperText}}
         @checked={{checked}}
         @error={{error}}
         @disabled={{disabled}}
@@ -33,7 +34,8 @@ Renders a form input checkbox.
     `,
     context: {
       label: text('text', 'Checkbox 🛎'),
-      description: text('description', 'This is an optional description paragraph.'),
+      description: text('description', 'Short description in label'),
+      helperText: text('helperText', 'This is an optional help text.'),
       name: text('name', 'checkbox-1'),
       checked: boolean('checked', false),
       error: boolean('error', false),

--- a/addons/rose/addon/components/rose/table/row/cell/index.js
+++ b/addons/rose/addon/components/rose/table/row/cell/index.js
@@ -13,16 +13,16 @@ export default Component.extend({
   }),
   cellShrink: computed(function () {
     if (this.shrink) {
-      return 'rose-table-cell-shrink'
+      return 'rose-table-cell-shrink';
     }
   }),
   cellAlignmentStyle: computed(function () {
     if (this.alignRight) {
       return 'align-right';
     }
-    
+
     if (this.alignCenter) {
       return 'align-center';
     }
-  })
+  }),
 });

--- a/addons/rose/addon/styles/rose/components/form/_checkbox.scss
+++ b/addons/rose/addon/styles/rose/components/form/_checkbox.scss
@@ -4,12 +4,15 @@
 .rose-form-checkbox {
   @include type.type(m);
   position: relative;
-  margin-bottom: sizing.rems(xs);
-  color: var(--ui-gray);
+  margin-bottom: sizing.rems(m);
 
   .rose-form-errors {
     margin-top: sizing.rems(xs);
     margin-bottom: sizing.rems(xs);
+  }
+
+  .rose-form-helper-text {
+    padding-left: sizing.rems(l);
   }
 
   .rose-form-checkbox-label {
@@ -23,6 +26,7 @@
     }
 
     .rose-form-checkbox-label-description {
+      margin-bottom: 0;
       margin-top: sizing.rems(xs);
     }
 
@@ -52,6 +56,10 @@
       content: ' ';
       background: no-repeat 50%/50% 50%;
     }
+  }
+
+  .rose-form-helper-text {
+    margin-top: sizing.rems(xs);
   }
 
   .rose-form-checkbox-field {

--- a/addons/rose/addon/styles/rose/components/table/_table.scss
+++ b/addons/rose/addon/styles/rose/components/table/_table.scss
@@ -12,9 +12,9 @@
 
   // This styles are add to stop the input to apply extra margin (default on forms)
   .rose-form-input-field,
-  .rose-form-select, 
-  .rose-form-input { 
-    margin: 0; 
+  .rose-form-select,
+  .rose-form-input {
+    margin: 0;
     width: 100%;
   }
 
@@ -22,8 +22,12 @@
   .rose-table-header-cell {
     vertical-align: middle;
 
-    &.align-right { text-align: right; }
-    &.align-center { text-align: center; }
+    &.align-right {
+      text-align: right;
+    }
+    &.align-center {
+      text-align: center;
+    }
   }
 
   .rose-table-header-cell {
@@ -62,7 +66,6 @@
       line-height: $lineHeight;
       padding: (sizing.rems(s) / 2) sizing.rems(s);
     }
-
   }
 
   .rose-table-row-visually-hidden {

--- a/addons/rose/tests/integration/components/rose/form/checkbox-test.js
+++ b/addons/rose/tests/integration/components/rose/form/checkbox-test.js
@@ -9,9 +9,9 @@ module('Integration | Component | rose/form/checkbox', function (hooks) {
   test('it renders', async function (assert) {
     assert.expect(3);
     await render(hbs`<Rose::Form::Checkbox @label="Label" />`);
-    assert.equal(await find('label').textContent.trim(), 'Label');
-    assert.ok(await find('input'));
-    assert.notOk(await find('.rose-form-checkbox-label-description'));
+    assert.equal(find('label').textContent.trim(), 'Label');
+    assert.ok(find('input'));
+    assert.notOk(find('.rose-form-checkbox-label-description'));
   });
 
   test('it renders optional description paragraph', async function (assert) {
@@ -20,14 +20,14 @@ module('Integration | Component | rose/form/checkbox', function (hooks) {
       hbs`<Rose::Form::Checkbox @label="Label" @description="Hello world" />`
     );
     assert.equal(
-      await find('.rose-form-checkbox-label-text').textContent.trim(),
+      find('.rose-form-checkbox-label-text').textContent.trim(),
       'Label'
     );
     assert.equal(
-      await find('.rose-form-checkbox-label-description').textContent.trim(),
+      find('.rose-form-checkbox-label-description').textContent.trim(),
       'Hello world'
     );
-    assert.ok(await find('input'));
+    assert.ok(find('input'));
   });
 
   test('it renders optional helper text', async function (assert) {
@@ -36,7 +36,7 @@ module('Integration | Component | rose/form/checkbox', function (hooks) {
       hbs`<Rose::Form::Checkbox @label="Label" @helperText="Hello world" />`
     );
     assert.equal(
-      await find('.rose-form-helper-text').textContent.trim(),
+      find('.rose-form-helper-text').textContent.trim(),
       'Hello world'
     );
   });
@@ -60,26 +60,26 @@ module('Integration | Component | rose/form/checkbox', function (hooks) {
 
   test('it is not checked by default', async function (assert) {
     await render(hbs`<Rose::Form::Checkbox />`);
-    assert.equal(await find('input').checked, false);
+    assert.equal(find('input').checked, false);
   });
 
   test('it is not disabled by default', async function (assert) {
     await render(hbs`<Rose::Form::Checkbox />`);
-    assert.equal(await find('input').disabled, false);
+    assert.equal(find('input').disabled, false);
   });
 
   test('it is checked when @checked={{true}}', async function (assert) {
     await render(hbs`<Rose::Form::Checkbox @checked={{true}} />`);
-    assert.equal(await find('input').checked, true);
+    assert.equal(find('input').checked, true);
   });
 
   test('it marks error when @error={{true}}', async function (assert) {
     await render(hbs`<Rose::Form::Checkbox @error={{true}} />`);
-    assert.ok(await find('.error'));
+    assert.ok(find('.error'));
   });
 
   test('it is disabled when @disabled={{true}}', async function (assert) {
     await render(hbs`<Rose::Form::Checkbox @disabled={{true}} />`);
-    assert.equal(await find('input').disabled, true);
+    assert.equal(find('input').disabled, true);
   });
 });

--- a/addons/rose/tests/integration/components/rose/form/checkbox-test.js
+++ b/addons/rose/tests/integration/components/rose/form/checkbox-test.js
@@ -30,6 +30,17 @@ module('Integration | Component | rose/form/checkbox', function (hooks) {
     assert.ok(await find('input'));
   });
 
+  test('it renders optional helper text', async function (assert) {
+    assert.expect(1);
+    await render(
+      hbs`<Rose::Form::Checkbox @label="Label" @helperText="Hello world" />`
+    );
+    assert.equal(
+      await find('.rose-form-helper-text').textContent.trim(),
+      'Hello world'
+    );
+  });
+
   test('it displays optional errors', async function (assert) {
     await render(hbs`
       <Rose::Form::Checkbox @error={{true}} as |field|>


### PR DESCRIPTION
This PR adds support for helper text to the checkbox component, bringing it in line with other form components that already support help.  Helper text is optional.


<img width="368" alt="Screenshot 2021-05-21 at 13 47 55" src="https://user-images.githubusercontent.com/8390120/119180809-c4f41000-ba3e-11eb-94a9-1abce0087bc4.png"> 


<img width="304" alt="Screenshot 2021-05-21 at 13 48 36" src="https://user-images.githubusercontent.com/8390120/119180806-c45b7980-ba3e-11eb-84e4-2a346223b1a7.png">
<img width="353" alt="Screenshot 2021-05-21 at 13 48 30" src="https://user-images.githubusercontent.com/8390120/119180807-c4f41000-ba3e-11eb-8613-57ee1a712287.png">
<img width="365" alt="Screenshot 2021-05-21 at 13 48 02" src="https://user-images.githubusercontent.com/8390120/119180808-c4f41000-ba3e-11eb-8d87-ca475229c915.png">
