### PR TITLE
fix: 🐛 fix broken LinkButton component and associated new tests

### DIFF
--- a/addons/rose/addon/components/rose/link-button/index.hbs
+++ b/addons/rose/addon/components/rose/link-button/index.hbs
@@ -1,8 +1,6 @@
 <LinkTo
   class="rose-link-button {{if @style (concat "rose-button-" @style)}} {{if @iconOnly 'has-icon-only'}} {{if @iconLeft 'has-icon-left'}} {{if @iconRight 'has-icon-right'}}"
-  @route={{if @route @route}}
-  @query={{if @query @query}}
-  @model={{if @model @model}}
+  @route={{@route}}
   ...attributes>
   <span class="rose-button-wrapper">
     {{#if @iconLeft}}

--- a/ui/admin/tests/acceptance/accounts/create-test.js
+++ b/ui/admin/tests/acceptance/accounts/create-test.js
@@ -94,25 +94,25 @@ module('Acceptance | accounts | create', function (hooks) {
 
   test('Users can navigate to new account route with proper authorization', async function (assert) {
     assert.expect(2);
-    await visit(urls.authMethod);
+    await visit(urls.accounts);
     assert.ok(
       instances.authMethod.authorized_collection_actions.accounts.includes(
         'create'
       )
     );
-    assert.ok(find(`[href="${urls.accounts}"]`));
+    assert.ok(find(`[href="${urls.newAccount}"]`));
   });
 
   test('Users cannot navigate to new account route without proper authorization', async function (assert) {
     assert.expect(2);
     instances.authMethod.authorized_collection_actions.accounts = [];
-    await visit(urls.authMethod);
+    await visit(urls.accounts);
     assert.notOk(
       instances.authMethod.authorized_collection_actions.accounts.includes(
         'create'
       )
     );
-    assert.notOk(find(`[href="${urls.accounts}"]`));
+    assert.notOk(find(`[href="${urls.newAccount}"]`));
   });
 
   test('can cancel a new account creation', async function (assert) {

--- a/ui/admin/tests/acceptance/auth-methods/create-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/create-test.js
@@ -75,25 +75,25 @@ module('Acceptance | auth-methods | create ', function (hooks) {
       'create',
       'list',
     ];
-    await visit(urls.orgScope);
+    await visit(urls.authMethods);
     assert.ok(
       instances.orgScope.authorized_collection_actions['auth-methods'].includes(
         'create'
       )
     );
-    assert.ok(find(`[href="${urls.authMethods}"]`));
+    assert.ok(find(`[href="${urls.newAuthMethod}"]`));
   });
 
   test('Users cannot navigate to new auth-methods route without proper authorization', async function (assert) {
     assert.expect(2);
     instances.orgScope.authorized_collection_actions['auth-methods'] = [];
-    await visit(urls.orgScope);
+    await visit(urls.authMethods);
     assert.notOk(
       instances.orgScope.authorized_collection_actions['auth-methods'].includes(
         'create'
       )
     );
-    assert.notOk(find(`[href="${urls.authMethods}"]`));
+    assert.notOk(find(`[href="${urls.newAuthMethod}"]`));
   });
 
   test('can cancel new auth method creation', async function (assert) {

--- a/ui/admin/tests/acceptance/credential-library/create-test.js
+++ b/ui/admin/tests/acceptance/credential-library/create-test.js
@@ -29,7 +29,6 @@ module('Acceptance | credential-libraries | create', function (hooks) {
     credentialLibrary: null,
     credentialLibraries: null,
     newCredentialLibrary: null,
-    unknownCredentialLibrary: null,
   };
 
   hooks.beforeEach(function () {
@@ -59,7 +58,6 @@ module('Acceptance | credential-libraries | create', function (hooks) {
     urls.credentialLibraries = `${urls.credentialStore}/credential-libraries`;
     urls.credentialLibrary = `${urls.credentialLibraries}/${instances.credentialLibrary.id}`;
     urls.newCredentialLibrary = `${urls.credentialLibraries}/new`;
-    urls.unknownCredentialLibrary = `${urls.credentialLibraries}/foo`;
     // Generate resource counter
     getCredentialLibraryCount = () =>
       this.server.schema.credentialLibraries.all().models.length;
@@ -76,14 +74,6 @@ module('Acceptance | credential-libraries | create', function (hooks) {
     assert.equal(currentURL(), urls.credentialLibrary);
   });
 
-  test('visiting an unknown credential library displays 404 message', async function (assert) {
-    assert.expect(1);
-    await visit(urls.unknownCredentialLibrary);
-    await a11yAudit();
-    console.debug(find('.rose-message-subtitle'));
-    assert.ok(find('.rose-message-subtitle').textContent.trim(), 'Error 404');
-  });
-
   test('can create a credential library', async function (assert) {
     assert.expect(1);
     const count = getCredentialLibraryCount();
@@ -98,13 +88,13 @@ module('Acceptance | credential-libraries | create', function (hooks) {
     instances.credentialStore.authorized_collection_actions[
       'credential-libraries'
     ] = [];
-    await visit(urls.credentialStore);
+    await visit(urls.credentialLibraries);
     assert.notOk(
       instances.credentialStore.authorized_collection_actions[
         'credential-libraries'
       ].includes('create')
     );
-    assert.notOk(find(`[href="${urls.credentialLibraries}"]`));
+    assert.notOk(find(`[href="${urls.newCredentialLibrary}"]`));
   });
 
   test('can cancel create a new credential library', async function (assert) {

--- a/ui/admin/tests/acceptance/credential-library/read-test.js
+++ b/ui/admin/tests/acceptance/credential-library/read-test.js
@@ -77,4 +77,12 @@ module('Acceptance | credential-libraries | read', function (hooks) {
     await visit(urls.credentialLibraries);
     assert.notOk(find('main tbody .rose-table-header-cell a'));
   });
+
+  test('visiting an unknown credential library displays 404 message', async function (assert) {
+    assert.expect(1);
+    await visit(urls.unknownCredentialLibrary);
+    await a11yAudit();
+    console.debug(find('.rose-message-subtitle'));
+    assert.ok(find('.rose-message-subtitle').textContent.trim(), 'Error 404');
+  });
 });

--- a/ui/admin/tests/acceptance/credential-store/create-test.js
+++ b/ui/admin/tests/acceptance/credential-store/create-test.js
@@ -24,7 +24,6 @@ module('Acceptance | credential-stores | create', function (hooks) {
     projectScope: null,
     credentialStores: null,
     credentialStore: null,
-    unknownCredentialStore: null,
     newCredentialStore: null,
   };
 
@@ -47,7 +46,6 @@ module('Acceptance | credential-stores | create', function (hooks) {
     urls.projectScope = `/scopes/${instances.scopes.project.id}`;
     urls.credentialStores = `${urls.projectScope}/credential-stores`;
     urls.credentialStore = `${urls.credentialStores}/${instances.credentialStore.id}`;
-    urls.unknownCredentialStore = `${urls.credentialStores}/foo`;
     urls.newCredentialStore = `${urls.credentialStores}/new`;
     // Generate resource counter
     getCredentialStoresCount = () => {
@@ -80,13 +78,13 @@ module('Acceptance | credential-stores | create', function (hooks) {
     instances.scopes.project.authorized_collection_actions[
       'credential-stores'
     ] = [];
-    await visit(urls.projectScope);
+    await visit(urls.credentialStores);
     assert.notOk(
       instances.scopes.project.authorized_collection_actions[
         'credential-stores'
       ].includes('create')
     );
-    assert.notOk(find(`[href="${urls.credentialStores}"]`));
+    assert.notOk(find(`[href="${urls.newCredentialStore}"]`));
   });
 
   test('saving a new credential store with invalid fields displays error messages', async function (assert) {

--- a/ui/admin/tests/acceptance/groups/create-test.js
+++ b/ui/admin/tests/acceptance/groups/create-test.js
@@ -13,7 +13,6 @@ import {
 module('Acceptance | groups | create', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  let orgURL;
 
   const instances = {
     scopes: {
@@ -45,7 +44,6 @@ module('Acceptance | groups | create', function (hooks) {
     urls.groups = `/scopes/${instances.orgScope.id}/groups`;
     urls.group = `${urls.groups}/${instances.group.id}`;
     urls.newGroup = `${urls.groups}/new`;
-    orgURL = `/scopes/${instances.orgScope.id}`;
   });
 
   test('can create new group', async function (assert) {
@@ -59,21 +57,21 @@ module('Acceptance | groups | create', function (hooks) {
 
   test('can navigate to new groups route with proper authorization', async function (assert) {
     assert.expect(2);
-    await visit(orgURL);
+    await visit(urls.groups);
     assert.ok(
       instances.orgScope.authorized_collection_actions.groups.includes('create')
     );
-    assert.ok(find(`[href="${urls.groups}"]`));
+    assert.ok(find(`[href="${urls.newGroup}"]`));
   });
 
   test('cannot navigate to new groups route without proper authorization', async function (assert) {
     assert.expect(2);
     instances.orgScope.authorized_collection_actions.groups = [];
-    await visit(orgURL);
+    await visit(urls.groups);
     assert.notOk(
       instances.orgScope.authorized_collection_actions.groups.includes('create')
     );
-    assert.notOk(find(`[href="${urls.groups}"]`));
+    assert.notOk(find(`[href="${urls.newGroup}"]`));
   });
   test('can cancel new group creation', async function (assert) {
     assert.expect(2);

--- a/ui/admin/tests/acceptance/host-catalogs/create-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/create-test.js
@@ -92,26 +92,26 @@ module('Acceptance | host-catalogs | create', function (hooks) {
 
   test('Users can navigate to new host catalogs route with proper authorization', async function (assert) {
     assert.expect(2);
-    await visit(urls.projectScope);
+    await visit(urls.hostCatalogs);
     assert.ok(
       instances.scopes.project.authorized_collection_actions[
         'host-catalogs'
       ].includes('create')
     );
-    assert.ok(find(`[href="${urls.hostCatalogs}"]`));
+    assert.ok(find(`[href="${urls.newHostCatalog}"]`));
   });
 
   test('Users cannot navigate to new host catalogs route without proper authorization', async function (assert) {
     assert.expect(2);
     instances.scopes.project.authorized_collection_actions['host-catalogs'] =
       [];
-    await visit(urls.projectScope);
+    await visit(urls.hostCatalogs);
     assert.notOk(
       instances.scopes.project.authorized_collection_actions[
         'host-catalogs'
       ].includes('create')
     );
-    assert.notOk(find(`[href="${urls.hostCatalogs}"]`));
+    assert.notOk(find(`[href="${urls.newHostCatalog}"]`));
   });
 
   test('saving a new host catalog with invalid fields displays error messages', async function (assert) {

--- a/ui/admin/tests/acceptance/host-catalogs/host-sets/create-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/host-sets/create-test.js
@@ -94,13 +94,13 @@ module('Acceptance | host-catalogs | host sets | create', function (hooks) {
   test('Users cannot navigate to new host sets route without proper authorization', async function (assert) {
     assert.expect(2);
     instances.hostCatalog.authorized_collection_actions['host-sets'] = [];
-    await visit(urls.hostCatalog);
+    await visit(urls.hostSets);
     assert.notOk(
       instances.hostCatalog.authorized_collection_actions['host-sets'].includes(
         'create'
       )
     );
-    assert.notOk(find(`[href="${urls.hostSets}"]`));
+    assert.notOk(find(`[href="${urls.newHostSet}"]`));
   });
 
   test('can cancel create new host', async function (assert) {

--- a/ui/admin/tests/acceptance/host-catalogs/hosts/create-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/hosts/create-test.js
@@ -90,27 +90,27 @@ module('Acceptance | host-catalogs | hosts | create', function (hooks) {
     );
     assert.notOk(find(`.rose-layout-page-actions [href="${urls.newHost}"]`));
   });
-  test('Users can navigate to new host catalogs route with proper authorization', async function (assert) {
+  test('Users can navigate to new host route with proper authorization', async function (assert) {
     assert.expect(2);
-    await visit(urls.hostCatalog);
+    await visit(urls.hosts);
     assert.ok(
       instances.hostCatalog.authorized_collection_actions.hosts.includes(
         'create'
       )
     );
-    assert.ok(find(`[href="${urls.hosts}"]`));
+    assert.ok(find(`[href="${urls.newHost}"]`));
   });
 
-  test('Users cannot navigate to new host catalogs route without proper authorization', async function (assert) {
+  test('Users cannot navigate to new host route without proper authorization', async function (assert) {
     assert.expect(2);
     instances.hostCatalog.authorized_collection_actions.hosts = [];
-    await visit(urls.hostCatalog);
+    await visit(urls.hosts);
     assert.notOk(
       instances.hostCatalog.authorized_collection_actions.hosts.includes(
         'create'
       )
     );
-    assert.notOk(find(`[href="${urls.hosts}"]`));
+    assert.notOk(find(`[href="${urls.newHost}"]`));
   });
 
   test('can cancel create new host', async function (assert) {

--- a/ui/admin/tests/acceptance/roles/create-test.js
+++ b/ui/admin/tests/acceptance/roles/create-test.js
@@ -73,21 +73,21 @@ module('Acceptance | roles | create', function (hooks) {
 
   test('Users can navigate to new roles route with proper authorization', async function (assert) {
     assert.expect(2);
-    await visit(urls.orgScope);
+    await visit(urls.roles);
     assert.ok(
       instances.orgScope.authorized_collection_actions.roles.includes('create')
     );
-    assert.ok(find(`[href="${urls.roles}"]`));
+    assert.ok(find(`[href="${urls.newRole}"]`));
   });
 
   test('Users cannot navigate to new roles route without proper authorization', async function (assert) {
     assert.expect(2);
     instances.orgScope.authorized_collection_actions.roles = [];
-    await visit(urls.orgScope);
+    await visit(urls.roles);
     assert.notOk(
       instances.orgScope.authorized_collection_actions.roles.includes('create')
     );
-    assert.notOk(find(`[href="${urls.roles}"]`));
+    assert.notOk(find(`[href="${urls.newRole}"]`));
   });
 
   test('can cancel new role creation', async function (assert) {

--- a/ui/admin/tests/acceptance/roles/list-test.js
+++ b/ui/admin/tests/acceptance/roles/list-test.js
@@ -18,7 +18,6 @@ module('Acceptance | roles | list', function (hooks) {
       global: null,
       org: null,
     },
-    orgScope: null,
   };
 
   const urls = {
@@ -26,50 +25,46 @@ module('Acceptance | roles | list', function (hooks) {
       org: null,
     },
     roles: null,
-    orgScope: null,
   };
 
   hooks.beforeEach(function () {
-    instances.orgScope = this.server.create(
-      'scope',
-      {
-        type: 'org',
-        scope: { id: 'global', type: 'global' },
-      },
-      'withChildren'
-    );
-    instances.role = this.server.create('role', {
-      scope: instances.orgScope,
+    instances.scopes.global = this.server.create('scope', { id: 'global' });
+    instances.scopes.org = this.server.create('scope', {
+      type: 'org',
+      scope: { id: 'global', type: 'global' },
     });
-    urls.orgScope = `/scopes/${instances.orgScope.id}`;
+    instances.role = this.server.create('role', {
+      scope: instances.scopes.org,
+    });
+    urls.scopes.org = `/scopes/${instances.scopes.org.id}`;
 
-    urls.roles = `/scopes/${instances.orgScope.id}/roles`;
+    urls.roles = `/scopes/${instances.scopes.org.id}/roles`;
     authenticateSession({});
   });
 
   test('Users can navigate to roles with proper authorization', async function (assert) {
     assert.expect(2);
-    await visit(urls.orgScope);
+    await visit(urls.scopes.org);
     assert.ok(
-      instances.orgScope.authorized_collection_actions.roles.includes('list')
+      instances.scopes.org.authorized_collection_actions.roles.includes('list')
     );
     assert.ok(find(`[href="${urls.roles}"]`));
   });
 
   test('Users cannot navigate to index without either list or create actions', async function (assert) {
     assert.expect(2);
-    instances.orgScope.authorized_collection_actions.roles = [];
-    await visit(urls.orgScope);
+    instances.scopes.org.authorized_collection_actions.roles = [];
+    await visit(urls.scopes.org);
     assert.notOk(
-      instances.orgScope.authorized_collection_actions.roles.includes('list')
+      instances.scopes.org.authorized_collection_actions.roles.includes('list')
     );
     assert.notOk(find(`[href="${urls.roles}"]`));
   });
 
   test('Users can navigate to index with only create action', async function (assert) {
     assert.expect(1);
-    instances.orgScope.authorized_collection_actions.roles = ['create'];
-    await visit(urls.orgScope);
+    instances.scopes.org.authorized_collection_actions.roles = ['create'];
+    await visit(urls.scopes.org);
     assert.ok(find(`[href="${urls.roles}"]`));
   });
 });

--- a/ui/admin/tests/acceptance/targets/create-test.js
+++ b/ui/admin/tests/acceptance/targets/create-test.js
@@ -69,25 +69,25 @@ module('Acceptance | targets | create', function (hooks) {
 
   test('can navigate to new targets route with proper authorization', async function (assert) {
     assert.expect(2);
-    await visit(urls.projectScope);
+    await visit(urls.targets);
     assert.ok(
       instances.scopes.project.authorized_collection_actions.targets.includes(
         'create'
       )
     );
-    assert.ok(find(`[href="${urls.targets}"]`));
+    assert.ok(find(`[href="${urls.newTarget}"]`));
   });
 
   test('cannot navigate to new targets route without proper authorization', async function (assert) {
     assert.expect(2);
     instances.scopes.project.authorized_collection_actions.targets = [];
-    await visit(urls.projectScope);
+    await visit(urls.targets);
     assert.notOk(
       instances.scopes.project.authorized_collection_actions.targets.includes(
         'create'
       )
     );
-    assert.notOk(find(`[href="${urls.targets}"]`));
+    assert.notOk(find(`[href="${urls.newTarget}"]`));
   });
 
   test('can cancel create new targets', async function (assert) {

--- a/ui/admin/tests/acceptance/users/create-test.js
+++ b/ui/admin/tests/acceptance/users/create-test.js
@@ -15,7 +15,6 @@ module('Acceptance | users | create', function (hooks) {
   setupMirage(hooks);
 
   let orgScope;
-  let orgURL;
   let usersURL;
   let newUserURL;
 
@@ -30,7 +29,6 @@ module('Acceptance | users | create', function (hooks) {
       'withChildren'
     );
 
-    orgURL = `/scopes/${orgScope.id}`;
     usersURL = `/scopes/${orgScope.id}/users`;
     newUserURL = `${usersURL}/new`;
 
@@ -48,19 +46,19 @@ module('Acceptance | users | create', function (hooks) {
 
   test('Users can navigate to new users route with proper authorization', async function (assert) {
     assert.expect(2);
-    await visit(orgURL);
+    await visit(usersURL);
     assert.ok(orgScope.authorized_collection_actions.users.includes('create'));
-    assert.ok(find(`[href="${orgURL}/users"]`));
+    assert.ok(find(`[href="${newUserURL}"]`));
   });
 
   test('Users cannot navigate to new users route without proper authorization', async function (assert) {
     assert.expect(2);
     orgScope.authorized_collection_actions.users = [];
-    await visit(orgURL);
+    await visit(usersURL);
     assert.notOk(
       orgScope.authorized_collection_actions.users.includes('create')
     );
-    assert.notOk(find(`[href="${orgURL}/users"]`));
+    assert.notOk(find(`[href="${newUserURL}"]`));
   });
 
   test('can cancel creation of a new user', async function (assert) {


### PR DESCRIPTION
The LinkButton was silently broken due to a problem with a recent refactor.  This PR fixes that problem and updates the create acceptance tests in admin to test for the expected URLs in link buttons.