### PR TITLE
chore: 🤖 Refactor cache for dependencies within CI

### DIFF
--- a/.github/workflows/monorepo-validate.yaml
+++ b/.github/workflows/monorepo-validate.yaml
@@ -2,8 +2,8 @@ name: Validate Monorepo
 on: pull_request
 jobs:
 
-  compliance:
-    name: License Compliance
+  dependencies:
+    name: Install dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,11 +18,29 @@ jobs:
         with:
           node-version: '16.x'
       - run: yarn install
+
+  compliance:
+    name: License Compliance
+    needs: [dependencies]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        id: node-modules-cache
+        with:
+          path: '**/node_modules'
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            node-modules-
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - run: yarn run compliance:licenses
 
   lint:
     name: Lint
+    needs: [dependencies]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -37,12 +55,12 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
-      - run: yarn install
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - run: yarn lint
 
   test:
     name: Test
+    needs: [dependencies]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -55,6 +73,5 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
-      - run: yarn install
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - run: yarn test

--- a/.github/workflows/monorepo-validate.yaml
+++ b/.github/workflows/monorepo-validate.yaml
@@ -8,15 +8,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
-        id: cache
+        id: node-modules-cache
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/setup-node@v1
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            node-modules-
+      - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
       - run: yarn install
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - run: yarn run compliance:licenses
 
   lint:
@@ -26,15 +28,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
-        id: cache
+        id: node-modules-cache
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/setup-node@v1
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            node-modules-
+      - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
       - run: yarn install
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - run: yarn lint
 
   test:
@@ -44,13 +48,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
-        id: cache
+        id: node-modules-cache
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/setup-node@v1
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
       - run: yarn install
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - run: yarn test


### PR DESCRIPTION
Refactor the cache for dependencies within the CI.

**How the cache used to work:**
- Cache was working JUST at PR/branch level. So a workflow running on branch A, could not access any other cache that the one generated by branch A.
- Per each new PR we have no cache available (reasons mentioned above), so every PR at first run will need to install all dependencies, after that it generated a cache for that PR.
- The cache could not be shared within the same workflow if the runner Operating System changed.
- Every job of the workflow (3 in this case) were installing dependencies 3 times (but simultaneously).

**How the cache works now:**
- Cache works at project level. So any workflow running within the project, doesn't matter what head the PR is pointing to, has access to the cache.
- Cache now is agnostic of OS runner. The only thing it checks is hashing the yarn.lock file. If there are no changes in dependencies, cache does not change.
- Create one job to take care of dependencies. The job checks if cache is available for that run, if not install dependencies and generates a new cache. All the jobs in the workflow now depend on this one and DO NOT try to install dependencies, it assumes the first job takes care of that.


**Screenshots running the same GH workflow (Validate Monorepo):**

Before the change:
<img width="1278" alt="Screen Shot 2022-03-10 at 4 32 01 PM" src="https://user-images.githubusercontent.com/9775006/157785474-be959550-7567-41d6-80d0-5cd4f00cb5b7.png">

After the change:
<img width="1277" alt="Screen Shot 2022-03-10 at 4 32 24 PM" src="https://user-images.githubusercontent.com/9775006/157785554-2017e4fb-3d66-4348-a780-2b02a37de65f.png">
