### PR TITLE
chore: 🤖 Update doctoc

### DIFF
--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -41,7 +41,7 @@
     "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
-    "doctoc": "^2.0.1",
+    "doctoc": "^2.1.0",
     "ember-auto-import": "^1.12.0",
     "ember-cli": "~4.1.0",
     "ember-cli-dependency-checker": "^3.2.0",

--- a/addons/auth/package.json
+++ b/addons/auth/package.json
@@ -34,7 +34,7 @@
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "core": "*",
-    "doctoc": "^2.0.1",
+    "doctoc": "^2.1.0",
     "ember-auto-import": "^1.12.0",
     "ember-cli": "~4.1.0",
     "ember-cli-dependency-checker": "^3.2.0",

--- a/addons/core/package.json
+++ b/addons/core/package.json
@@ -47,7 +47,7 @@
     "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
-    "doctoc": "^2.0.1",
+    "doctoc": "^2.1.0",
     "ember-auto-import": "^1.12.0",
     "ember-cli": "~4.1.0",
     "ember-cli-dependency-checker": "^3.2.0",

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -61,7 +61,7 @@
     "babel-loader": "^8.2.2",
     "babel-plugin-ember-modules-api-polyfill": "^2.12.0",
     "broccoli-asset-rev": "^3.0.0",
-    "doctoc": "^2.0.1",
+    "doctoc": "^2.1.0",
     "ember-auto-import": "^1.12.0",
     "ember-cli": "~4.1.0",
     "ember-cli-dependency-checker": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "cz-conventional-changelog": "^3.1.0",
-    "doctoc": "^2.0.1",
+    "doctoc": "^2.1.0",
     "git-cz": "^4.3.1",
     "license-checker": "^25.0.1"
   },

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -46,7 +46,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "clipboard": "^2.0.8",
     "core": "*",
-    "doctoc": "^2.0.1",
+    "doctoc": "^2.1.0",
     "ember-a11y-testing": "^4.2.0",
     "ember-auto-import": "^1.12.0",
     "ember-breadcrumbs": "^0.2.3",

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -67,7 +67,7 @@
     "core": "*",
     "cross-env": "^7.0.3",
     "cross-os": "^1.4.0",
-    "doctoc": "^2.0.1",
+    "doctoc": "^2.1.0",
     "ember-a11y-testing": "^4.2.0",
     "ember-auto-import": "^1.12.0",
     "ember-autofocus-modifier": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10100,10 +10100,10 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-doctoc@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/doctoc/-/doctoc-2.0.1.tgz#d5aee2bce65a438ff8717d9e51df3d540caa3b78"
-  integrity sha512-JsxnSVZtLCThKehjFPBDhP1+ZLmdfXQynZH/0ABAwrnd1Zf3AV6LigC9oWJyaZ+c6RXCDnlGUNJ7I+1v8VaaRg==
+doctoc@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctoc/-/doctoc-2.1.0.tgz#e7cbcd1f9e65519c295461423b2e7195d9e0d7ab"
+  integrity sha512-0darEVEuWKLyIlpGOzE5cILf/pgUu25qUs6YwCqLqfxb8+3b9Cl4iakA8vwYrBQOkJ5SwpHKEPVMu2KOMrTA7A==
   dependencies:
     "@textlint/markdown-to-ast" "~6.1.7"
     anchor-markdown-header "~0.5.7"


### PR DESCRIPTION
Update doctoc from `2.0.1` to `2.1.0`. No risk on the update.