### PR TITLE
add static port and address mappings

### DIFF
--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -59,8 +59,8 @@ handle('cliExists', () => boundaryCli.exists());
 /**
  * Establishes a boundary session and returns session details.
  */
-handle('connect', ({ target_id, token, host_id }) =>
-  sessionManager.start(runtimeSettings.origin, target_id, token, host_id)
+handle('connect', ({ target_id, token, host_id, listenAddr, listenPort }) =>
+  sessionManager.start(runtimeSettings.origin, target_id, token, host_id, listenAddr, listenPort)
 );
 
 /**

--- a/ui/desktop/electron-app/src/models/session-manager.js
+++ b/ui/desktop/electron-app/src/models/session-manager.js
@@ -18,9 +18,11 @@ class SessionManager {
    * @param {string} target_id
    * @param {string} token
    * @param {string} host_id
+   * @param {string} listenAddr
+   * @param {string} listenPort
    */
-  start(addr, target_id, token, host_id) {
-    const session = new Session(addr, target_id, token, host_id);
+  start(addr, target_id, token, host_id, listenAddr, listenPort) {
+    const session = new Session(addr, target_id, token, host_id, listenAddr, listenPort);
     this.#sessions.push(session);
     return session.start();
   }

--- a/ui/desktop/electron-app/src/models/session.js
+++ b/ui/desktop/electron-app/src/models/session.js
@@ -11,6 +11,8 @@ class Session {
   #process;
   #targetId;
   #proxyDetails;
+  #listenAddr;
+  #listenPort;
 
   /**
    * Initialize a session to a controller address
@@ -19,12 +21,16 @@ class Session {
    * @param {string} targetId
    * @param {string} token
    * @param {string} hostId
+   * @param {string} listenAddr
+   * @param {string} listenPort
    */
-  constructor(addr, targetId, token, hostId) {
+  constructor(addr, targetId, token, hostId, listenAddr, listenPort) {
     this.#addr = addr;
     this.#targetId = targetId;
     this.#token = token;
     this.#hostId = hostId;
+    this.#listenAddr = listenAddr;
+    this.#listenPort = listenPort;
   }
 
   /**
@@ -102,6 +108,14 @@ class Session {
     if (this.#hostId) {
       sanitized.host_id = sanitizer.base62EscapeAndValidate(this.#hostId);
       command.push(`-host-id=${sanitized.host_id}`);
+    }
+
+    if (this.#listenAddr) {
+      command.push(`-listen-addr=${this.#listenAddr}`);
+    }
+
+    if (this.#listenPort) {
+      command.push(`-listen-port=${this.#listenPort}`);
     }
     return command;
   }


### PR DESCRIPTION
This PR add simple static port mappings logic that will create new proxy on fixed local port and IP on selected host in Boundary Desktop

This change can help users that need host proxy on specific local port, in my case I have Mysql Workbench that connect via Boundary Desktop to remote cloud databases, I have 20+ database templates that contains database credentials - fixed port to databases is really helps my to work with multiples databases in various clouds

If target name has name that starts with 3 digits and dash (regexp `^(\d{3})-.+$`), and host name starts with number between 0-99 and dash (regexp `^(\d{1}|\d{2})-.+$`) - only in this case Boundary Desktop will create proxy to selected host on port that will contains digits from target and host name name

If host name has name that ends with dash and IP address (regexp `.+-(\d+.\d+.\d+.\d+)$`) - in this case Boundary Desktop will create proxy that will be listened on selected IP

| Target name  | Host name | Proxy address that will be created |
| ------------- | ------------- | ------------- |
| 181-Database service AZURE PROD  | 5-az-dbs-payment-master  | 127.0.0.1:18105  |
| 161-Database service AWS PROD  | 17-promo-master  | 127.0.0.1:16117  |
| 171-Database service AWS DEV  | 45-main-master-0.0.0.0  | 0.0.0.0:17145  |

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>