### PR TITLE
fix: 🐛 Fix missing translation

### DIFF
--- a/addons/api/mirage/generated/factories/host.js
+++ b/addons/api/mirage/generated/factories/host.js
@@ -5,7 +5,7 @@ import { random, date, internet, datatype } from 'faker';
  * GeneratedHostModelFactory
  */
 export default Factory.extend({
-  type: 'static',
+  type: () => random.arrayElement(['static', 'plugin']),
   name: () => random.words(),
   description: () => random.words(),
   created_time: () => date.recent(),

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -130,6 +130,7 @@ host:
     delete: Delete Host
   types:
     static: Static
+    plugin: Plugin
 session:
   title: Session
   title_plural: Sessions


### PR DESCRIPTION
Fix missing translation for hosts list within host-catalog.

[Link to fix screen](https://boundary-ui-git-fix-missing-translation-host-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/host-catalogs/2/hosts)

Without the fix:
<img width="1502" alt="Screen Shot 2021-11-23 at 7 51 53 AM" src="https://user-images.githubusercontent.com/9775006/143057766-a8c0ff67-d3f0-41bd-9a62-f41f3b09d7ab.png">

With the fix
<img width="1505" alt="Screen Shot 2021-11-23 at 7 53 38 AM" src="https://user-images.githubusercontent.com/9775006/143057915-f0e4e948-398b-4c2f-95cb-1b22bfc3ed42.png">
