### PR TITLE
Support nested attributes with no dependencies

### DIFF
--- a/addons/api/addon/models/fragment-target-attributes.js
+++ b/addons/api/addon/models/fragment-target-attributes.js
@@ -1,9 +1,0 @@
-import Fragment from 'ember-data-model-fragments/fragment';
-import { attr } from '@ember-data/model';
-
-export default class FragmentTargetAttributesModel extends Fragment {
-  @attr('number', {
-    description: 'The  default port a target should use if present.',
-  })
-  default_port;
-}

--- a/addons/api/addon/models/target.js
+++ b/addons/api/addon/models/target.js
@@ -1,15 +1,16 @@
 import GeneratedTargetModel from '../generated/models/target';
-import { fragment, fragmentArray } from 'ember-data-model-fragments/attributes';
+import { attr } from '@ember-data/model';
+import { fragmentArray } from 'ember-data-model-fragments/attributes';
 import { computed } from '@ember/object';
 
 export default class TargetModel extends GeneratedTargetModel {
   // =attributes
 
-  /**
-   * Attributes of this resource, if any, represented as a JSON fragment.
-   * @type {FragmentTargetAttributesModel}
-   */
-  @fragment('fragment-target-attributes', { defaultValue: {} }) attributes;
+  @attr('number', {
+    isNestedAttribute: true,
+    description: 'The  default port a target should use if present.',
+  })
+  default_port;
 
   /**
    * @type {[FragmentHostSourceModel]}

--- a/addons/api/addon/serializers/application.js
+++ b/addons/api/addon/serializers/application.js
@@ -50,6 +50,12 @@ export default class ApplicationSerializer extends RESTSerializer {
     // Do not serialize `disabled` fields.
     // TODO:  disabled is temporarily disabled
     if (key === 'disabled') delete json[key];
+    // Push nested attributes down into the attributes key
+    if (options.isNestedAttribute && json[key]) {
+      if (!json.attributes) json.attributes = {};
+      json.attributes[key] = json[key];
+      delete json[key];
+    }
     return value;
   }
 
@@ -195,9 +201,37 @@ export default class ApplicationSerializer extends RESTSerializer {
    * @return {Object}
    */
   normalize(typeClass, hash) {
-    const normalizedHash = copy(hash, true);
+    let normalizedHash = copy(hash, true);
     const scopeID = get(normalizedHash, 'scope.id');
     if (scopeID) normalizedHash.scope.scope_id = scopeID;
+    normalizedHash = this.normalizeNestedAttributes(typeClass, normalizedHash);
     return super.normalize(typeClass, normalizedHash);
+  }
+
+  /**
+   * Certain typed resources in the API have type-specific fields nested under
+   * an `attributes` key in the payload
+   * (e.g. `attributes: { fieldName: '123' }`).  Since Ember Data lacks
+   * first-class support for nested attributes, these fields must be hoisted up
+   * into the main body of the payload.
+   *
+   * In order to annotate a field as being a nested attribute, add the key name
+   * to the `nestedAttributes` field on the serializer:
+   *   `@attr('string', { isNestedAttribute: true }) fieldName;`
+   *
+   * @param {Model} typeClass
+   * @param {Object} hash
+   * @return {Object}
+   */
+  normalizeNestedAttributes(typeClass, hash) {
+    const normalizedHash = copy(hash, true);
+    typeClass.attributes.forEach((attribute) => {
+      const { isNestedAttribute } = attribute.options;
+      const attributeValue = normalizedHash.attributes?.[attribute.name];
+      if (isNestedAttribute && attributeValue) {
+        normalizedHash[attribute.name] = attributeValue;
+      }
+    });
+    return normalizedHash;
   }
 }

--- a/addons/api/addon/serializers/application.js
+++ b/addons/api/addon/serializers/application.js
@@ -51,7 +51,7 @@ export default class ApplicationSerializer extends RESTSerializer {
     // TODO:  disabled is temporarily disabled
     if (key === 'disabled') delete json[key];
     // Push nested attributes down into the attributes key
-    if (options.isNestedAttribute && json[key]) {
+    if (options.isNestedAttribute && json[key] !== undefined) {
       if (!json.attributes) json.attributes = {};
       json.attributes[key] = json[key];
       delete json[key];

--- a/addons/api/app/models/fragment-target-attributes.js
+++ b/addons/api/app/models/fragment-target-attributes.js
@@ -1,1 +1,0 @@
-export { default } from 'api/models/fragment-target-attributes';

--- a/addons/api/tests/unit/serializers/target-test.js
+++ b/addons/api/tests/unit/serializers/target-test.js
@@ -20,6 +20,7 @@ module('Unit | Serializer | target', function (hooks) {
         scope_id: 'org_1',
         type: 'org',
       },
+      default_port: 1234,
       version: 1,
       type: 'tcp',
     });
@@ -35,7 +36,7 @@ module('Unit | Serializer | target', function (hooks) {
       session_max_seconds: 28800,
       session_connection_limit: 1,
       attributes: {
-        default_port: null,
+        default_port: 1234,
       },
     });
   });
@@ -117,6 +118,40 @@ module('Unit | Serializer | target', function (hooks) {
             { host_source_id: '3', host_catalog_id: '4' },
           ],
           application_credential_source_ids: [{ value: '1' }],
+        },
+        relationships: {},
+      },
+    });
+  });
+
+  test('it normalizes records with nested attributes', function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('target');
+    const targetModelClass = store.createRecord('target').constructor;
+    const payload = {
+      id: '1',
+      name: 'Target 1',
+      attributes: {
+        default_port: 1234,
+      },
+    };
+    const normalized = serializer.normalizeSingleResponse(
+      store,
+      targetModelClass,
+      payload
+    );
+    assert.deepEqual(normalized, {
+      included: [],
+      data: {
+        id: '1',
+        type: 'target',
+        attributes: {
+          application_credential_source_ids: [],
+          authorized_actions: [],
+          host_sources: [],
+          name: 'Target 1',
+          default_port: 1234,
         },
         relationships: {},
       },

--- a/ui/admin/app/components/form/target/index.hbs
+++ b/ui/admin/app/components/form/target/index.hbs
@@ -94,7 +94,7 @@
   <form.input
     @name='default_port'
     @type='number'
-    @value={{@model.attributes.default_port}}
+    @value={{@model.default_port}}
     @label={{t 'form.default_port.label'}}
     @error={{@model.errors.default_port}}
     @helperText={{t 'form.default_port.help'}}


### PR DESCRIPTION
Boundary UI has generally relied on ember model fragments to support nested fields (e.g. under `attributes`).  However this approach is complex (requiring additional models and serialisers) and couples Boundary to another third-party dependency.  This PR introduces first-class support for nested attributes by hoisting them up into the payload body at normalisation time.  It then serialises them back out to the nested attributes field.  To start, the **Target** resource is refactored to use the new approach.

For example in a model:

```js
@attr('string', { isNestedAttribute: true }) fieldName;
```