### PR TITLE
feat: Add KeyValue Dropdown Item

### DIFF
--- a/addons/rose/addon/components/rose/dropdown/index.hbs
+++ b/addons/rose/addon/components/rose/dropdown/index.hbs
@@ -29,6 +29,7 @@
       item=(component "rose/anonymous" class="rose-dropdown-item")
       separator=(component "rose/anonymous" tagName="hr" class="rose-dropdown-separator")
       section=(component "rose/dropdown/section" style=this.style)
+      key-value=(component "rose/dropdown/key-value" style=this.style)
     )}}
   </div>
 

--- a/addons/rose/addon/components/rose/dropdown/index.hbs
+++ b/addons/rose/addon/components/rose/dropdown/index.hbs
@@ -29,7 +29,7 @@
       item=(component "rose/anonymous" class="rose-dropdown-item")
       separator=(component "rose/anonymous" tagName="hr" class="rose-dropdown-separator")
       section=(component "rose/dropdown/section" style=this.style)
-      key-value=(component "rose/dropdown/key-value" style=this.style)
+      key-value=(component "rose/dropdown/key-value")
     )}}
   </div>
 

--- a/addons/rose/addon/components/rose/dropdown/index.hbs
+++ b/addons/rose/addon/components/rose/dropdown/index.hbs
@@ -22,15 +22,28 @@
 
   </summary>
 
