### PR TITLE
fix: Add type field to Credential Library

### DIFF
--- a/addons/api/addon/generated/models/credential-library.js
+++ b/addons/api/addon/generated/models/credential-library.js
@@ -9,6 +9,11 @@ export default class GeneratedCredentialLibraryModel extends BaseModel {
   // =attributes
 
   @attr('string', {
+    description: 'The type of the resource, to help differentiate schemas',
+  })
+  type;
+
+  @attr('string', {
     description: 'The owning credential store ID.',
   })
   credential_store_id;

--- a/addons/api/mirage/factories/credential-library.js
+++ b/addons/api/mirage/factories/credential-library.js
@@ -1,14 +1,20 @@
 import factory from '../generated/factories/credential-library';
 import { random, system } from 'faker';
 
+const types = ['vault'];
+
 export default factory.extend({
   id: (i) => `credential-library-id-${i}`,
+  type: (i) => types[i % types.length],
 
   attributes() {
-    return {
-      http_method: 'GET',
-      http_request_body: random.word(),
-      path: system.directoryPath(),
-    };
+    switch (this.type) {
+      case 'vault':
+        return {
+          http_method: 'GET',
+          http_request_body: random.word(),
+          path: system.directoryPath(),
+        };
+    }
   },
 });

--- a/addons/api/tests/unit/serializers/credential-library-test.js
+++ b/addons/api/tests/unit/serializers/credential-library-test.js
@@ -9,6 +9,7 @@ module('Unit | Serializer | credential library', function (hooks) {
     const store = this.owner.lookup('service:store');
     const serializer = store.serializerFor('credential-library');
     const record = store.createRecord('credential-library', {
+      type: 'vault',
       name: 'Name',
       description: 'Description',
       attributes: {
@@ -20,6 +21,7 @@ module('Unit | Serializer | credential library', function (hooks) {
     const snapshot = record._createSnapshot();
     const serializedRecord = serializer.serialize(snapshot);
     assert.deepEqual(serializedRecord, {
+      type: 'vault',
       credential_store_id: null,
       name: 'Name',
       description: 'Description',
@@ -40,6 +42,7 @@ module('Unit | Serializer | credential library', function (hooks) {
         id: '1',
         type: 'credential-library',
         attributes: {
+          type: 'vault',
           name: 'Name',
           description: 'Description',
           attributes: {
@@ -54,6 +57,7 @@ module('Unit | Serializer | credential library', function (hooks) {
     const snapshot = record._createSnapshot();
     const serializedRecord = serializer.serialize(snapshot);
     assert.deepEqual(serializedRecord, {
+      type: 'vault',
       credential_store_id: null,
       name: 'Name',
       description: 'Description',

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -288,6 +288,8 @@ credential-store:
       title: Welcome to Credential Stores
   actions:
     delete: Delete Credential Store
+  types:
+    vault: Vault
 credential-library:
   title: Credential Library
   title_plural: Credential Libraries
@@ -309,3 +311,5 @@ credential-library:
     http_request_body:
       label: HTTP Method POST Request Body
       help: The body of the HTTP request the library sends to Vault when requesting credentials. Only allowed when HTTP method is set to POST.
+  types:
+    vault: Vault

--- a/ui/admin/app/components/form/credential-library/index.hbs
+++ b/ui/admin/app/components/form/credential-library/index.hbs
@@ -5,6 +5,14 @@
   @showEditToggle={{if @model.isNew false true}}
   as |form|
 >
+
+  <form.input
+    @value={{@model.type}}
+    @label={{t 'form.type.label'}}
+    readonly={{true}}
+    @disabled={{true}}
+  />
+
   <form.input
     @name='name'
     @type='name'

--- a/ui/admin/app/components/form/target/add-credential-libraries/index.hbs
+++ b/ui/admin/app/components/form/target/add-credential-libraries/index.hbs
@@ -17,6 +17,7 @@
         <header.row as |row|>
           <row.headerCell>{{t 'form.id.label'}}</row.headerCell>
           <row.headerCell>{{t 'form.name.label'}}</row.headerCell>
+          <row.headerCell>{{t 'form.type.label'}}</row.headerCell>
         </header.row>
       </table.header>
       <table.body as |body|>
@@ -30,6 +31,13 @@
               />
             </row.headerCell>
             <row.cell>{{credentialLibrary.name}}</row.cell>
+            <row.cell>
+              <Rose::Badge>{{t
+                  (concat
+                    'resources.credential-library.types.' credentialLibrary.type
+                  )
+                }}</Rose::Badge>
+            </row.cell>
           </body.row>
         {{/each}}
       </table.body>

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/new.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/new.js
@@ -8,10 +8,11 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
    * @return {CredentialLibraryModel}
    */
   model() {
-    const { id: credential_store_id } = this.modelFor(
+    const { id: credential_store_id, type } = this.modelFor(
       'scopes.scope.credential-stores.credential-store'
     );
     return this.store.createRecord('credential-library', {
+      type,
       credential_store_id,
     });
   }

--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credential-libraries/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credential-libraries/index.hbs
@@ -4,6 +4,7 @@
     <table.header as |header|>
       <header.row as |row|>
         <row.headerCell>{{t 'form.name.label'}}</row.headerCell>
+        <row.headerCell>{{t 'form.type.label'}}</row.headerCell>
         <row.headerCell>{{t 'form.id.label'}}</row.headerCell>
       </header.row>
     </table.header>
@@ -19,6 +20,13 @@
             </LinkTo>
             <p>{{credentialLibrary.description}}</p>
           </row.headerCell>
+          <row.cell>
+            <Rose::Badge>{{t
+                (concat
+                  'resources.credential-library.types.' credentialLibrary.type
+                )
+              }}</Rose::Badge>
+          </row.cell>
           <row.cell>
             <Copyable
               @text={{credentialLibrary.id}}

--- a/ui/admin/app/templates/scopes/scope/credential-stores/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/index.hbs
@@ -48,7 +48,11 @@
                 <p>{{credentialStore.description}}</p>
               </row.headerCell>
               <row.cell>
-                <Rose::Badge>{{credentialStore.type}}</Rose::Badge>
+                <Rose::Badge>{{t
+                    (concat
+                      'resources.credential-store.types.' credentialStore.type
+                    )
+                  }}</Rose::Badge>
               </row.cell>
               <row.cell>
                 <Copyable

--- a/ui/admin/app/templates/scopes/scope/targets/target/credential-libraries.hbs
+++ b/ui/admin/app/templates/scopes/scope/targets/target/credential-libraries.hbs
@@ -6,6 +6,7 @@
     <table.header as |header|>
       <header.row as |row|>
         <row.headerCell>{{t 'form.name.label'}}</row.headerCell>
+        <row.headerCell>{{t 'form.type.label'}}</row.headerCell>
         <row.headerCell>{{t 'form.id.label'}}</row.headerCell>
       </header.row>
     </table.header>
@@ -24,6 +25,13 @@
             </LinkTo>
             <p>{{credentialLibrary.description}}</p>
           </row.headerCell>
+          <row.cell>
+            <Rose::Badge>{{t
+                (concat
+                  'resources.credential-library.types.' credentialLibrary.type
+                )
+              }}</Rose::Badge>
+          </row.cell>
           <row.cell>
             <Copyable
               @text={{credentialLibrary.id}}


### PR DESCRIPTION
#### Credential Libraries list in a Credential Store:
<img width="1001" alt="Screen Shot 2021-07-27 at 11 52 29" src="https://user-images.githubusercontent.com/111036/127186319-bcd4b11f-a691-4d66-af11-2709ea00605f.png">

#### Create a Credential Library:
<img width="375" alt="Screen Shot 2021-07-27 at 11 52 37" src="https://user-images.githubusercontent.com/111036/127186324-32802cb3-1134-4b7c-a385-9010801e640d.png">

#### View a Credential Library:
<img width="373" alt="Screen Shot 2021-07-27 at 11 52 49" src="https://user-images.githubusercontent.com/111036/127186334-f39e1bae-4a3d-4e8e-8fa6-441cfcbacaf3.png">

#### View Credential Libraries in a Target
<img width="1047" alt="Screen Shot 2021-07-27 at 11 52 56" src="https://user-images.githubusercontent.com/111036/127186350-06ce3834-a694-4279-9f54-83e86299e1f6.png">

#### Add Credential Libraries to a Target
<img width="1311" alt="Screen Shot 2021-07-27 at 11 53 03" src="https://user-images.githubusercontent.com/111036/127186360-6b364115-11d2-49c5-910b-bb071e29b252.png">
