### PR TITLE
chore: 🤖 Update resolutions follow-redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ember-cli-babel": "^7.26.8",
     "jsonpointer": "5.0.0",
     "json-schema": "^0.4.0",
-    "follow-redirects": "^1.14.7",
+    "follow-redirects": "^1.14.8",
     "node-fetch": "^2.6.7",
     "shelljs": "^0.8.5",
     "ember-template-recast": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13110,10 +13110,10 @@ focus-trap@^6.4.0:
   dependencies:
     tabbable "^5.2.1"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.7:
-  version "1.14.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
-  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+follow-redirects@^1.0.0, follow-redirects@^1.14.8:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Update version of `follow-redirects` in resolutions as per [dependabot alert](https://github.com/hashicorp/boundary-ui/security/dependabot/21).