### PR TITLE
chore: 🤖 Deprecate ember-source-channel-url

### DIFF
--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -57,7 +57,6 @@
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~3.28.4",
-    "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^3.7.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",

--- a/addons/auth/package.json
+++ b/addons/auth/package.json
@@ -50,7 +50,6 @@
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~3.28.4",
-    "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^3.7.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",

--- a/addons/core/package.json
+++ b/addons/core/package.json
@@ -63,7 +63,6 @@
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~3.28.4",
-    "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^3.7.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -79,7 +79,6 @@
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.3",
     "ember-source": "~3.28.4",
-    "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^3.7.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
We are not using `ember-source-channel-url`. We were using it in `ember-try` (deprecated) config file, [here](https://github.com/hashicorp/boundary-ui/pull/1002/files#diff-4d75bd18581f5d1a73ba9e1019b68dc4abbd7d5f9ff521e1cc82b142b0029889L3).

The only reason still appearing in `yarn-lock` file because it is a sub-dependency of `ember-cli`.