### PR TITLE
chore: 🤖 Add nth-check desktop resolutions

### DIFF
--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -48,6 +48,7 @@
     "normalize-url": "^4.5.1",
     "jszip": "^3.7.0",
     "path-parse": "^1.0.7",
-    "tar": "^6.1.9"
+    "tar": "^6.1.9",
+    "nth-check": "^2.0.1"
   }
 }

--- a/ui/desktop/electron-app/yarn.lock
+++ b/ui/desktop/electron-app/yarn.lock
@@ -2600,10 +2600,10 @@ npmlog@^4.0.2, npmlog@^4.1.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.0.tgz#1bb4f6dac70072fc313e8c9cd1417b5074c0a125"
-  integrity sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==
+nth-check@^2.0.0, nth-check@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
+  integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
   dependencies:
     boolbase "^1.0.0"
 


### PR DESCRIPTION
Add nth-check, transitive dependency, to desktop resolutions to avoid security vulnerability