### PR TITLE
chore: 🤖 Delete xmldom from resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "normalize-url": "^4.5.1",
     "glob-parent": "^5.1.2",
     "tar": "^6.1.2",
-    "xmldom": "github:xmldom/xmldom#0.7.0",
     "path-parse": "^1.0.7"
   },
   "config": {

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -42,7 +42,6 @@
   },
   "resolutions": {
     "highlight.js": "^10.4.1",
-    "xmldom": "~0.5.0",
     "yargs-parser": "~20.2.7",
     "trim-newlines": "^3.0.1",
     "normalize-url": "^4.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21696,9 +21696,10 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmldom@^0.6.0, "xmldom@github:xmldom/xmldom#0.7.0":
-  version "0.7.0"
-  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/c568938641cc1f121cef5b4df80fcfda1e489b6e"
+xmldom@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.6.0.tgz#43a96ecb8beece991cef382c08397d82d4d0c46f"
+  integrity sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==
 
 xmlhttprequest-ssl@^1.6.2:
   version "1.6.3"


### PR DESCRIPTION
Delete xmldom transitive dependency from resolutions.

**Why this is happening?:** XLMDOM is a transitive dependency which we were forcing to resolve above certain version due to security vulnerabilities. This library now changed its name space in the NPM registry, so this will not work anymore. It will keep resolving a version with security vulnerabilities. [More information about their name space change](https://github.com/xmldom/xmldom/issues/271).

**What are next steps to solve this issue?** Because this is a transitive dependency, we are going to follow up what dependencies are bringing XLMDOM and updating them. Is the best we can do. I already checked `testem` one dependency that brings XLMDOM and they already update to the new namespace, [prove here](https://github.com/testem/testem/blob/master/package.json#L24). 