### PR TITLE
chore: 🤖 Update Electron from 12.x to 13.x

### DIFF
--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -39,7 +39,7 @@
     "@electron-forge/maker-zip": "^6.0.0-beta.54",
     "decompress": "^4.2.1",
     "devtron": "^1.4.0",
-    "electron": "12.1.2"
+    "electron": "13.6.7"
   },
   "resolutions": {
     "highlight.js": "^10.4.1",

--- a/ui/desktop/electron-app/yarn.lock
+++ b/ui/desktop/electron-app/yarn.lock
@@ -1257,10 +1257,10 @@ electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@12.1.2:
-  version "12.1.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-12.1.2.tgz#aca178efc40fe422f7bfeddeeec63e40c11a16c5"
-  integrity sha512-yWlnKfJYDsvJjV2GyiBqpbqYI4DkTwk1OP/YRVodp9tfDLqAp9VdE8VZXbl1y29pZtIY+/YtUedBQc1RY3RMqQ==
+electron@13.6.7:
+  version "13.6.7"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.6.7.tgz#7e28c54c67ef867426216bd8334bf79bc9ef7d2a"
+  integrity sha512-gzCru/TpyCZ3yRjR/TVKph6Q/rmFZnLszxoeESaiijHjobB0xxr2oTHQLGVhpali2ddrM+4Pz6+MyZwS6Us+xA==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
Update Electron from `12.1.2` to `13.6.7`.

Reason behind this update:
- Security vulnerability, more [info here](https://github.com/hashicorp/boundary-ui/security/dependabot/29).
- Performance improvements.

**Testing:**
- The build process has been tested locally within the 3 environments: `MacOS (arm)`, `Windows (amd64)` and `Linux (amd64)`.
- The CI also when through the build process successfully, [build here](https://app.circleci.com/pipelines/github/hashicorp/boundary-ui-releases/989/workflows/1c7c0e9a-ad90-4803-bd05-c1712cfe2527).
- Staged builds are available within tag `1.111.11-beta`.