### PR TITLE
fix: 🐛 missed value field

### DIFF
--- a/ui/admin/app/components/form/host-catalog/azure/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/azure/index.hbs
@@ -160,6 +160,7 @@
   <form.input
     @name='secret_value'
     @type='secret_value'
+    @value={{@model.secret_value}}
     @label={{t 'form.secret.label'}}
     @helperText={{t 'form.secret.help'}}
     @linkText={{t 'actions.learn-more'}}


### PR DESCRIPTION
client_secret_value was empty due to missing a value field on the input element. 


https://boundary-ui-git-fix-val-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/host-catalogs/host-catalog-id-3
<img width="1068" alt="Screen Shot 2022-02-16 at 10 35 42 AM" src="https://user-images.githubusercontent.com/15043878/154332933-57ffa178-7c48-4c7f-ac49-44203f9b48ac.png">


