### PR TITLE
chore: 🤖 Fix missing target in sessions scenarios in mirage

### DIFF
--- a/addons/api/mirage/scenarios/default.js
+++ b/addons/api/mirage/scenarios/default.js
@@ -47,8 +47,9 @@ export default function (server) {
   // Other resources
   server.schema.scopes.where({ type: 'project' }).models.forEach((scope) => {
     server.createList('host-catalog', 2, { scope }, 'withChildren');
-    server.createList('session', 4, { scope }, 'withAssociations');
     server.createList('credential-store', 3, { scope }, 'withAssociations');
     server.createList('target', 2, { scope }, 'withAssociations');
+    // Sessions have target data. Create it after targets.
+    server.createList('session', 4, { scope }, 'withAssociations');
   });
 }


### PR DESCRIPTION
When viewing sessions in desktop client with mirage enabled, missing target information blocks view from rendering. This is due to sessions mock data being generated before targets. Fix is to generate target mock data before sessions so that sessions will have targets available for assignment.

Error:
```
vendor.js:80053 Uncaught (in promise) Error: Expected id to be a string or number, received null
    at ensureStringId (vendor.js:80053)
    at Store.peekRecord (vendor.js:88151)
    at SessionModel.get target [as target] (vendor.js:95825)
    at getPossibleMandatoryProxyValue (vendor.js:13974)
    at _getProp (vendor.js:14039)
    at vendor.js:46608
    at vendor.js:46556
    at track (vendor.js:55304)
    at valueForRef (vendor.js:46555)
    at vendor.js:46605
```