### PR TITLE
Desktop sessions filtering

### DIFF
--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -26,16 +26,18 @@ export default function () {
 
   this.get(
     '/scopes',
-    ({ scopes }, { queryParams: { scope_id, recursive } }) => {
+    ({ scopes }, { queryParams: { scope_id, recursive, filter } }) => {
+      let resultSet;
       // Default parent scope is global
       if (!scope_id) scope_id = 'global';
       if (recursive && scope_id === 'global') {
-        return scopes.all();
+        resultSet = scopes.all();
       } else {
-        return scopes.where((scope) => {
+        resultSet = scopes.where((scope) => {
           return scope.scope ? scope.scope.id === scope_id : false;
         });
       }
+      return resultSet.filter(makeBooleanFilter(filter));
     }
   );
   this.post('/scopes', function ({ scopes }) {

--- a/ui/desktop/app/routes/scopes/scope/projects.js
+++ b/ui/desktop/app/routes/scopes/scope/projects.js
@@ -19,6 +19,7 @@ export default class ScopesScopeProjectsRoute extends Route {
   // =services
 
   @service session;
+  @service resourceFilterStore;
 
   // =methods
 
@@ -34,8 +35,12 @@ export default class ScopesScopeProjectsRoute extends Route {
    * @return {Promise{ScopeModel}}
    */
   model() {
-    return this.store
-      .query('scope', { recursive: true, scope_id: 'global' })
-      .filter(({ isProject }) => isProject);
+    const { id: scope_id } = this.modelFor('scopes.scope');
+    const projects = this.resourceFilterStore.queryBy(
+      'scope',
+      { type: 'project' },
+      { recursive: true, scope_id }
+    );
+    return projects;
   }
 }

--- a/ui/desktop/app/routes/scopes/scope/projects/sessions.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions.js
@@ -121,5 +121,6 @@ export default class ScopesScopeProjectsSessionsRoute extends Route {
     @action
     clearAllFilters() {
       this.status = [];
+      this.project = [];
     }
 }

--- a/ui/desktop/app/routes/scopes/scope/projects/sessions.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions.js
@@ -23,6 +23,12 @@ export default class ScopesScopeProjectsSessionsRoute extends Route {
     defaultValue: ['active','pending', 'canceling']
   }) status;
 
+  @resourceFilter({
+    allowed: (route) => route.modelFor('scopes.scope.projects'),
+    serialize: ({ id }) => id,
+    findBySerialized: ({ id }, value) => id === value
+  }) project;
+
   /**
    * A simple Ember Concurrency-based polling task that refreshes the route
    * every POLL_TIMEOUT_SECONDS seconds.  This is necessary to display changes
@@ -53,14 +59,19 @@ export default class ScopesScopeProjectsSessionsRoute extends Route {
   /**
    * Loads all sessions under the current scope and encapsulates them into
    * an array of objects filtering to current user
-   * @return {Promise{[{session: SessionModel, target: TargetModel}]}}
+   * @return {Promise{SessionModel[]}}
    */
   async model() {
     const { status } = this;
     const { id: scope_id } = this.modelFor('scopes.scope');
     const { user_id } = this.session.data.authenticated;
+    const projects = this.project || [];
     await this.store.query('target', { recursive: true, scope_id });
-    return await this.resourceFilterStore.queryBy('session', { user_id , status }, {
+    return await this.resourceFilterStore.queryBy('session', {
+      user_id,
+      status,
+      scope_id: projects.map(({ id }) => id)
+    }, {
       recursive: true,
       scope_id
     });

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
@@ -14,7 +14,7 @@
         (or
           @model
           (has-resource-filter-selections
-            'scopes.scope.projects.sessions' 'type'
+            'scopes.scope.projects.sessions' 'status' 'project'
           )
         )
       }}
@@ -78,7 +78,7 @@
 
             {{#if
               (has-resource-filter-selections
-                'scopes.scope.projects.sessions' 'type'
+                'scopes.scope.projects.sessions' 'status' 'project'
               )
             }}
               <Rose::Button
@@ -170,7 +170,7 @@
         </table.body>
       </Rose::Table>
     {{else if (has-resource-filter-selections
-      'scopes.scope.projects.sessions' 'type'
+      'scopes.scope.projects.sessions' 'status' 'project'
     )}}
       <Rose::Layout::Centered>
         <Rose::Message @title={{t 'titles.no-results'}} as |message|>

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
@@ -49,6 +49,33 @@
               </Rose::Dropdown>
             {{/with}}
 
+            {{#with
+              (resource-filter 'scopes.scope.projects.sessions' 'project')
+              as |filter|
+            }}
+              <Rose::Dropdown
+                @text={{t (concat 'resources.' filter.name '.title')}}
+                @count={{filter.selectedValue.length}}
+                @ignoreClickInside={{true}}
+                as |dropdown|
+              >
+                <form.checkboxGroup
+                  @name={{filter.name}}
+                  @items={{filter.allowedValues}}
+                  @selectedItems={{filter.selectedValue}}
+                  @onChange={{route-action 'filterBy' filter.name}}
+                  as |group|
+                >
+                  <dropdown.item>
+                    <group.checkbox
+                      @label={{group.item.displayName}}
+                      value={{group.item}}
+                    />
+                  </dropdown.item>
+                </form.checkboxGroup>
+              </Rose::Dropdown>
+            {{/with}}
+
             {{#if
               (has-resource-filter-selections
                 'scopes.scope.projects.sessions' 'type'


### PR DESCRIPTION
This PR introduces dynamic filtering of sessions in Desktop by project.  This is useful UX enhancement because Desktop aggregates sessions across scopes.

[Demo link](https://boundary-ui-desktop-2136btvqm-hashicorp.vercel.app/scopes/global/projects/sessions?filter-project=%5B%22s_s9n819zgko7%22%2C%22s_xk1i4dk50v8%22%5D)

<img width="1032" alt="Screenshot 2021-12-13 at 13 59 05" src="https://user-images.githubusercontent.com/8390120/145878466-2c8fb86f-a67a-42e6-b156-80894f40d646.png">

