### PR TITLE
fix: 🐛 update fieldset font weight

### DIFF
--- a/addons/rose/addon/styles/rose/components/form/_fieldset.scss
+++ b/addons/rose/addon/styles/rose/components/form/_fieldset.scss
@@ -5,7 +5,7 @@
   margin-bottom: sizing.rems(m);
 
   .rose-form-fieldset-title {
-    @include type.type(s, bold);
+    @include type.type(s, semibold);
   }
 
   .rose-form-fieldset-description {


### PR DESCRIPTION
Updating `fieldset` weight to be in sync with the label style. conversation [here](https://github.com/hashicorp/boundary-ui/pull/656)