### PR TITLE
fix: 🐛 Fix host mock data attributes

### DIFF
--- a/addons/api/mirage/factories/host.js
+++ b/addons/api/mirage/factories/host.js
@@ -2,32 +2,6 @@ import factory from '../generated/factories/host';
 import permissions from '../helpers/permissions';
 import { internet, datatype } from 'faker';
 
-/**
- * Returns an array of strings with IP addresses.
- * @returns {array}
- */
-const returnIpAddressesArray = () => {
-  const addressesAmount = Math.floor(Math.random() * 6) + 1;
-  let result = [];
-  for (let i = 0; i < addressesAmount; ++i) {
-    result.push(internet.ip());
-  }
-  return result;
-};
-
-/**
- * Returns an array of strings with DNS names.
- * @param {string} hostType
- */
-const returnDnsNames = () => {
-  const dnsNamesAmount = Math.floor(Math.random() * 6) + 1;
-  let result = [];
-  for (let i = 0; i < dnsNamesAmount; i++) {
-    result.push(internet.domainName());
-  }
-  return result;
-};
-
 export default factory.extend({
   id: (i) => `host-id-${i}`,
   type() {
@@ -45,13 +19,26 @@ export default factory.extend({
       return this.hostCatalog.plugin;
     }
   },
-  attributes() {
-    return {
-      address: internet.ipv6(),
-      ip_addresses: returnIpAddressesArray(),
-      external_id: datatype.uuid(),
-      // Only aws plugins have dns_names
-      dns_names: this.plugin?.name === 'aws' ? returnDnsNames() : undefined,
-    };
+  ip_addresses() {
+    const addressesAmount = Math.floor(Math.random() * 6) + 1;
+    let result = [];
+    for (let i = 0; i < addressesAmount; ++i) {
+      result.push(internet.ip());
+    }
+    return result;
+  },
+  external_id() {
+    return datatype.uuid();
+  },
+  // Only aws plugins have dns_names
+  dns_names() {
+    if (this.plugin?.name === 'aws') {
+      const dnsNamesAmount = Math.floor(Math.random() * 6) + 1;
+      let result = [];
+      for (let i = 0; i < dnsNamesAmount; i++) {
+        result.push(internet.domainName());
+      }
+      return result;
+    }
   },
 });

--- a/addons/api/mirage/generated/factories/host.js
+++ b/addons/api/mirage/generated/factories/host.js
@@ -1,5 +1,5 @@
 import { Factory } from 'ember-cli-mirage';
-import { random, date, datatype } from 'faker';
+import { random, date, datatype, internet } from 'faker';
 
 /**
  * GeneratedHostModelFactory
@@ -11,4 +11,7 @@ export default Factory.extend({
   created_time: () => date.recent(),
   updated_time: () => date.recent(),
   version: () => datatype.number(),
+  attributes: () => {
+    return { address: internet.ipv6() };
+  },
 });


### PR DESCRIPTION
Refactor `ip_addresses`, `dns_names` and `external_id` to not be nested under `attributes: {}` when generating mock data.