### PR TITLE
refactor: 💡 copyable component no longer uses ember-concurrency

### DIFF
--- a/ui/admin/app/components/copyable/index.js
+++ b/ui/admin/app/components/copyable/index.js
@@ -2,11 +2,10 @@ import Component from '@glimmer/component';
 import ClipboardJS from 'clipboard';
 import { action } from '@ember/object';
 import { generateComponentID } from 'rose/utilities/component-auto-id';
-import { task, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
+import { later } from '@ember/runloop';
 
 export default class CopyableComponent extends Component {
-
   // =attributes
 
   id = generateComponentID();
@@ -21,23 +20,10 @@ export default class CopyableComponent extends Component {
 
   clipboard = null;
 
-  /**
-   * A Ember Concurrency-based task that updates copy icon to a success state
-   * and back after 1 second. This icon flash indicates success on
-   * copy to clipboard action.
-   *
-   * NOTE:  tasks are sort of attributes and sort of methods, but they are not
-   * language-level constructs.  Thus we annotate this task as if it
-   * is an attribute.
-   * @type {Task}
-   */
-  /* istanbul ignore next */
-  @task(function * () {
+  confirmCopy() {
     this.copied = true;
-    yield timeout(1000);
-    this.copied = false;
-  /* eslint-disable-next-line prettier/prettier */
-  }).drop() confirmCopyTimer;
+    later(() => (this.copied = false), 1000);
+  }
 
   /**
    * Checks for ClipboardJS support.
@@ -62,7 +48,7 @@ export default class CopyableComponent extends Component {
     /* istanbul ignore next */
     this.clipboard.on('success', (clipboardEvent) => {
       clipboardEvent.clearSelection();
-      this.confirmCopyTimer.perform();
+      this.confirmCopy();
     });
   }
 
@@ -73,7 +59,5 @@ export default class CopyableComponent extends Component {
   tearDown() {
     this.clipboard?.destroy();
     this.clipboard = null;
-    this.confirmCopyTimer.cancelAll();
   }
-
 }


### PR DESCRIPTION
In an effort to remove uses of ember-concurrency in preparation for Ember 4.0, this PR refactors the copyable components to use pure Ember code instead.  Using `later()`, the same effect is achieved with no third-party dependency.

This PR has no user-facing effect.