### PR TITLE
Feature desktop sessions filter

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects/sessions.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions.js
@@ -4,6 +4,7 @@ import { task, timeout } from 'ember-concurrency';
 import config from '../../../../config/environment';
 import { action } from '@ember/object';
 import { notifySuccess, notifyError } from 'core/decorators/notify';
+import { resourceFilterParam } from 'core/decorators/resource-filter-param';
 
 const POLL_TIMEOUT_SECONDS = config.sessionPollingTimeoutSeconds;
 
@@ -16,6 +17,8 @@ export default class ScopesScopeProjectsSessionsRoute extends Route {
   @service resourceFilterStore;
 
   // =attributes
+
+  @resourceFilterParam(['active', 'pending', 'canceling', 'terminated']) status;
 
   /**
    * A simple Ember Concurrency-based polling task that refreshes the route
@@ -50,10 +53,11 @@ export default class ScopesScopeProjectsSessionsRoute extends Route {
    * @return {Promise{[{session: SessionModel, target: TargetModel}]}}
    */
   async model() {
+    const { status } = this;
     const { id: scope_id } = this.modelFor('scopes.scope');
     const { user_id } = this.session.data.authenticated;
     await this.store.query('target', { recursive: true, scope_id });
-    return await this.resourceFilterStore.queryBy('session', { user_id }, {
+    return await this.resourceFilterStore.queryBy('session', { user: user_id , status }, {
       recursive: true,
       scope_id
     });
@@ -86,4 +90,22 @@ export default class ScopesScopeProjectsSessionsRoute extends Route {
     await session.cancelSession();
     await this.ipc.invoke('stop', { session_id: session.id });
   }
+
+    /**
+ * Sets the specified resource filter field to the specified value.
+ * @param {string} field
+ * @param value
+ */
+    @action
+    filterBy(field, value) {
+      this[field] = value;
+    }
+  
+    /**
+     * Clears and filter selections.
+     */
+    @action
+    clearAllFilters() {
+      this.status = [];
+    }
 }

--- a/ui/desktop/app/routes/scopes/scope/projects/sessions.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions.js
@@ -57,7 +57,7 @@ export default class ScopesScopeProjectsSessionsRoute extends Route {
     const { id: scope_id } = this.modelFor('scopes.scope');
     const { user_id } = this.session.data.authenticated;
     await this.store.query('target', { recursive: true, scope_id });
-    return await this.resourceFilterStore.queryBy('session', { user: user_id , status }, {
+    return await this.resourceFilterStore.queryBy('session', { user_id , status }, {
       recursive: true,
       scope_id
     });

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
@@ -9,7 +9,58 @@
   </page.header>
 
   <page.body>
+    {{#if (feature-flag 'filter')}}
+      {{#if
+        (or
+          @model (has-resource-filter-param-selections 'scopes.scope.projects.sessions')
+        )
+      }}
+        <Rose::Toolbar>
+          <Rose::Form as |form|>
+            {{#with
+              (resource-filter-param 'scopes.scope.projects.sessions' 'status')
+              as |filter|
+            }}
+              <Rose::Dropdown
+                @text={{t (concat 'form.' filter.name '.label')}}
+                @count={{filter.selectedValue.length}}
+                @ignoreClickInside={{true}}
+                as |dropdown|
+              >
+                <form.checkboxGroup
+                  @name={{filter.name}}
+                  @items={{filter.allowedValues}}
+                  @selectedItems={{filter.selectedValue}}
+                  @onChange={{route-action 'filterBy' filter.name}}
+                  as |group|
+                >
+                  <dropdown.item>
+                    <group.checkbox
+                      @label={{t
+                        (concat 'resources.session.status.' group.item)
+                      }}
+                      value={{group.item}}
+                    />
+                  </dropdown.item>
+                </form.checkboxGroup>
+              </Rose::Dropdown>
+            {{/with}}
 
+            {{#if
+              (has-resource-filter-param-selections 'scopes.scope.projects.sessions')
+            }}
+              <Rose::Button
+                @style='inline-link-action'
+                @iconLeft='flight-icons/svg/x-16'
+                {{on 'click' (route-action 'clearAllFilters')}}
+              >{{t 'actions.clear-all-filters'}}
+              </Rose::Button>
+            {{/if}}
+          </Rose::Form>
+        </Rose::Toolbar>
+      {{/if}}
+    {{/if}}
+    {{#if @model}}
     {{#if this.sorted}}
 
       <Rose::Table as |table|>
@@ -87,7 +138,14 @@
           {{/each}}
         </table.body>
       </Rose::Table>
-
+    {{else if (has-resource-filter-param-selections 'scopes.scope.projects.sessions')}}
+      <Rose::Layout::Centered>
+        <Rose::Message @title={{t 'titles.no-results'}} as |message|>
+          <message.description>
+            {{t 'descriptions.no-results'}}
+          </message.description>
+        </Rose::Message>
+      </Rose::Layout::Centered>
     {{else}}
 
       <Rose::Layout::Centered>
@@ -102,7 +160,7 @@
       </Rose::Layout::Centered>
 
     {{/if}}
-
+    {{/if}}
   </page.body>
 
 </Rose::Layout::Page>

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
@@ -12,7 +12,10 @@
     {{#if (feature-flag 'filter')}}
       {{#if
         (or
-          @model (has-resource-filter-param-selections 'scopes.scope.projects.sessions')
+          @model
+          (has-resource-filter-param-selections
+            'scopes.scope.projects.sessions'
+          )
         )
       }}
         <Rose::Toolbar>
@@ -47,7 +50,9 @@
             {{/with}}
 
             {{#if
-              (has-resource-filter-param-selections 'scopes.scope.projects.sessions')
+              (has-resource-filter-param-selections
+                'scopes.scope.projects.sessions'
+              )
             }}
               <Rose::Button
                 @style='inline-link-action'
@@ -60,9 +65,8 @@
         </Rose::Toolbar>
       {{/if}}
     {{/if}}
-    {{#if @model}}
-    {{#if this.sorted}}
 
+    {{#if this.sorted}}
       <Rose::Table as |table|>
         <table.header as |header|>
           <header.row as |row|>
@@ -138,7 +142,9 @@
           {{/each}}
         </table.body>
       </Rose::Table>
-    {{else if (has-resource-filter-param-selections 'scopes.scope.projects.sessions')}}
+    {{else if (has-resource-filter-param-selections
+      'scopes.scope.projects.sessions'
+    )}}
       <Rose::Layout::Centered>
         <Rose::Message @title={{t 'titles.no-results'}} as |message|>
           <message.description>
@@ -147,7 +153,6 @@
         </Rose::Message>
       </Rose::Layout::Centered>
     {{else}}
-
       <Rose::Layout::Centered>
         <Rose::Message
           @title={{t 'resources.session.messages.none-friendly.title'}}
@@ -158,8 +163,6 @@
           </message.description>
         </Rose::Message>
       </Rose::Layout::Centered>
-
-    {{/if}}
     {{/if}}
   </page.body>
 

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -159,7 +159,7 @@ app.on('ready', async () => {
   runtimeSettings.onOriginChange(() => mainWindow.loadURL(emberAppURL));
 
   // If you want to open up dev tools programmatically, call
-  mainWindow.openDevTools();
+  // mainWindow.openDevTools();
 
   // Load the ember application
   mainWindow.loadURL(emberAppURL);

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -159,7 +159,7 @@ app.on('ready', async () => {
   runtimeSettings.onOriginChange(() => mainWindow.loadURL(emberAppURL));
 
   // If you want to open up dev tools programmatically, call
-  // mainWindow.openDevTools();
+  mainWindow.openDevTools();
 
   // Load the ember application
   mainWindow.loadURL(emberAppURL);


### PR DESCRIPTION
This pr adds `toolbar` with filters to desktop sessions

**No results:**
<img width="992" alt="Screen Shot 2021-11-16 at 10 20 29 AM" src="https://user-images.githubusercontent.com/15043878/142046067-03864327-051e-4f24-b8bb-eb8f8ec02a04.png">

 
**landing page:**

<img width="1410" alt="Screen Shot 2021-11-16 at 9 45 51 AM" src="https://user-images.githubusercontent.com/15043878/142044571-6bdc3d23-4da5-4b16-9e96-e03aec3a6e35.png">

**active and terminated selected:**
<img width="1401" alt="Screen Shot 2021-11-16 at 9 45 42 AM" src="https://user-images.githubusercontent.com/15043878/142044576-3cbd3233-f499-46b7-a44d-2790319feafe.png">

