### PR TITLE
feat: 🎸 Add managed groups delete CRUD operation

### DIFF
--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -522,6 +522,7 @@ export default function () {
     }
   );
   this.get('/managed-groups/:id');
+  this.del('/managed-groups/:id');
 
   /* Uncomment the following line and the Response import above
    * Then change the response code to simulate error responses.

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups.js
@@ -1,7 +1,14 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
+import { confirm } from 'core/decorators/confirm';
+import loading from 'ember-loading/decorator';
+import { notifySuccess, notifyError } from 'core/decorators/notify';
 
 export default class ScopesScopeAuthMethodsAuthMethodManagedGroupsRoute extends Route {
+  // =services
+
+  @service notify;
   /**
    *
    * @returns {Promise{[ManagedGroupsModel]}}
@@ -24,5 +31,22 @@ export default class ScopesScopeAuthMethodsAuthMethodManagedGroupsRoute extends 
     if (isNew) {
       this.transitionTo('scopes.scope.auth-methods.auth-method.managed-groups');
     }
+  }
+
+  /**
+   * Delete a managed group in current scope and redirect to index
+   * @param {ManagedGroupModel} managed group
+   */
+  @action
+  @loading
+  @confirm('questions.delete-confirm')
+  @notifyError(({ message }) => message, { catch: true })
+  @notifySuccess('notifications.delete-success')
+  async deleteManagedGroup(managedGroup) {
+    await managedGroup.destroyRecord();
+    await this.replaceWith(
+      'scopes.scope.auth-methods.auth-method.managed-groups'
+    );
+    this.refresh();
   }
 }

--- a/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/managed-groups/managed-group/-actions.hbs
+++ b/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/managed-groups/managed-group/-actions.hbs
@@ -4,7 +4,11 @@
     @dropdownRight={{true}}
     as |dropdown|
   >
-    <dropdown.button @style='danger' @disabled={{@model.canSave}}>
+    <dropdown.button
+      @style='danger'
+      @disabled={{@model.canSave}}
+      {{on 'click' (route-action 'deleteManagedGroup' @model)}}
+    >
       {{t 'resources.managed-group.actions.delete'}}
     </dropdown.button>
   </Rose::Dropdown>


### PR DESCRIPTION
Add delete CRUD operation to managed groups.

**[Preview link](https://boundary-ui-git-feature-managed-group-delete-hashicorp.vercel.app/scopes/global/auth-methods/auth-method-id-1/managed-groups/managed-groups-id-0)**

<img width="1505" alt="Screen Shot 2021-11-09 at 11 56 56 AM" src="https://user-images.githubusercontent.com/9775006/140996281-428fb71a-397b-4fee-b557-b6e4b274bc33.png">

<img width="1505" alt="Screen Shot 2021-11-09 at 11 57 20 AM" src="https://user-images.githubusercontent.com/9775006/140996293-8fb45795-06d4-4026-acd7-ac2535f52d54.png">
