### PR TITLE
fix: 🐛 Refactor host-set dropdown separator

### DIFF
--- a/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/-actions.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/-actions.hbs
@@ -14,9 +14,9 @@
     >
       {{t 'resources.host-set.actions.add-hosts'}}
     </dropdown.link>
+    <dropdown.separator />
   {{/if}}
   {{#if (can 'delete model' @model)}}
-    <dropdown.separator />
     <dropdown.button
       @style='danger'
       @disabled={{@model.canSave}}


### PR DESCRIPTION
Refactor host-set actions dropdown separator to not be show when there is just 1 option.

[Jira ticket](https://hashicorp.atlassian.net/browse/ICU-3477)

Before the fix:
![32ff16b6-3509-4f9a-875f-aba5bf06c2eb](https://user-images.githubusercontent.com/9775006/154314925-d630fc49-a496-4af6-ad64-3cc2031b8fb1.png)

After the fix:
<img width="1278" alt="Screen Shot 2022-02-16 at 8 50 22 AM" src="https://user-images.githubusercontent.com/9775006/154315091-298218a5-6273-443d-8d85-f5990d7cc75b.png">
