### PR TITLE
fix: 🐛 Host address field shows value for type plugin

### DIFF
--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target/hosts.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target/hosts.hbs
@@ -29,6 +29,8 @@
           <row.cell>
             {{#if host.isStatic}}
               {{host.address}}
+            {{else}}
+              {{t 'resources.host-catalog.types.dynamic'}}
             {{/if}}
           </row.cell>
           <row.cell>


### PR DESCRIPTION
Host address field shows Dynamic value on list when it is not type static.

[Direct link to feature](https://boundary-ui-desktop-git-fix-host-address-field-2f79ac-hashicorp.vercel.app/scopes/global/projects/targets/1/hosts)

Before:
<img width="1254" alt="Screen Shot 2022-02-16 at 11 13 11 AM" src="https://user-images.githubusercontent.com/9775006/154534501-63b0895e-ce37-4569-858b-88fd2c348829.png">

After:
<img width="1267" alt="Screen Shot 2022-02-17 at 9 14 32 AM" src="https://user-images.githubusercontent.com/9775006/154534845-7a7fa1e8-d8e8-412a-b742-c04c78d255b7.png">

