### PR TITLE
Remove ember-get-config

### DIFF
--- a/addons/api/addon/adapters/application.js
+++ b/addons/api/addon/adapters/application.js
@@ -2,7 +2,7 @@ import RESTAdapter from '@ember-data/adapter/rest';
 import { serializeIntoHash } from '@ember-data/adapter/-private';
 /* eslint-disable-next-line ember/no-mixins */
 import AdapterBuildURLMixin from '../mixins/adapter-build-url';
-import config from 'ember-get-config';
+import { getOwner } from '@ember/application';
 import { get } from '@ember/object';
 import { InvalidError } from '@ember-data/adapter/error';
 import { dasherize } from '@ember/string';
@@ -44,19 +44,36 @@ export default class ApplicationAdapter extends RESTAdapter.extend(
 ) {
   // =attributes
 
+  #host;
+  #namespace;
+
   /**
    * Sets host to the `api.host` string in the application's config,
    * if set.
    * @type {string}
    */
-  host = get(config, 'api.host');
+  get host() {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    return this.#host || get(config, 'api.host');
+  }
+  set host(value) {
+    // Setting this value is useful for testing purposes.
+    this.#host = value;
+  }
 
   /**
    * Sets namespace to the `api.namespace` string in the application's config,
    * if set.
    * @type {string}
    */
-  namespace = get(config, 'api.namespace');
+  get namespace() {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    return this.#namespace || get(config, 'api.namespace');
+  }
+  set namespace(value) {
+    // Setting this value is useful for testing purposes.
+    this.#namespace = value;
+  }
 
   // =methods
 

--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -8,7 +8,7 @@ import makeBooleanFilter from './helpers/bexpr-filter';
 const isTesting = config.environment === 'test';
 
 export default function () {
-  initializeMockIPC(this);
+  initializeMockIPC(this, config);
 
   // make this `http://localhost:8080`, for example, if your API is on a different server
   // this.urlPrefix = '';

--- a/addons/api/mirage/scenarios/ipc.js
+++ b/addons/api/mirage/scenarios/ipc.js
@@ -1,9 +1,8 @@
-import config from 'ember-get-config';
 import { datatype } from 'faker';
 
-const isTesting = config.environment === 'test';
+export default function initializeMockIPC(server, config) {
+  const isTesting = config.environment === 'test';
 
-export default function initializeMockIPC(server) {
   /**
    * We strive to make this application runnable in a regular web browser, since
    * it is a convenient environment for development and testing.  But only an

--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -51,7 +51,6 @@
     "ember-copy": "^2.0.1",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
-    "ember-get-config": "^0.3.0",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^1.0.0",
     "ember-page-title": "^6.2.2",

--- a/addons/api/tests/unit/adapters/application-test.js
+++ b/addons/api/tests/unit/adapters/application-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import config from 'ember-get-config';
 import RESTAdapter from '@ember-data/adapter/rest';
 import { InvalidError } from '@ember-data/adapter/error';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,6 +8,12 @@ import { Response } from 'miragejs';
 module('Unit | Adapter | application', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
+
+  let config;
+
+  hooks.beforeEach(function () {
+    config = this.owner.resolveRegistration('config:environment');
+  });
 
   test('its namespace is equal to the configured namespace', function (assert) {
     assert.expect(2);

--- a/addons/core/addon/helpers/app-name.js
+++ b/addons/core/addon/helpers/app-name.js
@@ -1,6 +1,9 @@
-import { helper } from '@ember/component/helper';
-import config from 'ember-get-config';
+import Helper from '@ember/component/helper';
+import { getOwner } from '@ember/application';
 
-export default helper(function appName() {
-  return config.appName;
-});
+export default class extends Helper {
+  compute() {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    return config.appName;
+  }
+}

--- a/addons/core/addon/helpers/company-copyright.js
+++ b/addons/core/addon/helpers/company-copyright.js
@@ -1,7 +1,10 @@
-import { helper } from '@ember/component/helper';
-import config from 'ember-get-config';
+import Helper from '@ember/component/helper';
+import { getOwner } from '@ember/application';
 
-export default helper(function companyCopyright() {
-  const currentYear = new Date().getFullYear();
-  return `© ${currentYear} ${config.companyName}`;
-});
+export default class extends Helper {
+  compute() {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    const currentYear = new Date().getFullYear();
+    return `© ${currentYear} ${config.companyName}`;
+  }
+}

--- a/addons/core/addon/helpers/company-name.js
+++ b/addons/core/addon/helpers/company-name.js
@@ -1,6 +1,9 @@
-import { helper } from '@ember/component/helper';
-import config from 'ember-get-config';
+import Helper from '@ember/component/helper';
+import { getOwner } from '@ember/application';
 
-export default helper(function companyName() {
-  return config.companyName;
-});
+export default class extends Helper {
+  compute() {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    return config.companyName;
+  }
+}

--- a/addons/core/addon/helpers/doc-url.js
+++ b/addons/core/addon/helpers/doc-url.js
@@ -1,20 +1,23 @@
-import { helper } from '@ember/component/helper';
+import Helper from '@ember/component/helper';
+import { getOwner } from '@ember/application';
 import { assert } from '@ember/debug';
-import config from 'ember-get-config';
 
-export default helper(function docUrl(params /*, hash*/) {
-  const baseURL = config.documentation.baseURL;
-  const docKey = params[0] || '';
-  const configuredPath = config.documentation.topics[docKey];
-  if (docKey) {
-    assert(
-      `
-      Documentation for "${docKey}" could not be found. Please ensure that
-      this key exists under "documentation" in your app config.
-    `,
-      configuredPath
-    );
+export default class extends Helper {
+  compute(params) {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    const baseURL = config.documentation.baseURL;
+    const docKey = params[0] || '';
+    const configuredPath = config.documentation.topics[docKey];
+    if (docKey) {
+      assert(
+        `
+        Documentation for "${docKey}" could not be found. Please ensure that
+        this key exists under "documentation" in your app config.
+      `,
+        configuredPath
+      );
+    }
+    const path = configuredPath || '';
+    return `${baseURL}${path}`;
   }
-  const path = configuredPath || '';
-  return `${baseURL}${path}`;
-});
+}

--- a/addons/core/addon/initializers/deprecations.js
+++ b/addons/core/addon/initializers/deprecations.js
@@ -1,9 +1,8 @@
 import { registerDeprecationHandler } from '@ember/debug';
-import config from 'ember-get-config';
 
-const isTesting = config.environment === 'test';
-
-export function initialize(/* application */) {
+export function initialize(application) {
+  const config = application.resolveRegistration('config:environment');
+  const isTesting = config.environment === 'test';
   if (isTesting) {
     // Disable all deprecations for now in tests.
     registerDeprecationHandler((/*message, options, next*/) => {

--- a/addons/core/addon/services/confirm.js
+++ b/addons/core/addon/services/confirm.js
@@ -3,7 +3,7 @@ import { filterBy } from '@ember/object/computed';
 import { A } from '@ember/array';
 import { tracked } from '@glimmer/tracking';
 import { defer, resolve } from 'rsvp';
-import config from 'ember-get-config';
+import { getOwner } from '@ember/application';
 
 /**
  * A simple service that emits Confirmation instances and
@@ -17,13 +17,21 @@ import config from 'ember-get-config';
 export default class ConfirmationsService extends Service {
   // =attributes
 
+  #enabled;
+
   /**
    * When the confirm service is disabled, it always returns resolving promises.
    * By default the service is enabled but it is useful to disable it for test
    * purposes.
    * @type {boolean}
    */
-  enabled = config.enableConfirmService ?? true;
+  get enabled() {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    return this.#enabled ?? config.enableConfirmService ?? true;
+  }
+  set enabled(value) {
+    this.#enabled = value;
+  }
 
   /**
    * @type {Array}

--- a/addons/core/package.json
+++ b/addons/core/package.json
@@ -34,7 +34,6 @@
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-feature-flags": "^6.0.0",
-    "ember-get-config": "^0.3.0",
     "ember-intl": "^5.7.0",
     "ember-loading": "^0.4.0",
     "ember-route-action-helper": "^2.0.8",

--- a/addons/core/tests/integration/helpers/doc-url-test.js
+++ b/addons/core/tests/integration/helpers/doc-url-test.js
@@ -2,13 +2,13 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import config from 'ember-get-config';
 
 module('Integration | Helper | doc-url', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders a URL generated from the documentation config', async function (assert) {
     assert.expect(3);
+    const config = this.owner.resolveRegistration('config:environment');
     const baseURL = config.documentation.baseURL;
     const path = config.documentation.topics.account;
     await render(hbs`{{doc-url 'account'}}`);
@@ -19,7 +19,8 @@ module('Integration | Helper | doc-url', function (hooks) {
 
   test('it throws an error if the specified documentation path cannot be found', async function (assert) {
     assert.expect(2);
-    const helper = this.owner.lookup('helper:doc-url');
+    const Helper = this.owner.lookup('helper:doc-url');
+    const helper = new Helper(this.owner);
     assert.ok(helper.compute(['account']), 'Specified document exists.');
     assert.throws(() => {
       helper.compute(['no.such.doc']);

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -38,7 +38,6 @@
     "emberx-select": "github:adopted-ember-addons/emberx-select#bc5f774"
   },
   "devDependencies": {
-    "ember-get-config": "^0.3.0",
     "@babel/core": "^7.15.5",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.4.2",

--- a/addons/rose/tests/dummy/app/initializers/deprecations.js
+++ b/addons/rose/tests/dummy/app/initializers/deprecations.js
@@ -1,9 +1,8 @@
 import { registerDeprecationHandler } from '@ember/debug';
-import config from 'ember-get-config';
 
-const isTesting = config.environment === 'test';
-
-export function initialize(/* application */) {
+export function initialize(application) {
+  const config = application.resolveRegistration('config:environment');
+  const isTesting = config.environment === 'test';
   if (isTesting) {
     // Disable all deprecations for now in tests.
     registerDeprecationHandler((/*message, options, next*/) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9984,7 +9984,7 @@ ember-focus-trap@^0.7.0:
     ember-modifier-manager-polyfill "^1.2.0"
     focus-trap "^6.4.0"
 
-"ember-get-config@^0.2.4 || ^0.3.0", ember-get-config@^0.3.0:
+"ember-get-config@^0.2.4 || ^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.3.0.tgz#a73a1a87b48d9dde4c66a0e52ed5260b8a48cfbd"
   integrity sha512-0e2pKzwW5lBZ4oJnvu9qHOht4sP1MWz/m3hyz8kpSoMdrlZVf62LDKZ6qfKgy8drcv5YhCMYE6QV7MhnqlrzEQ==


### PR DESCRIPTION
Boundary UI used `ember-get-config` in multiple places, but this was ultimately unnecessary.  Removing our dependence on this addon brings us a step closer to adopting [Embroider](https://github.com/embroider-build/embroider).