### PR TITLE
chore: 🤖 Update ember-cli-htmlbars

### DIFF
--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "ember-can": "^3.1.0",
     "ember-cli-babel": "^7.26.8",
-    "ember-cli-htmlbars": "^5.7.1",
+    "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-mirage": "^2.2.0",
     "ember-data": "^3.20.0",
     "ember-data-model-fragments": "5.0.0-beta.2",

--- a/addons/auth/package.json
+++ b/addons/auth/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.8",
-    "ember-cli-htmlbars": "^5.7.1",
+    "ember-cli-htmlbars": "^6.0.1",
     "ember-fetch": "^8.1.1",
     "ember-simple-auth": "^4.0.0"
   },

--- a/addons/core/package.json
+++ b/addons/core/package.json
@@ -32,7 +32,7 @@
     "auth": "*",
     "ember-browser-services": "^2.0.0",
     "ember-cli-babel": "^7.26.8",
-    "ember-cli-htmlbars": "^5.7.1",
+    "ember-cli-htmlbars": "^6.0.1",
     "ember-feature-flags": "^6.0.0",
     "ember-intl": "^5.7.0",
     "ember-loading": "^2.0.0",

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.8",
-    "ember-cli-htmlbars": "^5.7.1",
+    "ember-cli-htmlbars": "^6.0.1",
     "ember-composable-helpers": "^4.5.0",
     "ember-focus-trap": "^0.7.0",
     "ember-named-blocks-polyfill": "^0.2.4",

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -56,7 +56,7 @@
     "ember-cli-code-coverage": "^1.0.3",
     "ember-cli-content-security-policy": "^1.1.1",
     "ember-cli-dependency-checker": "^3.2.0",
-    "ember-cli-htmlbars": "^5.7.1",
+    "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -76,7 +76,7 @@
     "ember-cli-babel": "^7.26.8",
     "ember-cli-code-coverage": "^1.0.3",
     "ember-cli-dependency-checker": "^3.2.0",
-    "ember-cli-htmlbars": "^5.7.1",
+    "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",


### PR DESCRIPTION
Update ember-cli-htmlbars from `5.7.1` to `6.0.1`.

As [per changelog](https://github.com/ember-cli/ember-cli-htmlbars/blob/master/CHANGELOG.md) no risk on the update.