### PR TITLE
chore: 🤖 Update ember-page-title

### DIFF
--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -53,7 +53,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^1.0.0",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~3.28.4",

--- a/addons/auth/package.json
+++ b/addons/auth/package.json
@@ -46,7 +46,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^1.0.0",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~3.28.4",

--- a/addons/core/package.json
+++ b/addons/core/package.json
@@ -59,7 +59,7 @@
     "ember-inline-svg": "^1.0.0",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^1.0.0",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~3.28.4",

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -75,7 +75,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^1.0.0",
     "ember-modifier": "^1.0.3",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~3.28.4",

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -68,7 +68,7 @@
     "ember-maybe-import-regenerator": "^1.0.0",
     "ember-modifier": "^2.1.2",
     "ember-notify": "^6.0.1",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-pollster": "^0.0.1-beta.2",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -90,7 +90,7 @@
     "ember-maybe-import-regenerator": "^1.0.0",
     "ember-modifier": "^2.1.2",
     "ember-notify": "^6.0.1",
-    "ember-page-title": "^6.2.2",
+    "ember-page-title": "^7.0.0",
     "ember-pollster": "^0.0.1-beta.2",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11394,12 +11394,12 @@ ember-notify@^6.0.1:
     ember-cli-babel "^7.23.1"
     ember-cli-htmlbars "^5.3.2"
 
-ember-page-title@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/ember-page-title/-/ember-page-title-6.2.2.tgz#980838c44e96cba1d00f42435d707936af627324"
-  integrity sha512-YTXA+cylZrh9zO0zwjlaAGReT2MVOxAMnVO1OOygFrs1JBs4D6CKV3tImoilg3AvIXFBeJfFNNUbJOdRd9IGGg==
+ember-page-title@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/ember-page-title/-/ember-page-title-7.0.0.tgz#11bebd4901d80757646c9006954a13e4fc187421"
+  integrity sha512-oq6+HYbeVD/BnxIO5AkP4gWlsatdgW2HFO10F8+XQiJZrwa7cC7Wm54JNGqQkavkDQTgNSiy1Fe2NILJ14MmAg==
   dependencies:
-    ember-cli-babel "^7.23.1"
+    ember-cli-babel "^7.26.6"
 
 ember-pollster@^0.0.1-beta.2:
   version "0.0.1-beta.2"


### PR DESCRIPTION
Update `ember-page-title` from `6.2.2` to `7.0.0` as [per changelong](https://github.com/ember-cli/ember-page-title/blob/master/CHANGELOG.md), there is no risk on the update.