### PR TITLE
Delete unnecessary else clause in host list within targets

### DIFF
--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target/hosts.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target/hosts.hbs
@@ -29,8 +29,6 @@
           <row.cell>
             {{#if host.isStatic}}
               {{host.address}}
-            {{else}}
-              &nbsp;
             {{/if}}
           </row.cell>
           <row.cell>


### PR DESCRIPTION
Delete unnecessary else clause in host list within targets.