### PR TITLE
feat: 🎸 add type check helper methods to target model

### DIFF
--- a/addons/api/addon/models/target.js
+++ b/addons/api/addon/models/target.js
@@ -207,4 +207,20 @@ export default class TargetModel extends GeneratedTargetModel {
   removeCredentialSource(credentialLibraryID, options) {
     return this.removeCredentialSources([credentialLibraryID], options);
   }
+
+  /**
+   * True if the target type is tcp.
+   * @type {boolean}
+   */
+  get isTCP() {
+    return this.type === 'tcp';
+  }
+
+  /**
+   * True if the target type is ssh.
+   * @type {boolean}
+   */
+  get isSSH() {
+    return this.type === 'ssh';
+  }
 }

--- a/addons/api/tests/unit/models/target-test.js
+++ b/addons/api/tests/unit/models/target-test.js
@@ -395,7 +395,7 @@ module('Unit | Model | target', function (hooks) {
     assert.false(modelSSH.isTCP);
   });
 
-  test('it has isTCP property and returns the expected values', async function (assert) {
+  test('it has isTCP property and returns the expected values', function (assert) {
     assert.expect(2);
     const store = this.owner.lookup('service:store');
     const modelTCP = store.createRecord('target', {

--- a/addons/api/tests/unit/models/target-test.js
+++ b/addons/api/tests/unit/models/target-test.js
@@ -385,7 +385,7 @@ module('Unit | Model | target', function (hooks) {
     await model.removeCredentialSource('2');
   });
 
-  test('it has isSSH property and returns the expected values', async function (assert) {
+  test('it has isSSH property and returns the expected values', function (assert) {
     assert.expect(2);
     const store = this.owner.lookup('service:store');
     const modelSSH = store.createRecord('target', {

--- a/addons/api/tests/unit/models/target-test.js
+++ b/addons/api/tests/unit/models/target-test.js
@@ -384,4 +384,24 @@ module('Unit | Model | target', function (hooks) {
     const model = store.peekRecord('target', '123abc');
     await model.removeCredentialSource('2');
   });
+
+  test('it has isSSH property and returns the expected values', async function (assert) {
+    assert.expect(2);
+    const store = this.owner.lookup('service:store');
+    const modelSSH = store.createRecord('target', {
+      type: 'ssh',
+    });
+    assert.true(modelSSH.isSSH);
+    assert.false(modelSSH.isTCP);
+  });
+
+  test('it has isTCP property and returns the expected values', async function (assert) {
+    assert.expect(2);
+    const store = this.owner.lookup('service:store');
+    const modelTCP = store.createRecord('target', {
+      type: 'tcp',
+    });
+    assert.true(modelTCP.isTCP);
+    assert.false(modelTCP.isSSH);
+  });
 });


### PR DESCRIPTION
This pr adds TCP and SSH type check methods to the target model. This is required to support both the target types. 