### PR TITLE
ICU 3488: Display DNS Names for AWS Hosts in Admin UI

### DIFF
--- a/addons/core/translations/en-us.yaml
+++ b/addons/core/translations/en-us.yaml
@@ -33,6 +33,7 @@ titles:
   choose-a-provider: Choose a provider
   provider: Provider
   ip-addresses: Latest IP Addresses
+  dns-names: DNS Names
 descriptions:
   empty-set: There are no items to display yet.  You may be able to add items or try back later.
   origin-initialization: To get started, please enter your origin URL

--- a/ui/admin/app/components/form/host/aws/index.hbs
+++ b/ui/admin/app/components/form/host/aws/index.hbs
@@ -86,6 +86,17 @@
     </:body>
   </form.fieldset>
 
+  <form.fieldset>
+
+    <:title>{{t 'titles.dns-names'}}</:title>
+    <:body>
+      {{#each @model.dns_names as |dns_name|}}
+
+        <form.input @value={{dns_name}} readonly={{true}} @disabled={{true}} />
+      {{/each}}
+    </:body>
+  </form.fieldset>
+
   {{#if (can 'save model' @model)}}
     <form.actions
       @disabled={{if @model.cannotSave @model.cannotSave}}

--- a/ui/admin/app/components/form/host/aws/index.hbs
+++ b/ui/admin/app/components/form/host/aws/index.hbs
@@ -76,7 +76,6 @@
     <:title>{{t 'titles.ip-addresses'}}</:title>
     <:body>
       {{#each @model.ip_addresses as |ip_address|}}
-
         <form.input
           @value={{ip_address}}
           readonly={{true}}
@@ -87,11 +86,9 @@
   </form.fieldset>
 
   <form.fieldset>
-
     <:title>{{t 'titles.dns-names'}}</:title>
     <:body>
       {{#each @model.dns_names as |dns_name|}}
-
         <form.input @value={{dns_name}} readonly={{true}} @disabled={{true}} />
       {{/each}}
     </:body>


### PR DESCRIPTION
The test cases need to be updated to handle the different types of host-catalogs properly. Test will be updated and added in a later PR. @joshuaogle the wireframe didn't have a suggested name for the title so I went with "DNS Names". Let me know if you have another suggestion.
Old:
<img width="778" alt="Screen Shot 2022-02-25 at 10 10 30 AM" src="https://user-images.githubusercontent.com/29386339/155749672-b574bcf9-b533-4825-bf64-339600c44d71.png">

New:
<img width="778" alt="Screen Shot 2022-02-25 at 10 12 23 AM" src="https://user-images.githubusercontent.com/29386339/155749700-a952b76f-68ef-46d2-99e7-3bf3d83144e5.png">

