### PR TITLE
Bump flight icons

### DIFF
--- a/addons/core/addon/components/doc-link/index.hbs
+++ b/addons/core/addon/components/doc-link/index.hbs
@@ -4,5 +4,5 @@
   target="_blank"
   rel="noreferrer noopener"
   title={{t "actions.get-topic-help"}}>
-  <Rose::Icon @name="flight-icons/help-24" @size={{@iconSize}} />
+  <Rose::Icon @name="flight-icons/svg/help-24" @size={{@iconSize}} />
 </a>

--- a/addons/core/addon/components/error/message/index.js
+++ b/addons/core/addon/components/error/message/index.js
@@ -28,11 +28,11 @@ export default class ErrorMessageComponent extends MessageComponent {
   get icon() {
     switch (this.args.status) {
       case '404':
-        return 'flight-icons/help-16';
+        return 'flight-icons/svg/help-16';
       case '401':
       case '403':
       default:
-        return 'flight-icons/alert-circle-16';
+        return 'flight-icons/svg/alert-circle-16';
     }
   }
 

--- a/addons/rose/addon/components/rose/badge/index.stories.mdx
+++ b/addons/rose/addon/components/rose/badge/index.stories.mdx
@@ -13,7 +13,7 @@ When style definition isn't supplied, a default style will be supplied.
 Styles: outline, dark, informational, informational-outline, success, success-outline, error, error-outline, warning, warning-outline, alert, alert-outline
 
 ```html
-<Rose::Badge @style="outline" @icon="flight-icons/org-16">Badge</Rose::Badge>
+<Rose::Badge @style="outline" @icon="flight-icons/svg/org-16">Badge</Rose::Badge>
 ```
 
 <Preview>
@@ -43,9 +43,9 @@ Styles: outline, dark, informational, informational-outline, success, success-ou
         'none'
       ),
       icon: select('icon', {
-          'flight-icons/org-16': 'flight-icons/org-16',
+          'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
         },
-        'flight-icons/org-16'
+        'flight-icons/svg/org-16'
       ),
     }
   }}</Story>
@@ -56,7 +56,7 @@ Styles: outline, dark, informational, informational-outline, success, success-ou
     template: hbs`
     <Rose::Badge>default style</Rose::Badge>
     <Rose::Badge @style="outline">outline</Rose::Badge>
-    <Rose::Badge @icon="flight-icons/org-16">default style with icon</Rose::Badge>
+    <Rose::Badge @icon="flight-icons/svg/org-16">default style with icon</Rose::Badge>
     <Rose::Badge @style="dark">dark</Rose::Badge>
     <Rose::Badge @style="informational">informational</Rose::Badge>
     <Rose::Badge @style="informational-outline">informational-outline</Rose::Badge>

--- a/addons/rose/addon/components/rose/button/index.stories.mdx
+++ b/addons/rose/addon/components/rose/button/index.stories.mdx
@@ -12,7 +12,7 @@ to trigger actions or to submit forms.  Avoid using buttons as simple links to
 other routes.  For accessibility, use links instead.
 
 ```htmlbars
-<Rose::Button @style="primary" @iconRight="flight-icons/entry-point-16">
+<Rose::Button @style="primary" @iconRight="flight-icons/svg/entry-point-16">
   Action
 </Rose::Button>
 ```
@@ -49,18 +49,18 @@ other routes.  For accessibility, use links instead.
       iconLeft: select(
         'iconLeft',
         {
-          'flight-icons/check-circle-16': 'flight-icons/check-circle-16',
-          'flight-icons/clipboard-copy-16': 'flight-icons/clipboard-copy-16',
+          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
+          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
         },
-        'flight-icons/check-circle-16'
+        'flight-icons/svg/check-circle-16'
       ),
       iconRight: select(
         'iconRight',
         {
-          'flight-icons/check-circle-16': 'flight-icons/check-circle-16',
-          'flight-icons/clipboard-copy-16': 'flight-icons/clipboard-copy-16',
+          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
+          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
         },
-        'flight-icons/clipboard-copy-16'
+        'flight-icons/svg/clipboard-copy-16'
       ),
       onClick: action('clicked'),
     },
@@ -81,10 +81,10 @@ button in this case for accessibility.
       iconOnly: select(
         'iconOnly',
         {
-          'flight-icons/check-circle-16': 'flight-icons/check-circle-16',
-          'flight-icons/clipboard-copy-16': 'flight-icons/clipboard-copy-16',
+          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
+          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
         },
-        'flight-icons/check-circle-16'
+        'flight-icons/svg/check-circle-16'
       ),
     },
   }}</Story>

--- a/addons/rose/addon/components/rose/card/link/index.stories.mdx
+++ b/addons/rose/addon/components/rose/card/link/index.stories.mdx
@@ -13,7 +13,7 @@ Card link component wraps content with `LinkTo` component. Supports title and de
   @title='Card title'
   @description='Card description'
   @id='resource_id_1234'
-  @icon='flight-icons/org-16'
+  @icon='flight-icons/svg/org-16'
   @route='about'/>
 ```
 
@@ -32,9 +32,9 @@ Card link component wraps content with `LinkTo` component. Supports title and de
       description: text('description', 'Card description'),
       id: text('id', 'resource_id_1234'),
       icon: select('icon', {
-          'flight-icons/org-16': 'flight-icons/org-16',
+          'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
         },
-        'flight-icons/org-16'
+        'flight-icons/svg/org-16'
       ),
     },
   }}</Story>

--- a/addons/rose/addon/components/rose/cards/index.stories.mdx
+++ b/addons/rose/addon/components/rose/cards/index.stories.mdx
@@ -18,35 +18,35 @@ A set of cards arranged side-by-side.
           @title="Card Title"
           @description="Description"
           @id="resource_id_1234"
-          @icon="flight-icons/org-16"
+          @icon="flight-icons/svg/org-16"
         />
         <cards.link
           @route="index"
           @title="Card Title"
           @description="Description"
           @id="resource_id_1234"
-          @icon="flight-icons/org-16"
+          @icon="flight-icons/svg/org-16"
         />
         <cards.link
           @route="index"
           @title="Card Title"
           @description="Description"
           @id="resource_id_1234"
-          @icon="flight-icons/org-16"
+          @icon="flight-icons/svg/org-16"
         />
         <cards.link
           @route="index"
           @title="Card Title"
           @description="Description"
           @id="resource_id_1234"
-          @icon="flight-icons/org-16"
+          @icon="flight-icons/svg/org-16"
         />
         <cards.link
           @route="index"
           @title="Card Title"
           @description="Description"
           @id="resource_id_1234"
-          @icon="flight-icons/org-16"
+          @icon="flight-icons/svg/org-16"
         />
       </Rose::Cards>
     `,
@@ -62,14 +62,14 @@ A set of cards arranged side-by-side.
     @title="Card Title"
     @description="Description"
     @id="resource_id_1234"
-    @icon="flight-icons/org-16"
+    @icon="flight-icons/svg/org-16"
   />
   <cards.link
     @route="index"
     @title="Card Title"
     @description="Description"
     @id="resource_id_1234"
-    @icon="flight-icons/org-16"
+    @icon="flight-icons/svg/org-16"
   />
 </Rose::Cards>
 ```

--- a/addons/rose/addon/components/rose/dialog/index.hbs
+++ b/addons/rose/addon/components/rose/dialog/index.hbs
@@ -27,7 +27,7 @@
         title={{@dismissButtonText}}
         {{on "click" (fn this.dismiss @dismiss)}}
       >
-        <Rose::Icon @name="flight-icons/x-16" @size="small" />
+        <Rose::Icon @name="flight-icons/svg/x-16" @size="small" />
       </button>
 
     </header>
@@ -62,7 +62,7 @@
           title={{@dismissButtonText}}
           {{on "click" (fn this.dismiss @dismiss)}}
         >
-          <Rose::Icon @name="flight-icons/x-16" @size="small" />
+          <Rose::Icon @name="flight-icons/svg/x-16" @size="small" />
         </button>
 
       </header>

