### PR TITLE
test: 💍 Verify target worker filter is created correctly

### DIFF
--- a/ui/admin/tests/acceptance/targets/create-test.js
+++ b/ui/admin/tests/acceptance/targets/create-test.js
@@ -78,21 +78,41 @@ module('Acceptance | targets | create', function (hooks) {
   });
 
   test('can create new targets of type TCP', async function (assert) {
-    assert.expect(1);
+    assert.expect(3);
     const count = getTargetCount();
     await visit(urls.newTCPTarget);
     await fillIn('[name="name"]', 'random string');
+    await fillIn('[name="worker_filter"]', 'random filter');
     await click('[type="submit"]');
     assert.equal(getTargetCount(), count + 1);
+    assert.equal(
+      this.server.schema.targets.all().models[getTargetCount() - 1].name,
+      'random string'
+    );
+    assert.equal(
+      this.server.schema.targets.all().models[getTargetCount() - 1]
+        .workerFilter,
+      'random filter'
+    );
   });
 
   test('can create new targets of type SSH', async function (assert) {
-    assert.expect(1);
+    assert.expect(3);
     const count = getTargetCount();
     await visit(urls.newSSHTarget);
     await fillIn('[name="name"]', 'random string');
+    await fillIn('[name="worker_filter"]', 'random filter');
     await click('[type="submit"]');
     assert.equal(getTargetCount(), count + 1);
+    assert.equal(
+      this.server.schema.targets.all().models[getTargetCount() - 1].name,
+      'random string'
+    );
+    assert.equal(
+      this.server.schema.targets.all().models[getTargetCount() - 1]
+        .workerFilter,
+      'random filter'
+    );
   });
 
   test('can navigate to new targets route with proper authorization', async function (assert) {


### PR DESCRIPTION
✅ Closes: ICU-3893

:tickets: [Jira ticket]()

## Description
Add to existing tests that the worker filter fields are saved correctly when creating a new target

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:rose: [Rose preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

<!-- Add a brief description of changes here. Include any other necessary relevant links -->

### Screenshots (if appropriate):
