### PR TITLE
refactor: 💡 remove deprecated renderTemplate usage in desktop

### DIFF
--- a/ui/desktop/app/controllers/scopes/scope.js
+++ b/ui/desktop/app/controllers/scopes/scope.js
@@ -1,0 +1,8 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default class ScopesScopeController extends Controller {
+  // =services
+
+  @service session;
+}

--- a/ui/desktop/app/routes/scopes/scope.js
+++ b/ui/desktop/app/routes/scopes/scope.js
@@ -74,18 +74,4 @@ export default class ScopesScopeRoute extends Route {
     const scopes = this.scopes;
     controller.setProperties({ scopes });
   }
-
-  /**
-   * Renders the scope-specific sidebar template.
-   * @override
-   * @param {object} controller
-   * @param {object} model
-   */
-  renderTemplate() {
-    super.renderTemplate(...arguments);
-    this.render('scopes/scope/-header-nav', {
-      into: 'application',
-      outlet: 'header-nav',
-    });
-  }
 }

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
@@ -12,28 +12,4 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
   model({ target_id }) {
     return this.store.findRecord('target', target_id, { reload: true });
   }
-
-  /**
-   * Renders the target-specific templates for actions, header and navigation
-   * page sections.
-   * @override
-   */
-  renderTemplate() {
-    super.renderTemplate(...arguments);
-
-    this.render('scopes/scope/projects/targets/target/-actions', {
-      into: 'scopes/scope/projects/targets/target',
-      outlet: 'actions',
-    });
-
-    this.render('scopes/scope/projects/targets/target/-header', {
-      into: 'scopes/scope/projects/targets/target',
-      outlet: 'header',
-    });
-
-    this.render('scopes/scope/projects/targets/target/-navigation', {
-      into: 'scopes/scope/projects/targets/target',
-      outlet: 'navigation',
-    });
-  }
 }

--- a/ui/desktop/app/templates/application.hbs
+++ b/ui/desktop/app/templates/application.hbs
@@ -12,11 +12,10 @@
       as |header|
     >
       <header.brand @logo='logo-app' @text={{app-name}} />
-      {{#if this.session.isAuthenticated}}
-        <header.nav>
-          {{outlet 'header-nav'}}
-        </header.nav>
-      {{/if}}
+
+      <header.nav>
+        <div id='header-nav'></div>
+      </header.nav>
 
       <header.utilities as |utilities|>
         {{#if this.showWindowActions}}

--- a/ui/desktop/app/templates/scopes/scope.hbs
+++ b/ui/desktop/app/templates/scopes/scope.hbs
@@ -1,1 +1,27 @@
 {{outlet}}
+
+{{#if this.session.isAuthenticated}}
+  <EmberWormhole @to='header-nav'>
+    <Rose::Dropdown
+      @text={{this.scopes.selectedOrg.displayName}}
+      @icon={{if
+        this.scopes.selectedOrg.isGlobal
+        'flight-icons/svg/globe-16'
+        'flight-icons/svg/org-16'
+      }}
+      as |dropdown|
+    >
+      {{!-- {{#if this.session.data.authenticated.isGlobal}} --}}
+      <dropdown.link @route='scopes.scope' @model='global'>
+        {{t 'titles.global'}}
+      </dropdown.link>
+      <dropdown.separator />
+      {{!-- {{/if}} --}}
+      {{#each this.scopes.orgs as |scope|}}
+        <dropdown.link @route='scopes.scope' @model={{scope.id}}>
+          {{scope.displayName}}
+        </dropdown.link>
+      {{/each}}
+    </Rose::Dropdown>
+  </EmberWormhole>
+{{/if}}

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target.hbs
@@ -3,15 +3,45 @@
 <Rose::Layout::Page as |page|>
 
   <page.header>
-    {{outlet 'header'}}
+    <h2>
+      {{@model.displayName}}
+      {{#if @model.isActive}}
+        &nbsp;
+        <Rose::Badge @style='success'>
+          {{t 'states.active'}}
+        </Rose::Badge>
+      {{/if}}
+    </h2>
+    <p>{{@model.description}}</p>
+    <p>
+      <Copyable
+        @text={{@model.id}}
+        @buttonText={{t 'actions.copy-to-clipboard'}}
+        @acknowledgeText={{t 'states.copied'}}
+      >
+        <code>{{@model.id}}</code>
+      </Copyable>
+    </p>
   </page.header>
 
   <page.actions>
-    {{outlet 'actions'}}
+    <Rose::Button
+      @style='primary'
+      {{on 'click' (route-action 'connect' @model)}}
+    >
+      {{t 'resources.session.actions.connect'}}
+    </Rose::Button>
   </page.actions>
 
   <page.navigation>
-    {{outlet 'navigation'}}
+    <Rose::Nav::Tabs as |nav|>
+      <nav.link @route='scopes.scope.projects.targets.target.sessions'>
+        {{t 'resources.session.active_plural'}}
+      </nav.link>
+      <nav.link @route='scopes.scope.projects.targets.target.hosts'>
+        {{t 'resources.host.title_plural'}}
+      </nav.link>
+    </Rose::Nav::Tabs>
   </page.navigation>
 
   <page.body>

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -97,6 +97,7 @@
     "ember-source": "~3.28.4",
     "ember-template-lint": "^3.7.0",
     "ember-template-lint-plugin-prettier": "^2.0.0",
+    "ember-wormhole": "^0.6.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-ember": "^10.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9375,7 +9375,7 @@ debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debuglog@^1.0.1:
+debuglog@*, debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -11218,6 +11218,14 @@ ember-window-mock@^0.7.2:
   dependencies:
     broccoli-funnel "^3.0.3"
     ember-cli-babel "^7.23.0"
+    ember-cli-htmlbars "^5.3.1"
+
+ember-wormhole@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/ember-wormhole/-/ember-wormhole-0.6.0.tgz#1f9143aa05c0f0abdf14a97ff22520ebaf85eca0"
+  integrity sha512-b7RrRxkwCBEJxM2zR34dEzIET81BOZWTcYNJtkidLycLQvdbxPys5QJEjJ/IfDikT/z5HuQBdZRKBhXI0vZNXQ==
+  dependencies:
+    ember-cli-babel "^7.22.1"
     ember-cli-htmlbars "^5.3.1"
 
 "emberx-select@github:adopted-ember-addons/emberx-select#bc5f774":
@@ -14258,7 +14266,7 @@ import-lazy@^4.0.0:
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
   integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
 
-imurmurhash@^0.1.4:
+imurmurhash@*, imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -16072,6 +16080,11 @@ lodash._baseflatten@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash._baseindexof@*:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
+  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
+
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -16080,10 +16093,15 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@^3.0.0:
+lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
+
+lodash._cacheindexof@*:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
+  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
 
 lodash._createassigner@^3.0.0:
   version "3.1.1"
@@ -16094,12 +16112,19 @@ lodash._createassigner@^3.0.0:
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
 
+lodash._createcache@*:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
+  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
+  dependencies:
+    lodash._getnative "^3.0.0"
+
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@^3.0.0:
+lodash._getnative@*, lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -16317,7 +16342,7 @@ lodash.pick@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
 
-lodash.restparam@^3.0.0:
+lodash.restparam@*, lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
   integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=


### PR DESCRIPTION
This PR removes `renderTemplate` usage from routes in Desktop.  This API is now deprecated:  https://deprecations.emberjs.com/v3.x/#toc_route-render-template