### PR TITLE
chore: 🤖 adds support for development capabilities toggle

### DIFF
--- a/addons/api/mirage/factories/account.js
+++ b/addons/api/mirage/factories/account.js
@@ -1,8 +1,15 @@
 import factory from '../generated/factories/account';
 import { random, internet } from 'faker';
+import permissions from '../helpers/permissions';
 
 export default factory.extend({
-  authorized_actions: () => ['no-op', 'read', 'update', 'delete'],
+  authorized_actions: () =>
+    permissions.authorizedActionsFor('account') || [
+      'no-op',
+      'read',
+      'update',
+      'delete',
+    ],
   attributes() {
     switch (this.type) {
       case 'password':

--- a/addons/api/mirage/helpers/permissions.js
+++ b/addons/api/mirage/helpers/permissions.js
@@ -1,0 +1,58 @@
+import { copy } from 'ember-copy';
+
+/**
+ * Allows development-time toggling of resource permissions via the window
+ * querystring.  Pass a JSON object into the query to toggle permissions.
+ * Note that the value must be a valid JSON object in order to be parsed.
+ *
+ * @example
+ *   ?authorized_actions={"account": ["read"]}
+ *
+ * Within a Mirage factory, pass the actions into the mock:
+ *
+ * @example
+ *   import { Factory } from 'ember-cli-mirage';
+ *   import permissions from '../helpers/permissions';
+ *
+ *   export default Factory.extend({
+ *     authorized_actions: () =>
+ *       permissions.authorizedActionsFor('account') ||
+ *       ['no-op', 'read', 'update', 'delete']
+ *   });
+ */
+class ToggledCapabilities {
+  // =attributes
+
+  // Get the query string and drop the leading '?'
+  #rawQuery = window.location.search.substring(1);
+
+  // Split the querystring into key/value pairs
+  #queryPairs = this.#rawQuery.split('&').map((item) => item.split('='));
+
+  // Find the value of a pair with key `authorized_actions`
+  // Safe-ish when the item is not present
+  #rawAuthorizedActions = (this.#queryPairs.find(
+    (item) => item[0] === 'authorized_actions'
+  ) || [])[1];
+
+  // Safe-ish when the value is not present
+  #authorizedActions =
+    JSON.parse(
+      decodeURIComponent(this.#rawAuthorizedActions || '') || 'null'
+    ) || {};
+
+  // =methods
+
+  /**
+   * Returns authorized actions for the specified field, if any are defined
+   * in the `authorized_actions` query.  Returns undefined otherwise.
+   * @return {?string[]}
+   */
+  authorizedActionsFor(field) {
+    if (this.#authorizedActions[field]) {
+      return copy(this.#authorizedActions[field], true);
+    }
+  }
+}
+
+export default new ToggledCapabilities();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7680,7 +7680,7 @@ debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -12389,7 +12389,7 @@ import-lazy@^4.0.0:
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
   integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -14073,11 +14073,6 @@ lodash._baseflatten@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -14086,15 +14081,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
 
 lodash._createassigner@^3.0.0:
   version "3.1.1"
@@ -14105,19 +14095,12 @@ lodash._createassigner@^3.0.0:
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
 
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -14335,7 +14318,7 @@ lodash.pick@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
   integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=


### PR DESCRIPTION
This PR adds development time support for capabilities toggling on mock resources.  To use the toggle, add a query string to the URL, with as many resources and permissions as desired.  For convenience, these should persist even as you navigate through the application.  Example:

`?authorized_actions={"account": ["read"]}`

Note that this feature is provided as a convenience and does not come with rigorous tests.  As it is only intended for use by our Mirage mocks, it only needs to be just _good enough_ to solve the development use case (and not cause tests to fail).