### PR TITLE
fix: 🐛 Fix filter field for host-set in mirage

### DIFF
--- a/addons/api/mirage/factories/host-set.js
+++ b/addons/api/mirage/factories/host-set.js
@@ -43,7 +43,7 @@ export default factory.extend({
   // Azure specific
   filter() {
     if (this.plugin?.name === 'azure') {
-      return `${database.column}=${database.collation}`;
+      return `${database.column()}=${database.collation()}`;
     }
   },
 });


### PR DESCRIPTION
Fix the filter field for host-set in mirage. It was returning an error rather than a string.