### PR TITLE
Refactor UI generated artifacts creation.

### DIFF
--- a/.github/workflows/build-admin-ui.yaml
+++ b/.github/workflows/build-admin-ui.yaml
@@ -34,13 +34,32 @@ jobs:
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             node-modules-
-      - uses: actions/setup-node@v3
+      - name: Build OSS version
+        uses: actions/setup-node@v3
         with:
           node-version: '16.x'
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-      - run: yarn run build:ui:admin
-      - name: Upload artifact
+      - run: yarn run build:ui:admin:oss
+      - name: Upload artifact admin-ui
         uses: actions/upload-artifact@v3
         with:
           name: admin-ui
+          path: ./ui/admin/dist/
+      - name: Upload artifact admin-ui-oss
+        uses: actions/upload-artifact@v3
+        with:
+          name: admin-ui-oss
+          path: ./ui/admin/dist/
+      - name: Clean dist/ folder
+        run: rm -rf ./ui/admin/dist/
+      - name: Build enterprise version
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      - run: yarn run build:ui:admin:enterprise
+      - name: Upload artifact admin-ui-enterprise
+        uses: actions/upload-artifact@v3
+        with:
+          name: admin-ui-enterprise
           path: ./ui/admin/dist/

--- a/.github/workflows/build-admin-ui.yaml
+++ b/.github/workflows/build-admin-ui.yaml
@@ -21,8 +21,8 @@ jobs:
         with:
           node-version: '16.x'
       - run: yarn install
-  build:
-    name: Build Admin UI
+  build-admin-ui-oss:
+    name: Build Admin UI OSS
     needs: [dependencies]
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +34,7 @@ jobs:
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             node-modules-
-      - name: Build OSS version
+      - name: Build
         uses: actions/setup-node@v3
         with:
           node-version: '16.x'
@@ -50,9 +50,20 @@ jobs:
         with:
           name: admin-ui-oss
           path: ./ui/admin/dist/
-      - name: Clean dist/ folder
-        run: rm -rf ./ui/admin/dist/
-      - name: Build enterprise version
+  build-admin-ui-enterprise:
+    name: Build Admin UI Enterprise
+    needs: [dependencies]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        id: node-modules-cache
+        with:
+          path: '**/node_modules'
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            node-modules-
+      - name: Build
         uses: actions/setup-node@v3
         with:
           node-version: '16.x'


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-4219)

## Description

Refactor UI generated artifacts creation. Now we generate 2 artifacts: `admin-ui-oss` and `admin-ui-enterprise`.

As per deprecation procedure, we will keep generating `admin-ui` per 2 more weeks after the merge of this PR.

## Discard approach:
We wanted to keep it simple, both UI's oss and enterprise use the exact same dependencies, the only difference is the build procedure.
Because that we decided to refactor the current build job adding two more steps. 
- Clean the /dist folder after OSS built.
- Build enterprise

## Approach:
After working on the first approach and discard it, this approach embrace splitting each build in a separate job but running parallel, so no ime is wasted.

## Screenshots:
This screenshot represent the last test build on the refactor branch.
![Screenshot from 2022-05-11 11-09-38](https://user-images.githubusercontent.com/9775006/167917445-5813ca81-a446-4500-b7ca-c84450a2caed.png)