### PR TITLE
Disable non-static hosts navigation

### DIFF
--- a/addons/api/mirage/factories/host-catalog.js
+++ b/addons/api/mirage/factories/host-catalog.js
@@ -11,6 +11,11 @@ const pluginTypes = ['aws', 'azure', 'foobar'];
 let pluginTypeCounter = 1;
 
 export default factory.extend({
+  id: (i) => `host-catalog-id-${i}`,
+
+  // Cycle through available types
+  type: (i) => types[i % types.length],
+
   authorized_actions: () =>
     permissions.authorizedActionsFor('host-catalog') || [
       'no-op',
@@ -18,17 +23,14 @@ export default factory.extend({
       'update',
       'delete',
     ],
-  authorized_collection_actions: () => {
+  authorized_collection_actions: function () {
+    const isStatic = this.type === 'static';
     return {
-      hosts: ['create', 'list'],
+      // only static catalogs allow host create at this time
+      hosts: isStatic ? ['create', 'list'] : ['list'],
       'host-sets': ['create', 'list'],
     };
   },
-
-  id: (i) => `host-catalog-id-${i}`,
-
-  // Cycle through available types
-  type: (i) => types[i % types.length],
 
   plugin: function (i) {
     if (this.type === 'plugin') {

--- a/addons/api/mirage/factories/host-set.js
+++ b/addons/api/mirage/factories/host-set.js
@@ -2,18 +2,16 @@ import factory from '../generated/factories/host-set';
 import permissions from '../helpers/permissions';
 
 export default factory.extend({
-  authorized_actions: () =>
-    permissions.authorizedActionsFor('host-set') || [
-      'no-op',
-      'read',
-      'update',
-      'delete',
-      'add-hosts',
-      'remove-hosts',
-    ],
   id: (i) => `host-set-id-${i}`,
   type() {
     return this.hostCatalog?.type || factory.attrs.type;
+  },
+  authorized_actions: function () {
+    const isStatic = this.type === 'static';
+    const defaults = ['no-op', 'read', 'update', 'delete'];
+    // Only static allows host management at this time.
+    if (isStatic) defaults.push('add-hosts', 'remove-hosts');
+    return permissions.authorizedActionsFor('host-set') || defaults;
   },
   plugin() {
     if (this.type === 'plugin') {

--- a/addons/api/mirage/factories/host.js
+++ b/addons/api/mirage/factories/host.js
@@ -2,16 +2,16 @@ import factory from '../generated/factories/host';
 import permissions from '../helpers/permissions';
 
 export default factory.extend({
-  authorized_actions: () =>
-    permissions.authorizedActionsFor('host') || [
-      'no-op',
-      'read',
-      'update',
-      'delete',
-    ],
   id: (i) => `host-id-${i}`,
   type() {
     return this.hostCatalog?.type || factory.attrs.type;
+  },
+  authorized_actions: function () {
+    const isStatic = this.type === 'static';
+    const defaults = ['no-op', 'read'];
+    // Only static allows update/delete at this time.
+    if (isStatic) defaults.push('update', 'delete');
+    return permissions.authorizedActionsFor('host') || defaults;
   },
   plugin() {
     if (this.type === 'plugin') {

--- a/ui/admin/app/abilities/host-catalog.js
+++ b/ui/admin/app/abilities/host-catalog.js
@@ -1,0 +1,17 @@
+import HostCatalogAbility from 'api/abilities/host-catalog';
+
+export default class OverrideHostCatalogAbility extends HostCatalogAbility {
+  /**
+   * Navigating to a resource is allowed if either list or create grants
+   * are present, except in the following case.  Navigating to hosts directly
+   * from a dynamic host catalog is not allowed, since this might present more
+   * hosts than is practical or useful.
+   * @type {boolean}
+   */
+  get canNavigate() {
+    const { isPlugin } = this.model;
+    const isHostsCollection = this.collection === 'hosts';
+    const isDynamicHostsNavigation = isPlugin && isHostsCollection;
+    return !isDynamicHostsNavigation && (this.canList || this.canCreate);
+  }
+}

--- a/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/-navigation.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/-navigation.hbs
@@ -2,12 +2,12 @@
   <nav.link @route='scopes.scope.host-catalogs.host-catalog.index'>
     {{t 'titles.details'}}
   </nav.link>
-  {{#if (can 'navigate model' @model collection='hosts')}}
+  {{#if (can 'navigate host-catalog' @model collection='hosts')}}
     <nav.link @route='scopes.scope.host-catalogs.host-catalog.hosts'>
       {{t 'resources.host.title_plural'}}
     </nav.link>
   {{/if}}
-  {{#if (can 'navigate model' @model collection='host-sets')}}
+  {{#if (can 'navigate host-catalog' @model collection='host-sets')}}
     <nav.link @route='scopes.scope.host-catalogs.host-catalog.host-sets'>
       {{t 'resources.host-set.title_plural'}}
     </nav.link>


### PR DESCRIPTION
This PR disallows navigation from dynamic host catalogs directly to hosts, since there may be too many hosts (the existence of which is also dynamic) to be of practical value.  This PR also corrects the grant mocks for dynamic host catalogs to be more realistic.

Static host catalog navigation:
<img width="316" alt="Screenshot 2022-02-02 at 17 38 14" src="https://user-images.githubusercontent.com/8390120/152249819-4d302746-69a1-490a-a78c-6b7e74f87283.png">

Dynamic host catalog navigation:
<img width="396" alt="Screenshot 2022-02-02 at 17 38 28" src="https://user-images.githubusercontent.com/8390120/152249829-37f56128-ad9f-471c-86fc-772fc6097523.png">

