### PR TITLE
Bump @hashicorp/flight-icons to 1.0.0 with ^

### DIFF
--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -43,7 +43,7 @@
     "@ember/test-helpers": "^2.4.2",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@hashicorp/flight-icons": "0.0.9-beta",
+    "@hashicorp/flight-icons": "^1.0.0",
     "@storybook/addon-actions": "^6.3.8",
     "@storybook/addon-docs": "^6.3.8",
     "@storybook/addon-knobs": "^6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2321,10 +2321,10 @@
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"
   integrity sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==
 
-"@hashicorp/flight-icons@0.0.9-beta":
-  version "0.0.9-beta"
-  resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-0.0.9-beta.tgz#d31f1afb8fcae55ca4a874dde351e552af8416b5"
-  integrity sha512-0UlHlg6tC41OQczgnAAq532bxL3me+Gd0av6eNxXTaqcF50t1JcmjPj4CWCgtXtRan2ae3BGSTqvqcjMILWjWQ==
+"@hashicorp/flight-icons@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-1.0.0.tgz#488ec6c3aaa8702d7878274abb8a5352eae1f6a2"
+  integrity sha512-LehZZOxbHZmVLzF6fy2w1LqJ5jQv+QXCfGlb7oToBc3u6YPxlIb3S1+bKQJIXzn7TELFRjRndnCtuYYXFO90Ng==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
Bump package to 1.0.0 🚀 

I think dependabot will pick up future bumps with the `^` and we are following SemVer.

IS:
![image](https://user-images.githubusercontent.com/1372946/134738191-1a8f396a-516b-466e-8b1e-66d6114c8b2d.png)

cc design systems folks @didoo @Dhaulagiri @MelSumner 