### PR TITLE
feat: 🎸 Add host catalog type basic support

### DIFF
--- a/addons/api/addon/generated/models/host-catalog.js
+++ b/addons/api/addon/generated/models/host-catalog.js
@@ -49,7 +49,7 @@ export default class GeneratedHostCatalogModel extends BaseModel {
   })
   version;
 
-  @attr('string', {
+  @attr({
     description: 'Plugin information for this resource.',
     readOnly: true,
   })

--- a/addons/api/addon/generated/models/host-catalog.js
+++ b/addons/api/addon/generated/models/host-catalog.js
@@ -48,4 +48,10 @@ export default class GeneratedHostCatalogModel extends BaseModel {
     description: 'Current version number of this resource.',
   })
   version;
+
+  @attr('string', {
+    description: 'Plugin information for this resource.',
+    readOnly: true,
+  })
+  plugin;
 }

--- a/addons/api/addon/models/host-catalog.js
+++ b/addons/api/addon/models/host-catalog.js
@@ -40,4 +40,16 @@ export default class HostCatalogModel extends GeneratedHostCatalogModel {
   get compositeType() {
     return this.isPlugin ? this.plugin.name : this.type;
   }
+
+  /**
+   * Sets type, if type is different than static, sets plugin name to type
+   */
+  set compositeType(type) {
+    if (type === 'static') {
+      this.type = 'static';
+    } else {
+      this.type = 'plugin';
+      this.plugin.name = type;
+    }
+  }
 }

--- a/addons/api/addon/models/host-catalog.js
+++ b/addons/api/addon/models/host-catalog.js
@@ -2,6 +2,14 @@ import GeneratedHostCatalogModel from '../generated/models/host-catalog';
 
 export default class HostCatalogModel extends GeneratedHostCatalogModel {
   /**
+   * Returns if the host-catalog is static type or not.
+   * @type {boolean}
+   */
+  get isStatic() {
+    return this.type === 'static';
+  }
+
+  /**
    * Returns if the host-catalog is a plugin or not.
    * @type {boolean}
    */
@@ -23,5 +31,13 @@ export default class HostCatalogModel extends GeneratedHostCatalogModel {
    */
   get isAzure() {
     return this.plugin.name === 'azure';
+  }
+
+  /** If host-catalog is a plugins returns its name,
+   * otherwise returns the host-catalog type
+   * @type {string}
+   */
+  get compositeType() {
+    return this.isPlugin ? this.plugin.name : this.type;
   }
 }

--- a/addons/api/addon/models/host-catalog.js
+++ b/addons/api/addon/models/host-catalog.js
@@ -49,7 +49,7 @@ export default class HostCatalogModel extends GeneratedHostCatalogModel {
       this.type = 'static';
     } else {
       this.type = 'plugin';
-      this.plugin = { name: type }
+      this.plugin = { name: type };
     }
   }
 }