-  <div class="rose-dropdown-content" {{on-click-inside this.close}}>
-    {{yield (hash
-      link=(component "rose/dropdown/link" style=this.style)
-      button=(component "rose/dropdown/button" style=this.style)
-      item=(component "rose/anonymous" class="rose-dropdown-item")
-      separator=(component "rose/anonymous" tagName="hr" class="rose-dropdown-separator")
-      section=(component "rose/dropdown/section" style=this.style)
-      key-value=(component "rose/dropdown/key-value")
-    )}}
-  </div>
+  {{#if @ignoreClickInside}}
+    <div class="rose-dropdown-content">
+      {{yield (hash
+        link=(component "rose/dropdown/link" style=this.style)
+        button=(component "rose/dropdown/button" style=this.style)
+        item=(component "rose/anonymous" class="rose-dropdown-item")
+        separator=(component "rose/anonymous" tagName="hr" class="rose-dropdown-separator")
+        section=(component "rose/dropdown/section" style=this.style)
+        key-value=(component "rose/dropdown/key-value")
+      )}}
+    </div>
+  {{else}}
+    <div class="rose-dropdown-content" {{on-click-inside this.close}}>
+      {{yield (hash
+        link=(component "rose/dropdown/link" style=this.style)
+        button=(component "rose/dropdown/button" style=this.style)
+        item=(component "rose/anonymous" class="rose-dropdown-item")
+        separator=(component "rose/anonymous" tagName="hr" class="rose-dropdown-separator")
+        section=(component "rose/dropdown/section" style=this.style)
+        key-value=(component "rose/dropdown/key-value")
+      )}}
+    </div>
+  {{/if}}
 
 </details>

--- a/addons/rose/addon/components/rose/dropdown/index.stories.mdx
+++ b/addons/rose/addon/components/rose/dropdown/index.stories.mdx
@@ -66,7 +66,7 @@ A simple dropdown component with support for links and buttons.
 <Preview>
   <Story name="Dropdown with Key Value Items" height="13rem">{{
     template: hbs`
-      <Rose::Dropdown @text="View details" @showCaret={{showCaret}} as |dropdown|>
+      <Rose::Dropdown @text="View details" @showCaret={{showCaret}} @ignoreClickInside={{true}} as |dropdown|>
         <dropdown.key-value>
           <:key>Name</:key>
           <:value>Key/Value</:value>
@@ -142,4 +142,15 @@ form field.
     </Rose::Dropdown>
   </form.radioGroup>
 </Rose::Form>
+```
+
+Closing dropdown after clicking inside it's content can be ignored using `ignoreClickInside`. This is useful when dropdown contains keyvalue items that users need to select/copy/interact with.
+
+```html
+<Rose::Dropdown @text="View details" @showCaret={{true}} @ignoreClickInside={{true}} as |dropdown|>
+  <dropdown.key-value>
+    <:key>ID</:key>
+    <:value>cl_nbv9375hLHs</:value>
+  </dropdown.key-value>
+</Rose::Dropdown>
 ```

--- a/addons/rose/addon/components/rose/dropdown/index.stories.mdx
+++ b/addons/rose/addon/components/rose/dropdown/index.stories.mdx
@@ -63,6 +63,24 @@ A simple dropdown component with support for links and buttons.
   }}</Story>
 </Preview>
 
+<Preview>
+  <Story name="Dropdown with Key Value Items" height="13rem">{{
+    template: hbs`
+      <Rose::Dropdown @text="View details" @showCaret={{showCaret}} as |dropdown|>
+        <dropdown.key-value>
+          <:key>Name</:key>
+          <:value>Key/Value</:value>
+        </dropdown.key-value>
+        <dropdown.separator />
+        <dropdown.key-value>
+          <:key>Description</:key>
+          <:value>Lorem ipsum dolor sit amet consectetur adipisicing elit. Assumenda illo ratione libero ducimus magnam, porro sed provident repellat mollitia a, repellendus placeat. Magni consequuntur cumque, debitis obcaecati dolores quasi natus?</:value>
+        </dropdown.key-value>
+      </Rose::Dropdown>
+    `,
+  }}</Story>
+</Preview>
+
 
 ```html
   <Rose::Dropdown @text="Choose One&hellip;" as |dropdown|>

--- a/addons/rose/addon/components/rose/dropdown/key-value/index.hbs
+++ b/addons/rose/addon/components/rose/dropdown/key-value/index.hbs
@@ -1,0 +1,9 @@
+<dl class='rose-dropdown-key-value rose-dropdown-item'>
+  <dt class='rose-dropdown-key'>
+    {{yield to='key'}}
+  </dt>
+
+  <dd class='rose-dropdown-value'>
+      {{yield to='value'}}
+  </dd>
+</dl>

--- a/addons/rose/addon/styles/rose/components/dropdown/_index.scss
+++ b/addons/rose/addon/styles/rose/components/dropdown/_index.scss
@@ -3,3 +3,4 @@
 @import 'link';
 @import 'item';
 @import 'section';
+@import 'key-value';

--- a/addons/rose/addon/styles/rose/components/dropdown/_key-value.scss
+++ b/addons/rose/addon/styles/rose/components/dropdown/_key-value.scss
@@ -1,0 +1,11 @@
+@use '../../variables/sizing';
+
+.rose-dropdown-key-value {
+  .rose-dropdown-key {
+    text-transform: capitalize;
+  }
+  .rose-dropdown-value {
+    color: var(--ui-gray);
+    padding: sizing.rems(xxs) sizing.rems(s) 0 0;
+  }
+}

--- a/addons/rose/app/components/rose/dropdown/key-value.js
+++ b/addons/rose/app/components/rose/dropdown/key-value.js
@@ -1,0 +1,1 @@
+export { default } from 'rose/components/rose/dropdown/key-value';

--- a/addons/rose/tests/dummy/app/templates/index.hbs
+++ b/addons/rose/tests/dummy/app/templates/index.hbs
@@ -1,3 +1,30 @@
+<h2>KeyValue Dropdown</h2>
+<Rose::Dropdown
+  @text="Credential library details"
+  @showCaret={{true}}
+  as |dropdown|
+>
+  <dropdown.key-value>
+    <:key>ID</:key>
+    <:value>cl_nbv9375hLHs</:value>
+  </dropdown.key-value>
+
+  <dropdown.separator />
+
+  <dropdown.key-value>
+    <:key>Name</:key>
+    <:value>Key/Value</:value>
+  </dropdown.key-value>
+
+  <dropdown.separator />
+
+  <dropdown.key-value>
+    <:key>Description</:key>
+    <:value>Lorem ipsum dolor sit amet consectetur adipisicing elit. Assumenda illo ratione libero ducimus magnam, porro sed provident repellat mollitia a, repellendus placeat. Magni consequuntur cumque, debitis obcaecati dolores quasi natus?</:value>
+  </dropdown.key-value>
+
+</Rose::Dropdown>
+
 <h2>Condensed dropdown</h2>
 <Rose::Dropdown
   @style="condensed"

--- a/addons/rose/tests/dummy/app/templates/index.hbs
+++ b/addons/rose/tests/dummy/app/templates/index.hbs
@@ -2,6 +2,7 @@
 <Rose::Dropdown
   @text="Credential library details"
   @showCaret={{true}}
+  @ignoreClickInside={{true}}
   as |dropdown|
 >
   <dropdown.key-value>

--- a/addons/rose/tests/integration/components/rose/dropdown/key-value-test.js
+++ b/addons/rose/tests/integration/components/rose/dropdown/key-value-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, find } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | rose/dropdown/key-value', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <Rose::Dropdown::KeyValue>
+        <:key>key</:key>
+        <:value>value</:value>
+      </Rose::Dropdown::KeyValue>
+    `);
+
+    assert.equal(find('.rose-dropdown-key').textContent.trim(), 'key');
+    assert.equal(find('.rose-dropdown-value').textContent.trim(), 'value');
+  });
+});


### PR DESCRIPTION
Simple key-value item for use in `Rose::Dropdown`. Supports `key` and `value` named blocks.
<img width="440" alt="Screen Shot 2021-06-22 at 13 26 49" src="https://user-images.githubusercontent.com/111036/122973459-3f29f400-d35f-11eb-89b0-80641575e75d.png">

```js
<Rose::Dropdown
  @text="Credential library details"
  @showCaret={{true}}
  as |dropdown|
>
  <dropdown.key-value>
    <:key>ID</:key>
    <:value>cl_nbv9375hLHs</:value>
  </dropdown.key-value>

  <dropdown.separator />

  <dropdown.key-value>
    <:key>Name</:key>
    <:value>Key/Value</:value>
  </dropdown.key-value>

  <dropdown.separator />

  <dropdown.key-value>
    <:key>Description</:key>
    <:value>Lorem ipsum dolor sit amet consectetur adipisicing elit. Assumenda illo ratione libero ducimus magnam, porro sed provident repellat mollitia a, repellendus placeat. Magni consequuntur cumque, debitis obcaecati dolores quasi natus?</:value>
  </dropdown.key-value>

</Rose::Dropdown>
```