### PR TITLE
feat: 🎸 Update Target types help text

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -279,8 +279,8 @@ target:
     tcp: TCP
     ssh: SSH
   help: 
-    tcp: This target belongs to an TCP host catalog and will use TCP to connect
-    ssh: This target belongs to an SSH host catalog and will use SSH to connect
+    tcp: Connections are made over TCP to support a broad range of protocols, including SSH, RDP, databases, and more.  This is the most general-purpose type.
+    ssh: Protocol-aware connections are made over SSH.  Use when requiring SSH connections to remote hosts.
   host-source:
     title: Host Source
     title_plural: Host Sources

--- a/addons/rose/addon/styles/rose/components/form/_fieldset.scss
+++ b/addons/rose/addon/styles/rose/components/form/_fieldset.scss
@@ -8,6 +8,10 @@
     @include type.type(s, semibold);
   }
 
+  .rose-form-fieldset-body {
+    display: flex;
+  }
+
   .rose-form-fieldset-description {
     margin: sizing.rems(xxs) 0;
     @include type.type(xs);

--- a/addons/rose/addon/styles/rose/components/form/_radio-card.scss
+++ b/addons/rose/addon/styles/rose/components/form/_radio-card.scss
@@ -78,7 +78,7 @@ $radio-svg: (
     display: flex;
     color: var(--black);
     width: ($size-m) * 23;
-    height: ($size-m) * 7.4;
+    height: 100%;
     display: block;
     position: relative;
     text-align: left;
@@ -86,7 +86,7 @@ $radio-svg: (
     box-shadow: 0 $size-xxs $size-xxs
       rgba(var(--stark-components), var(--opacity-2));
     border-radius: $size-xxs;
-    padding: $size-s $size-m;
+    padding: $size-s $size-m $size-xl;
     box-sizing: border-box;
     background-color: var(--white);
     .rose-form-helper-text {

--- a/addons/rose/addon/styles/rose/components/form/_radio-card.scss
+++ b/addons/rose/addon/styles/rose/components/form/_radio-card.scss
@@ -86,11 +86,12 @@ $radio-svg: (
     box-shadow: 0 $size-xxs $size-xxs
       rgba(var(--stark-components), var(--opacity-2));
     border-radius: $size-xxs;
-    padding: $size-s $size-m $size-xl;
+    padding: $size-s $size-m ($size-xl + $size-m);
     box-sizing: border-box;
     background-color: var(--white);
     .rose-form-helper-text {
       @include type.type(xs, normal);
+      padding-top: $size-xs;
     }
 
     &::after {

--- a/ui/admin/app/components/form/target/details/index.hbs
+++ b/ui/admin/app/components/form/target/details/index.hbs
@@ -56,13 +56,13 @@
             @label={{t 'resources.target.types.tcp'}}
             @helperText={{t 'resources.target.help.tcp'}}
             @value='tcp'
-            @layout='tile'
+            @layout='wide'
           />
           <radioGroup.card
             @label={{t 'resources.target.types.ssh'}}
             @helperText={{t 'resources.target.help.ssh'}}
             @value='ssh'
-            @layout='tile'
+            @layout='wide'
           />
         </form.radioGroup>
       {{else}}
@@ -75,7 +75,7 @@
             @label={{t (concat 'resources.target.types.' @model.type)}}
             @helperText={{t (concat 'resources.target.help.' @model.type)}}
             @value={{@model.type}}
-            @layout='tile'
+            @layout='wide'
             readonly={{true}}
             @disabled={{true}}
           />

--- a/ui/admin/app/components/form/target/details/index.hbs
+++ b/ui/admin/app/components/form/target/details/index.hbs
@@ -56,13 +56,13 @@
             @label={{t 'resources.target.types.tcp'}}
             @helperText={{t 'resources.target.help.tcp'}}
             @value='tcp'
-            @layout='wide'
+            @layout='tile'
           />
           <radioGroup.card
             @label={{t 'resources.target.types.ssh'}}
             @helperText={{t 'resources.target.help.ssh'}}
             @value='ssh'
-            @layout='wide'
+            @layout='tile'
           />
         </form.radioGroup>
       {{else}}
@@ -75,7 +75,7 @@
             @label={{t (concat 'resources.target.types.' @model.type)}}
             @helperText={{t (concat 'resources.target.help.' @model.type)}}
             @value={{@model.type}}
-            @layout='wide'
+            @layout='tile'
             readonly={{true}}
             @disabled={{true}}
           />


### PR DESCRIPTION
✅ Closes: ICU-4014

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-4014)

## Description

Update Radio card help text for TCP and SSH targets. Please let me know if there is a better solution to the text spacing issue seen in the screenshots below.

:technologist: [Admin preview - View/Edit Target](https://boundary-7debbjpfy-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/targets/1)
🎯 [Admin preview - New Target](https://boundary-7debbjpfy-hashicorp.vercel.app/scopes/s_xk1i4dk50v2/targets/new)
🌹 [Rose preview - Wide Radio Card](https://boundary-ui-storybook-mtwi3jy5m-hashicorp.vercel.app/?path=/story/rose-form-radio-radio-card--wide)

### Screenshots (if appropriate):
Below is the new changes. Radio card has been changed to a `tile` layout to make room for TCP help text.
New Target screen:
<img width="816" alt="Screen Shot 2022-04-21 at 11 49 11 AM" src="https://user-images.githubusercontent.com/29386339/164510989-bc747341-7bf6-4d86-981b-e0c7ba0c8ecb.png">
View/Edit Target screen:
<img width="656" alt="Screen Shot 2022-04-21 at 9 34 58 AM" src="https://user-images.githubusercontent.com/29386339/164481958-f63a9d2f-a756-4c87-8e33-8e5b0655fc56.png">

Below has the new text changes but keeps the current `wide` layout for the radio card. You can see that the TCP help text is cut off.
Old New Target screen:
<img width="656" alt="Screen Shot 2022-04-20 at 11 57 36 AM" src="https://user-images.githubusercontent.com/29386339/164286225-6c41b7c2-7573-4b43-ad8f-a40e4c13d84a.png">
Old View/Edit Target screen:
<img width="656" alt="Screen Shot 2022-04-20 at 11 57 28 AM" src="https://user-images.githubusercontent.com/29386339/164286223-6462f494-369d-4d39-8c41-e0b51b8845a1.png">

Below is the New Host Catalog screen that uses `tile` and `wide` radio cards:
<img width="656" alt="Screen Shot 2022-04-21 at 9 09 10 AM" src="https://user-images.githubusercontent.com/29386339/164482225-7287ceb0-7075-4cc0-98b6-bf70465b03ab.png">
