### PR TITLE
Ssh target tests

### DIFF
--- a/ui/admin/config/environment.js
+++ b/ui/admin/config/environment.js
@@ -157,6 +157,7 @@ module.exports = function (environment) {
     ENV.enableConfirmService = false;
 
     // Enable tests for development features
+    ENV.featureFlags['ssh-target'] = true;
   }
 
   if (environment === 'production') {

--- a/ui/admin/tests/acceptance/targets/create-test.js
+++ b/ui/admin/tests/acceptance/targets/create-test.js
@@ -9,6 +9,7 @@ import {
   //currentSession,
   //invalidateSession,
 } from 'ember-simple-auth/test-support';
+import { enableFeature } from 'ember-feature-flags/test-support';
 
 module('Acceptance | targets | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -53,11 +54,18 @@ module('Acceptance | targets | create', function (hooks) {
     urls.targets = `${urls.projectScope}/targets`;
     urls.target = `${urls.targets}/${instances.target.id}`;
     urls.unknownTarget = `${urls.targets}/foo`;
+    urls.newTarget = `${urls.targets}/new`;
     urls.newTCPTarget = `${urls.targets}/new?type=tcp`;
     urls.newSSHTarget = `${urls.targets}/new?type=ssh`;
     // Generate resource couner
     getTargetCount = () => this.server.schema.targets.all().models.length;
     authenticateSession({});
+  });
+
+  test('defaults to a new TCP target when no query param provided', async function (assert) {
+    assert.expect(1);
+    await visit(urls.newTarget);
+    assert.equal(find('input[disabled]').value, 'tcp');
   });
 
   test('can create new targets of type TCP', async function (assert) {
@@ -79,7 +87,8 @@ module('Acceptance | targets | create', function (hooks) {
   });
 
   test('can navigate to new targets route with proper authorization', async function (assert) {
-    assert.expect(2);
+    assert.expect(3);
+    enableFeature('ssh-target');
     await visit(urls.targets);
     assert.ok(
       instances.scopes.project.authorized_collection_actions.targets.includes(
@@ -87,10 +96,11 @@ module('Acceptance | targets | create', function (hooks) {
       )
     );
     assert.ok(find(`[href="${urls.newTCPTarget}"]`));
+    assert.ok(find(`[href="${urls.newSSHTarget}"]`));
   });
 
   test('cannot navigate to new targets route without proper authorization', async function (assert) {
-    assert.expect(2);
+    assert.expect(3);
     instances.scopes.project.authorized_collection_actions.targets = [];
     await visit(urls.targets);
     assert.notOk(
@@ -99,9 +109,10 @@ module('Acceptance | targets | create', function (hooks) {
       )
     );
     assert.notOk(find(`[href="${urls.newTCPTarget}"]`));
+    assert.notOk(find(`[href="${urls.newSSHTarget}"]`));
   });
 
-  test('can cancel create new targets', async function (assert) {
+  test('can cancel create new TCP target', async function (assert) {
     assert.expect(2);
     const count = getTargetCount();
     await visit(urls.newTCPTarget);
@@ -111,7 +122,17 @@ module('Acceptance | targets | create', function (hooks) {
     assert.equal(getTargetCount(), count);
   });
 
-  test('saving a new target with invalid fields displays error messages', async function (assert) {
+  test('can cancel create new SSH target', async function (assert) {
+    assert.expect(2);
+    const count = getTargetCount();
+    await visit(urls.newSSHTarget);
+    await fillIn('[name="name"]', 'random string');
+    await click('.rose-form-actions [type="button"]');
+    assert.equal(currentURL(), urls.targets);
+    assert.equal(getTargetCount(), count);
+  });
+
+  test('saving a new TCP target with invalid fields displays error messages', async function (assert) {
     assert.expect(2);
     this.server.post('/targets', () => {
       return new Response(
@@ -133,6 +154,39 @@ module('Acceptance | targets | create', function (hooks) {
       );
     });
     await visit(urls.newTCPTarget);
+    await click('[type="submit"]');
+    assert.ok(
+      find('[role="alert"]').textContent.trim(),
+      'The request was invalid.'
+    );
+    assert.ok(
+      find('.rose-form-error-message').textContent.trim(),
+      'Name is required.'
+    );
+  });
+
+  test('saving a new SSH target with invalid fields displays error messages', async function (assert) {
+    assert.expect(2);
+    this.server.post('/targets', () => {
+      return new Response(
+        400,
+        {},
+        {
+          status: 400,
+          code: 'invalid_argument',
+          message: 'The request was invalid.',
+          details: {
+            request_fields: [
+              {
+                name: 'name',
+                description: 'Name is required.',
+              },
+            ],
+          },
+        }
+      );
+    });
+    await visit(urls.newSSHTarget);
     await click('[type="submit"]');
     assert.ok(
       find('[role="alert"]').textContent.trim(),

--- a/ui/admin/tests/acceptance/targets/create-test.js
+++ b/ui/admin/tests/acceptance/targets/create-test.js
@@ -95,7 +95,7 @@ module('Acceptance | targets | create', function (hooks) {
     assert.equal(getTargetCount(), count + 1);
   });
 
-  test('able to navigate to new targets route with proper authorization', async function (assert) {
+  test('can navigate to new targets route with proper authorization', async function (assert) {
     assert.expect(3);
     await visit(urls.targets);
     assert.ok(
@@ -107,7 +107,7 @@ module('Acceptance | targets | create', function (hooks) {
     assert.ok(find(`[href="${urls.newSSHTarget}"]`));
   });
 
-  test('not able to navigate to new targets route without proper authorization', async function (assert) {
+  test('cannot navigate to new targets route without proper authorization', async function (assert) {
     assert.expect(3);
     instances.scopes.project.authorized_collection_actions.targets = [];
     await visit(urls.targets);
@@ -120,7 +120,7 @@ module('Acceptance | targets | create', function (hooks) {
     assert.notOk(find(`[href="${urls.newSSHTarget}"]`));
   });
 
-  test('not able to navigate to new SSH targets route when ssh feature is disabled', async function (assert) {
+  test('cannot navigate to new SSH targets route when ssh feature is disabled', async function (assert) {
     featuresService.disable('ssh-target');
     assert.expect(2);
     await visit(urls.targets);


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-3845)

## Description

:technologist: [Admin preview](https://boundary-ui-git-ssh-target-tests-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/targets)

This PR adds SSH target specific tests that verify our `ssh-target` feature flag is showing or hiding the correct UI elements.

<!-- Add a brief description of changes here. Include any other necessary relevant links -->
Currently we are using [this ember addon](https://github.com/kategengler/ember-feature-flags) to manage feature flags in our tests using `enableFeature`. There is a [disableFeature](https://github.com/kategengler/ember-feature-flags#enablefeature--disablefeature) function but it is not included in the most recent release we are using. However, I was able to mimic the same functionality in these new tests. There is an [issue](https://github.com/kategengler/ember-feature-flags/issues/107) open to get disableFeature added but there has been little activity recently. Please let me know if we should be handling feature flag management within our tests differently than what I have added in this PR.