### PR TITLE
chore: 🤖 Updated pr-template to include Jira base url

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-:tickets: [Jira ticket]()
+:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER)
 
 ## Description
 


### PR DESCRIPTION
## Description

In most cases we have a Jira ticket number in our commit description via the "✅ Closes: ICU-****". I have included the base url for Jira so we just have to copy over the ticket number to finish off the `:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/)` portion of our PR template. Thoughts on this?

### Screenshots (if appropriate):
<img width="579" alt="Screen Shot 2022-04-15 at 2 13 38 PM" src="https://user-images.githubusercontent.com/29386339/163622727-ae98b950-2e92-465f-8a51-bd9193a092c3.png">

