### PR TITLE
chore: support `filters` when it is a string by converting to an array

### DIFF
--- a/addons/api/addon/serializers/host-set.js
+++ b/addons/api/addon/serializers/host-set.js
@@ -1,4 +1,5 @@
 import ApplicationSerializer from './application';
+import { copy } from 'ember-copy';
 
 const fieldByType = {
   aws: ['preferred_endpoints', 'filters'],
@@ -68,5 +69,20 @@ export default class HostSetSerializer extends ApplicationSerializer {
       }
     }
     return value;
+  }
+
+  /**
+   * Temporarily converts `filters` to an array if it is a string.  This is a
+   * quirk of the API.
+   *
+   * TODO:  remove once API consistently returns arrays.
+   */
+  normalize(typeClass, hash, ...rest) {
+    const normalizedHash = copy(hash, true);
+    if (typeof normalizedHash?.filters === 'string') {
+      normalizedHash.filters = [normalizedHash.filters];
+    }
+    const normalized = super.normalize(typeClass, normalizedHash, ...rest);
+    return normalized;
   }
 }


### PR DESCRIPTION
This PR adds (temporary) support for host set `filters` when it is returned by the API as a string.  It is converted to an array in normalisation.  Eventually this can be rolled back once the API consistently returns an array.