### PR TITLE
Revert "fix: 🐛 Disable polling for targets on Desktop"

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects/targets.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets.js
@@ -2,10 +2,10 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { resourceFilter } from 'core/decorators/resource-filter';
-// import runEvery from 'ember-pollster/decorators/route/run-every';
-// import config from '../../../../config/environment';
+import runEvery from 'ember-pollster/decorators/route/run-every';
+import config from '../../../../config/environment';
 
-// const POLL_TIMEOUT_SECONDS = config.sessionPollingTimeoutSeconds;
+const POLL_TIMEOUT_SECONDS = config.sessionPollingTimeoutSeconds;
 
 export default class ScopesScopeProjectsTargetsRoute extends Route {
   // =services
@@ -65,16 +65,10 @@ export default class ScopesScopeProjectsTargetsRoute extends Route {
     );
   }
 
-  /**
-   * Update: disable polling due to large amounts of sessions crashing the app
-   * This is a temp solution till we have a pagination on the UI
-   * and concrete backend solution to support large amounts of sessions.
-   */
-
-  // @runEvery(POLL_TIMEOUT_SECONDS * 1000)
-  // poller() {
-  //   return this.refresh();
-  // }
+  @runEvery(POLL_TIMEOUT_SECONDS * 1000)
+  poller() {
+    return this.refresh();
+  }
 
   // =actions
 


### PR DESCRIPTION
Reverts hashicorp/boundary-ui#1059