### PR TITLE
fix: 🐛 Fix yarn warning due to strict version declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "merge": "^2.1.1",
     "xmlhttprequest-ssl": "^1.6.2",
     "underscore": "^1.12.1",
-    "hosted-git-info": "3.0.8",
+    "hosted-git-info": "^3.0.8",
     "trim": "~1.0.1",
     "browserslist": "^4.16.5",
     "ws": "^7.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12030,7 +12030,7 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
-hosted-git-info@3.0.8, hosted-git-info@^2.1.4, hosted-git-info@^2.7.1, hosted-git-info@^2.8.9, hosted-git-info@^3.0.2, hosted-git-info@^4.0.1:
+hosted-git-info@^2.1.4, hosted-git-info@^2.7.1, hosted-git-info@^2.8.9, hosted-git-info@^3.0.2, hosted-git-info@^3.0.8, hosted-git-info@^4.0.1:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.8.tgz#6e35d4cc87af2c5f816e4cb9ce350ba87a3f370d"
   integrity sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==


### PR DESCRIPTION
Fix yarn warning due to a strict version declaration of `hosted-git-info`.
Now the yarn warning is gone when running `yarn install`.