### PR TITLE
feat: 🎸 add sync_interval_seconds to plugin host-sets

### DIFF
--- a/addons/api/addon/generated/models/host-set.js
+++ b/addons/api/addon/generated/models/host-set.js
@@ -57,6 +57,13 @@ export default class GeneratedHostSetModel extends BaseModel {
   })
   plugin;
 
+  @attr('number', {
+    description:
+      "The number of seconds between the time boundary syncs the hosts in this set using this host set's plugin. If not provided a system determined default is used",
+    defaultValue: 0,
+  })
+  sync_interval_seconds;
+
   // Azure specific
   @attr('string', {
     description: '',

--- a/addons/api/addon/generated/models/host-set.js
+++ b/addons/api/addon/generated/models/host-set.js
@@ -60,7 +60,6 @@ export default class GeneratedHostSetModel extends BaseModel {
   @attr('number', {
     description:
       "The number of seconds between the time boundary syncs the hosts in this set using this host set's plugin. If not provided a system determined default is used",
-    defaultValue: 0,
   })
   sync_interval_seconds;
 

--- a/addons/api/addon/serializers/host-set.js
+++ b/addons/api/addon/serializers/host-set.js
@@ -55,6 +55,7 @@ export default class HostSetSerializer extends ApplicationSerializer {
     // Delete unnecessary fields for static type
     delete serialized.attributes;
     delete serialized.preferred_endpoints;
+    delete serialized.sync_interval_seconds;
     return serialized;
   }
 

--- a/addons/api/addon/serializers/host-set.js
+++ b/addons/api/addon/serializers/host-set.js
@@ -2,8 +2,8 @@ import ApplicationSerializer from './application';
 import { copy } from 'ember-copy';
 
 const fieldByType = {
-  aws: ['preferred_endpoints', 'filters'],
-  azure: ['preferred_endpoints', 'filter'],
+  aws: ['preferred_endpoints', 'filters', 'sync_interval_seconds'],
+  azure: ['preferred_endpoints', 'filter', 'sync_interval_seconds'],
 };
 export default class HostSetSerializer extends ApplicationSerializer {
   // =properties

--- a/addons/api/mirage/factories/host-set.js
+++ b/addons/api/mirage/factories/host-set.js
@@ -29,6 +29,7 @@ export default factory.extend({
       return result;
     }
   },
+  sync_interval_seconds: () => datatype.number(),
   // AWS specific
   filters() {
     if (this.plugin?.name === 'aws') {

--- a/addons/api/mirage/factories/host-set.js
+++ b/addons/api/mirage/factories/host-set.js
@@ -29,7 +29,11 @@ export default factory.extend({
       return result;
     }
   },
-  sync_interval_seconds: () => datatype.number(),
+  sync_interval_seconds() {
+    if (this.type === 'plugin') {
+      return datatype.number();
+    }
+  },
   // AWS specific
   filters() {
     if (this.plugin?.name === 'aws') {

--- a/addons/api/tests/unit/serializers/host-set-test.js
+++ b/addons/api/tests/unit/serializers/host-set-test.js
@@ -12,14 +12,12 @@ module('Unit | Serializer | host set', function (hooks) {
       compositeType: 'static',
       description: 'Description',
       host_catalog_id: '123',
-      sync_interval_seconds: 1,
       version: 1,
     });
     assert.deepEqual(record.serialize(), {
       name: 'Host Set 1',
       description: 'Description',
       host_catalog_id: '123',
-      sync_interval_seconds: 1,
       version: 1,
     });
   });

--- a/addons/api/tests/unit/serializers/host-set-test.js
+++ b/addons/api/tests/unit/serializers/host-set-test.js
@@ -12,12 +12,14 @@ module('Unit | Serializer | host set', function (hooks) {
       compositeType: 'static',
       description: 'Description',
       host_catalog_id: '123',
+      sync_interval_seconds: 1,
       version: 1,
     });
     assert.deepEqual(record.serialize(), {
       name: 'Host Set 1',
       description: 'Description',
       host_catalog_id: '123',
+      sync_interval_seconds: 1,
       version: 1,
     });
   });
@@ -53,6 +55,7 @@ module('Unit | Serializer | host set', function (hooks) {
       host_catalog_id: '123',
       version: 1,
       preferred_endpoints: [{ value: 'option 1' }, { value: 'option 2' }],
+      sync_interval_seconds: 1,
       filters: [{ value: 'filter 1' }, { value: 'filter 2' }],
     });
     assert.deepEqual(record.serialize(), {
@@ -61,6 +64,7 @@ module('Unit | Serializer | host set', function (hooks) {
       host_catalog_id: '123',
       version: 1,
       preferred_endpoints: ['option 1', 'option 2'],
+      sync_interval_seconds: 1,
       attributes: {
         filters: ['filter 1', 'filter 2'],
       },
@@ -77,6 +81,7 @@ module('Unit | Serializer | host set', function (hooks) {
       host_catalog_id: '123',
       version: 1,
       preferred_endpoints: [{ value: 'option 1' }, { value: 'option 2' }],
+      sync_interval_seconds: 1,
       filter: 'filter 1 && filter 2',
     });
     assert.deepEqual(record.serialize(), {
@@ -85,6 +90,7 @@ module('Unit | Serializer | host set', function (hooks) {
       host_catalog_id: '123',
       version: 1,
       preferred_endpoints: ['option 1', 'option 2'],
+      sync_interval_seconds: 1,
       attributes: {
         filter: 'filter 1 && filter 2',
       },


### PR DESCRIPTION
this pr adds the missing attribute `sync_interval_seconds` to plugin host-sets. 

displaying this field in the host-set forms will be handled in a separate PR. 