### PR TITLE
feature: add toolbar refresher component

### DIFF
--- a/addons/core/addon/components/relative-datetime-live/index.js
+++ b/addons/core/addon/components/relative-datetime-live/index.js
@@ -95,6 +95,9 @@ export default class RelativeDatetimeLiveComponent extends Component {
    * @type {string}
    */
   get formatted() {
-    return this.intl.formatRelative(this.scaledDelta, { unit: this.unit });
+    return this.intl.formatRelative(this.scaledDelta, {
+      unit: this.unit,
+      numeric: 'auto',
+    });
   }
 }

--- a/ui/desktop/app/components/toolbar-refresher/index.hbs
+++ b/ui/desktop/app/components/toolbar-refresher/index.hbs
@@ -1,0 +1,9 @@
+{{#if this.lastRefreshed}}
+  <Rose::Toolbar::Info>
+    <RelativeDatetimeLive @date={{this.lastRefreshed}} />
+  </Rose::Toolbar::Info>
+{{/if}}
+
+<LoadingButton @onClick={{this.onClick}}>
+  {{t 'actions.refresh'}}
+</LoadingButton>

--- a/ui/desktop/app/components/toolbar-refresher/index.js
+++ b/ui/desktop/app/components/toolbar-refresher/index.js
@@ -1,0 +1,20 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class ToolbarRefresherComponent extends Component {
+  // =properties
+
+  @tracked lastRefreshed = null;
+
+  // =methods
+
+  /**
+   * Executes the click handler argument and trackes the time it completed.
+   */
+  @action
+  async onClick() {
+    await this.args.onClick();
+    this.lastRefreshed = new Date();
+  }
+}

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
@@ -112,9 +112,9 @@
               >{{t 'actions.clear-all-filters'}}
               </Rose::Button>
             {{/if}}
-            <LoadingButton @onClick={{route-action 'refreshSessions'}}>
-              {{t 'actions.refresh'}}
-            </LoadingButton>
+
+            <ToolbarRefresher @onClick={{route-action 'refreshSessions'}} />
+
           </Rose::Form>
         </Rose::Toolbar>
       {{/if}}


### PR DESCRIPTION
## Description

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:desktop_computer: [Desktop preview](https://boundary-ui-desktop-git-feature-last-refreshed-time-hashicorp.vercel.app/scopes/global/projects/sessions)

This PR introduces a component to Desktop that composes the loading button and the live relative datetime components.

### Screenshots (if appropriate):

<img width="632" alt="Screenshot 2022-04-28 at 18 30 25" src="https://user-images.githubusercontent.com/8390120/165859511-0c1f7a2f-78ae-4c05-8d17-6b6a20e1aa70.png">
