### PR TITLE
chore: 🤖 Update ember-composable-helpers

### DIFF
--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.26.8",
     "ember-cli-htmlbars": "^5.7.1",
-    "ember-composable-helpers": "^4.5.0",
+    "ember-composable-helpers": "^5.0.0",
     "ember-focus-trap": "^0.7.0",
     "ember-named-blocks-polyfill": "^0.2.4",
     "ember-radio-button": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11076,10 +11076,10 @@ ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.1.2, ember-co
     fs-extra "^9.1.0"
     semver "^5.4.1"
 
-ember-composable-helpers@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/ember-composable-helpers/-/ember-composable-helpers-4.5.0.tgz#94febbdf4348e64f45f7a6f993f326e32540a61e"
-  integrity sha512-XjpDLyVPsLCy6kd5dIxZonOECCO6AA5sY5Hr6tYUbJg3s5ghFAiFWaNcYraYC+fL2yPJQAswwpfwGlQORUJZkw==
+ember-composable-helpers@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ember-composable-helpers/-/ember-composable-helpers-5.0.0.tgz#055bab3a3e234ab2917499b1465e968c253ca885"
+  integrity sha512-gyUrjiSju4QwNrsCLbBpP0FL6VDFZaELNW7Kbcp60xXhjvNjncYgzm4zzYXhT+i1lLA6WEgRZ3lOGgyBORYD0w==
   dependencies:
     "@babel/core" "^7.0.0"
     broccoli-funnel "2.0.1"


### PR DESCRIPTION
Update ember-composable-helpers from `4.5.0` to `5.0.0`.

As [per changelog](https://github.com/DockYard/ember-composable-helpers/blob/master/CHANGELOG.md) there is no risk on the update.