### PR TITLE
Expose disable credential rotation field

### DIFF
--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -118,7 +118,7 @@ callback_url:
 filter:
   label: Filter
   help: A boolean expression defining a filter run against the provided information.
-tenant_id: 
+tenant_id:
   label: Tenant ID
   help: The tenant (directory) ID for your Azure Active Directory application.
   link-text: Learn more
@@ -134,20 +134,22 @@ secret_access_key:
   label: Secret Access Key
   help: The subscription ID for the subscription with read access.
   link-text: Learn more
-region: 
+region:
   label: Region
 provider:
   label: Provider Details
   description: This is the provider for this host catalog. The format of the host set filters are specific to each provider.
-  help: 
-  client: 
+  help:
+  client:
     label: Client ID
     help: The client ID for the client you want Boundary to use.
     link-text : Learn more
-  choose_a_provider: 
-    label: Choose a provider 
+  choose_a_provider:
+    label: Choose a provider
     description: There are several built-in plugins for the most common providers. You can choose from on of the included plugins or use a custom plugin.
-  filter: 
+  filter:
     label: Filter
     help: Create a filter to select resources using values such as tag name or tag value. Filter format is specific to each provider.
     link-text: Learn more about using filters for Azure resources.
+disable_credential_rotation:
+  label: Disable credential rotation

--- a/ui/admin/app/components/form/host-catalog/aws/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/aws/index.hbs
@@ -13,7 +13,6 @@
     @label={{t 'form.name.label'}}
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
-    disabled={{@model.isSaving}}
     readonly={{false}}
     as |field|
   >
@@ -33,7 +32,6 @@
     @label={{t 'form.description.label'}}
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
-    disabled={{@model.isSaving}}
     readonly={{false}}
     as |field|
   >
@@ -156,6 +154,16 @@
     @link='https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts'
     readonly={{false}}
   />
