### PR TITLE
chore: 🤖 Update xmldom dependency resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "mem": "^4.0.0",
     "minimist": "^1.2.3",
     "normalize-url": "^4.5.1",
-    "glob-parent": "^5.1.2"
+    "glob-parent": "^5.1.2",
+    "xmldom": "github:xmldom/xmldom#0.7.0"
   },
   "config": {
     "commitizen": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21927,15 +21927,9 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmldom@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
-  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
-
-xmldom@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.6.0.tgz#43a96ecb8beece991cef382c08397d82d4d0c46f"
-  integrity sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==
+xmldom@^0.5.0, xmldom@^0.6.0, "xmldom@github:xmldom/xmldom#0.7.0":
+  version "0.7.0"
+  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/c568938641cc1f121cef5b4df80fcfda1e489b6e"
 
 xmlhttprequest-ssl@^1.6.2:
   version "1.6.3"


### PR DESCRIPTION
Update xmldom transitive dependency resolution to avoid a security vulnerability.

**Readme before reviews:**
The maintainer of the project is having an issue to publish the latest version on NPM, they are working on it, in the meantime they recommend to resolve the package against their GH repo. [More info about it here](https://github.com/xmldom/xmldom/issues/271).

I already set a reminder on my calendar to check this periodically until the issuue is resolved, then I will provide a PR to delete the resolution with gh in favour of npm.