### PR TITLE
[draft] Create host catalog form should support static catalog type

### DIFF
--- a/ui/admin/app/components/form/host-catalog/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/index.hbs
@@ -45,6 +45,20 @@
       </field.errors>
     {{/if}}
   </form.textarea>
+
+  <p>Place Radio Button Group Here</p>
+
+  {{#if @model.isNew}}
+    {{#if @model.type}}
+      {{component
+        (concat 'form/host-catalog/' @model.type)
+        model=@model
+        submit=@submit
+        cancel=@cancel
+      }}
+    {{/if}}
+  {{/if}}
+
   {{#if (can 'save model' @model)}}
     <form.actions
       @disabled={{if @model.cannotSave @model.cannotSave}}

--- a/ui/admin/app/components/form/host-catalog/static/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/static/index.hbs
@@ -1,0 +1,1 @@
+I'm a static host catalog form.

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
@@ -18,8 +18,7 @@ export default class ScopesScopeHostCatalogsNewRoute extends Route {
    */
   model(params) {
     const scopeModel = this.modelFor('scopes.scope');
-    // TODO Use model provider type method
-    //  to set params.type to 'static' if type is not provided
+    // FIXME Should default static type be specified when type is undefined?
     params.type = 'static';
     return this.store.createRecord('host-catalog', {
       type: params.type,

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
@@ -1,16 +1,27 @@
 import Route from '@ember/routing/route';
 
 export default class ScopesScopeHostCatalogsNewRoute extends Route {
+  // =attributes
+
+  queryParams = {
+    type: {
+      refreshModel: true,
+    },
+  };
+
   // =methods
 
   /**
    * Creates a new unsaved host catalog belonging to the current scope.
    * @return {HostCatalogModel}
    */
-  model() {
+  model(params) {
     const scopeModel = this.modelFor('scopes.scope');
+    // TODO Use model provider type method
+    //  to set params.type to 'static' if type is not provided
+    params.type = 'static';
     return this.store.createRecord('host-catalog', {
-      type: 'static',
+      type: params.type,
       scopeModel,
     });
   }

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
 export default class ScopesScopeHostCatalogsNewRoute extends Route {
   // =attributes
@@ -24,5 +25,14 @@ export default class ScopesScopeHostCatalogsNewRoute extends Route {
       type: params.type,
       scopeModel,
     });
+  }
+
+  /**
+   * Update type of host catalog
+   * @param {string} type
+   */
+  @action
+  async changeType(type) {
+    await this.router.replaceWith({ type });
   }
 }

--- a/ui/admin/app/templates/scopes/scope/host-catalogs/new.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/new.hbs
@@ -18,6 +18,7 @@
       @model={{@model}}
       @submit={{route-action 'save' @model}}
       @cancel={{route-action 'cancel' @model}}
+      @changeType={{route-action 'changeType' @model.type}}
     />
   </page.body>
 


### PR DESCRIPTION
This PR adds 'static' type support to host catalog creation form by splitting  `form/host-catalog/index.hbs` to `form/host-catalog/static/index.hbs`, adding `?type` query param support, and new `changeType` action to update route.

TODOs:
Should `type` be set to `static` host catalog by default?
