### PR TITLE
fix: append ?plugin_name to dynamic host catalog create requests

### DIFF
--- a/addons/api/addon/adapters/host-catalog.js
+++ b/addons/api/addon/adapters/host-catalog.js
@@ -1,28 +1,23 @@
 import ApplicationAdapter from './application';
-import { serializeIntoHash } from '@ember-data/adapter/-private';
 
 export default class HostCatalogAdapter extends ApplicationAdapter {
   /**
-    Called by the store when a newly created record is
-    saved via the `save` method on a model record instance.
-
-    The `createRecord` method serializes the record and makes an Ajax (HTTP POST) request
-    to a URL computed by `buildURL`.
-
-    See `serialize` for information on how to customize the serialized form
-    of a record.
-
-    @method createRecord
-    @param {Store} store
-    @param {Model} type
-    @param {Snapshot} snapshot
-    @return {Promise} promise
-  */
-  createRecord(store, type, snapshot) {
-    let url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
-    const pluginName = snapshot.attr('plugin')?.name;
-    if (pluginName) url = `${url}?plugin_name=${pluginName}`;
-    const data = serializeIntoHash(store, type, snapshot);
-    return this.ajax(url, 'POST', { data });
+   * Overrides the default `buildURL` such that on _create_, URLs for records of
+   * type `plugin` get an extra query parameter `?plugin_name`.  All other
+   * request types behave as normal.
+   *
+   * @override
+   * @param {string} modelName
+   * @param {string} id
+   * @return {string} url
+   * @return {string} requestType
+   */
+  buildURL(modelName, id, snapshot, requestType) {
+    let url = super.buildURL(...arguments);
+    if (requestType === 'createRecord') {
+      const pluginName = snapshot.attr('plugin')?.name;
+      if (pluginName) url = `${url}?plugin_name=${pluginName}`;
+    }
+    return url;
   }
 }

--- a/addons/api/addon/adapters/host-catalog.js
+++ b/addons/api/addon/adapters/host-catalog.js
@@ -1,0 +1,28 @@
+import ApplicationAdapter from './application';
+import { serializeIntoHash } from '@ember-data/adapter/-private';
+
+export default class HostCatalogAdapter extends ApplicationAdapter {
+  /**
+    Called by the store when a newly created record is
+    saved via the `save` method on a model record instance.
+
+    The `createRecord` method serializes the record and makes an Ajax (HTTP POST) request
+    to a URL computed by `buildURL`.
+
+    See `serialize` for information on how to customize the serialized form
+    of a record.
+
+    @method createRecord
+    @param {Store} store
+    @param {Model} type
+    @param {Snapshot} snapshot
+    @return {Promise} promise
+  */
+  createRecord(store, type, snapshot) {
+    let url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
+    const pluginName = snapshot.attr('plugin')?.name;
+    if (pluginName) url = `${url}?plugin_name=${pluginName}`;
+    const data = serializeIntoHash(store, type, snapshot);
+    return this.ajax(url, 'POST', { data });
+  }
+}

--- a/addons/api/app/adapters/host-catalog.js
+++ b/addons/api/app/adapters/host-catalog.js
@@ -1,0 +1,1 @@
+export { default } from 'api/adapters/host-catalog';

--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -270,7 +270,19 @@ export default function () {
       return hostCatalogs.where({ scopeId });
     }
   );
-  this.post('/host-catalogs');
+  this.post(
+    '/host-catalogs',
+    function ({ hostCatalogs }, { queryParams: { plugin_name } }) {
+      const attrs = this.normalizedRequestAttrs();
+      if (plugin_name) {
+        attrs.type = 'plugin';
+        attrs.plugin = {
+          name: plugin_name,
+        };
+      }
+      return hostCatalogs.create(attrs);
+    }
+  );
   this.get('/host-catalogs/:id');
   this.patch('/host-catalogs/:id');
   this.del('/host-catalogs/:id');

--- a/addons/api/tests/unit/adapters/host-catalog-test.js
+++ b/addons/api/tests/unit/adapters/host-catalog-test.js
@@ -4,9 +4,45 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Adapter | host catalog', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let adapter = this.owner.lookup('adapter:host-catalog');
-    assert.ok(adapter);
+  test('it generates correct createRecord URLs for static host catalogs', function (assert) {
+    assert.expect(1);
+    const scopeID = 'o_1';
+    const mockSnapshot = {
+      adapterOptions: {
+        scopeID,
+      },
+      attr() {
+        return null;
+      },
+    };
+    const adapter = this.owner.lookup('adapter:host-catalog');
+    const createRecordURL = adapter.buildURL(
+      'host-catalog',
+      null,
+      mockSnapshot,
+      'createRecord'
+    );
+    assert.equal(createRecordURL, '/v1/host-catalogs');
+  });
+
+  test('it generates correct createRecord URLs for dynamic host catalogs with extra query parameter ?plugin_name', function (assert) {
+    assert.expect(1);
+    const scopeID = 'o_1';
+    const mockSnapshot = {
+      adapterOptions: {
+        scopeID,
+      },
+      attr() {
+        return { name: 'aws' };
+      },
+    };
+    const adapter = this.owner.lookup('adapter:host-catalog');
+    const createRecordURL = adapter.buildURL(
+      'host-catalog',
+      null,
+      mockSnapshot,
+      'createRecord'
+    );
+    assert.equal(createRecordURL, '/v1/host-catalogs?plugin_name=aws');
   });
 });

--- a/addons/api/tests/unit/adapters/host-catalog-test.js
+++ b/addons/api/tests/unit/adapters/host-catalog-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | host catalog', function (hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let adapter = this.owner.lookup('adapter:host-catalog');
+    assert.ok(adapter);
+  });
+});


### PR DESCRIPTION
The API requires us to send ?plugin_name on create. This is how we set the type for dynamic host catalogs. It does not accept this via the payload.