### PR TITLE
refactor: 💡 Refactor app normalize and host catalog normalize

### DIFF
--- a/addons/api/addon/serializers/application.js
+++ b/addons/api/addon/serializers/application.js
@@ -236,7 +236,7 @@ export default class ApplicationSerializer extends RESTSerializer {
     typeClass.attributes.forEach((attribute) => {
       const { isNestedAttribute } = attribute.options;
       const attributeValue = hash.attributes?.[attribute.name];
-      if (isNestedAttribute && attributeValue) {
+      if (isNestedAttribute && typeof attributeValue != 'undefined') {
         hash[attribute.name] = attributeValue;
       }
     });
@@ -261,7 +261,15 @@ export default class ApplicationSerializer extends RESTSerializer {
         name,
         options: { isNestedSecret },
       } = attribute;
-      if (isNestedSecret) hash[name] = null;
+      const attributeValue = hash.secrets?.[name];
+
+      // FIXME: This could be improved
+      if (isNestedSecret) {
+        hash[name] = null;
+        if (attributeValue) {
+          hash[name] = attributeValue;
+        }
+      }
     });
     return hash;
   }

--- a/addons/api/addon/serializers/application.js
+++ b/addons/api/addon/serializers/application.js
@@ -266,7 +266,7 @@ export default class ApplicationSerializer extends RESTSerializer {
       // FIXME: This could be improved
       if (isNestedSecret) {
         hash[name] = null;
-        if (attributeValue) {
+        if (typeof attributeValue != 'undefined') {
           hash[name] = attributeValue;
         }
       }

--- a/addons/api/addon/serializers/host-catalog.js
+++ b/addons/api/addon/serializers/host-catalog.js
@@ -1,4 +1,5 @@
 import ApplicationSerializer from './application';
+import { copy } from 'ember-copy';
 
 const fieldsByType = {
   aws: [
@@ -55,5 +56,12 @@ export default class HostCatalogSerializer extends ApplicationSerializer {
     delete serialized.attributes;
     delete serialized.secrets;
     return serialized;
+  }
+
+  normalize(typeClass, hash, ...rest) {
+    let normalizedHash = copy(hash, true);
+    const normalized = super.normalize(typeClass, normalizedHash, ...rest);
+    delete normalized.data.attributes.attributes;
+    return normalized;
   }
 }

--- a/addons/api/tests/unit/serializers/host-catalog-test.js
+++ b/addons/api/tests/unit/serializers/host-catalog-test.js
@@ -4,14 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Serializer | host catalog', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    const store = this.owner.lookup('service:store');
-    const serializer = store.serializerFor('host-catalog');
-
-    assert.ok(serializer);
-  });
-
   test('it serializes records', function (assert) {
     const store = this.owner.lookup('service:store');
     const record = store.createRecord('host-catalog', {});
@@ -170,5 +162,160 @@ module('Unit | Serializer | host catalog', function (hooks) {
       },
     };
     assert.deepEqual(record.serialize(), expectedResult);
+  });
+
+  test('it normalizes an static host catalog as expected', function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('host-catalog');
+    const hostCatalog = store.createRecord('host-catalog').constructor;
+    const payload = {
+      id: '1',
+      name: 'Host catalog test',
+      description: 'Test description',
+      authorized_actions: ['no-op'],
+      type: 'static',
+    };
+    const normalized = serializer.normalizeSingleResponse(
+      store,
+      hostCatalog,
+      payload
+    );
+    assert.deepEqual(normalized, {
+      data: {
+        id: '1',
+        type: 'host-catalog',
+        attributes: {
+          name: 'Host catalog test',
+          description: 'Test description',
+          authorized_actions: ['no-op'],
+          type: 'static',
+          access_key_id: null,
+          secret_access_key: null,
+          secret_id: null,
+          secret_value: null,
+        },
+        relationships: {},
+      },
+      included: [],
+    });
+  });
+
+  test('it normalizes an aws plugin type host catalog as expected', function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('host-catalog');
+    const hostCatalog = store.createRecord('host-catalog').constructor;
+    const payload = {
+      id: '1',
+      name: 'Host catalog test',
+      description: 'Test description',
+      authorized_actions: ['no-op'],
+      type: 'plugin',
+      plugin: {
+        id: 'plugin-id-5',
+        name: 'aws',
+        description: 'aws host catalog',
+      },
+      attributes: {
+        disable_credential_rotation: false,
+        region: 'Illinois',
+      },
+      secrets: {
+        access_key_id: '0xF3B0a6f8',
+        secret_access_key: 'zq{2:IVc8@W^',
+      },
+    };
+    const normalized = serializer.normalizeSingleResponse(
+      store,
+      hostCatalog,
+      payload
+    );
+    assert.deepEqual(normalized, {
+      data: {
+        id: '1',
+        type: 'host-catalog',
+        attributes: {
+          name: 'Host catalog test',
+          type: 'plugin',
+          description: 'Test description',
+          authorized_actions: ['no-op'],
+          plugin: {
+            id: 'plugin-id-5',
+            name: 'aws',
+            description: 'aws host catalog',
+          },
+          disable_credential_rotation: false,
+          region: 'Illinois',
+          access_key_id: '0xF3B0a6f8',
+          secret_access_key: 'zq{2:IVc8@W^',
+          secret_id: null,
+          secret_value: null,
+        },
+        relationships: {},
+      },
+      included: [],
+    });
+  });
+
+  test('it normalizes an azure plugin type host catalog as expected', function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('host-catalog');
+    const hostCatalog = store.createRecord('host-catalog').constructor;
+    const payload = {
+      id: '1',
+      name: 'Host catalog test',
+      description: 'Test description',
+      authorized_actions: ['no-op', 'read', 'update', 'delete'],
+      type: 'plugin',
+      plugin: {
+        id: 'plugin-id-6',
+        name: 'azure',
+        description: 'azure host catalog',
+      },
+      attributes: {
+        disable_credential_rotation: true,
+        tenant_id: 'tenant',
+        client_id: 'client',
+        subscription_id: 'subscription',
+      },
+      secrets: {
+        secret_id: '0xF3B0a6f8',
+        secret_value: 'zq{2:IVc8@W^',
+      },
+    };
+    const normalized = serializer.normalizeSingleResponse(
+      store,
+      hostCatalog,
+      payload
+    );
+    assert.deepEqual(normalized, {
+      data: {
+        id: '1',
+        type: 'host-catalog',
+        attributes: {
+          name: 'Host catalog test',
+          type: 'plugin',
+          description: 'Test description',
+          authorized_actions: ['no-op', 'read', 'update', 'delete'],
+          plugin: {
+            id: 'plugin-id-6',
+            name: 'azure',
+            description: 'azure host catalog',
+          },
+          disable_credential_rotation: true,
+          secret_id: '0xF3B0a6f8',
+          secret_value: 'zq{2:IVc8@W^',
+          client_id: 'client',
+          tenant_id: 'tenant',
+          subscription_id: 'subscription',
+          access_key_id: null,
+          secret_access_key: null,
+        },
+        relationships: {},
+      },
+      included: [],
+    });
   });
 });


### PR DESCRIPTION
Refactor app normalize to deal with nestedAttributes and nestedSecrets as expected, before it was not working as expected. Refactor the host catalog normalize method. Add normalize test on host catalog to validate changes on normalize methods.