### PR TITLE
feat: 🎸 Add table header for hosts list within targets

### DIFF
--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target/hosts.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target/hosts.hbs
@@ -7,7 +7,6 @@
       <header.row as |row|>
         <row.headerCell>{{t 'form.name.label'}}</row.headerCell>
         <row.headerCell>{{t 'form.id.label'}}</row.headerCell>
-        <row.headerCell>{{t 'form.type.label'}}</row.headerCell>
         <row.headerCell>{{t 'form.address.label'}}</row.headerCell>
         <row.headerCell />
       </header.row>
@@ -27,11 +26,6 @@
             >
               <code>{{host.id}}</code>
             </Copyable>
-          </row.cell>
-          <row.cell>
-            <Rose::Badge>{{t
-                (concat 'resources.host.types.' host.type)
-              }}</Rose::Badge>
           </row.cell>
           <row.cell>{{host.attributes.address}}</row.cell>
           <row.cell>

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target/hosts.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target/hosts.hbs
@@ -3,6 +3,15 @@
 {{#if @model.hosts}}
 
   <Rose::Table as |table|>
+    <table.header as |header|>
+      <header.row as |row|>
+        <row.headerCell>{{t 'form.name.label'}}</row.headerCell>
+        <row.headerCell>{{t 'form.id.label'}}</row.headerCell>
+        <row.headerCell>{{t 'form.type.label'}}</row.headerCell>
+        <row.headerCell>{{t 'form.address.label'}}</row.headerCell>
+        <row.headerCell />
+      </header.row>
+    </table.header>
     <table.body as |body|>
       {{#each @model.hosts as |host|}}
         <body.row as |row|>
@@ -19,12 +28,12 @@
               <code>{{host.id}}</code>
             </Copyable>
           </row.cell>
-          <row.cell>{{host.attributes.address}}</row.cell>
           <row.cell>
             <Rose::Badge>{{t
                 (concat 'resources.host.types.' host.type)
               }}</Rose::Badge>
           </row.cell>
+          <row.cell>{{host.attributes.address}}</row.cell>
           <row.cell>
             <Rose::Button
               @style='secondary'


### PR DESCRIPTION
Add table header for hosts list within targets.

Also change the columns order to reflect latest design, [link here](https://www.figma.com/file/a8vdiYPLJqAw5RxGwpTMvM/Dynamic-Hosts-Catalog?node-id=305%3A9700)

[Direct link to desktop](https://boundary-ui-desktop-git-feature-add-targets-ho-66b587-hashicorp.vercel.app/scopes/global/projects/targets/1/hosts)

Before: No header
<img width="1261" alt="Screen Shot 2021-12-14 at 10 23 52 AM" src="https://user-images.githubusercontent.com/9775006/146059730-1f4c5420-63a7-4dd4-8197-b9c729c4530f.png">

After:
<img width="1263" alt="Screen Shot 2021-12-14 at 10 19 54 AM" src="https://user-images.githubusercontent.com/9775006/146059778-2a0b7a6f-1fcf-4311-8270-27da86d2c9ef.png">

