### PR TITLE
feat: 🎸 Combine columns on target host list for desktop

### DIFF
--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -130,12 +130,14 @@ access_key_id:
 secret_access_key:
   label: Secret Access Key
   help: The secret access key found on the Security Credentials page in AWS.
-region: 
+region:
   label: Region
-secret: 
+secret:
   label: Client secret value
   help: The client secret value for the client you want Boundary to use
 disable_credential_rotation:
   label: Disable credential rotation
 dns_names:
   label: Latest DNS Names
+host:
+  label: Host

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target/hosts.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target/hosts.hbs
@@ -30,7 +30,9 @@
             {{#if host.isStatic}}
               {{host.address}}
             {{else}}
-              {{t 'resources.host-catalog.types.dynamic'}}
+              <Rose::Badge>
+                {{t 'resources.host-catalog.types.dynamic'}}
+              </Rose::Badge>
             {{/if}}
           </row.cell>
           <row.cell>


### PR DESCRIPTION
Combine the columns `name` and `id` into a new column call `Host`.

[Link to feature](https://boundary-ui-desktop-git-feature-combine-column-7b5dac-hashicorp.vercel.app/scopes/global/projects/targets/1/hosts).

Screenshot before:
<img width="1729" alt="Screen Shot 2022-02-22 at 17 09 43" src="https://user-images.githubusercontent.com/9775006/155575438-1b306bad-a634-42b1-9e15-b1be8fdb432c.png">

Screenshot after:
<img width="1280" alt="Screen Shot 2022-02-28 at 10 40 05 AM" src="https://user-images.githubusercontent.com/9775006/156039618-8bb1c3d3-3c0d-4a86-8c71-40663887f7f2.png">

