### PR TITLE
fix: 🐛 Fix style and accessibility issues for hidden secret

### DIFF
--- a/addons/core/translations/actions/en-us.yaml
+++ b/addons/core/translations/actions/en-us.yaml
@@ -33,3 +33,4 @@ edit-form: Edit Form
 change-origin: Change Origin URL
 change-state: Change State
 close: Close
+toggle-secret: Toggle secret visibility

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -267,6 +267,8 @@ target:
       add:
         title: Add Host Sets
         description: Select host sets to assign to this target.
+  secret:
+    toggle: Toggle secret visibility.
 credential-store:
   title: Credential Store
   title_plural: Credential Stores

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -267,8 +267,6 @@ target:
       add:
         title: Add Host Sets
         description: Select host sets to assign to this target.
-  secret:
-    toggle: Toggle secret visibility.
 credential-store:
   title: Credential Store
   title_plural: Credential Stores

--- a/ui/desktop/app/components/hidden-secret/index.hbs
+++ b/ui/desktop/app/components/hidden-secret/index.hbs
@@ -1,9 +1,11 @@
 <div class='hidden-secret'>
-  <Rose::Icon
-    @name={{if this.isHidden 'visibility-show' 'visibility-hide'}}
-    @size='medium'
+  <Rose::Button
+    @style='ghost'
+    @iconOnly={{if this.isHidden 'visibility-show' 'visibility-hide'}}
     {{on 'click' this.toggleSecretVisibility}}
-  />
+  >
+    {{t 'resources.target.secret.toggle'}}
+  </Rose::Button>
   <Copyable
     @text={{@secret}}
     @buttonText={{t 'actions.copy-to-clipboard'}}
@@ -12,7 +14,7 @@
     {{#if this.isHidden}}
       {{@secret}}
     {{else}}
-      {{this.textMask}}
+      <span class='secret-mask'>{{this.textMask}}</span>
     {{/if}}
   </Copyable>
 </div>

--- a/ui/desktop/app/components/hidden-secret/index.hbs
+++ b/ui/desktop/app/components/hidden-secret/index.hbs
@@ -4,7 +4,7 @@
     @iconOnly={{if this.isHidden 'visibility-show' 'visibility-hide'}}
     {{on 'click' this.toggleSecretVisibility}}
   >
-    {{t 'resources.target.secret.toggle'}}
+    {{t 'actions.toggle-secret'}}
   </Rose::Button>
   <Copyable
     @text={{@secret}}

--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -478,20 +478,22 @@ $chevron-down: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%231
 .hidden-secret {
   display: flex;
   align-items: center;
-  color: var(--ui-gray-subtler-2);
-
-  .rose-icon {
-    margin-top: sizing.rems(xxxs);
-    margin-right: sizing.rems(s);
-  }
 
   .copyable {
     display: flex;
     width: 100%;
     justify-content: space-between;
+
+    .secret-mask {
+      color: var(--ui-gray-subtler-2);
+    }
+
+    .rose-button-ghost { // Copyable button icon.
+      color: var(--ui-gray-subtler-1);
+    }
   }
 
-  .rose-button-ghost {
-    color: var(--ui-gray-subtler-1);
+  .rose-button-ghost { // Hide/Show secret button icon.
+    color: var(--ui-gray);
   }
 }


### PR DESCRIPTION
Fix style and accessibility issues for hidden secret component.

This PR fixes issues commented in old (already merged) PR, more info [here](https://github.com/hashicorp/boundary-ui/pull/637#pullrequestreview-710864720).

- Fix reveal icon not having clickable area. Made it a button with Icon:
<img width="55" alt="Screen Shot 2021-07-20 at 1 31 49 PM" src="https://user-images.githubusercontent.com/9775006/126391605-ab868bb5-cd79-403d-bbaf-3375719f5a4b.png">

- Fix color issues with reveal icon, secret mask, and secret value:
<img width="572" alt="Screen Shot 2021-07-20 at 1 30 39 PM" src="https://user-images.githubusercontent.com/9775006/126391724-a313e977-16c0-4b0b-b9f9-35d55920fb61.png">

- Fix padding issues with copyable Icon:
<img width="41" alt="Screen Shot 2021-07-20 at 1 34 00 PM" src="https://user-images.githubusercontent.com/9775006/126391840-83d1cb4a-f48e-4c38-bc26-6fca936bd8b4.png">

- Fix accessibility issue, adding a description to the button:
<img width="488" alt="Screen Shot 2021-07-20 at 1 37 31 PM" src="https://user-images.githubusercontent.com/9775006/126392400-18e189c8-6cfa-4085-a28b-dc443d7c03b8.png">