--- a/addons/api/addon/models/host-catalog.js
+++ b/addons/api/addon/models/host-catalog.js
@@ -2,9 +2,26 @@ import GeneratedHostCatalogModel from '../generated/models/host-catalog';
 
 export default class HostCatalogModel extends GeneratedHostCatalogModel {
   /**
+   * Returns if the host-catalog is a plugin or not.
    * @type {boolean}
    */
-  get isStatic() {
-    return this.type === 'static';
+  get isPlugin() {
+    return this.type === 'plugin';
+  }
+
+  /**
+   * Returns if host-catalog plugin is AWS or not
+   * @type {boolean}
+   */
+  get isAWS() {
+    return this.plugin.name === 'aws';
+  }
+
+  /**
+   * Return if host-catalog plugin is Azure or not.
+   * @type {boolean}
+   */
+  get isAzure() {
+    return this.plugin.name === 'azure';
   }
 }

--- a/addons/api/addon/models/host-catalog.js
+++ b/addons/api/addon/models/host-catalog.js
@@ -22,7 +22,7 @@ export default class HostCatalogModel extends GeneratedHostCatalogModel {
    * @type {boolean}
    */
   get isAWS() {
-    return this.plugin.name === 'aws';
+    return this.compositeType === 'aws';
   }
 
   /**
@@ -30,7 +30,7 @@ export default class HostCatalogModel extends GeneratedHostCatalogModel {
    * @type {boolean}
    */
   get isAzure() {
-    return this.plugin.name === 'azure';
+    return this.compositeType === 'azure';
   }
 
   /** If host-catalog is a plugins returns its name,
@@ -49,7 +49,7 @@ export default class HostCatalogModel extends GeneratedHostCatalogModel {
       this.type = 'static';
     } else {
       this.type = 'plugin';
-      this.plugin.name = type;
+      this.plugin = { name: type }
     }
   }
 }

--- a/addons/api/mirage/generated/factories/host-catalog.js
+++ b/addons/api/mirage/generated/factories/host-catalog.js
@@ -15,7 +15,7 @@ export default Factory.extend({
     if (this.type == 'plugin') {
       return {
         id: `pl_${datatype.hexaDecimal(5)}`,
-        name: random.arrayElement(['azure', 'aws']),
+        name: i % 2 ? 'aws' : 'azure',
         description: random.words(),
       };
     }

--- a/addons/api/mirage/generated/factories/host-catalog.js
+++ b/addons/api/mirage/generated/factories/host-catalog.js
@@ -11,4 +11,15 @@ export default Factory.extend({
   created_time: () => date.recent(),
   updated_time: () => date.recent(),
   disabled: () => datatype.boolean(),
+  plugin: function () {
+    if (this.type == 'plugin') {
+      return {
+        id: `pl_${datatype.hexaDecimal(5)}`,
+        name: random.arrayElement(['azure', 'aws']),
+        description: random.words(),
+      };
+    } else {
+      return undefined;
+    }
+  },
 });

--- a/addons/api/mirage/generated/factories/host-catalog.js
+++ b/addons/api/mirage/generated/factories/host-catalog.js
@@ -11,7 +11,7 @@ export default Factory.extend({
   created_time: () => date.recent(),
   updated_time: () => date.recent(),
   disabled: () => datatype.boolean(),
-  plugin: function () {
+  plugin: function (i) {
     if (this.type == 'plugin') {
       return {
         id: `pl_${datatype.hexaDecimal(5)}`,

--- a/addons/api/mirage/generated/factories/host-catalog.js
+++ b/addons/api/mirage/generated/factories/host-catalog.js
@@ -18,8 +18,6 @@ export default Factory.extend({
         name: random.arrayElement(['azure', 'aws']),
         description: random.words(),
       };
-    } else {
-      return undefined;
     }
   },
 });

--- a/addons/api/tests/unit/models/host-catalog-test.js
+++ b/addons/api/tests/unit/models/host-catalog-test.js
@@ -57,4 +57,37 @@ module('Unit | Model | host catalog', function (hooks) {
     assert.true(modelAzure.isAzure);
     assert.false(modelRandom.isAzure);
   });
+
+  test('get compositeType returns expected values', async function (assert) {
+    assert.expect(3);
+    const store = this.owner.lookup('service:store');
+    const modelPlugin = store.createRecord('host-catalog', {
+      type: 'plugin',
+      plugin: { name: 'Test name' },
+    });
+    const modelStatic = store.createRecord('host-catalog', {
+      type: 'static',
+    });
+    assert.equal(typeof modelPlugin.compositeType, 'string');
+    assert.equal(modelPlugin.compositeType, 'Test name');
+    assert.equal(modelStatic.compositeType, 'static');
+  });
+
+  test('set compositeType sets expected values', async function (assert) {
+    assert.expect(3);
+    const store = this.owner.lookup('service:store');
+    const modelPlugin = store.createRecord('host-catalog', {
+      type: 'plugin',
+      plugin: { name: 'Test name' },
+    });
+    const modelStatic = store.createRecord('host-catalog', {
+      type: 'static',
+    });
+    modelPlugin.set('compositeType', 'aws');
+    modelStatic.set('compositeType', 'static');
+
+    assert.equal(modelPlugin.type, 'plugin');
+    assert.equal(modelPlugin.plugin.name, 'aws');
+    assert.equal(modelStatic.type, 'static');
+  });
 });

--- a/addons/api/tests/unit/models/host-catalog-test.js
+++ b/addons/api/tests/unit/models/host-catalog-test.js
@@ -79,14 +79,11 @@ module('Unit | Model | host catalog', function (hooks) {
     assert.expect(3);
     const store = this.owner.lookup('service:store');
     const modelPlugin = store.createRecord('host-catalog', {
-      type: 'plugin',
-      plugin: { name: 'Test name' },
+      compositeType: 'aws'
     });
     const modelStatic = store.createRecord('host-catalog', {
-      type: 'static',
+      compositeType: 'static',
     });
-    modelPlugin.set('compositeType', 'aws');
-    modelStatic.set('compositeType', 'static');
 
     assert.equal(modelPlugin.type, 'plugin');
     assert.equal(modelPlugin.plugin.name, 'aws');

--- a/addons/api/tests/unit/models/host-catalog-test.js
+++ b/addons/api/tests/unit/models/host-catalog-test.js
@@ -10,6 +10,16 @@ module('Unit | Model | host catalog', function (hooks) {
     assert.ok(model);
   });
 
+  test('it has isStatic function and returns the expected values', async function (assert) {
+    assert.expect(3);
+    const store = this.owner.lookup('service:store');
+    const modelA = store.createRecord('host-catalog', { type: 'static' });
+    const modelB = store.createRecord('host-catalog', { type: 'plugin' });
+    assert.equal(typeof modelA.isStatic, 'boolean');
+    assert.true(modelA.isStatic);
+    assert.false(modelB.isStatic);
+  });
+
   test('it has isPlugin function and returns the expected values', async function (assert) {
     assert.expect(3);
     const store = this.owner.lookup('service:store');

--- a/addons/api/tests/unit/models/host-catalog-test.js
+++ b/addons/api/tests/unit/models/host-catalog-test.js
@@ -79,7 +79,7 @@ module('Unit | Model | host catalog', function (hooks) {
     assert.expect(3);
     const store = this.owner.lookup('service:store');
     const modelPlugin = store.createRecord('host-catalog', {
-      compositeType: 'aws'
+      compositeType: 'aws',
     });
     const modelStatic = store.createRecord('host-catalog', {
       compositeType: 'static',

--- a/addons/api/tests/unit/models/host-catalog-test.js
+++ b/addons/api/tests/unit/models/host-catalog-test.js
@@ -10,13 +10,41 @@ module('Unit | Model | host catalog', function (hooks) {
     assert.ok(model);
   });
 
-  test('it has isStatic function and returns the expected values', async function (assert) {
+  test('it has isPlugin function and returns the expected values', async function (assert) {
     assert.expect(3);
     const store = this.owner.lookup('service:store');
-    const modelA = store.createRecord('host-catalog', { type: 'static' });
-    const modelB = store.createRecord('host-catalog', { type: 'plugin' });
-    assert.equal(typeof modelA.isStatic, 'boolean');
-    assert.true(modelA.isStatic);
-    assert.false(modelB.isStatic);
+    const modelPlugin = store.createRecord('host-catalog', { type: 'plugin' });
+    const modelStatic = store.createRecord('host-catalog', { type: 'static' });
+    assert.equal(typeof modelPlugin.isPlugin, 'boolean');
+    assert.true(modelPlugin.isPlugin);
+    assert.false(modelStatic.isPlugin);
+  });
+
+  test('it has isAWS function and returns the expected values', async function (assert) {
+    assert.expect(3);
+    const store = this.owner.lookup('service:store');
+    const modelAws = store.createRecord('host-catalog', {
+      plugin: { name: 'aws' },
+    });
+    const modelRandom = store.createRecord('host-catalog', {
+      plugin: { name: 'random' },
+    });
+    assert.equal(typeof modelAws.isAWS, 'boolean');
+    assert.true(modelAws.isAWS);
+    assert.false(modelRandom.isAWS);
+  });
+
+  test('it has isAzure function and return the expected values', async function (assert) {
+    assert.expect(3);
+    const store = this.owner.lookup('service:store');
+    const modelAzure = store.createRecord('host-catalog', {
+      plugin: { name: 'azure' },
+    });
+    const modelRandom = store.createRecord('host-catalog', {
+      plugin: { name: 'random' },
+    });
+    assert.equal(typeof modelAzure.isAzure, 'boolean');
+    assert.true(modelAzure.isAzure);
+    assert.false(modelRandom.isAzure);
   });
 });

--- a/addons/api/tests/unit/models/host-catalog-test.js
+++ b/addons/api/tests/unit/models/host-catalog-test.js
@@ -34,6 +34,7 @@ module('Unit | Model | host catalog', function (hooks) {
     assert.expect(3);
     const store = this.owner.lookup('service:store');
     const modelAws = store.createRecord('host-catalog', {
+      type: 'plugin',
       plugin: { name: 'aws' },
     });
     const modelRandom = store.createRecord('host-catalog', {
@@ -48,6 +49,7 @@ module('Unit | Model | host catalog', function (hooks) {
     assert.expect(3);
     const store = this.owner.lookup('service:store');
     const modelAzure = store.createRecord('host-catalog', {
+      type: 'plugin',
       plugin: { name: 'azure' },
     });
     const modelRandom = store.createRecord('host-catalog', {

--- a/ui/admin/app/templates/scopes/scope/host-catalogs/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/index.hbs
@@ -56,11 +56,23 @@
                 <p>{{hostCatalog.description}}</p>
               </row.headerCell>
               <row.cell>
-                <Rose::Badge>
-                  {{t
-                    (concat 'resources.host-catalog.types.' hostCatalog.type)
-                  }}
-                </Rose::Badge>
+                {{#if hostCatalog.isStatic}}
+                  <Rose::Badge>
+                    {{t
+                      (concat 'resources.host-catalog.types.' hostCatalog.type)
+                    }}
+                  </Rose::Badge>
+                {{else}}
+                  <Rose::Badge
+                    @icon={{concat
+                      'flight-icons/svg/'
+                      hostCatalog.compositeType
+                      '-color-16'
+                    }}
+                  >
+                    {{hostCatalog.compositeType}}
+                  </Rose::Badge>
+                {{/if}}
               </row.cell>
               <row.cell>
                 <Copyable

--- a/ui/admin/app/templates/scopes/scope/host-catalogs/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/index.hbs
@@ -41,39 +41,37 @@
         </table.header>
         <table.body as |body|>
           {{#each @model as |hostCatalog|}}
-            {{#if hostCatalog.isStatic}}
-              <body.row as |row|>
-                <row.headerCell>
-                  {{#if (can 'read model' hostCatalog)}}
-                    <LinkTo
-                      @route='scopes.scope.host-catalogs.host-catalog'
-                      @model={{hostCatalog.id}}
-                    >
-                      {{hostCatalog.displayName}}
-                    </LinkTo>
-                  {{else}}
-                    {{hostCatalog.displayName}}
-                  {{/if}}
-                  <p>{{hostCatalog.description}}</p>
-                </row.headerCell>
-                <row.cell>
-                  <Rose::Badge>
-                    {{t
-                      (concat 'resources.host-catalog.types.' hostCatalog.type)
-                    }}
-                  </Rose::Badge>
-                </row.cell>
-                <row.cell>
-                  <Copyable
-                    @text={{hostCatalog.id}}
-                    @buttonText={{t 'actions.copy-to-clipboard'}}
-                    @acknowledgeText={{t 'states.copied'}}
+            <body.row as |row|>
+              <row.headerCell>
+                {{#if (can 'read model' hostCatalog)}}
+                  <LinkTo
+                    @route='scopes.scope.host-catalogs.host-catalog'
+                    @model={{hostCatalog.id}}
                   >
-                    <code>{{hostCatalog.id}}</code>
-                  </Copyable>
-                </row.cell>
-              </body.row>
-            {{/if}}
+                    {{hostCatalog.displayName}}
+                  </LinkTo>
+                {{else}}
+                  {{hostCatalog.displayName}}
+                {{/if}}
+                <p>{{hostCatalog.description}}</p>
+              </row.headerCell>
+              <row.cell>
+                <Rose::Badge>
+                  {{t
+                    (concat 'resources.host-catalog.types.' hostCatalog.type)
+                  }}
+                </Rose::Badge>
+              </row.cell>
+              <row.cell>
+                <Copyable
+                  @text={{hostCatalog.id}}
+                  @buttonText={{t 'actions.copy-to-clipboard'}}
+                  @acknowledgeText={{t 'states.copied'}}
+                >
+                  <code>{{hostCatalog.id}}</code>
+                </Copyable>
+              </row.cell>
+            </body.row>
           {{/each}}
         </table.body>
       </Rose::Table>


### PR DESCRIPTION
Add host catalog type basic support. Delete previous conditional rendering to just render static types.

This PR already adds this model changes within Mirage.

[Direct link](https://boundary-ui-23zp7iqbu-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/host-catalogs)

Screenshot:
<img width="1278" alt="Screen Shot 2022-01-12 at 12 23 31 PM" src="https://user-images.githubusercontent.com/9775006/149240623-fe5fb854-7ca8-4241-baed-b58de8f91868.png">
