### PR TITLE
feat: 🎸 Add new fields to host

### DIFF
--- a/addons/api/addon/generated/models/host.js
+++ b/addons/api/addon/generated/models/host.js
@@ -45,8 +45,26 @@ export default class GeneratedHostModel extends BaseModel {
   version;
 
   @attr({
+    description: 'Attributes specific to the host type',
+  })
+  attributes;
+
+  @attr('string', {
+    description: 'The address (DNS or IP name) used to reach the host',
+    isNestedAttribute: true,
+  })
+  address;
+
+  @attr({
     description: 'Plugin information for this resource.',
     readOnly: true,
   })
   plugin;
+
+  @attr('string', {
+    description: '',
+    readOnly: true,
+    isNestedAttribute: true,
+  })
+  external_id;
 }

--- a/addons/api/addon/generated/models/host.js
+++ b/addons/api/addon/generated/models/host.js
@@ -45,26 +45,8 @@ export default class GeneratedHostModel extends BaseModel {
   version;
 
   @attr({
-    description: 'Attributes specific to the host type',
-  })
-  attributes;
-
-  @attr('string', {
-    description: 'The address (DNS or IP name) used to reach the host',
-    isNestedAttribute: true,
-  })
-  address;
-
-  @attr({
     description: 'Plugin information for this resource.',
     readOnly: true,
   })
   plugin;
-
-  @attr('string', {
-    description: '',
-    readOnly: true,
-    isNestedAttribute: true,
-  })
-  external_id;
 }

--- a/addons/api/addon/models/fragment-host-attributes.js
+++ b/addons/api/addon/models/fragment-host-attributes.js
@@ -1,9 +1,0 @@
-import Fragment from 'ember-data-model-fragments/fragment';
-import { attr } from '@ember-data/model';
-
-export default class FragmentHostAttributesModel extends Fragment {
-  @attr('string', {
-    description: 'The address (DNS or IP name) used to reach the host',
-  })
-  address;
-}

--- a/addons/api/addon/models/host.js
+++ b/addons/api/addon/models/host.js
@@ -1,13 +1,28 @@
 import GeneratedHostModel from '../generated/models/host';
