### PR TITLE
fix: Use name in connect header

### DIFF
--- a/addons/api/addon/models/session.js
+++ b/addons/api/addon/models/session.js
@@ -44,7 +44,6 @@ class SessionCredential {
   // =attributes
   rawCredential;
   library;
-  purpose;
   #rawSecretValue;
 
   /**
@@ -69,7 +68,6 @@ class SessionCredential {
     this.library = new SessionCredential.Library(id, name, description, type);
     this.#rawSecretValue = cred.secret;
     this.rawCredential = cred;
-    this.purpose = cred.purpose;
   }
 }
 

--- a/addons/api/mirage/scenarios/ipc.js
+++ b/addons/api/mirage/scenarios/ipc.js
@@ -67,7 +67,6 @@ export default function initializeMockIPC(server) {
               credential_store_id: 'csvlt_Q1HFGt7Jpm',
               type: 'vault',
             },
-            purpose: 'application',
             secret: 'just-a-random-string',
           },
           {
@@ -78,7 +77,6 @@ export default function initializeMockIPC(server) {
               credential_store_id: 'csvlt_Q1HFGt7Jpm',
               type: 'vault',
             },
-            purpose: 'ingress',
             secret: {
               key1: 'value 1',
               key2: true,
@@ -93,7 +91,6 @@ export default function initializeMockIPC(server) {
               credential_store_id: 'csvlt_Q1HFGt7Jpm',
               type: 'vault',
             },
-            purpose: 'application',
             secret: 'just-a-random-string',
           },
           {
@@ -104,7 +101,6 @@ export default function initializeMockIPC(server) {
               credential_store_id: 'csvlt_Q1HFGt7Jpm',
               type: 'vault',
             },
-            purpose: 'egress',
             secret: {
               key1: 'value 1',
               key2: true,

--- a/ui/desktop/app/templates/scopes/scope/projects/targets.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets.hbs
@@ -39,13 +39,11 @@
 
               {{#each session.credentials as |credential|}}
                 <Card
-                  @heading={{concat
-                    (t 'resources.session.credential.title')
-                    (if
-                      credential.library.name
-                      (concat ' (' credential.library.name ')')
-                    )
-                  }}
+                  @heading='{{t 'resources.session.credential.title'}}
+                    {{if
+                    credential.library.name
+                    (concat ' (' credential.library.name ')')
+                  }}'
                   @icon='app-icons/credential'
                 >
                   <:header>
@@ -74,6 +72,12 @@
                         <:key>{{t 'form.type.label'}}</:key>
                         <:value>{{credential.library.type}}</:value>
                       </dropdown.key-value>
+                      {{#if credential.library.name}}
+                        <dropdown.key-value>
+                          <:key>{{t 'form.name.label'}}</:key>
+                          <:value>{{credential.library.name}}</:value>
+                        </dropdown.key-value>
+                      {{/if}}
                       {{#if credential.library.description}}
                         <dropdown.key-value>
                           <:key>{{t 'form.description.label'}}</:key>

--- a/ui/desktop/app/templates/scopes/scope/projects/targets.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets.hbs
@@ -41,7 +41,10 @@
                 <Card
                   @heading={{concat
                     (t 'resources.session.credential.title')
-                    (if credential.purpose (concat ' (' credential.purpose ')'))
+                    (if
+                      credential.library.name
+                      (concat ' (' credential.library.name ')')
+                    )
                   }}
                   @icon='app-icons/credential'
                 >
@@ -71,12 +74,6 @@
                         <:key>{{t 'form.type.label'}}</:key>
                         <:value>{{credential.library.type}}</:value>
                       </dropdown.key-value>
-                      {{#if credential.library.name}}
-                        <dropdown.key-value>
-                          <:key>{{t 'form.name.label'}}</:key>
-                          <:value>{{credential.library.name}}</:value>
-                        </dropdown.key-value>
-                      {{/if}}
                       {{#if credential.library.description}}
                         <dropdown.key-value>
                           <:key>{{t 'form.description.label'}}</:key>


### PR DESCRIPTION
This PR removes unused credential purpose property from UI and displays name in credential header (instead of purpose).