### PR TITLE
Make UI reverse proxy path compatible

### DIFF
--- a/ui/admin/config/environment.js
+++ b/ui/admin/config/environment.js
@@ -2,12 +2,13 @@
 
 const APP_NAME = process.env.APP_NAME || 'Boundary';
 const API_HOST = process.env.API_HOST || '';
+const ROOT_URL = process.env.ROOT_URL || '/';
 
 module.exports = function (environment) {
   let ENV = {
     modulePrefix: 'admin',
     environment,
-    rootURL: '/',
+    rootURL: ROOT_URL,
     locationType: 'auto',
     EmberENV: {
       FEATURES: {

--- a/ui/desktop/config/environment.js
+++ b/ui/desktop/config/environment.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const APP_NAME = process.env.APP_NAME || 'Boundary';
+const ROOT_URL = process.env.ROOT_URL || '/';
 
 module.exports = function (environment) {
   let ENV = {
     modulePrefix: 'desktop',
     environment,
-    rootURL: process.env.EMBER_CLI_ELECTRON ? '' : '/',
+    rootURL: process.env.EMBER_CLI_ELECTRON ? '' : ROOT_URL,
     locationType: process.env.EMBER_CLI_ELECTRON ? 'hash' : 'auto',
     EmberENV: {
       FEATURES: {


### PR DESCRIPTION
Hi,
I'm running the boundary in my infrastructure, where I have a reverse proxy and an FQDN(myorg.com) with a valid SSL certificate. So theoretically I should be able to access boundary UI and the API server behind the proxy with a path like `myorg.com/boundary`, which will offload tasks like maintaining another domain/SSL etc. 
API will work with `myorg.com/bounday` but UI won't; because when the initial request for `/index.html` is passed, the response has all resources pointing to the root path `/style.css` rather than `/boundary/style.css` which will pass the request to another root ( because proxy will forward all request to `/boundary` to my boundary instance, and `/` to default app)

So if there is any way to prepend the proxy_path then the reverse proxy can pass the requests to `/boundary/<resource>`

![image](https://user-images.githubusercontent.com/2563385/139796793-6c782ca8-4fe3-453c-8734-861eb3a1aeb7.png)

