### PR TITLE
chore: 🤖 Update babel-plugin-ember-modules-api-polyfill

### DIFF
--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -59,7 +59,7 @@
     "@storybook/theming": "^6.3.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.2",
-    "babel-plugin-ember-modules-api-polyfill": "^2.12.0",
+    "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
     "broccoli-asset-rev": "^3.0.0",
     "doctoc": "^2.0.1",
     "ember-auto-import": "^1.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6932,13 +6932,6 @@ babel-plugin-ember-data-packages-polyfill@^0.1.2:
   dependencies:
     "@ember-data/rfc395-data" "^0.0.4"
 
-babel-plugin-ember-modules-api-polyfill@^2.12.0:
-  version "2.13.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz#cf62bc9bfd808c48d810d5194f4329e9453bd603"
-  integrity sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==
-  dependencies:
-    ember-rfc176-data "^0.3.13"
-
 babel-plugin-ember-modules-api-polyfill@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.5.0.tgz#27b6087fac75661f779f32e60f94b14d0e9f6965"
@@ -11475,7 +11468,7 @@ ember-resolver@^8.0.3:
     ember-cli-version-checker "^5.1.2"
     resolve "^1.20.0"
 
-ember-rfc176-data@^0.3.13, ember-rfc176-data@^0.3.15, ember-rfc176-data@^0.3.17:
+ember-rfc176-data@^0.3.15, ember-rfc176-data@^0.3.17:
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.17.tgz#d4fc6c33abd6ef7b3440c107a28e04417b49860a"
   integrity sha512-EVzTTKqxv9FZbEh6Ktw56YyWRAA0MijKvl7H8C06wVF+8f/cRRz3dXxa4nkwjzyVwx4rzKGuIGq77hxJAQhWWw==


### PR DESCRIPTION
Update babel-plugin-ember-modules-api-polyfill from `2.12.0` to `3.5.0`.
As [per changelog](https://github.com/ember-cli/babel-plugin-ember-modules-api-polyfill/blob/master/CHANGELOG.md), no risk on the update.