### PR TITLE
fix: 🐛 multiple labels

### DIFF
--- a/ui/admin/app/components/form/host/aws/index.hbs
+++ b/ui/admin/app/components/form/host/aws/index.hbs
@@ -72,18 +72,20 @@
     </:body>
   </form.fieldset>
 
-  {{#each @model.ip_addresses as |ip_address|}}
-    <form.fieldset>
-      <:title>{{t 'titles.ip-addresses'}}</:title>
-      <:body>
+  <form.fieldset>
+    <:title>{{t 'titles.ip-addresses'}}</:title>
+    <:body>
+      {{#each @model.ip_addresses as |ip_address|}}
+
         <form.input
           @value={{ip_address}}
           readonly={{true}}
           @disabled={{true}}
         />
-      </:body>
-    </form.fieldset>
-  {{/each}}
+      {{/each}}
+    </:body>
+  </form.fieldset>
+
   {{#if (can 'save model' @model)}}
     <form.actions
       @disabled={{if @model.cannotSave @model.cannotSave}}


### PR DESCRIPTION
this fixes multiple label issues in AWS host latest IP addresses

 
AWS:
https://boundary-ui-git-fix-labels-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/host-catalogs/host-catalog-id-5/hosts/host-id-50

Azure: https://boundary-ui-git-fix-labels-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/host-catalogs/host-catalog-id-3/hosts/host-id-30

