### PR TITLE
fix: 🐛 Update validateOrigin to throw error on bad request

### DIFF
--- a/ui/desktop/electron-app/src/models/runtime-settings.js
+++ b/ui/desktop/electron-app/src/models/runtime-settings.js
@@ -31,7 +31,10 @@ class RuntimeSettings {
     // test to see if the origin is API-compatible with the desktop client.
     const scopesEndpoint = `${origin}/v1/scopes`;
     try {
-      await netRequestPromise(scopesEndpoint);
+      const result = await netRequestPromise(scopesEndpoint);
+      if (result.statusCode >= 300) {
+        throw new Error();
+      }
     } catch (e) {
       throw new Error(`Origin ${origin} could not be validated.`);
     }

--- a/ui/desktop/electron-app/src/models/runtime-settings.js
+++ b/ui/desktop/electron-app/src/models/runtime-settings.js
@@ -32,7 +32,7 @@ class RuntimeSettings {
     const scopesEndpoint = `${origin}/v1/scopes`;
     try {
       const result = await netRequestPromise(scopesEndpoint);
-      if (result.statusCode >= 300) {
+      if (result.statusCode >= 400) {
         throw new Error();
       }
     } catch (e) {

--- a/ui/desktop/electron-app/src/models/runtime-settings.js
+++ b/ui/desktop/electron-app/src/models/runtime-settings.js
@@ -32,7 +32,9 @@ class RuntimeSettings {
     const scopesEndpoint = `${origin}/v1/scopes`;
     try {
       const result = await netRequestPromise(scopesEndpoint);
-      if (result.statusCode >= 400) {
+      // Redirects (3xx) are handled in the netRequest Promist, so we only
+      // throw an error for 4xx or 5xx responses.
+      if (result.statusCode > 399) {
         throw new Error();
       }
     } catch (e) {

--- a/ui/desktop/electron-app/src/models/runtime-settings.js
+++ b/ui/desktop/electron-app/src/models/runtime-settings.js
@@ -34,7 +34,7 @@ class RuntimeSettings {
       const result = await netRequestPromise(scopesEndpoint);
       // Redirects (3xx) are handled in the netRequest Promist, so we only
       // throw an error for 4xx or 5xx responses.
-      if (result.statusCode > 399) {
+      if (result.statusCode >= 400) {
         throw new Error();
       }
     } catch (e) {

--- a/ui/desktop/electron-app/src/models/runtime-settings.js
+++ b/ui/desktop/electron-app/src/models/runtime-settings.js
@@ -32,7 +32,7 @@ class RuntimeSettings {
     const scopesEndpoint = `${origin}/v1/scopes`;
     try {
       const result = await netRequestPromise(scopesEndpoint);
-      // Redirects (3xx) are handled in the netRequest Promist, so we only
+      // Redirects (3xx) are handled in the netRequest Promise, so we only
       // throw an error for 4xx or 5xx responses.
       if (result.statusCode >= 400) {
         throw new Error();


### PR DESCRIPTION
✅ Closes: ICU-4238

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-4238)

## Description

If the result from netRequestPromise is successful but a not a 200
response, validateOrigin will throw an error

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:desktop_computer: [Desktop preview](https://boundary-ui-desktop-git-icu-4238-enhancement-u-b49f83-hashicorp.vercel.app/origin) Note: I do not think this is able to be replicated with mirage.

### Screenshots (if appropriate):

#### Before:
![dc-before](https://user-images.githubusercontent.com/29386339/168170125-24e9b215-9bd0-46d2-a01e-99707b4c3ce4.gif)

#### After:
![dc-after](https://user-images.githubusercontent.com/29386339/168170144-183c9fdc-89cb-4f99-bd46-9053fbc4da82.gif)

