### PR TITLE
feat: 🎸 Update @ember/test-helpers

### DIFF
--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -36,7 +36,7 @@
     "js-bexpr": "hashicorp/js-bexpr#9b4a4b54d85eba67fdfc0990133d1518d890b1e1",
     "@babel/core": "^7.16.5",
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.4.2",
+    "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",

--- a/addons/auth/package.json
+++ b/addons/auth/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.4.2",
+    "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",

--- a/addons/core/package.json
+++ b/addons/core/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.4.2",
+    "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.5",
     "@ember/optional-features": "^2.0.0",
-    "@ember/test-helpers": "^2.4.2",
+    "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "@hashicorp/flight-icons": "^2.0.1",

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "^7.16.5",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.2",
-    "@ember/test-helpers": "^2.4.2",
+    "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -56,7 +56,7 @@
     "@doyensec/electronegativity": "^1.9.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.2",
-    "@ember/test-helpers": "^2.4.2",
+    "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "@playwright/test": "^1.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,10 +2943,10 @@
     ember-cli-htmlbars "^5.7.1"
     ember-destroyable-polyfill "^2.0.3"
 
-"@ember/test-helpers@^2.4.2":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.4.2.tgz#e5be97e316dc502d7da933461135fbcb9254726e"
-  integrity sha512-++k/dXZ0IeOQLSm0Yu5QuCRe9UoptuckMhaXHY37VLb1varLHRuP8908kigVNt9c5waiocaK4jPjDBkKYRLlfA==
+"@ember/test-helpers@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.6.0.tgz#d687515c6ab49ba72717fc62046970ef4a72ea9c"
+  integrity sha512-N5sr3layWk60wB3maCy+/5hFHQRcTh8aqxcZTSs3Od9QkuHdWBtRgMGLP/35mXpJlgWuu3xqLpt6u3dGHc8gCg==
   dependencies:
     "@ember/test-waiters" "^3.0.0"
     broccoli-debug "^0.6.5"


### PR DESCRIPTION
Update @ember/test-helpers from `2.4.2` to `2.6.0`.

[As per changelog ](https://github.com/emberjs/ember-test-helpers/blob/master/CHANGELOG.md)there is no risk.