### PR TITLE
updates to rose radio component

### DIFF
--- a/addons/rose/addon/components/rose/form/radio/radio/index.hbs
+++ b/addons/rose/addon/components/rose/form/radio/radio/index.hbs
@@ -1,4 +1,4 @@
-<div class="rose-form-radio{{if @error " error"}} {{if @inline "inline"}}">
+<div class="{{this.className}} {{if @error " error"}} {{if @inline "inline"}}">
 
   <RadioButton
     ...attributes

--- a/addons/rose/addon/components/rose/form/radio/radio/index.js
+++ b/addons/rose/addon/components/rose/form/radio/radio/index.js
@@ -3,6 +3,6 @@ import { generateComponentID } from '../../../../../utilities/component-auto-id'
 
 export default class RoseFormRadioRadioComponent extends Component {
   // =attributes
-
+  className = 'rose-form-radio';
   id = generateComponentID();
 }

--- a/ui/admin/app/templates/scopes/scope/auth-methods/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/auth-methods/index.hbs
@@ -35,10 +35,6 @@
   </page.actions>
 
   <page.body>
-<Rose::Form::Radio::RadioCard>
-  ffwefewfw
-</Rose::Form::Radio::RadioCard>
-
     {{#if
       (or
         @model

--- a/ui/admin/app/templates/scopes/scope/auth-methods/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/auth-methods/index.hbs
@@ -35,6 +35,7 @@
   </page.actions>
 
   <page.body>
+
     {{#if
       (or
         @model

--- a/ui/admin/app/templates/scopes/scope/auth-methods/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/auth-methods/index.hbs
@@ -35,6 +35,9 @@
   </page.actions>
 
   <page.body>
+<Rose::Form::Radio::RadioCard>
+  ffwefewfw
+</Rose::Form::Radio::RadioCard>
 
     {{#if
       (or


### PR DESCRIPTION
This pr migrates the main component class `rose-form-radio` from a static hard-coded value in the template to a component class attribute. this update allows passing in different class names to support radioCard field (upcoming pr)