### PR TITLE
disable polling in admin UI

### DIFF
--- a/addons/api/mirage/scenarios/default.js
+++ b/addons/api/mirage/scenarios/default.js
@@ -48,8 +48,8 @@ export default function (server) {
   server.schema.scopes.where({ type: 'project' }).models.forEach((scope) => {
     server.createList('host-catalog', 8, { scope }, 'withChildren');
     server.createList('credential-store', 3, { scope }, 'withAssociations');
-    server.createList('target', 12, { scope }, 'withAssociations');
+    server.createList('target', 2, { scope }, 'withAssociations');
     // Sessions have target data. Create it after targets.
-    server.createList('session', 95, { scope }, 'withAssociations');
+    server.createList('session', 4, { scope }, 'withAssociations');
   });
 }

--- a/addons/api/mirage/scenarios/default.js
+++ b/addons/api/mirage/scenarios/default.js
@@ -48,8 +48,8 @@ export default function (server) {
   server.schema.scopes.where({ type: 'project' }).models.forEach((scope) => {
     server.createList('host-catalog', 8, { scope }, 'withChildren');
     server.createList('credential-store', 3, { scope }, 'withAssociations');
-    server.createList('target', 2, { scope }, 'withAssociations');
+    server.createList('target', 12, { scope }, 'withAssociations');
     // Sessions have target data. Create it after targets.
-    server.createList('session', 4, { scope }, 'withAssociations');
+    server.createList('session', 95, { scope }, 'withAssociations');
   });
 }

--- a/ui/admin/app/routes/scopes/scope/sessions.js
+++ b/ui/admin/app/routes/scopes/scope/sessions.js
@@ -3,12 +3,12 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { all, hash } from 'rsvp';
 import { A } from '@ember/array';
-import runEvery from 'ember-pollster/decorators/route/run-every';
+// import runEvery from 'ember-pollster/decorators/route/run-every';
 import { notifySuccess, notifyError } from 'core/decorators/notify';
-import config from '../../../config/environment';
+// import config from '../../../config/environment';
 import { resourceFilter } from 'core/decorators/resource-filter';
 
-const POLL_TIMEOUT_SECONDS = config.sessionPollingTimeoutSeconds;
+// const POLL_TIMEOUT_SECONDS = config.sessionPollingTimeoutSeconds;
 
 export default class ScopesScopeSessionsRoute extends Route {
   // =services
@@ -27,10 +27,16 @@ export default class ScopesScopeSessionsRoute extends Route {
   })
   status;
 
-  @runEvery(POLL_TIMEOUT_SECONDS * 1000)
-  poller() {
-    return this.refresh();
-  }
+  /**
+   * Update: disable polling due to large amounts of sessions crashing the app
+   * This is a temp solution till we have a pagination on the UI
+   * and concrete backend solution to support large amounts of sessions.
+   */
+
+  // @runEvery(POLL_TIMEOUT_SECONDS * 1000)
+  // poller() {
+  //   return this.refresh();
+  // }
 
   // =methods
 


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-3952)

## Description
Disabling sessions polling due to UI not showing a large amount of sessions data
<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](https://boundary-arfi0qvqw-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/sessions?filter-status=%5B%5D)

:rose: [Rose preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

<!-- Add a brief description of changes here. Include any other necessary relevant links -->

### Screenshots (if appropriate):
