### PR TITLE
fix: 🐛 Mac os window lifecycle

### DIFF
--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -222,6 +222,18 @@ app.on('ready', async () => {
 
   // Check for updates on launch
   appUpdater.run({ suppressNoUpdatePrompt: true });
+
+  /**
+   * Need for Mac OS behaviour of closing the window but not the app.
+   * This allows to reopen the window if the user clicks Boundary icon in the dock
+   * while the app is not close.
+   * More info: https://www.electronjs.org/docs/latest/tutorial/quick-start#open-a-window-if-none-are-open-macos
+   */
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      mainWindow = createWindow(partition, closeWindowCB);
+    }
+  });
 });
 
 /**


### PR DESCRIPTION
## Description
**BLOCK BY:** https://github.com/hashicorp/boundary-ui/pull/1066

This PR fix the Mac OS Bug for managing window lifecycle.

Mac OS behaviour when closing the main window differs from Linux or Windows.

After closing the main window, macOS apps generally continue running even without any windows open, and activating the app (click in the Boundary icon on the dock) when no windows are available should open a new one.

## Testing
Tested this in `mac os (arm64)` and on `Linux (amd64)`. In Linux, I just tested that nothing is broken since the behaviour should not change in Linux or Windows.

## Testing procedure
Within `boundary-ui/ui/desktop` run `yarn start:desktop` and check we got the desired behaviour while no exceptions are throw in the console.