### PR TITLE
Test acceptance credential stores

### DIFF
--- a/ui/admin/app/components/form/credential-store/index.hbs
+++ b/ui/admin/app/components/form/credential-store/index.hbs
@@ -2,6 +2,7 @@
   @onSubmit={{@submit}}
   @cancel={{@cancel}}
   @disabled={{@model.isSaving}}
+  @error={{@model.errors.base}}
   @showEditToggle={{if @model.isNew false true}}
   as |form|
 >
@@ -18,16 +19,38 @@
     @value={{@model.name}}
     @label={{t 'form.name.label'}}
     @helperText={{t 'form.name.help'}}
+    @error={{@model.errors.name}}
     readonly={{false}}
-  />
+    as |field|
+  >
+    {{#if @model.errors.name}}
+      <field.errors as |errors|>
+        {{#each @model.errors.name as |error|}}
+          <errors.message>{{error.message}}</errors.message>
+        {{/each}}
+      </field.errors>
+    {{/if}}
+  </form.input>
 
   <form.textarea
     @name='description'
     @type='description'
     @value={{@model.description}}
     @label={{t 'form.description.label'}}
+    @error={{@model.errors.description}}
     @helperText={{t 'form.description.help'}}
-  />
+    disabled={{@model.isSaving}}
+    readonly={{false}}
+    as |field|
+  >
+    {{#if @model.errors.description}}
+      <field.errors as |errors|>
+        {{#each @model.errors.description as |error|}}
+          <errors.message>{{error.message}}</errors.message>
+        {{/each}}
+      </field.errors>
+    {{/if}}
+  </form.textarea>
 
   <form.actions
     @disabled={{if @model.cannotSave @model.cannotSave}}

--- a/ui/admin/tests/acceptance/credential-stores-test.js
+++ b/ui/admin/tests/acceptance/credential-stores-test.js
@@ -1,12 +1,15 @@
 import { module, test } from 'qunit';
-import { visit, currentURL } from '@ember/test-helpers';
+import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
 
 module('Acceptance | credential-stores', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+
+  let getCredentialStoresCount;
 
   const instances = {
     scopes: {
@@ -32,17 +35,40 @@ module('Acceptance | credential-stores', function (hooks) {
       type: 'project',
       scope: { id: instances.scopes.org.id, type: 'org' },
     });
+    instances.credentialStore = this.server.create('credential-store', {
+      scope: instances.scopes.project,
+    });
     // Generate route URLs for resources
     urls.globalScope = `/scopes/global/scopes`;
     urls.orgScope = `/scopes/${instances.scopes.org.id}/scopes`;
     urls.projectScope = `/scopes/${instances.scopes.project.id}`;
     urls.credentialStores = `${urls.projectScope}/credential-stores`;
+    urls.credentialStore = `${urls.credentialStores}/${instances.credentialStore.id}`;
+    urls.unknownCredentialStore = `${urls.credentialStores}/foo`;
+    urls.newCredentialStore = `${urls.credentialStores}/new`;
+    // Generate resource counter
+    getCredentialStoresCount = () => {
+      return this.server.schema.credentialStores.all().models.length;
+    };
+    authenticateSession({});
   });
 
   test('visiting /credential-stores', async function (assert) {
-    assert.expect(1);
+    assert.expect(2);
     await visit(urls.credentialStores);
     await a11yAudit();
     assert.equal(currentURL(), urls.credentialStores);
+    await visit(urls.credentialStore);
+    await a11yAudit();
+    assert.equal(currentURL(), urls.credentialStore);
+  });
+
+  test('can create a new credential store', async function (assert) {
+    assert.expect(1);
+    const count = getCredentialStoresCount();
+    await visit(urls.newCredentialStore);
+    await fillIn('[name="name"]', 'random string');
+    await click('[type="submit"]');
+    assert.equal(getCredentialStoresCount(), count + 1);
   });
 });

--- a/ui/admin/tests/acceptance/credential-stores-test.js
+++ b/ui/admin/tests/acceptance/credential-stores-test.js
@@ -69,13 +69,14 @@ module('Acceptance | credential-stores', function (hooks) {
     assert.equal(currentURL(), urls.credentialStore);
   });
 
-  // This test is returning an issue regarding not finding resource.
-  // It is a false positive.
-  test.skip('visiting an unknown credential store display 404 message', async function (assert) {
+  test('visiting an unknown credential store display 404 message', async function (assert) {
     assert.expect(1);
     await visit(urls.unknownCredentialStore);
     await a11yAudit();
-    assert.ok(find('.rose-message-subtitle').textContent.trim(), 'Error 404');
+    assert.equal(
+      find('.rose-message-subtitle').textContent.trim(),
+      'Error 404'
+    );
   });
 
   test('can create a new credential stores', async function (assert) {


### PR DESCRIPTION
Add acceptance tests for list, create and edit credential stores.

Missing Delete tests because the delete feature is not available yet.