### PR TITLE
fix: 🐛 add featureflag to target creation template

### DIFF
--- a/ui/admin/app/components/form/target/details/index.hbs
+++ b/ui/admin/app/components/form/target/details/index.hbs
@@ -46,25 +46,41 @@
     <:title>{{t 'form.type.label'}}</:title>
     <:body>
       {{#if @model.isNew}}
-        <form.radioGroup
-          @name='types'
-          @selectedValue={{@model.type}}
-          @changed={{@changeType}}
-          as |radioGroup|
-        >
-          <radioGroup.card
-            @label={{t 'resources.target.types.tcp'}}
-            @helperText={{t 'resources.target.help.tcp'}}
-            @value='tcp'
-            @layout='wide'
-          />
-          <radioGroup.card
-            @label={{t 'resources.target.types.ssh'}}
-            @helperText={{t 'resources.target.help.ssh'}}
-            @value='ssh'
-            @layout='wide'
-          />
-        </form.radioGroup>
+        {{#if (feature-flag 'ssh-target')}}
+          <form.radioGroup
+            @name='types'
+            @selectedValue={{@model.type}}
+            @changed={{@changeType}}
+            as |radioGroup|
+          >
+            <radioGroup.card
+              @label={{t 'resources.target.types.tcp'}}
+              @helperText={{t 'resources.target.help.tcp'}}
+              @value='tcp'
+              @layout='wide'
+            />
+            <radioGroup.card
+              @label={{t 'resources.target.types.ssh'}}
+              @helperText={{t 'resources.target.help.ssh'}}
+              @value='ssh'
+              @layout='wide'
+            />
+          </form.radioGroup>
+        {{else}}
+          <form.radioGroup
+            @name='types'
+            @selectedValue={{@model.type}}
+            @changed={{@changeType}}
+            as |radioGroup|
+          >
+            <radioGroup.card
+              @label={{t 'resources.target.types.tcp'}}
+              @helperText={{t 'resources.target.help.tcp'}}
+              @value='tcp'
+              @layout='wide'
+            />
+          </form.radioGroup>
+        {{/if}}
       {{else}}
         <form.radioGroup
           @name='types'

--- a/ui/admin/app/components/form/target/details/index.hbs
+++ b/ui/admin/app/components/form/target/details/index.hbs
@@ -46,41 +46,27 @@
     <:title>{{t 'form.type.label'}}</:title>
     <:body>
       {{#if @model.isNew}}
-        {{#if (feature-flag 'ssh-target')}}
-          <form.radioGroup
-            @name='types'
-            @selectedValue={{@model.type}}
-            @changed={{@changeType}}
-            as |radioGroup|
-          >
-            <radioGroup.card
-              @label={{t 'resources.target.types.tcp'}}
-              @helperText={{t 'resources.target.help.tcp'}}
-              @value='tcp'
-              @layout='wide'
-            />
+        <form.radioGroup
+          @name='types'
+          @selectedValue={{@model.type}}
+          @changed={{@changeType}}
+          as |radioGroup|
+        >
+          <radioGroup.card
+            @label={{t 'resources.target.types.tcp'}}
+            @helperText={{t 'resources.target.help.tcp'}}
+            @value='tcp'
+            @layout='wide'
+          />
+          {{#if (feature-flag 'ssh-target')}}
             <radioGroup.card
               @label={{t 'resources.target.types.ssh'}}
               @helperText={{t 'resources.target.help.ssh'}}
               @value='ssh'
               @layout='wide'
             />
-          </form.radioGroup>
-        {{else}}
-          <form.radioGroup
-            @name='types'
-            @selectedValue={{@model.type}}
-            @changed={{@changeType}}
-            as |radioGroup|
-          >
-            <radioGroup.card
-              @label={{t 'resources.target.types.tcp'}}
-              @helperText={{t 'resources.target.help.tcp'}}
-              @value='tcp'
-              @layout='wide'
-            />
-          </form.radioGroup>
-        {{/if}}
+          {{/if}}
+        </form.radioGroup>
       {{else}}
         <form.radioGroup
           @name='types'


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-4362)

## Description

This pr hides ssh targets from the target creation form in OSS edition.

**To test:** 

OSS: 
1. download the recent OSS binary 
2. [build OSS](https://github.com/hashicorp/boundary-ui/blob/main/package.json#L18) assets on your terminal within boundary-ui
3. run boundary dev instance by following [these steps ](https://github.com/hashicorp/boundary#ui-development) (make sure the assets are pointed to your relative path from step 2)
4. go to http://127.0.0.1:9200 and inspect the ember app, which should show you the `production` mode of the assets we just built in step 2.  
5. you should not see the `ssh target` radioCard in the creation form

Enterprise: 
1. download the recent enterprise binary from the boundary repo->actions 
2. [build ENT](https://github.com/hashicorp/boundary-ui/blob/main/package.json#L19) assets on your terminal within boundary-ui
3. run boundary dev instance by following [these steps ](https://github.com/hashicorp/boundary#ui-development) (make sure the assets are pointed to your relative path from step 2)
4. go to http://127.0.0.1:9200 and inspect the ember app, which should show you the `production` mode of the assets we just built in step 2.  
5. you should see the `ssh target` radioCard in the creation form

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:rose: [Rose preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

<!-- Add a brief description of changes here. Include any other necessary relevant links -->

### Screenshots (if appropriate):

OSS: 

<img width="1839" alt="Screen Shot 2022-05-12 at 4 04 25 PM" src="https://user-images.githubusercontent.com/15043878/168184414-d1707961-25ca-4d83-af3e-6c2ddbdff77d.png">

Enterprise:
<img width="1824" alt="Screen Shot 2022-05-12 at 4 12 56 PM" src="https://user-images.githubusercontent.com/15043878/168184458-acdabe88-a617-4a7d-a6e0-714d184ed31f.png">
 

