### PR TITLE
fix: 🐛 add client secret value field

### DIFF
--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -144,6 +144,10 @@ provider:
     label: Client ID
     help: The client ID for the client you want Boundary to use.
     link-text : Learn more
+    secret: 
+      label: Client secret value
+      help: The client secret value for the client you want Boundary to use
+      link-text: Learn more
   choose_a_provider: 
     label: Choose a provider 
     description: There are several built-in plugins for the most common providers. You can choose from on of the included plugins or use a custom plugin.

--- a/ui/admin/app/components/form/host-catalog/azure/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/azure/index.hbs
@@ -161,6 +161,16 @@
     readonly={{false}}
   />
 
+  <form.input
+    @name='secret_value'
+    @type='secret_value'
+    @label={{t 'form.provider.client.secret.label'}}
+    @helperText={{t 'form.provider.client.secret.help'}}
+    @linkText={{t 'form.provider.client.secret.link-text'}}
+    @link='https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts'
+    readonly={{false}}
+  />
+
   {{#if (can 'save model' @model)}}
     <form.actions
       @disabled={{if @model.cannotSave @model.cannotSave}}


### PR DESCRIPTION
this pr addresses the missing secret_value field in AWS host catalog form.