### PR TITLE
test: 💍 Verify target worker filter can be edited

### DIFF
--- a/ui/admin/tests/acceptance/targets/update-test.js
+++ b/ui/admin/tests/acceptance/targets/update-test.js
@@ -90,16 +90,22 @@ module('Acceptance | targets | update', function (hooks) {
   });
 
   test('can save changes to existing target', async function (assert) {
-    assert.expect(3);
+    assert.expect(5);
     assert.notEqual(instances.target.name, 'random string');
+    assert.notEqual(instances.target.worker_filter, 'random filter');
     await visit(urls.target);
     await click('form [type="button"]', 'Activate edit mode');
     await fillIn('[name="name"]', 'random string');
+    await fillIn('[name="worker_filter"]', 'random filter');
     await click('.rose-form-actions [type="submit"]');
     assert.equal(currentURL(), urls.target);
     assert.equal(
       this.server.schema.targets.all().models[0].name,
       'random string'
+    );
+    assert.equal(
+      this.server.schema.targets.all().models[0].workerFilter,
+      'random filter'
     );
   });
 


### PR DESCRIPTION
✅ Closes: ICU-3892

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-3892)

## Description
Add to existing test that the worker filter input field can be edited on an existing target.

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](https://boundary-ui-git-icu-3892-edit-worker-filter-in-b400ec-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/targets/1)

