### PR TITLE
fix: 🐛 Fix host list table missing address field

### DIFF
--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target/hosts.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target/hosts.hbs
@@ -26,7 +26,13 @@
               <code>{{host.id}}</code>
             </Copyable>
           </row.cell>
-          <row.cell>{{host.attributes.address}}</row.cell>
+          <row.cell>
+            {{#if host.isStatic}}
+              {{host.address}}
+            {{else}}
+              &nbsp;
+            {{/if}}
+          </row.cell>
           <row.cell>
             <Rose::Button
               @style='secondary'


### PR DESCRIPTION
Fix address missing field for static hosts in the host list.

Before:
<img width="1676" alt="desktop-view" src="https://user-images.githubusercontent.com/9775006/154341999-b27bc162-bb84-46af-8ba9-20b2200a9251.png">

After:
<img width="1265" alt="Screen Shot 2022-02-16 at 11 14 34 AM" src="https://user-images.githubusercontent.com/9775006/154342056-dea47821-a405-4a5f-ad77-79916f2f0be5.png">
