### PR TITLE
chore: 🤖 Update node version used in GH actions

### DIFF
--- a/.github/workflows/monorepo-validate.yaml
+++ b/.github/workflows/monorepo-validate.yaml
@@ -14,7 +14,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - run: yarn install
         if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn run compliance:licenses
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - run: yarn install
         if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn lint
@@ -50,7 +50,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - run: yarn install
         if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn test


### PR DESCRIPTION
Update node version from `12.x` LTS to `16.x` LTS for the github action workflow validate-monorepo.

As per [Node release schedule](https://nodejs.org/en/about/releases/) the active and supported LTS is `16.x`. `12.x` It is just in mantainance mode and the EOL `2022-04-30`