+
+  <form.checkbox
+    @name='disable_credential_rotation'
+    @value={{@model.disable_credential_rotation}}
+    @label={{t 'form.disable_credential_rotation.label'}}
+    @onChange={{fn this.toggleDisableCredentialRotation @model}}
+  />
+
+  &nbsp;
+
   {{#if (can 'save model' @model)}}
     <form.actions
       @disabled={{if @model.cannotSave @model.cannotSave}}

--- a/ui/admin/app/components/form/host-catalog/aws/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/aws/index.hbs
@@ -157,7 +157,7 @@
 
   <form.checkbox
     @name='disable_credential_rotation'
-    @value={{@model.disable_credential_rotation}}
+    @checked={{@model.disable_credential_rotation}}
     @label={{t 'form.disable_credential_rotation.label'}}
     @onChange={{fn this.toggleDisableCredentialRotation @model}}
   />

--- a/ui/admin/app/components/form/host-catalog/aws/index.js
+++ b/ui/admin/app/components/form/host-catalog/aws/index.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class FormHostCatalogAwsComponent extends Component {
+  // =actions
+
+  @action
+  toggleDisableCredentialRotation(model) {
+    model.disable_credential_rotation = !model.disable_credential_rotation;
+  }
+}

--- a/ui/admin/app/components/form/host-catalog/azure/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/azure/index.hbs
@@ -13,7 +13,6 @@
     @label={{t 'form.name.label'}}
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
-    disabled={{@model.isSaving}}
     readonly={{false}}
     as |field|
   >
@@ -33,7 +32,6 @@
     @label={{t 'form.description.label'}}
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
-    disabled={{@model.isSaving}}
     readonly={{false}}
     as |field|
   >
@@ -160,6 +158,15 @@
     @link='https://learn.hashicorp.com/tutorials/boundary/cloud-host-catalogs#set-up-cloud-hosts'
     readonly={{false}}
   />
+
+  <form.checkbox
+    @name='disable_credential_rotation'
+    @value={{@model.disable_credential_rotation}}
+    @label={{t 'form.disable_credential_rotation.label'}}
+    @disabled={{true}}
+  />
+
+  &nbsp;
 
   {{#if (can 'save model' @model)}}
     <form.actions

--- a/ui/admin/app/components/form/host-catalog/azure/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/azure/index.hbs
@@ -159,15 +159,6 @@
     readonly={{false}}
   />
 
-  <form.checkbox
-    @name='disable_credential_rotation'
-    @value={{@model.disable_credential_rotation}}
-    @label={{t 'form.disable_credential_rotation.label'}}
-    @disabled={{true}}
-  />
-
-  &nbsp;
-
   {{#if (can 'save model' @model)}}
     <form.actions
       @disabled={{if @model.cannotSave @model.cannotSave}}

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/new.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/new.js
@@ -15,10 +15,6 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsNewRoute extends 
     const { id: host_catalog_id, compositeType } = this.modelFor(
       'scopes.scope.host-catalogs.host-catalog'
     );
-    if (this.currentModel?.isNew) {
-      this.currentModel.rollbackAttributes();
-    }
-    console.log('typedwed', compositeType);
     return this.store.createRecord('host-set', {
       compositeType,
       host_catalog_id,
@@ -55,17 +51,10 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsNewRoute extends 
       model: model,
     });
   }
-  /**
-   * Update type of host set
-   * @param {string} type
-   */
-  @action
-  async changeType(type) {
-    await this.router.replaceWith({ queryParams: { type } });
-  }
+
   /**
    * Adds a string item to array `property` on the passed `filter`.
-   
+
    * @param {hostSetModel} hostSet
    * @param {string} property
    * @param {string} value

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
@@ -25,16 +25,20 @@ export default class ScopesScopeHostCatalogsNewRoute extends Route {
    */
   model({ type: compositeType = 'static' }) {
     const scopeModel = this.modelFor('scopes.scope');
-    let name, description;
+    let name, description, disable_credential_rotation;
     if (this.currentModel?.isNew) {
       ({ name, description } = this.currentModel);
       this.currentModel.rollbackAttributes();
+    }
+    if (compositeType === 'azure') {
+      disable_credential_rotation = true;
     }
     return this.store.createRecord('host-catalog', {
       scopeModel,
       compositeType,
       name,
       description,
+      disable_credential_rotation,
     });
   }
 

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
@@ -23,7 +23,7 @@ export default class ScopesScopeHostCatalogsNewRoute extends Route {
    * creating another, but reuse name/description if available.
    * @return {HostCatalogModel}
    */
-  model() {
+  model({ type: compositeType = 'static' }) {
     const scopeModel = this.modelFor('scopes.scope');
     let name, description;
     if (this.currentModel?.isNew) {
@@ -32,13 +32,10 @@ export default class ScopesScopeHostCatalogsNewRoute extends Route {
     }
     return this.store.createRecord('host-catalog', {
       scopeModel,
+      compositeType,
       name,
       description,
     });
-  }
-
-  afterModel(model, transition) {
-    this.changeType(transition.to.queryParams?.type);
   }
 
   /**
@@ -46,11 +43,8 @@ export default class ScopesScopeHostCatalogsNewRoute extends Route {
    * @param {string} type
    */
   @action
-  async changeType(type) {
-    const model = this.modelFor('scopes.scope.host-catalogs.new');
-    if (!type) type = 'static'; // Unknown host catalog type defaults to 'static'
-    if (model.isUnknown) type = 'aws'; //Is this the default case for plugin type?
-    model.compositeType = type;
-    await this.router.replaceWith({ queryParams: { type } });
+  changeType(type) {
+    if (type === 'plugin') type = 'aws';
+    this.router.replaceWith({ queryParams: { type } });
   }
 }

--- a/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/new.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/new.hbs
@@ -4,7 +4,6 @@
   @model={{@model}}
   @submit={{route-action 'save' @model}}
   @cancel={{route-action 'cancel' @model}}
-  @changeType={{route-action 'changeType' @model.type}}
   @removeItemByIndex={{route-action 'removeItemByIndex' @model}}
   @addStringItem={{route-action 'addStringItem' @model}}
 />


### PR DESCRIPTION
This PR exposes the `disable_credential_rotation` field for dynamic host catalogs.  For AWS it is editable.  For Azure, it is always `true`.

Demo:
https://boundary-ui-git-feature-disable-credential-rotation-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/host-catalogs/new?type=aws