### PR TITLE
feat: 🎸 Display DNS names for AWS hosts in Admin UI

### DIFF
--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -138,4 +138,4 @@ secret:
 disable_credential_rotation:
   label: Disable credential rotation
 dns_names:
-  label: DNS Names
+  label: Latest DNS Names

--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -137,3 +137,5 @@ secret:
   help: The client secret value for the client you want Boundary to use
 disable_credential_rotation:
   label: Disable credential rotation
+dns_names:
+  label: DNS Names

--- a/ui/admin/app/components/form/host/aws/index.hbs
+++ b/ui/admin/app/components/form/host/aws/index.hbs
@@ -76,12 +76,20 @@
     <:title>{{t 'titles.ip-addresses'}}</:title>
     <:body>
       {{#each @model.ip_addresses as |ip_address|}}
-
         <form.input
           @value={{ip_address}}
           readonly={{true}}
           @disabled={{true}}
         />
+      {{/each}}
+    </:body>
+  </form.fieldset>
+
+  <form.fieldset>
+    <:title>{{t 'form.dns_names.label'}}</:title>
+    <:body>
+      {{#each @model.dns_names as |dns_name|}}
+        <form.input @value={{dns_name}} readonly={{true}} @disabled={{true}} />
       {{/each}}
     </:body>
   </form.fieldset>


### PR DESCRIPTION
The test cases need to be updated to handle the different types of host-catalogs properly. Test will be updated and added in a later PR. @joshuaogle[](https://user-images.githubusercontent.com/29386339/155749672-b574bcf9-b533-4825-bf64-339600c44d71.png)[](https://user-images.githubusercontent.com/29386339/155749700-a952b76f-68ef-46d2-99e7-3bf3d83144e5.png) the wireframe didn't have a suggested name for the title so I went with "DNS Names". Let me know if you have another suggestion.
Old:
<img width="778" alt="Screen Shot 2022-02-25 at 10 10 30 AM" src="https://user-images.githubusercontent.com/29386339/155772514-6dc3d1c1-82b3-4281-b2ef-082c4af6b5e4.png">

New:
<img width="652" alt="Screen Shot 2022-02-25 at 2 01 16 PM" src="https://user-images.githubusercontent.com/29386339/155792168-50ade3f9-58e6-43e9-80d1-74a1e44657f4.png">

