### PR TITLE
fix: Update text font color and weight 

### DIFF
--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -94,6 +94,8 @@
 .rose-table {
   p {
     margin-bottom: 0;
+    color: var(--ui-gray-subtler-1);
+    font-weight: normal;
   }
 
   .rose-form-checkbox {

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -94,10 +94,13 @@
 .rose-table {
   p {
     margin-bottom: 0;
-    color: var(--ui-gray-subtler-1);
-    font-weight: normal;
   }
-
+  .rose-table-header-cell {
+    p {
+      color: var(--ui-gray-subtler-1);
+      font-weight: normal;
+    }
+  }
   .rose-form-checkbox {
     margin-bottom: 0;
 

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -32,7 +32,6 @@
     "posttest": "ember coverage-merge && yarn clean:coverage"
   },
   "dependencies": {
-    "ember": "^1.0.3",
     "ember-named-blocks-polyfill": "^0.2.4"
   },
   "devDependencies": {

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -32,6 +32,7 @@
     "posttest": "ember coverage-merge && yarn clean:coverage"
   },
   "dependencies": {
+    "ember": "^1.0.3",
     "ember-named-blocks-polyfill": "^0.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This pr fixes the font color and weight to be in sync with the design  

Before:
<img width="407" alt="Screen Shot 2021-07-09 at 10 56 59 AM" src="https://user-images.githubusercontent.com/15043878/125119442-f9329700-e0a5-11eb-8755-ac57f450f684.png">

After: 
<img width="522" alt="Screen Shot 2021-07-09 at 10 55 48 AM" src="https://user-images.githubusercontent.com/15043878/125119457-fdf74b00-e0a5-11eb-838c-8325b94e2600.png">
