### PR TITLE
feature: apply theme-color meta for more immersive UX

### DIFF
--- a/ui/admin/app/index.html
+++ b/ui/admin/app/index.html
@@ -6,6 +6,7 @@
     <title>Admin</title>
     <meta name="description" content="Simple and secure remote access with HashiCorp Boundary.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#f24c53">
 
     {{content-for "head"}}
 


### PR DESCRIPTION
[Applies the `theme-color` meta](https://css-tricks.com/safari-15-new-ui-theme-colors-and-a-css-tricks-cameo/) to Boundary UI, which adds brand color to the latest versions of macOS and iOS Safari.

<img width="1441" alt="Screenshot 2021-10-04 at 09 35 01" src="https://user-images.githubusercontent.com/8390120/135861779-cc0ed0cc-2585-447f-9a09-6e731c728c08.png">

