### PR TITLE
chore: host catalog form- add rest of the AWS and Azure fields

### DIFF
--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -136,3 +136,7 @@ secret_access_key:
   link-text: Learn more
 region: 
   label: Region
+provider_client_id: 
+  label: Client ID
+  link-text : Learn more
+  help: The client ID for the client you want Boundary to use.

--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -120,11 +120,19 @@ filter:
   help: A boolean expression defining a filter run against the provided information.
 tenant_id: 
   label: Tenant ID
+  help: The tenant (directory) ID for your Azure Active Directory application.
+  link-text: Learn more
 subscription_id:
   label: Subscription ID
+  help: The subscription ID for the subscription with read access.
+  link-text: Learn more
 access_key_id:
   label: Access Key ID
+  help: The access key ID found on the Security Credentials page in AWS.
+  link-text: Learn more
 secret_access_key:
   label: Secret Access Key
+  help: The subscription ID for the subscription with read access.
+  link-text: Learn more
 region: 
   label: Region

--- a/ui/admin/app/components/form/host-catalog/aws/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/aws/index.hbs
@@ -139,7 +139,7 @@
     readonly={{false}}
   />
 
-    <form.input
+  <form.input
     @name='access_key_id'
     @type='access_key_id'
     @helperText={{t 'form.access_key_id.help'}}
@@ -150,11 +150,12 @@
     readonly={{false}}
   />
 
-    <form.input
+  <form.input
     @name='secret_access_key'
     @type='secret_access_key'
     @value={{@model.secret_access_key}}
     @label={{t 'form.secret_access_key.label'}}
+    @helperText={{t 'form.secret_access_key.help'}}
     @linkText={{t 'form.secret_access_key.link-text'}}
     @link='https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts'
     readonly={{false}}

--- a/ui/admin/app/components/form/host-catalog/aws/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/aws/index.hbs
@@ -132,7 +132,7 @@
   {{/if}}
 
   <form.input
-    @name='Region'
+    @name='region'
     @type='region'
     @value={{@model.region}}
     @label={{t 'form.region.label'}}
@@ -142,10 +142,10 @@
   <form.input
     @name='access_key_id'
     @type='access_key_id'
-    @helperText={{t 'form.access_key_id.help'}}
-    @linkText={{t 'form.access_key_id.link-text'}}
     @value={{@model.access_key_id}}
     @label={{t 'form.access_key_id.label'}}
+    @helperText={{t 'form.access_key_id.help'}}
+    @linkText={{t 'form.access_key_id.link-text'}}
     @link='https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts'
     readonly={{false}}
   />

--- a/ui/admin/app/components/form/host-catalog/aws/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/aws/index.hbs
@@ -131,6 +131,26 @@
     readonly={{false}}
   />
 
+    <form.input
+    @name='access_key_id'
+    @type='access_key_id'
+    @helperText={{t 'form.access_key_id.help'}}
+    @linkText={{t 'form.access_key_id.link-text'}}
+    @value={{@model.access_key_id}}
+    @label={{t 'form.access_key_id.label'}}
+    @link='https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts'
+    readonly={{false}}
+  />
+
+    <form.input
+    @name='secret_access_key'
+    @type='secret_access_key'
+    @value={{@model.secret_access_key}}
+    @label={{t 'form.secret_access_key.label'}}
+    @linkText={{t 'form.secret_access_key.link-text'}}
+    @link='https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts'
+    readonly={{false}}
+  />
   {{#if (can 'save model' @model)}}
     <form.actions
       @disabled={{if @model.cannotSave @model.cannotSave}}

--- a/ui/admin/app/components/form/host-catalog/azure/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/azure/index.hbs
@@ -126,6 +126,28 @@
     @type='tenant_id'
     @value={{@model.tenant_id}}
     @label={{t 'form.tenant_id.label'}}
+    @linkText={{t 'form.tenant_id.link-text'}}
+    @link='https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts'
+    readonly={{false}}
+  />
+
+  <form.input
+    @name='subscription_id'
+    @type='subscription_id'
+    @value={{@model.subscription_id}}
+    @label={{t 'form.subscription_id.label'}}
+    @linkText={{t 'form.subscription_id.link-text'}}
+    @link='https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts'
+    readonly={{false}}
+  />
+
+  <form.input
+    @name='client_id'
+    @type='client_id'
+    @value={{@model.client_id}}
+    @label={{t 'form.client_id.label'}}
+    {{!-- @linkText={{t 'form.subscription_id.link-text'}} --}}
+    @link='https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts'
     readonly={{false}}
   />
 

--- a/ui/admin/app/components/form/host-catalog/azure/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/azure/index.hbs
@@ -141,6 +141,7 @@
     @type='tenant_id'
     @value={{@model.tenant_id}}
     @label={{t 'form.tenant_id.label'}}
+    @helperText={{t 'form.tenant_id.help'}}
     @linkText={{t 'form.tenant_id.link-text'}}
     @link='https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts'
     readonly={{false}}
@@ -151,6 +152,7 @@
     @type='subscription_id'
     @value={{@model.subscription_id}}
     @label={{t 'form.subscription_id.label'}}
+    @helperText={{t 'form.subscription_id.help'}}
     @linkText={{t 'form.subscription_id.link-text'}}
     @link='https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts'
     readonly={{false}}
@@ -160,8 +162,9 @@
     @name='client_id'
     @type='client_id'
     @value={{@model.client_id}}
-    @label={{t 'form.client_id.label'}}
-    {{!-- @linkText={{t 'form.subscription_id.link-text'}} --}}
+    @label={{t 'form.provider_client_id.label'}}
+    @helperText={{t 'form.provider_client_id.help'}}
+    @linkText={{t 'form.provider_client_id.link-text'}}
     @link='https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts'
     readonly={{false}}
   />


### PR DESCRIPTION
currently these are not supported: `access_key_id` and `secret_access_key` 
link [here](https://boundary-ui-kkx8779mx-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/host-catalogs/new?type=aws)
<img width="951" alt="Screen Shot 2022-02-08 at 1 12 11 PM" src="https://user-images.githubusercontent.com/15043878/153076494-41d8ddcd-4e26-406e-b8a5-6d2eb6b8d83a.png">


The POST request to the API is serialized properly, but we are missing these two fields (`access_key_id` and `secret_access_key` ) in the normalization.  This will be covered in a separate PR