### PR TITLE
feat: 🎸 Add type badges to host

### DIFF
--- a/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/hosts/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/hosts/index.hbs
@@ -27,9 +27,21 @@
             <p>{{host.description}}</p>
           </row.headerCell>
           <row.cell>
-            <Rose::Badge>
-              {{t (concat 'resources.host.types.' host.type)}}
-            </Rose::Badge>
+            {{#if host.isStatic}}
+              <Rose::Badge>
+                {{t (concat 'resources.host.types.' host.type)}}
+              </Rose::Badge>
+            {{else}}
+              <Rose::Badge
+                @icon={{concat
+                  'flight-icons/svg/'
+                  host.compositeType
+                  '-color-16'
+                }}
+              >
+                {{host.compositeType}}
+              </Rose::Badge>
+            {{/if}}
           </row.cell>
           <row.cell>
             <Copyable


### PR DESCRIPTION
Add type badges to host

- [Link to Azure host list](https://boundary-ui-git-feat-add-type-badges-host-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/host-catalogs/1/hosts).
- [Link to Aws host list](https://boundary-ui-git-feat-add-type-badges-host-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/host-catalogs/4/hosts).
- [Link to Static host list](https://boundary-ui-git-feat-add-type-badges-host-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/host-catalogs/2/hosts).

`Static` type host list:
<img width="1264" alt="Screen Shot 2022-01-27 at 11 08 51 AM" src="https://user-images.githubusercontent.com/9775006/151439479-7a58f16a-8353-4673-afe7-aa98836bb512.png">

`aws` type host list:
<img width="1261" alt="Screen Shot 2022-01-27 at 11 08 03 AM" src="https://user-images.githubusercontent.com/9775006/151439515-d8df2b3e-63b6-4e5c-943e-1759e1e54554.png">

`azure` type host list:
<img width="1265" alt="Screen Shot 2022-01-27 at 11 08 29 AM" src="https://user-images.githubusercontent.com/9775006/151439539-4a5b5ba1-0667-47d4-9883-77ef91aaf925.png">
