### PR TITLE
feat: 🎸 Add type badges for host-set

### DIFF
--- a/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/index.hbs
@@ -25,9 +25,21 @@
             <p>{{hostSet.description}}</p>
           </row.headerCell>
           <row.cell>
-            <Rose::Badge>
-              {{t (concat 'resources.host-set.types.' hostSet.type)}}
-            </Rose::Badge>
+            {{#if hostSet.isStatic}}
+              <Rose::Badge>
+                {{t (concat 'resources.host-set.types.' hostSet.type)}}
+              </Rose::Badge>
+            {{else}}
+              <Rose::Badge
+                @icon={{concat
+                  'flight-icons/svg/'
+                  hostSet.compositeType
+                  '-color-16'
+                }}
+              >
+                {{hostSet.compositeType}}
+              </Rose::Badge>
+            {{/if}}
           </row.cell>
           <row.cell>
             <Copyable


### PR DESCRIPTION
Add type badges for host-set.

When `type` === `static`:
<img width="1278" alt="Screen Shot 2022-01-26 at 8 16 33 AM" src="https://user-images.githubusercontent.com/9775006/151204270-2b506917-7843-4c12-bcab-3ffc9236253b.png">

When `type` is plugin (`aws` or `azure`):
<img width="1281" alt="Screen Shot 2022-01-26 at 8 19 15 AM" src="https://user-images.githubusercontent.com/9775006/151204361-5455cfe2-87a2-4470-a8e6-bb62f98d08e2.png">