--- a/addons/rose/addon/components/rose/dialog/index.stories.mdx
+++ b/addons/rose/addon/components/rose/dialog/index.stories.mdx
@@ -36,10 +36,10 @@ A dialog component with optional modal capabilities.
       icon: select(
         'icon',
         {
-          'flight-icons/check-circle-16': 'flight-icons/check-circle-16',
-          'flight-icons/clipboard-copy-16': 'flight-icons/clipboard-copy-16',
+          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
+          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
         },
-        'flight-icons/check-circle-16'
+        'flight-icons/svg/check-circle-16'
       ),
       style: select(
         'style',
@@ -58,7 +58,7 @@ A dialog component with optional modal capabilities.
 <Rose::Dialog
   @modal={{true}}
   @dismiss={{@dismissFn}}
-  @icon="flight-icons/check-circle-16"
+  @icon="flight-icons/svg/check-circle-16"
   @heading="Heading"
   @dismissButtonText="Dismiss"
 as |dialog|>

--- a/addons/rose/addon/components/rose/dropdown/index.stories.mdx
+++ b/addons/rose/addon/components/rose/dropdown/index.stories.mdx
@@ -11,7 +11,7 @@ A simple dropdown component with support for links and buttons.
 <Preview>
   <Story name="Basic Dropdown" height="7rem">{{
     template: hbs`
-      <Rose::Dropdown @text="Choose One&hellip;" @icon="flight-icons/org-16" @showCaret={{showCaret}} as |dropdown|>
+      <Rose::Dropdown @text="Choose One&hellip;" @icon="flight-icons/svg/org-16" @showCaret={{showCaret}} as |dropdown|>
         <dropdown.link @route="index">Menu item</dropdown.link>
         <dropdown.link @route="about">Menu item</dropdown.link>
         <dropdown.separator />
@@ -31,7 +31,7 @@ A simple dropdown component with support for links and buttons.
 <Preview>
   <Story name="Icon-only Dropdown" height="5rem">{{
     template: hbs`
-      <Rose::Dropdown @text="Choose One&hellip;" @icon="flight-icons/org-16" @iconOnly={{true}} as |dropdown|>
+      <Rose::Dropdown @text="Choose One&hellip;" @icon="flight-icons/svg/org-16" @iconOnly={{true}} as |dropdown|>
         <dropdown.link @route="index">Menu item</dropdown.link>
         <dropdown.link @route="about">Menu item</dropdown.link>
         <dropdown.separator />
@@ -117,7 +117,7 @@ Dropdown supports `danger` styling through `style` attribute.
 Dropdown indicator can be hidden using `showCaret` attribute.
 
 ```html
-<Rose::Dropdown @showCaret={{true}} @icon="flight-icons/more-horizontal-16" as |dropdown|>
+<Rose::Dropdown @showCaret={{true}} @icon="flight-icons/svg/more-horizontal-16" as |dropdown|>
     <dropdown.link @route="index">Menu item</dropdown.link>
     <dropdown.button>Button menu item</dropdown.button>
 </Rose::Dropdown>

--- a/addons/rose/addon/components/rose/form/errors/message/index.hbs
+++ b/addons/rose/addon/components/rose/form/errors/message/index.hbs
@@ -1,4 +1,4 @@
 <p class="rose-form-error-message" ...attributes>
-  <Rose::Icon @name="flight-icons/x-square-16" @size="medium" />
+  <Rose::Icon @name="flight-icons/svg/x-square-16" @size="medium" />
   {{yield}}
 </p>

--- a/addons/rose/addon/components/rose/form/radio/group/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/radio/group/index.stories.mdx
@@ -68,10 +68,10 @@ Renders a form radiofield group.
     firstFieldIcon: select(
       'first icon',
       {
-        'flight-icons/org-16': 'flight-icons/org-16',
-        'flight-icons/clipboard-copy-16': 'flight-icons/clipboard-copy-16',
+        'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
+        'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
       },
-      'flight-icons/org-16'
+      'flight-icons/svg/org-16'
     ),
     secondFieldLabel: text('second label', 'Maybe'),
     secondFieldValue: text('second value', 'maybe'),

--- a/addons/rose/addon/components/rose/form/radio/radio/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/radio/radio/index.stories.mdx
@@ -44,8 +44,8 @@ Renders a form radiofield.
         'icon',
         {
           'none': null,
-          'flight-icons/org-16': 'flight-icons/org-16',
-          'flight-icons/clipboard-copy-16': 'flight-icons/clipboard-copy-16',
+          'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
+          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
         },
         null
       ),
@@ -109,8 +109,8 @@ Renders a form radiofield.
         'icon',
         {
           'none': null,
-          'flight-icons/org-16': 'flight-icons/org-16',
-          'flight-icons/clipboard-copy-16': 'flight-icons/clipboard-copy-16',
+          'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
+          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
         },
         null
       ),

--- a/addons/rose/addon/components/rose/header/index.stories.mdx
+++ b/addons/rose/addon/components/rose/header/index.stories.mdx
@@ -27,7 +27,7 @@ A header component that allows three distinct sections to be configured: brand, 
     <utilities.dropdown
       @text="user@example.net"
       @iconOnly={{true}}
-      @icon="flight-icons/user-circle-16" as |dropdown|
+      @icon="flight-icons/svg/user-circle-16" as |dropdown|
     >
       <dropdown.link @route="index">Menu item</dropdown.link>
       <dropdown.link @route="about">Menu item</dropdown.link>
@@ -69,11 +69,11 @@ A header component that allows three distinct sections to be configured: brand, 
       dropdownIcon: select(
         'dropdownIcon',
         {
-          'flight-icons/user-circle-16': 'flight-icons/user-circle-16',
-          'flight-icons/check-circle-16': 'flight-icons/check-circle-16',
-          'flight-icons/clipboard-copy-16': 'flight-icons/clipboard-copy-16',
+          'flight-icons/svg/user-circle-16': 'flight-icons/svg/user-circle-16',
+          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
+          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
         },
-        'flight-icons/user-circle-16'
+        'flight-icons/svg/user-circle-16'
       ),
     },
   }}</Story>

--- a/addons/rose/addon/components/rose/icon/index.stories.mdx
+++ b/addons/rose/addon/components/rose/icon/index.stories.mdx
@@ -22,10 +22,10 @@ Renders a simple icon.
       name: select(
         'name',
         {
-          'flight-icons/check-circle-16': 'flight-icons/check-circle-16',
-          'flight-icons/clipboard-copy-16': 'flight-icons/clipboard-copy-16',
+          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
+          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
         },
-        'flight-icons/check-circle-16'
+        'flight-icons/svg/check-circle-16'
       ),
     }
   }}</Story>

--- a/addons/rose/addon/components/rose/link-button/index.stories.mdx
+++ b/addons/rose/addon/components/rose/link-button/index.stories.mdx
@@ -12,7 +12,7 @@ Styles supported: primary, secondary, warning, and ghost.
 Disabling link button is not supported as it is an action on form components only.
 
 ```html
-<Rose::LinkButton @route="index" @style="primary" @iconRight="flight-icons/entry-point-16">
+<Rose::LinkButton @route="index" @style="primary" @iconRight="flight-icons/svg/entry-point-16">
   Content
 </Rose::LinkButton>
 ```
@@ -45,18 +45,18 @@ Disabling link button is not supported as it is an action on form components onl
       iconLeft: select(
         'iconLeft',
         {
-          'flight-icons/check-circle-16': 'flight-icons/check-circle-16',
-          'flight-icons/clipboard-copy-16': 'flight-icons/clipboard-copy-16',
+          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
+          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
         },
-        'flight-icons/clipboard-copy-16'
+        'flight-icons/svg/clipboard-copy-16'
       ),
       iconRight: select(
         'iconRight',
         {
-          'flight-icons/check-circle-16': 'flight-icons/check-circle-16',
-          'flight-icons/clipboard-copy-16': 'flight-icons/clipboard-copy-16',
+          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
+          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
         },
-        'flight-icons/clipboard-copy-16'
+        'flight-icons/svg/clipboard-copy-16'
       ),
     },
   }}</Story>
@@ -65,7 +65,7 @@ Disabling link button is not supported as it is an action on form components onl
 Similar to `Rose::Button`, icon only link button is supported.
 
 ```html
-<Rose::LinkButton @route="index" @style="primary" @iconOnly="flight-icons/help-16" />
+<Rose::LinkButton @route="index" @style="primary" @iconOnly="flight-icons/svg/help-16" />
 ```
 
 <Preview>
@@ -88,10 +88,10 @@ Similar to `Rose::Button`, icon only link button is supported.
       iconOnly: select(
         'iconOnly',
         {
-          'flight-icons/check-circle-16': 'flight-icons/check-circle-16',
-          'flight-icons/help-16': 'flight-icons/help-16',
+          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
+          'flight-icons/svg/help-16': 'flight-icons/svg/help-16',
         },
-        'flight-icons/help-16'
+        'flight-icons/svg/help-16'
       ),
     },
   }}</Story>

--- a/addons/rose/addon/components/rose/list/key-value/index.stories.mdx
+++ b/addons/rose/addon/components/rose/list/key-value/index.stories.mdx
@@ -46,7 +46,7 @@ A simple key/value list with support for embedded form fields and buttons.
             <input.field />
           </item.cell>
           <item.cell>
-            <Rose::Button @style="secondary" @iconOnly="flight-icons/trash-16" title="Remove">Remove</Rose::Button>
+            <Rose::Button @style="secondary" @iconOnly="flight-icons/svg/trash-16" title="Remove">Remove</Rose::Button>
           </item.cell>
         </list.item>
       </Rose::Form::Input>
@@ -94,7 +94,7 @@ A simple key/value list with support for embedded form fields and buttons.
         <input.field />
       </item.cell>
       <item.cell>
-        <Rose::Button @style="secondary" @iconOnly="flight-icons/trash-16" title="Remove">Remove</Rose::Button>
+        <Rose::Button @style="secondary" @iconOnly="flight-icons/svg/trash-16" title="Remove">Remove</Rose::Button>
       </item.cell>
     </list.item>
   </Rose::Form::Input>

--- a/addons/rose/addon/components/rose/message/index.stories.mdx
+++ b/addons/rose/addon/components/rose/message/index.stories.mdx
@@ -18,7 +18,7 @@ Title can be configured with optional icon and subtitle.
         {{description}}
       </message.description>
       <message.link @route="index">
-        <Rose::Icon @name="flight-icons/chevron-left-16" />
+        <Rose::Icon @name="flight-icons/svg/chevron-left-16" />
         Go back
       </message.link>
       <message.link @route="index">
@@ -33,23 +33,23 @@ Title can be configured with optional icon and subtitle.
       icon: select(
         'icon',
         {
-          'flight-icons/alert-circle-16': 'flight-icons/alert-circle-16',
-          'flight-icons/help-16': 'flight-icons/help-16',
+          'flight-icons/svg/alert-circle-16': 'flight-icons/svg/alert-circle-16',
+          'flight-icons/svg/help-16': 'flight-icons/svg/help-16',
         },
-        'flight-icons/help-16'
+        'flight-icons/svg/help-16'
       ),
     },
   }}</Story>
 </Preview>
 
 ```html
-<Rose::Message @title="Page not found" @subtitle="Error 404" @icon="flight-icons/alert-circle-16" as |message|>
+<Rose::Message @title="Page not found" @subtitle="Error 404" @icon="flight-icons/svg/alert-circle-16" as |message|>
   <message.description>
       You must be granted permissions to view this data. Ask your administrator
       if you think you should have access.
   </message.description>
   <message.link @route="index">
-    <Rose::Icon @name="flight-icons/chevron-left-16" />
+    <Rose::Icon @name="flight-icons/svg/chevron-left-16" />
     Go back
   </message.link>
   <message.link @route="index">Need help?</message.link>

--- a/addons/rose/addon/components/rose/notification/index.hbs
+++ b/addons/rose/addon/components/rose/notification/index.hbs
@@ -26,7 +26,7 @@
       {{on "click" @dismiss}}
     >
       <Rose::Icon
-        @name="flight-icons/x-16"
+        @name="flight-icons/svg/x-16"
         @size="medium" />
       <span class="rose-notification-dismiss-text">
         {{@dismissText}}

--- a/addons/rose/addon/components/rose/notification/index.js
+++ b/addons/rose/addon/components/rose/notification/index.js
@@ -8,17 +8,17 @@ export default class RoseNotificationComponent extends Component {
    */
   @computed('style')
   get icon() {
-    let icon = 'flight-icons/info-16';
+    let icon = 'flight-icons/svg/info-16';
 
     switch (this.style) {
       case 'error':
-        icon = 'flight-icons/x-square-16';
+        icon = 'flight-icons/svg/x-square-16';
         break;
       case 'success':
-        icon = 'flight-icons/check-circle-16';
+        icon = 'flight-icons/svg/check-circle-16';
         break;
       case 'warning':
-        icon = 'flight-icons/alert-triangle-16';
+        icon = 'flight-icons/svg/alert-triangle-16';
         break;
     }
 

--- a/addons/rose/addon/components/rose/table/index.stories.mdx
+++ b/addons/rose/addon/components/rose/table/index.stories.mdx
@@ -122,7 +122,7 @@ Cell shrink should be applied to all the cells in a row. Otherwise the bigger ce
               </Rose::Form::Input>
             </row.cell>
             <row.cell @shrink={{true}} @alignRight={{true}}>
-              <Rose::Button @style="secondary" @iconOnly="flight-icons/trash-16" title="Remove">Remove</Rose::Button>
+              <Rose::Button @style="secondary" @iconOnly="flight-icons/svg/trash-16" title="Remove">Remove</Rose::Button>
             </row.cell>
           </body.row>
           <body.row as |row|>

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -43,7 +43,7 @@
     "@ember/test-helpers": "^2.2.8",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
-    "@hashicorp/flight-icons": "0.0.6-beta",
+    "@hashicorp/flight-icons": "0.0.9-beta",
     "@storybook/addon-actions": "^6.3.1",
     "@storybook/addon-docs": "^6.3.1",
     "@storybook/addon-knobs": "^6.3.0",

--- a/addons/rose/tests/dummy/app/templates/playground.hbs
+++ b/addons/rose/tests/dummy/app/templates/playground.hbs
@@ -19,7 +19,7 @@
         <utilities.dropdown
           @text="user@example.net"
           @iconOnly={{true}}
-          @icon="flight-icons/user-circle-16" as |dropdown|
+          @icon="flight-icons/svg/user-circle-16" as |dropdown|
         >
           <dropdown.link @route="index">Menu item</dropdown.link>
           <dropdown.link @route="about">Menu item</dropdown.link>
@@ -82,7 +82,7 @@
                 <input.field />
               </item.cell>
               <item.cell>
-                <Rose::Button @style="secondary" @iconOnly="flight-icons/trash-16" title="Remove">Remove</Rose::Button>
+                <Rose::Button @style="secondary" @iconOnly="flight-icons/svg/trash-16" title="Remove">Remove</Rose::Button>
               </item.cell>
             </list.item>
           </Rose::Form::Input>

--- a/addons/rose/tests/integration/components/rose/badge-test.js
+++ b/addons/rose/tests/integration/components/rose/badge-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | rose/badge', function (hooks) {
   });
 
   test('it renders an icon using @icon', async function (assert) {
-    await render(hbs`<Rose::Badge @icon="flight-icons/entry-point-16" />`);
+    await render(hbs`<Rose::Badge @icon="flight-icons/svg/entry-point-16" />`);
     assert.ok(find('.rose-icon'));
   });
 

--- a/addons/rose/tests/integration/components/rose/button-test.js
+++ b/addons/rose/tests/integration/components/rose/button-test.js
@@ -35,18 +35,18 @@ module('Integration | Component | rose/button', function (hooks) {
 
   test('it supports left and right icons', async function (assert) {
     await render(
-      hbs`<Rose::Button @iconLeft="flight-icons/chevron-left-16" />`
+      hbs`<Rose::Button @iconLeft="flight-icons/svg/chevron-left-16" />`
     );
     assert.ok(find('.has-icon-left .rose-icon'));
     await render(
-      hbs`<Rose::Button @iconRight="flight-icons/chevron-left-16" />`
+      hbs`<Rose::Button @iconRight="flight-icons/svg/chevron-left-16" />`
     );
     assert.ok(find('.has-icon-right .rose-icon'));
   });
 
   test('it supports an icon-only type', async function (assert) {
     await render(
-      hbs`<Rose::Button @iconOnly="flight-icons/chevron-left-16" />`
+      hbs`<Rose::Button @iconOnly="flight-icons/svg/chevron-left-16" />`
     );
     assert.ok(find('.has-icon-only .rose-icon'));
   });

--- a/addons/rose/tests/integration/components/rose/card/link-test.js
+++ b/addons/rose/tests/integration/components/rose/card/link-test.js
@@ -42,7 +42,7 @@ module('Integration | Component | rose/card/link', function (hooks) {
 
   test('it renders with @icon', async function (assert) {
     await render(
-      hbs`<Rose::Card::Link @title="foo" @icon="flight-icons/alert-circle-16" />`
+      hbs`<Rose::Card::Link @title="foo" @icon="flight-icons/svg/alert-circle-16" />`
     );
     assert.ok(find('.rose-icon'));
   });

--- a/addons/rose/tests/integration/components/rose/dropdown-test.js
+++ b/addons/rose/tests/integration/components/rose/dropdown-test.js
@@ -24,7 +24,9 @@ module('Integration | Component | rose/dropdown', function (hooks) {
   });
 
   test('it supports an icon', async function (assert) {
-    await render(hbs`<Rose::Dropdown @icon="flight-icons/user-circle-16" />`);
+    await render(
+      hbs`<Rose::Dropdown @icon="flight-icons/svg/user-circle-16" />`
+    );
     assert.ok(find('svg'));
   });
 

--- a/addons/rose/tests/integration/components/rose/dropdown/button-test.js
+++ b/addons/rose/tests/integration/components/rose/dropdown/button-test.js
@@ -33,7 +33,7 @@ module('Integration | Component | rose/dropdown/button', function (hooks) {
 
   test('it supports an icon-only type', async function (assert) {
     await render(
-      hbs`<Rose::Dropdown::Button @iconOnly="flight-icons/chevron-left-16" />`
+      hbs`<Rose::Dropdown::Button @iconOnly="flight-icons/svg/chevron-left-16" />`
     );
     assert.ok(find('.has-icon-only .rose-icon'));
   });

--- a/addons/rose/tests/integration/components/rose/form/radio/radio-test.js
+++ b/addons/rose/tests/integration/components/rose/form/radio/radio-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | rose/form/radio/radio', function (hooks) {
 
   test('it supports an icon', async function (assert) {
     await render(
-      hbs`<Rose::Form::Radio::Radio @icon="flight-icons/user-circle-16" />`
+      hbs`<Rose::Form::Radio::Radio @icon="flight-icons/svg/user-circle-16" />`
     );
     assert.ok(find('svg'));
   });

--- a/addons/rose/tests/integration/components/rose/icon-test.js
+++ b/addons/rose/tests/integration/components/rose/icon-test.js
@@ -7,13 +7,13 @@ module('Integration | Component | rose/icon', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-    await render(hbs`<Rose::Icon @name="flight-icons/globe-16" />`);
+    await render(hbs`<Rose::Icon @name="flight-icons/svg/globe-16" />`);
     assert.ok(find('svg'));
   });
 
   test('it supports optional @size', async function (assert) {
     await render(
-      hbs`<Rose::Icon @name="flight-icons/globe-16" @size="small" />`
+      hbs`<Rose::Icon @name="flight-icons/svg/globe-16" @size="small" />`
     );
     assert.ok(find('.small'));
   });

--- a/addons/rose/tests/integration/components/rose/link-button-test.js
+++ b/addons/rose/tests/integration/components/rose/link-button-test.js
@@ -35,7 +35,7 @@ module('Integration | Component | rose/link-button', function (hooks) {
 
   test('it supports left icon with @iconLeft', async function (assert) {
     await render(
-      hbs`<Rose::LinkButton @route="index" @iconLeft="flight-icons/chevron-left-16" />`
+      hbs`<Rose::LinkButton @route="index" @iconLeft="flight-icons/svg/chevron-left-16" />`
     );
     assert.ok(find('.rose-icon'));
     assert.ok(find('.has-icon-left'));
@@ -43,7 +43,7 @@ module('Integration | Component | rose/link-button', function (hooks) {
 
   test('it supports left icon with @iconRight', async function (assert) {
     await render(
-      hbs`<Rose::LinkButton @route="index" @iconRight="flight-icons/entry-point-16" />`
+      hbs`<Rose::LinkButton @route="index" @iconRight="flight-icons/svg/entry-point-16" />`
     );
     assert.ok(find('.rose-icon'));
     assert.ok(find('.has-icon-right'));
@@ -51,7 +51,7 @@ module('Integration | Component | rose/link-button', function (hooks) {
 
   test('it supports only icon with @iconOnly', async function (assert) {
     await render(
-      hbs`<Rose::LinkButton @route="index" @iconOnly="flight-icons/help-16" />`
+      hbs`<Rose::LinkButton @route="index" @iconOnly="flight-icons/svg/help-16" />`
     );
     assert.ok(find('.rose-icon'));
     assert.ok(find('.has-icon-only'));

--- a/ui/admin/app/components/copyable/index.js
+++ b/ui/admin/app/components/copyable/index.js
@@ -12,8 +12,8 @@ export default class CopyableComponent extends Component {
   id = generateComponentID();
   copyableButtonId = `copyable-button-${this.id}`;
 
-  actionIcon = 'flight-icons/clipboard-copy-16';
-  successIcon = 'flight-icons/clipboard-checked-16';
+  actionIcon = 'flight-icons/svg/clipboard-copy-16';
+  successIcon = 'flight-icons/svg/clipboard-checked-16';
   actionText = this.args.buttonText;
   successText = this.args.acknowledgeText;
 

--- a/ui/admin/app/components/form/auth-method/oidc/index.hbs
+++ b/ui/admin/app/components/form/auth-method/oidc/index.hbs
@@ -177,7 +177,7 @@
               <row.cell @shrink={{true}}>
                 <Rose::Button
                   @style='warning'
-                  @iconOnly='flight-icons/trash-16'
+                  @iconOnly='flight-icons/svg/trash-16'
                   title={{t 'actions.remove'}}
                   @disabled={{if
                     @model.isNew
@@ -278,7 +278,7 @@
               <row.cell @shrink={{true}}>
                 <Rose::Button
                   @style='warning'
-                  @iconOnly='flight-icons/trash-16'
+                  @iconOnly='flight-icons/svg/trash-16'
                   title={{t 'actions.remove'}}
                   @disabled={{if
                     @model.isNew
@@ -368,7 +368,7 @@
               <row.cell @shrink={{true}}>
                 <Rose::Button
                   @style='warning'
-                  @iconOnly='flight-icons/trash-16'
+                  @iconOnly='flight-icons/svg/trash-16'
                   title={{t 'actions.remove'}}
                   @disabled={{if
                     @model.isNew
@@ -477,7 +477,7 @@
               <row.cell @shrink={{true}}>
                 <Rose::Button
                   @style='warning'
-                  @iconOnly='flight-icons/trash-16'
+                  @iconOnly='flight-icons/svg/trash-16'
                   title={{t 'actions.remove'}}
                   @disabled={{if
                     @model.isNew
@@ -578,7 +578,7 @@
               <row.cell @shrink={{true}}>
                 <Rose::Button
                   @style='warning'
-                  @iconOnly='flight-icons/trash-16'
+                  @iconOnly='flight-icons/svg/trash-16'
                   title={{t 'actions.remove'}}
                   @disabled={{if
                     @model.isNew

--- a/ui/admin/app/components/form/group/add-members/index.hbs
+++ b/ui/admin/app/components/form/group/add-members/index.hbs
@@ -49,7 +49,7 @@
         {{t 'resources.group.messages.no-members.description'}}
       </message.description>
       <message.link @route='scopes.scope.groups.group.members'>
-        <Rose::Icon @name='flight-icons/chevron-left-16' />
+        <Rose::Icon @name='flight-icons/svg/chevron-left-16' />
         {{t 'actions.back'}}
       </message.link>
     </Rose::Message>

--- a/ui/admin/app/components/form/host-set/add-hosts/index.hbs
+++ b/ui/admin/app/components/form/host-set/add-hosts/index.hbs
@@ -55,7 +55,7 @@
       <message.link
         @route='scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts'
       >
-        <Rose::Icon @name='flight-icons/chevron-left-16' />
+        <Rose::Icon @name='flight-icons/svg/chevron-left-16' />
         {{t 'actions.back'}}
       </message.link>
     </Rose::Message>

--- a/ui/admin/app/components/form/role/add-principals/index.hbs
+++ b/ui/admin/app/components/form/role/add-principals/index.hbs
@@ -58,7 +58,7 @@
         {{t 'resources.role.principal.messages.none.description'}}
       </message.description>
       <message.link @route='scopes.scope.roles.role.principals'>
-        <Rose::Icon @name='flight-icons/chevron-left-16' />
+        <Rose::Icon @name='flight-icons/svg/chevron-left-16' />
         {{t 'actions.back'}}
       </message.link>
     </Rose::Message>

--- a/ui/admin/app/components/form/role/grants/index.hbs
+++ b/ui/admin/app/components/form/role/grants/index.hbs
@@ -74,7 +74,7 @@
         <item.cell>
           <Rose::Button
             @style='secondary'
-            @iconOnly='flight-icons/trash-16'
+            @iconOnly='flight-icons/svg/trash-16'
             title={{t 'actions.remove'}}
             {{on 'click' (fn @removeGrant grant.value)}}
           >

--- a/ui/admin/app/components/form/role/index.hbs
+++ b/ui/admin/app/components/form/role/index.hbs
@@ -69,11 +69,11 @@
           @text={{this.selectedGrantScope.displayName}}
           @icon={{if
             this.selectedGrantScope.isProject
-            'flight-icons/grid-16'
+            'flight-icons/svg/grid-16'
             (if
               this.selectedGrantScope.isOrg
-              'flight-icons/org-16'
-              'flight-icons/globe-16'
+              'flight-icons/svg/org-16'
+              'flight-icons/svg/globe-16'
             )
           }}
           as |dropdown|

--- a/ui/admin/app/components/form/target/add-credential-libraries/index.hbs
+++ b/ui/admin/app/components/form/target/add-credential-libraries/index.hbs
@@ -55,7 +55,7 @@
         {{t 'resources.target.credential-library.messages.none.description'}}
       </message.description>
       <message.link @route='scopes.scope.targets.target.credential-libraries'>
-        <Rose::Icon @name='flight-icons/chevron-left-16' />
+        <Rose::Icon @name='flight-icons/svg/chevron-left-16' />
         {{t 'actions.back'}}
       </message.link>
     </Rose::Message>

--- a/ui/admin/app/components/form/target/add-host-sets/index.hbs
+++ b/ui/admin/app/components/form/target/add-host-sets/index.hbs
@@ -59,7 +59,7 @@
         {{t 'resources.target.host-set.messages.none.description'}}
       </message.description>
       <message.link @route='scopes.scope.targets.target.host-sets'>
-        <Rose::Icon @name='flight-icons/chevron-left-16' />
+        <Rose::Icon @name='flight-icons/svg/chevron-left-16' />
         {{t 'actions.back'}}
       </message.link>
     </Rose::Message>

--- a/ui/admin/app/components/form/user/add-accounts/index.hbs
+++ b/ui/admin/app/components/form/user/add-accounts/index.hbs
@@ -59,7 +59,7 @@
         {{t 'resources.user.messages.no-accounts.description'}}
       </message.description>
       <message.link @route='scopes.scope.users.user.accounts'>
-        <Rose::Icon @name='flight-icons/chevron-left-16' />
+        <Rose::Icon @name='flight-icons/svg/chevron-left-16' />
         {{t 'actions.back'}}
       </message.link>
     </Rose::Message>

--- a/ui/admin/app/templates/application.hbs
+++ b/ui/admin/app/templates/application.hbs
@@ -16,7 +16,7 @@
         <header.utilities as |utilities|>
           <utilities.dropdown
             @text={{this.session.data.authenticated.username}}
-            @icon='flight-icons/user-circle-16'
+            @icon='flight-icons/svg/user-circle-16'
             as |dropdown|
           >
             <dropdown.link @route='account.change-password'>
@@ -100,7 +100,7 @@
     <Rose::Dialog
       @heading={{t 'titles.abandon-confirm'}}
       @dismissButtonText={{t 'actions.cancel'}}
-      @icon='flight-icons/alert-triangle-16'
+      @icon='flight-icons/svg/alert-triangle-16'
       @style='warning'
       @modal={{true}}
       @dismiss={{deny}}
@@ -126,7 +126,7 @@
         (t 'actions.confirm')
       }}
       @dismissButtonText={{t 'actions.cancel'}}
-      @icon='flight-icons/alert-triangle-16'
+      @icon='flight-icons/svg/alert-triangle-16'
       @style='warning'
       @modal={{true}}
       @dismiss={{deny}}

--- a/ui/admin/app/templates/scopes/index.hbs
+++ b/ui/admin/app/templates/scopes/index.hbs
@@ -8,7 +8,7 @@
         <Rose::Layout::Centered>
           <Rose::Message
             @title={{t 'auth.titles.no-scopes'}}
-            @icon='flight-icons/alert-circle-16'
+            @icon='flight-icons/svg/alert-circle-16'
             as |message|
           >
             <message.description>

--- a/ui/admin/app/templates/scopes/scope.hbs
+++ b/ui/admin/app/templates/scopes/scope.hbs
@@ -18,7 +18,7 @@
       {{#if @model.isGlobal}}
         <Rose::Nav::Sidebar @title={{t 'titles.general'}} as |nav|>
           <nav.link @route='scopes.scope.scopes'>
-            <Rose::Icon @name='flight-icons/org-16' @size='medium' />
+            <Rose::Icon @name='flight-icons/svg/org-16' @size='medium' />
             {{t 'resources.org.title_plural'}}
           </nav.link>
         </Rose::Nav::Sidebar>
@@ -28,12 +28,12 @@
         <Rose::Nav::Sidebar @title={{t 'titles.general'}} as |nav|>
           {{#if this.session.data.authenticated.isGlobal}}
             <nav.link @route='scopes.scope.scopes' @model='global'>
-              <Rose::Icon @name='flight-icons/org-16' @size='medium' />
+              <Rose::Icon @name='flight-icons/svg/org-16' @size='medium' />
               {{t 'resources.org.title_plural'}}
             </nav.link>
           {{/if}}
           <nav.link @route='scopes.scope.scopes'>
-            <Rose::Icon @name='flight-icons/grid-16' @size='medium' />
+            <Rose::Icon @name='flight-icons/svg/grid-16' @size='medium' />
             {{t 'resources.project.title_plural'}}
           </nav.link>
         </Rose::Nav::Sidebar>
@@ -43,12 +43,12 @@
         <Rose::Nav::Sidebar @title={{t 'titles.general'}} as |nav|>
           {{#if this.session.data.authenticated.isGlobal}}
             <nav.link @route='scopes.scope.scopes' @model='global'>
-              <Rose::Icon @name='flight-icons/org-16' @size='medium' />
+              <Rose::Icon @name='flight-icons/svg/org-16' @size='medium' />
               {{t 'resources.org.title_plural'}}
             </nav.link>
           {{/if}}
           <nav.link @route='scopes.scope.scopes' @model={{@model.scopeID}}>
-            <Rose::Icon @name='flight-icons/grid-16' @size='medium' />
+            <Rose::Icon @name='flight-icons/svg/grid-16' @size='medium' />
             {{t 'resources.project.title_plural'}}
           </nav.link>
         </Rose::Nav::Sidebar>
@@ -58,13 +58,13 @@
         <Rose::Nav::Sidebar @title={{t "titles.iam"}} as |nav|>
           <nav.link @route="scopes.scope.groups">
             <Rose::Icon
-              @name="flight-icons/folder-users-16"
+              @name="flight-icons/svg/folder-users-16"
               @size="medium" />
             {{t "resources.group.title_plural"}}
           </nav.link>
           <nav.link @route="scopes.scope.roles">
             <Rose::Icon
-              @name="flight-icons/identity-user-16"
+              @name="flight-icons/svg/identity-user-16"
               @size="medium" />
             {{t "resources.role.title_plural"}}
           </nav.link>
@@ -73,19 +73,28 @@
         <Rose::Nav::Sidebar @title={{t 'titles.resources'}} as |nav|>
           {{#if (can 'navigate collection' @model collection='sessions')}}
             <nav.link @route='scopes.scope.sessions'>
-              <Rose::Icon @name='flight-icons/entry-point-16' @size='medium' />
+              <Rose::Icon
+                @name='flight-icons/svg/entry-point-16'
+                @size='medium'
+              />
               {{t 'resources.session.title_plural'}}
             </nav.link>
           {{/if}}
           {{#if (can 'navigate collection' @model collection='targets')}}
             <nav.link @route='scopes.scope.targets'>
-              <Rose::Icon @name='flight-icons/crosshair-16' @size='medium' />
+              <Rose::Icon
+                @name='flight-icons/svg/crosshair-16'
+                @size='medium'
+              />
               {{t 'resources.target.title_plural'}}
             </nav.link>
           {{/if}}
           {{#if (can 'navigate collection' @model collection='host-catalogs')}}
             <nav.link @route='scopes.scope.host-catalogs'>
-              <Rose::Icon @name='flight-icons/collections-16' @size='medium' />
+              <Rose::Icon
+                @name='flight-icons/svg/collections-16'
+                @size='medium'
+              />
               {{t 'resources.host-catalog.title_plural'}}
             </nav.link>
           {{/if}}
@@ -94,7 +103,7 @@
           }}
             {{#if (feature-flag 'credential-store')}}
               <nav.link @route='scopes.scope.credential-stores'>
-                <Rose::Icon @name='flight-icons/key-16' @size='medium' />
+                <Rose::Icon @name='flight-icons/svg/key-16' @size='medium' />
                 {{t 'resources.credential-store.title_plural'}}
               </nav.link>
             {{/if}}
@@ -106,20 +115,23 @@
         <Rose::Nav::Sidebar @title={{t 'titles.iam'}} as |nav|>
           {{#if (can 'navigate collection' @model collection='users')}}
             <nav.link @route='scopes.scope.users'>
-              <Rose::Icon @name='flight-icons/users-16' @size='medium' />
+              <Rose::Icon @name='flight-icons/svg/users-16' @size='medium' />
               {{t 'resources.user.title_plural'}}
             </nav.link>
           {{/if}}
           {{#if (can 'navigate collection' @model collection='groups')}}
             <nav.link @route='scopes.scope.groups'>
-              <Rose::Icon @name='flight-icons/folder-users-16' @size='medium' />
+              <Rose::Icon
+                @name='flight-icons/svg/folder-users-16'
+                @size='medium'
+              />
               {{t 'resources.group.title_plural'}}
             </nav.link>
           {{/if}}
           {{#if (can 'navigate collection' @model collection='roles')}}
             <nav.link @route='scopes.scope.roles'>
               <Rose::Icon
-                @name='flight-icons/identity-user-16'
+                @name='flight-icons/svg/identity-user-16'
                 @size='medium'
               />
               {{t 'resources.role.title_plural'}}
@@ -127,7 +139,7 @@
           {{/if}}
           {{#if (can 'navigate collection' @model collection='auth-methods')}}
             <nav.link @route='scopes.scope.auth-methods'>
-              <Rose::Icon @name='flight-icons/lock-16' @size='medium' />
+              <Rose::Icon @name='flight-icons/svg/lock-16' @size='medium' />
               {{t 'resources.auth-method.title_plural'}}
             </nav.link>
           {{/if}}

--- a/ui/admin/app/templates/scopes/scope/-header-nav.hbs
+++ b/ui/admin/app/templates/scopes/scope/-header-nav.hbs
@@ -2,8 +2,8 @@
   @text={{this.scopes.selectedOrg.displayName}}
   @icon={{if
     this.scopes.selectedOrg.isGlobal
-    'flight-icons/globe-16'
-    'flight-icons/org-16'
+    'flight-icons/svg/globe-16'
+    'flight-icons/svg/org-16'
   }}
   as |dropdown|
 >
@@ -23,7 +23,7 @@
 {{#if this.scopes.selectedProject}}
   <Rose::Dropdown
     @text={{this.scopes.selectedProject.displayName}}
-    @icon='flight-icons/grid-16'
+    @icon='flight-icons/svg/grid-16'
     as |dropdown|
   >
     {{#each this.scopes.projects as |scope|}}

--- a/ui/admin/app/templates/scopes/scope/-sidebar.hbs
+++ b/ui/admin/app/templates/scopes/scope/-sidebar.hbs
@@ -1,18 +1,18 @@
 <Rose::Nav::Sidebar @title={{t 'titles.iam'}} as |nav|>
   <nav.link @route='scopes.scope.users'>
-    <Rose::Icon @name='flight-icons/users-16' @size='medium' />
+    <Rose::Icon @name='flight-icons/svg/users-16' @size='medium' />
     {{t 'resources.user.title_plural'}}
   </nav.link>
   <nav.link @route='scopes.scope.groups'>
-    <Rose::Icon @name='flight-icons/folder-users-16' @size='medium' />
+    <Rose::Icon @name='flight-icons/svg/folder-users-16' @size='medium' />
     {{t 'resources.group.title_plural'}}
   </nav.link>
   <nav.link @route='scopes.scope.roles'>
-    <Rose::Icon @name='flight-icons/identity-user-16' @size='medium' />
+    <Rose::Icon @name='flight-icons/svg/identity-user-16' @size='medium' />
     {{t 'resources.role.title_plural'}}
   </nav.link>
   <nav.link @route='scopes.scope.auth-methods'>
-    <Rose::Icon @name='flight-icons/lock-16' @size='medium' />
+    <Rose::Icon @name='flight-icons/svg/lock-16' @size='medium' />
     {{t 'resources.auth-method.title_plural'}}
   </nav.link>
 </Rose::Nav::Sidebar>

--- a/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/-actions.hbs
+++ b/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/-actions.hbs
@@ -3,9 +3,11 @@
     @text={{t (concat 'states.' @model.attributes.state)}}
     @icon={{if
       @model.isInactive
-      'flight-icons/x-circle-16'
+      'flight-icons/svg/x-circle-16'
       (if
-        @model.isPrivate 'flight-icons/lock-16' 'flight-icons/check-circle-16'
+        @model.isPrivate
+        'flight-icons/svg/lock-16'
+        'flight-icons/svg/check-circle-16'
       )
     }}
     @dropdownRight={{true}}

--- a/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/accounts/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/accounts/index.hbs
@@ -140,7 +140,7 @@
         <message.link
           @route='scopes.scope.auth-methods.auth-method.accounts.new'
         >
-          <Rose::Icon @name='flight-icons/plus-circle-16' />
+          <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
           {{t 'resources.account.actions.create'}}
         </message.link>
       {{/if}}

--- a/ui/admin/app/templates/scopes/scope/auth-methods/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/auth-methods/index.hbs
@@ -129,7 +129,7 @@
                     @dropdownRight={{true}}
                     @iconOnly={{true}}
                     @showCaret={{false}}
-                    @icon='flight-icons/more-horizontal-16'
+                    @icon='flight-icons/svg/more-horizontal-16'
                     as |dropdown|
                   >
                     {{#unless authMethod.isPrimary}}

--- a/ui/admin/app/templates/scopes/scope/authenticate.hbs
+++ b/ui/admin/app/templates/scopes/scope/authenticate.hbs
@@ -16,7 +16,7 @@
             }}</p>
           <Rose::Dropdown
             @text={{t 'actions.choose-different-org'}}
-            @icon='flight-icons/org-16'
+            @icon='flight-icons/svg/org-16'
             as |dropdown|
           >
             <dropdown.link @route='scopes.scope.authenticate' @model='global'>
@@ -79,7 +79,7 @@
             <Rose::Layout::Centered>
               <Rose::Message
                 @title={{t 'resources.auth-method.messages.none.title'}}
-                @icon='flight-icons/alert-circle-16'
+                @icon='flight-icons/svg/alert-circle-16'
                 as |message|
               >
                 <message.description>

--- a/ui/admin/app/templates/scopes/scope/authenticate/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/authenticate/index.hbs
@@ -2,7 +2,7 @@
   <Rose::Layout::Centered>
     <Rose::Message
       @title={{t 'resources.auth-method.messages.none.title'}}
-      @icon='flight-icons/alert-circle-16'
+      @icon='flight-icons/svg/alert-circle-16'
       as |message|
     >
       <message.description>

--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credential-libraries/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credential-libraries/index.hbs
@@ -92,7 +92,7 @@
         <message.link
           @route='scopes.scope.credential-stores.credential-store.credential-libraries.new'
         >
-          <Rose::Icon @name='flight-icons/plus-circle-16' />
+          <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
           {{t 'titles.new'}}
         </message.link>
       {{/if}}

--- a/ui/admin/app/templates/scopes/scope/credential-stores/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/index.hbs
@@ -107,7 +107,7 @@
             (can 'create collection' this.scope collection='credential-stores')
           }}
             <message.link @route='scopes.scope.credential-stores.new'>
-              <Rose::Icon @name='flight-icons/plus-circle-16' />
+              <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
               {{t 'titles.new'}}
             </message.link>
           {{/if}}

--- a/ui/admin/app/templates/scopes/scope/groups/group/members.hbs
+++ b/ui/admin/app/templates/scopes/scope/groups/group/members.hbs
@@ -27,7 +27,7 @@
           </row.cell>
           <row.cell>
             <Rose::Dropdown
-              @icon='flight-icons/more-horizontal-16'
+              @icon='flight-icons/svg/more-horizontal-16'
               @iconOnly={{true}}
               @showCaret={{false}}
               @dropdownRight={{true}}
@@ -58,7 +58,7 @@
         {{t 'resources.group.messages.members.description'}}
       </message.description>
       <message.link @route='scopes.scope.groups.group.add-members'>
-        <Rose::Icon @name='flight-icons/plus-circle-16' />
+        <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
         {{t 'resources.group.actions.add-members'}}
       </message.link>
     </Rose::Message>

--- a/ui/admin/app/templates/scopes/scope/groups/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/groups/index.hbs
@@ -90,7 +90,7 @@
           </message.description>
           {{#if (can 'create collection' this.scope collection='groups')}}
             <message.link @route='scopes.scope.groups.new'>
-              <Rose::Icon @name='flight-icons/plus-circle-16' />
+              <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
               {{t 'titles.new'}}
             </message.link>
           {{/if}}

--- a/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts.hbs
@@ -37,7 +37,7 @@
           </row.cell>
           <row.cell>
             <Rose::Dropdown
-              @icon='flight-icons/more-horizontal-16'
+              @icon='flight-icons/svg/more-horizontal-16'
               @iconOnly={{true}}
               @showCaret={{false}}
               @dropdownRight={{true}}
@@ -70,7 +70,7 @@
       </message.description>
       {{!--
       <message.link @route="scopes.scope.host-catalogs.host-catalog.host-sets.host-set.create-and-add-host">
-        <Rose::Icon @name="flight-icons/plus-circle-16" />
+        <Rose::Icon @name="flight-icons/svg/plus-circle-16" />
         {{t "resources.host-set.actions.create-and-add-host"}}
       </message.link>
       --}}

--- a/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/index.hbs
@@ -77,7 +77,7 @@
         <message.link
           @route='scopes.scope.host-catalogs.host-catalog.host-sets.new'
         >
-          <Rose::Icon @name='flight-icons/plus-circle-16' />
+          <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
           {{t 'titles.new'}}
         </message.link>
       {{/if}}

--- a/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/hosts/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/hosts/index.hbs
@@ -82,7 +82,7 @@
         <message.link
           @route='scopes.scope.host-catalogs.host-catalog.hosts.new'
         >
-          <Rose::Icon @name='flight-icons/plus-circle-16' />
+          <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
           {{t 'titles.new'}}
         </message.link>
       {{/if}}

--- a/ui/admin/app/templates/scopes/scope/host-catalogs/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/index.hbs
@@ -109,7 +109,7 @@
             (can 'create collection' this.scope collection='host-catalogs')
           }}
             <message.link @route='scopes.scope.host-catalogs.new'>
-              <Rose::Icon @name='flight-icons/plus-circle-16' />
+              <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
               {{t 'titles.new'}}
             </message.link>
           {{/if}}

--- a/ui/admin/app/templates/scopes/scope/roles/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/roles/index.hbs
@@ -89,7 +89,7 @@
           </message.description>
           {{#if (can 'create collection' this.scope collection='roles')}}
             <message.link @route='scopes.scope.roles.new'>
-              <Rose::Icon @name='flight-icons/plus-circle-16' />
+              <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
               {{t 'titles.new'}}
             </message.link>
           {{/if}}

--- a/ui/admin/app/templates/scopes/scope/roles/role/principals.hbs
+++ b/ui/admin/app/templates/scopes/scope/roles/role/principals.hbs
@@ -31,7 +31,7 @@
           </row.cell>
           <row.cell>
             <Rose::Dropdown
-              @icon='flight-icons/more-horizontal-16'
+              @icon='flight-icons/svg/more-horizontal-16'
               @iconOnly={{true}}
               @showCaret={{false}}
               @dropdownRight={{true}}
@@ -62,7 +62,7 @@
         {{t 'resources.role.principal.messages.welcome.description'}}
       </message.description>
       <message.link @route='scopes.scope.roles.role.add-principals'>
-        <Rose::Icon @name='flight-icons/plus-circle-16' />
+        <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
         {{t 'resources.role.principal.actions.add-principals'}}
       </message.link>
     </Rose::Message>

--- a/ui/admin/app/templates/scopes/scope/scopes/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/scopes/index.hbs
@@ -47,8 +47,8 @@
             @id={{scope.id}}
             @icon={{if
               scope.isOrg
-              'flight-icons/org-16'
-              'flight-icons/grid-16'
+              'flight-icons/svg/org-16'
+              'flight-icons/svg/grid-16'
             }}
             @route='scopes.scope'
             @model={{scope.id}}
@@ -71,7 +71,7 @@
               (can 'create collection' @model.currentScope collection='scopes')
             }}
               <message.link @route='scopes.scope.new'>
-                <Rose::Icon @name='flight-icons/plus-circle-16' />
+                <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
                 {{t 'titles.new'}}
               </message.link>
             {{/if}}
@@ -92,7 +92,7 @@
               (can 'create collection' @model.currentScope collection='scopes')
             }}
               <message.link @route='scopes.scope.new'>
-                <Rose::Icon @name='flight-icons/plus-circle-16' />
+                <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
                 {{t 'titles.new'}}
               </message.link>
             {{/if}}

--- a/ui/admin/app/templates/scopes/scope/sessions/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/sessions/index.hbs
@@ -36,7 +36,7 @@
                     'session-status-'
                     sessionAggregate.session.status
                   }}
-                  @name='flight-icons/entry-point-16'
+                  @name='flight-icons/svg/entry-point-16'
                   @size='medium'
                 />
                 <Copyable

--- a/ui/admin/app/templates/scopes/scope/targets/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/targets/index.hbs
@@ -104,7 +104,7 @@
 
           {{#if (can 'create collection' this.scope collection='targets')}}
             <message.link @route='scopes.scope.targets.new'>
-              <Rose::Icon @name='flight-icons/plus-circle-16' />
+              <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
               {{t 'titles.new'}}
             </message.link>
           {{/if}}

--- a/ui/admin/app/templates/scopes/scope/targets/target/add-credential-libraries.hbs
+++ b/ui/admin/app/templates/scopes/scope/targets/target/add-credential-libraries.hbs
@@ -19,7 +19,7 @@
         {{t 'resources.target.credential-library.messages.none.description'}}
       </message.description>
       <message.link @route='scopes.scope.targets.target.credential-libraries'>
-        <Rose::Icon @name='flight-icons/chevron-left-16' />
+        <Rose::Icon @name='flight-icons/svg/chevron-left-16' />
         {{t 'actions.back'}}
       </message.link>
     </Rose::Message>

--- a/ui/admin/app/templates/scopes/scope/targets/target/add-host-sets.hbs
+++ b/ui/admin/app/templates/scopes/scope/targets/target/add-host-sets.hbs
@@ -20,7 +20,7 @@
         {{t 'resources.target.host-set.messages.none.description'}}
       </message.description>
       <message.link @route='scopes.scope.targets.target.host-sets'>
-        <Rose::Icon @name='flight-icons/chevron-left-16' />
+        <Rose::Icon @name='flight-icons/svg/chevron-left-16' />
         {{t 'actions.back'}}
       </message.link>
     </Rose::Message>

--- a/ui/admin/app/templates/scopes/scope/targets/target/credential-libraries.hbs
+++ b/ui/admin/app/templates/scopes/scope/targets/target/credential-libraries.hbs
@@ -44,7 +44,7 @@
           </row.cell>
           <row.cell>
             <Rose::Dropdown
-              @icon='flight-icons/more-horizontal-16'
+              @icon='flight-icons/svg/more-horizontal-16'
               @iconOnly={{true}}
               @showCaret={{false}}
               @dropdownRight={{true}}
@@ -82,7 +82,7 @@
       <message.link
         @route='scopes.scope.targets.target.add-credential-libraries'
       >
-        <Rose::Icon @name='flight-icons/plus-circle-16' />
+        <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
         {{t 'resources.target.actions.add-credential-libraries'}}
       </message.link>
     </Rose::Message>

--- a/ui/admin/app/templates/scopes/scope/targets/target/host-sets.hbs
+++ b/ui/admin/app/templates/scopes/scope/targets/target/host-sets.hbs
@@ -34,7 +34,7 @@
           </row.cell>
           <row.cell>
             <Rose::Dropdown
-              @icon='flight-icons/more-horizontal-16'
+              @icon='flight-icons/svg/more-horizontal-16'
               @iconOnly={{true}}
               @showCaret={{false}}
               @dropdownRight={{true}}
@@ -68,7 +68,7 @@
         {{t 'resources.target.host-set.messages.welcome.description'}}
       </message.description>
       <message.link @route='scopes.scope.targets.target.add-host-sets'>
-        <Rose::Icon @name='flight-icons/plus-circle-16' />
+        <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
         {{t 'resources.target.actions.add-host-sets'}}
       </message.link>
     </Rose::Message>

--- a/ui/admin/app/templates/scopes/scope/users/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/users/index.hbs
@@ -89,7 +89,7 @@
           </message.description>
           {{#if (can 'create collection' this.scope collection='users')}}
             <message.link @route='scopes.scope.users.new'>
-              <Rose::Icon @name='flight-icons/plus-circle-16' />
+              <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
               {{t 'titles.new'}}
             </message.link>
           {{/if}}

--- a/ui/admin/app/templates/scopes/scope/users/user/accounts.hbs
+++ b/ui/admin/app/templates/scopes/scope/users/user/accounts.hbs
@@ -34,7 +34,7 @@
           </row.cell>
           <row.cell>
             <Rose::Dropdown
-              @icon='flight-icons/more-horizontal-16'
+              @icon='flight-icons/svg/more-horizontal-16'
               @iconOnly={{true}}
               @showCaret={{false}}
               @dropdownRight={{true}}
@@ -68,7 +68,7 @@
         {{t 'resources.user.messages.accounts.description'}}
       </message.description>
       <message.link @route='scopes.scope.users.user.add-accounts'>
-        <Rose::Icon @name='flight-icons/plus-circle-16' />
+        <Rose::Icon @name='flight-icons/svg/plus-circle-16' />
         {{t 'resources.user.actions.add-accounts'}}
       </message.link>
     </Rose::Message>

--- a/ui/admin/app/templates/scopes/scope/users/user/add-accounts.hbs
+++ b/ui/admin/app/templates/scopes/scope/users/user/add-accounts.hbs
@@ -20,7 +20,7 @@
         {{t 'resources.user.messages.no-accounts.description'}}
       </message.description>
       <message.link @route='scopes.scope.users.user.accounts'>
-        <Rose::Icon @name='flight-icons/chevron-left-16' />
+        <Rose::Icon @name='flight-icons/svg/chevron-left-16' />
         {{t 'actions.back'}}
       </message.link>
     </Rose::Message>

--- a/ui/desktop/app/components/copyable/index.js
+++ b/ui/desktop/app/components/copyable/index.js
@@ -13,8 +13,8 @@ export default class CopyableComponent extends Component {
   id = generateComponentID();
   copyableButtonId = `copyable-button-${this.id}`;
 
-  actionIcon = 'flight-icons/clipboard-copy-16';
-  successIcon = 'flight-icons/clipboard-checked-16';
+  actionIcon = 'flight-icons/svg/clipboard-copy-16';
+  successIcon = 'flight-icons/svg/clipboard-checked-16';
   actionText = this.args.buttonText;
   successText = this.args.acknowledgeText;
 

--- a/ui/desktop/app/components/hidden-secret/index.hbs
+++ b/ui/desktop/app/components/hidden-secret/index.hbs
@@ -3,8 +3,8 @@
     @style='ghost'
     @iconOnly={{if
       this.isHidden
-      'flight-icons/eye-16'
-      'flight-icons/eye-off-16'
+      'flight-icons/svg/eye-16'
+      'flight-icons/svg/eye-off-16'
     }}
     {{on 'click' this.toggleSecretVisibility}}
   >

--- a/ui/desktop/app/templates/application.hbs
+++ b/ui/desktop/app/templates/application.hbs
@@ -21,21 +21,21 @@
       <header.utilities as |utilities|>
         {{#if this.isFrameless}}
           <Rose::Button
-            @iconOnly='flight-icons/x-16'
+            @iconOnly='flight-icons/svg/x-16'
             @style='warning'
             class='button-window-close'
             title={{t 'actions.close'}}
             {{on 'click' (route-action 'close')}}
           />
           <Rose::Button
-            @iconOnly='flight-icons/square-16'
+            @iconOnly='flight-icons/svg/square-16'
             @style='secondary'
             class='button-window-fullscreen'
             title={{t 'actions.fullscreen'}}
             {{on 'click' (route-action 'toggleFullScreen')}}
           />
           <Rose::Button
-            @iconOnly='flight-icons/minus-16'
+            @iconOnly='flight-icons/svg/minus-16'
             @style='secondary'
             class='button-window-minimize'
             title={{t 'actions.minimize'}}
@@ -46,7 +46,7 @@
         {{#if this.session.isAuthenticated}}
           <utilities.dropdown
             @text={{this.session.data.authenticated.username}}
-            @icon='flight-icons/user-circle-16'
+            @icon='flight-icons/svg/user-circle-16'
             as |dropdown|
           >
             <dropdown.button {{on 'click' (route-action 'invalidateSession')}}>
@@ -110,7 +110,7 @@
     <Rose::Dialog
       @heading={{t 'states.error'}}
       @dismissButtonText={{t 'actions.ok'}}
-      @icon='flight-icons/x-square-16'
+      @icon='flight-icons/svg/x-square-16'
       @style='error'
       @modal={{true}}
       @dismiss={{deny}}
@@ -137,7 +137,7 @@
     <Rose::Dialog
       @heading={{t 'actions.confirm'}}
       @dismissButtonText={{t 'actions.cancel'}}
-      @icon='flight-icons/alert-triangle-16'
+      @icon='flight-icons/svg/alert-triangle-16'
       @style='warning'
       @modal={{true}}
       @dismiss={{deny}}

--- a/ui/desktop/app/templates/scopes/scope/-header-nav.hbs
+++ b/ui/desktop/app/templates/scopes/scope/-header-nav.hbs
@@ -2,8 +2,8 @@
   @text={{this.scopes.selectedOrg.displayName}}
   @icon={{if
     this.scopes.selectedOrg.isGlobal
-    'flight-icons/globe-16'
-    'flight-icons/org-16'
+    'flight-icons/svg/globe-16'
+    'flight-icons/svg/org-16'
   }}
   as |dropdown|
 >

--- a/ui/desktop/app/templates/scopes/scope/authenticate.hbs
+++ b/ui/desktop/app/templates/scopes/scope/authenticate.hbs
@@ -11,7 +11,7 @@
 
     <Rose::Dropdown
       @text={{t 'actions.choose-different-org'}}
-      @icon='flight-icons/org-16'
+      @icon='flight-icons/svg/org-16'
       as |dropdown|
     >
       <dropdown.link @route='scopes.scope.authenticate' @model='global'>
@@ -67,7 +67,7 @@
       <Rose::Layout::Centered>
         <Rose::Message
           @title={{t 'resources.auth-method.messages.none.title'}}
-          @icon='flight-icons/alert-circle-16'
+          @icon='flight-icons/svg/alert-circle-16'
           as |message|
         >
           <message.description>

--- a/ui/desktop/app/templates/scopes/scope/authenticate/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/authenticate/index.hbs
@@ -2,7 +2,7 @@
   <Rose::Layout::Centered>
     <Rose::Message
       @title={{t 'resources.auth-method.messages.none.title'}}
-      @icon='flight-icons/alert-circle-16'
+      @icon='flight-icons/svg/alert-circle-16'
       as |message|
     >
       <message.description>

--- a/ui/desktop/app/templates/scopes/scope/projects.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects.hbs
@@ -2,12 +2,12 @@
   <sidebarLayout.sidebar>
     <Rose::Nav::Sidebar as |nav|>
       <nav.link @route='scopes.scope.projects.targets'>
-        <Rose::Icon @name='flight-icons/crosshair-16' @size='medium' />
+        <Rose::Icon @name='flight-icons/svg/crosshair-16' @size='medium' />
         {{t 'resources.target.title_plural'}}
       </nav.link>
 
       <nav.link @route='scopes.scope.projects.sessions'>
-        <Rose::Icon @name='flight-icons/entry-point-16' @size='medium' />
+        <Rose::Icon @name='flight-icons/svg/entry-point-16' @size='medium' />
         {{t 'resources.session.title_plural'}}
       </nav.link>
     </Rose::Nav::Sidebar>

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
@@ -29,7 +29,7 @@
               <row.headerCell class='nowrap'>
                 <Rose::Icon
                   class={{concat 'session-status-' model.status}}
-                  @name='flight-icons/entry-point-16'
+                  @name='flight-icons/svg/entry-point-16'
                   @size='medium'
                 />
                 <Copyable

--- a/ui/desktop/app/templates/scopes/scope/projects/targets.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets.hbs
@@ -44,7 +44,7 @@
                     credential.library.name
                     (concat ' (' credential.library.name ')')
                   }}'
-                  @icon='flight-icons/key-16'
+                  @icon='flight-icons/svg/key-16'
                 >
                   <:header>
                     <Rose::Dropdown

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target/sessions.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target/sessions.hbs
@@ -17,7 +17,7 @@
           <row.cell class='nowrap'>
             <Rose::Icon
               class={{concat 'session-status-' session.status}}
-              @name='flight-icons/entry-point-16'
+              @name='flight-icons/svg/entry-point-16'
               @size='medium'
             />
             <Copyable

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -136,7 +136,13 @@ app.on('ready', async () => {
   // To show app icon in toolbar in linux, set browser window icon.
   // This is a limitation of electron build.
   if (isLinux())
-    browserWindowOptions.icon = path.join(__dirname, '..', 'assets', 'app-icons', 'icon.png');
+    browserWindowOptions.icon = path.join(
+      __dirname,
+      '..',
+      'assets',
+      'app-icons',
+      'icon.png'
+    );
 
   mainWindow = new BrowserWindow(browserWindowOptions);
 

--- a/ui/desktop/tests/integration/components/card-test.js
+++ b/ui/desktop/tests/integration/components/card-test.js
@@ -30,7 +30,7 @@ module('Integration | Component | card', function (hooks) {
     await render(hbs`
       <Card
         @heading='This is a heading test'
-        @icon='flight-icons/key-16'>
+        @icon='flight-icons/svg/key-16'>
         <:header></:header>
         <:body></:body>
         <:footer></:footer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2066,10 +2066,10 @@
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"
   integrity sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==
 
-"@hashicorp/flight-icons@0.0.6-beta":
-  version "0.0.6-beta"
-  resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-0.0.6-beta.tgz#49da48d4966c13ef0636a9853dc208fccc8d5c88"
-  integrity sha512-GJHFPig7n26mMyMDPuUiD2Szp8wEskkcLKxWGAx0wyCGASYotLgAYHAGfa4uLlUOsIkibxKjc/7Y/0ttQeN9hQ==
+"@hashicorp/flight-icons@0.0.9-beta":
+  version "0.0.9-beta"
+  resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-0.0.9-beta.tgz#d31f1afb8fcae55ca4a874dde351e552af8416b5"
+  integrity sha512-0UlHlg6tC41OQczgnAAq532bxL3me+Gd0av6eNxXTaqcF50t1JcmjPj4CWCgtXtRan2ae3BGSTqvqcjMILWjWQ==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
- Test of new version bump (already published to npm) https://github.com/hashicorp/flight/pull/227 that I made with @didoo 
- Addon has new namespacing, does this work for you @randallmorey?
- I think the find and replace second commit is a-ok, but please lmk if I missed something
- Note: For Boundary's end, AFAICT doesn't seem necessary to make this change now, I wanted to test the bump anyways so using Boundary as a great real-world example!
