### PR TITLE
fix: 🐛 fix right dropdown alignment

### DIFF
--- a/addons/rose/addon/styles/rose/components/dropdown/_dropdown.scss
+++ b/addons/rose/addon/styles/rose/components/dropdown/_dropdown.scss
@@ -111,6 +111,7 @@ $chevronGrey: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%2362
   }
 
   &.rose-dropdown-right {
+    vertical-align: middle;
     .rose-dropdown-content {
       right: 0;
     }


### PR DESCRIPTION
this pr fixes dropdown alignment. 

**before**
<img width="990" alt="Screen Shot 2021-10-11 at 4 11 42 PM" src="https://user-images.githubusercontent.com/15043878/136865831-a761de7b-8a71-4531-bd53-3e5c76a3675b.png">

**after**
<img width="1023" alt="Screen Shot 2021-10-11 at 4 11 22 PM" src="https://user-images.githubusercontent.com/15043878/136865849-1cf68277-1f5f-480e-8c6c-9a4b43e6c7c7.png">