+import { attr } from '@ember-data/model';
 import { fragmentArray } from 'ember-data-model-fragments/attributes';
 
 export default class HostModel extends GeneratedHostModel {
+  // =attributes (nested under attributes)
   @fragmentArray('fragment-string', {
     readOnly: true,
     emptyArrayIfMissing: true,
     isNestedAttribute: true,
   })
   ip_addresses;
+
+  @attr('string', {
+    description: 'The address (DNS or IP name) used to reach the host',
+    isNestedAttribute: true,
+  })
+  address;
+
+  @attr('string', {
+    description: '',
+    readOnly: true,
+    isNestedAttribute: true,
+  })
+  external_id;
 
   // Aws specific
   @fragmentArray('fragment-string', {

--- a/addons/api/addon/models/host.js
+++ b/addons/api/addon/models/host.js
@@ -1,34 +1,33 @@
 import GeneratedHostModel from '../generated/models/host';
 import { attr } from '@ember-data/model';
-import { fragmentArray } from 'ember-data-model-fragments/attributes';
 
 export default class HostModel extends GeneratedHostModel {
-  // =attributes (nested under attributes)
-  @fragmentArray('fragment-string', {
-    readOnly: true,
-    emptyArrayIfMissing: true,
-    isNestedAttribute: true,
-  })
-  ip_addresses;
+  // =attributes
 
+  // Static specific fields
   @attr('string', {
     description: 'The address (DNS or IP name) used to reach the host',
     isNestedAttribute: true,
   })
   address;
 
+  // Plugin specific fields
+  @attr({
+    readOnly: true,
+    emptyArrayIfMissing: true,
+  })
+  ip_addresses;
+
   @attr('string', {
     description: '',
     readOnly: true,
-    isNestedAttribute: true,
   })
   external_id;
 
   // Aws specific
-  @fragmentArray('fragment-string', {
+  @attr({
     readOnly: true,
     emptyArrayIfMissing: true,
-    isNestedAttribute: true,
   })
   dns_names;
 

--- a/addons/api/addon/models/host.js
+++ b/addons/api/addon/models/host.js
@@ -1,12 +1,21 @@
 import GeneratedHostModel from '../generated/models/host';
-import { fragment } from 'ember-data-model-fragments/attributes';
+import { fragmentArray } from 'ember-data-model-fragments/attributes';
 
 export default class HostModel extends GeneratedHostModel {
-  /**
-   * Attributes of this resource, if any, represented as a JSON fragment.
-   * @type {FragmentHostAttributesModel}
-   */
-  @fragment('fragment-host-attributes', { defaultValue: {} }) attributes;
+  @fragmentArray('fragment-string', {
+    readOnly: true,
+    emptyArrayIfMissing: true,
+    isNestedAttribute: true,
+  })
+  ip_addresses;
+
+  // Aws specific
+  @fragmentArray('fragment-string', {
+    readOnly: true,
+    emptyArrayIfMissing: true,
+    isNestedAttribute: true,
+  })
+  dns_names;
 
   /**
    * True if the host is static.

--- a/addons/api/app/models/fragment-host-attributes.js
+++ b/addons/api/app/models/fragment-host-attributes.js
@@ -1,1 +1,0 @@
-export { default } from 'api/models/fragment-host-attributes';

--- a/addons/api/tests/unit/serializers/host-test.js
+++ b/addons/api/tests/unit/serializers/host-test.js
@@ -48,4 +48,64 @@ module('Unit | Serializer | host', function (hooks) {
       },
     });
   });
+
+  test('it normalizes type static record', function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('host');
+    const host = store.createRecord('host').constructor;
+    const payload = {
+      id: '1',
+      name: 'host test',
+      type: 'static',
+    };
+    const normalized = serializer.normalizeSingleResponse(store, host, payload);
+    assert.deepEqual(normalized, {
+      included: [],
+      data: {
+        id: '1',
+        type: 'host',
+        attributes: {
+          name: 'host test',
+          type: 'static',
+          authorized_actions: [],
+          dns_names: [],
+          ip_addresses: [],
+        },
+        relationships: {},
+      },
+    });
+  });
+
+  test('it normalizes type plugin (aws) record', function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('host');
+    const host = store.createRecord('host').constructor;
+    const payload = {
+      id: '1',
+      name: 'host test',
+      type: 'plugin',
+      plugin: {
+        name: 'aws',
+      },
+    };
+    const normalized = serializer.normalizeSingleResponse(store, host, payload);
+    assert.deepEqual(normalized, {
+      included: [],
+      data: {
+        id: '1',
+        type: 'host',
+        attributes: {
+          name: 'host test',
+          type: 'plugin',
+          authorized_actions: [],
+          dns_names: [],
+          ip_addresses: [],
+          plugin: { name: 'aws' },
+        },
+        relationships: {},
+      },
+    });
+  });
 });

--- a/addons/api/tests/unit/serializers/host-test.js
+++ b/addons/api/tests/unit/serializers/host-test.js
@@ -27,29 +27,7 @@ module('Unit | Serializer | host', function (hooks) {
     });
   });
 
-  test('it serializes host with type plugin as expected', function (assert) {
-    assert.expect(1);
-    const store = this.owner.lookup('service:store');
-    const recordAws = store.createRecord('host', {
-      name: 'Host 2',
-      description: 'Description',
-      host_catalog_id: '123',
-      compositeType: 'aws',
-      address: '188e:68a9:b342:c05c:2595:2f46:499c:759f',
-    });
-
-    assert.deepEqual(recordAws.serialize(), {
-      name: 'Host 2',
-      description: 'Description',
-      host_catalog_id: '123',
-      type: 'plugin',
-      attributes: {
-        address: '188e:68a9:b342:c05c:2595:2f46:499c:759f',
-      },
-    });
-  });
-
-  test('it normalizes type static record', function (assert) {
+  test('it normalizes type static record as expected', function (assert) {
     assert.expect(1);
     const store = this.owner.lookup('service:store');
     const serializer = store.serializerFor('host');
@@ -58,9 +36,8 @@ module('Unit | Serializer | host', function (hooks) {
       id: '1',
       name: 'host test',
       type: 'static',
-      ip_addresses: ['10.0.0.1', '10.0.0.2', '10.0.0.3'],
       authorized_actions: ['no-op', 'read'],
-      dns_names: ['test.example.internal', 'test.example.external'],
+      address: '10.0.0.1',
     };
     const normalized = serializer.normalizeSingleResponse(store, host, payload);
     assert.deepEqual(normalized, {
@@ -72,22 +49,16 @@ module('Unit | Serializer | host', function (hooks) {
           name: 'host test',
           type: 'static',
           authorized_actions: ['no-op', 'read'],
-          dns_names: [
-            { value: 'test.example.internal' },
-            { value: 'test.example.external' },
-          ],
-          ip_addresses: [
-            { value: '10.0.0.1' },
-            { value: '10.0.0.2' },
-            { value: '10.0.0.3' },
-          ],
+          address: '10.0.0.1',
+          dns_names: [],
+          ip_addresses: [],
         },
         relationships: {},
       },
     });
   });
 
-  test('it normalizes type plugin (aws) record', function (assert) {
+  test('it normalizes type plugin (aws) record as expected', function (assert) {
     assert.expect(1);
     const store = this.owner.lookup('service:store');
     const serializer = store.serializerFor('host');
@@ -99,8 +70,8 @@ module('Unit | Serializer | host', function (hooks) {
       plugin: {
         name: 'aws',
       },
-      ip_addresses: ['10.0.0.1', '10.0.0.2', '10.0.0.3'],
       authorized_actions: ['no-op', 'read'],
+      ip_addresses: ['10.0.0.1', '10.0.0.2', '10.0.0.3'],
       dns_names: ['test.example.internal', 'test.example.external'],
     };
     const normalized = serializer.normalizeSingleResponse(store, host, payload);
@@ -113,15 +84,8 @@ module('Unit | Serializer | host', function (hooks) {
           name: 'host test',
           type: 'plugin',
           authorized_actions: ['no-op', 'read'],
-          dns_names: [
-            { value: 'test.example.internal' },
-            { value: 'test.example.external' },
-          ],
-          ip_addresses: [
-            { value: '10.0.0.1' },
-            { value: '10.0.0.2' },
-            { value: '10.0.0.3' },
-          ],
+          ip_addresses: ['10.0.0.1', '10.0.0.2', '10.0.0.3'],
+          dns_names: ['test.example.internal', 'test.example.external'],
           plugin: { name: 'aws' },
         },
         relationships: {},

--- a/addons/api/tests/unit/serializers/host-test.js
+++ b/addons/api/tests/unit/serializers/host-test.js
@@ -58,6 +58,9 @@ module('Unit | Serializer | host', function (hooks) {
       id: '1',
       name: 'host test',
       type: 'static',
+      ip_addresses: ['10.0.0.1', '10.0.0.2', '10.0.0.3'],
+      authorized_actions: ['no-op', 'read'],
+      dns_names: ['test.example.internal', 'test.example.external'],
     };
     const normalized = serializer.normalizeSingleResponse(store, host, payload);
     assert.deepEqual(normalized, {
@@ -68,9 +71,16 @@ module('Unit | Serializer | host', function (hooks) {
         attributes: {
           name: 'host test',
           type: 'static',
-          authorized_actions: [],
-          dns_names: [],
-          ip_addresses: [],
+          authorized_actions: ['no-op', 'read'],
+          dns_names: [
+            { value: 'test.example.internal' },
+            { value: 'test.example.external' },
+          ],
+          ip_addresses: [
+            { value: '10.0.0.1' },
+            { value: '10.0.0.2' },
+            { value: '10.0.0.3' },
+          ],
         },
         relationships: {},
       },
@@ -89,6 +99,9 @@ module('Unit | Serializer | host', function (hooks) {
       plugin: {
         name: 'aws',
       },
+      ip_addresses: ['10.0.0.1', '10.0.0.2', '10.0.0.3'],
+      authorized_actions: ['no-op', 'read'],
+      dns_names: ['test.example.internal', 'test.example.external'],
     };
     const normalized = serializer.normalizeSingleResponse(store, host, payload);
     assert.deepEqual(normalized, {
@@ -99,9 +112,16 @@ module('Unit | Serializer | host', function (hooks) {
         attributes: {
           name: 'host test',
           type: 'plugin',
-          authorized_actions: [],
-          dns_names: [],
-          ip_addresses: [],
+          authorized_actions: ['no-op', 'read'],
+          dns_names: [
+            { value: 'test.example.internal' },
+            { value: 'test.example.external' },
+          ],
+          ip_addresses: [
+            { value: '10.0.0.1' },
+            { value: '10.0.0.2' },
+            { value: '10.0.0.3' },
+          ],
           plugin: { name: 'aws' },
         },
         relationships: {},

--- a/addons/api/tests/unit/serializers/host-test.js
+++ b/addons/api/tests/unit/serializers/host-test.js
@@ -4,19 +4,48 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Serializer | host', function (hooks) {
   setupTest(hooks);
 
-  test('it exists', function (assert) {
-    let store = this.owner.lookup('service:store');
-    let serializer = store.serializerFor('host');
-
-    assert.ok(serializer);
+  test('it serializes host with type static as expected', function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const record = store.createRecord('host', {
+      name: 'Host 1',
+      compositeType: 'static',
+      description: 'Description',
+      host_catalog_id: '123',
+      version: 1,
+      address: '188e:68a9:b342:c05c:2595:2f46:499c:759f',
+    });
+    assert.deepEqual(record.serialize(), {
+      name: 'Host 1',
+      description: 'Description',
+      type: 'static',
+      host_catalog_id: '123',
+      version: 1,
+      attributes: {
+        address: '188e:68a9:b342:c05c:2595:2f46:499c:759f',
+      },
+    });
   });
 
-  test('it serializes records', function (assert) {
-    let store = this.owner.lookup('service:store');
-    let record = store.createRecord('host', {});
+  test('it serializes host with type plugin as expected', function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const recordAws = store.createRecord('host', {
+      name: 'Host 2',
+      description: 'Description',
+      host_catalog_id: '123',
+      compositeType: 'aws',
+      address: '188e:68a9:b342:c05c:2595:2f46:499c:759f',
+    });
 
-    let serializedRecord = record.serialize();
-
-    assert.ok(serializedRecord);
+    assert.deepEqual(recordAws.serialize(), {
+      name: 'Host 2',
+      description: 'Description',
+      host_catalog_id: '123',
+      type: 'plugin',
+      attributes: {
+        address: '188e:68a9:b342:c05c:2595:2f46:499c:759f',
+      },
+    });
   });
 });


### PR DESCRIPTION
Add new fields to host and refactor field address to use no more `fragment-host-attribute-model`.

**Be aware:** These changes does NOT include these new fields in mirage, that will come in a separate PR.