### PR TITLE
refactor: Rename target host sets and credential libraries

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -253,32 +253,36 @@ target:
   actions:
     create: New Target
     delete: Delete Target
-    add-host-sets: Add Host Sets
-    add-credential-libraries: Add Credential Libraries
+    add-host-sets: Add Host Sources
+    add-credential-libraries: Add Credential Sources
   types:
     tcp: TCP
   host-set:
+    title: Host Source
+    title_plural: Host Sources
     messages:
       welcome:
-        title: Welcome to Host Sets
-        description: No hosts sets in this target.
+        title: Welcome to Host Sources
+        description: No hosts sources in this target.
       none:
-        title: No Host Sets Available
-        description: No hosts sets available to add to target.
+        title: No Host Sources Available
+        description: No hosts sources available to add to target.
       add:
-        title: Add Host Sets
-        description: Select host sets to assign to this target.
+        title: Add Host Sources
+        description: Select host sources to assign to this target.
   credential-library:
+    title: Credential Source
+    title_plural: Credential Sources
     messages:
       welcome:
-        title: Welcome to Credential Libraries
-        description: No credential libraries in this target.
+        title: Welcome to Credential Sources
+        description: No credential sources in this target.
       none:
-        title: No Credential Libraries Available
-        description: No credential libraries available to add to this target.
+        title: No Credential Sources Available
+        description: No credential sources available to add to this target.
       add:
-        title: Add Credential Libraries
-        description: Select credential libraries to assign to this target.
+        title: Add Credential Sources
+        description: Select credential sources to assign to this target.
 credential-store:
   title: Credential Store
   title_plural: Credential Stores

--- a/ui/admin/app/components/form/target/add-host-sets/index.hbs
+++ b/ui/admin/app/components/form/target/add-host-sets/index.hbs
@@ -9,7 +9,7 @@
   >
 
     <form.actions
-      @submitText={{t 'actions.add-host-sets'}}
+      @submitText={{t 'resources.target.actions.add-host-sets'}}
       @cancelText={{t 'actions.cancel'}}
     />
 

--- a/ui/admin/app/templates/scopes/scope/targets/target/-navigation.hbs
+++ b/ui/admin/app/templates/scopes/scope/targets/target/-navigation.hbs
@@ -3,11 +3,11 @@
     {{t 'titles.details'}}
   </nav.link>
   <nav.link @route='scopes.scope.targets.target.host-sets'>
-    {{t 'resources.host-set.title_plural'}}
+    {{t 'resources.target.host-set.title_plural'}}
   </nav.link>
   {{#if (feature-flag 'credential-store')}}
     <nav.link @route='scopes.scope.targets.target.credential-libraries'>
-      {{t 'resources.credential-library.title_plural'}}
+      {{t 'resources.target.credential-library.title_plural'}}
     </nav.link>
   {{/if}}
 </Rose::Nav::Tabs>

--- a/ui/admin/app/templates/scopes/scope/targets/target/credential-libraries.hbs
+++ b/ui/admin/app/templates/scopes/scope/targets/target/credential-libraries.hbs
@@ -1,4 +1,4 @@
-{{page-title (t 'resources.credential-library.title_plural')}}
+{{page-title (t 'resources.target.credential-library.title_plural')}}
 
 {{#if @model.credentialLibraries}}
 
@@ -79,6 +79,12 @@
       <message.description>
         {{t 'resources.target.credential-library.messages.welcome.description'}}
       </message.description>
+      <message.link
+        @route='scopes.scope.targets.target.add-credential-libraries'
+      >
+        <Rose::Icon @name='plus-circle-outline' />
+        {{t 'resources.target.actions.add-credential-libraries'}}
+      </message.link>
     </Rose::Message>
   </Rose::Layout::Centered>
 

--- a/ui/admin/app/templates/scopes/scope/targets/target/host-sets.hbs
+++ b/ui/admin/app/templates/scopes/scope/targets/target/host-sets.hbs
@@ -1,4 +1,4 @@
-{{page-title (t 'resources.host-set.title_plural')}}
+{{page-title (t 'resources.target.host-set.title_plural')}}
 
 {{#if @model.hostSets}}
 


### PR DESCRIPTION
Rename to Target Host Sources and Target Credential Sources.

#### Target tabs and actions
<img width="1164" alt="Screen Shot 2021-07-29 at 14 09 34" src="https://user-images.githubusercontent.com/111036/127544945-74207d3b-6cd8-43c2-bc0b-4969b6cee161.png">

<img width="691" alt="Screen Shot 2021-07-29 at 14 11 56" src="https://user-images.githubusercontent.com/111036/127545142-1fc47314-6108-41d7-b651-61c0e2e5b11b.png">

<img width="741" alt="Screen Shot 2021-07-29 at 14 13 23" src="https://user-images.githubusercontent.com/111036/127545158-2b23b90e-c17b-46c6-883f-99966838a648.png">


#### Host source association view
<img width="360" alt="Screen Shot 2021-07-29 at 14 11 14" src="https://user-images.githubusercontent.com/111036/127545063-6168d8a7-7185-459c-bc70-224a71d54e2f.png">

<img width="726" alt="Screen Shot 2021-07-29 at 14 13 56" src="https://user-images.githubusercontent.com/111036/127545188-7d076a13-917c-48a0-a3d3-6f2086f89748.png">

#### Credential source association view
<img width="391" alt="Screen Shot 2021-07-29 at 14 09 49" src="https://user-images.githubusercontent.com/111036/127545052-ed55e4e9-6942-43f3-89cd-efb95710bdf2.png">

<img width="754" alt="Screen Shot 2021-07-29 at 14 14 18" src="https://user-images.githubusercontent.com/111036/127545206-02faef0a-5ac2-4e67-9309-73d9a5222326.png">

