### PR TITLE
Chore windows container build

### DIFF
--- a/docker-compose-embedding.yml
+++ b/docker-compose-embedding.yml
@@ -26,7 +26,7 @@ services:
   build-desktop-production:
     <<: *node
     entrypoint: bash
-    command: '-c "yarn install && yarn build:ui:desktop:production && chmod -R 777 ."'
+    command: '-c "yarn install --frozen-lockfile --non-interactive && yarn build:ui:desktop:production && chmod -R 777 ."'
 
 volumes:
   icu_node_modules:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "yarn build:ui:admin",
     "build:ui:admin": "cd ui/admin && yarn build",
     "build:ui:desktop": "cd ui/desktop && yarn build",
+    "build:ui:desktop:win": "docker-compose -f docker-compose-embedding.yml run build-desktop-production && yarn run build:ui:desktop:app",
     "build:ui:desktop:production": "cd ui/desktop && yarn build:production",
     "build:ui:desktop:app": "cd ui/desktop && yarn build:desktop",
     "lint": "npm-run-all lint:*",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "yarn build:ui:admin",
     "build:ui:admin": "cd ui/admin && yarn build",
     "build:ui:desktop": "cd ui/desktop && yarn build",
-    "build:ui:desktop:win": "docker-compose -f docker-compose-embedding.yml run build-desktop-production && yarn run build:ui:desktop:app",
+    "build:ui:desktop:win": "docker-compose -f docker-compose-embedding.yml run build-desktop-production && yarn build:ui:desktop:app",
     "build:ui:desktop:production": "cd ui/desktop && yarn build:production",
     "build:ui:desktop:app": "cd ui/desktop && yarn build:desktop",
     "lint": "npm-run-all lint:*",


### PR DESCRIPTION
This PR introduces a yarn command that runs a windows asset build inside a container, rather than directly on the host, in order to work around an issue with translations paths not building correctly in windows.