### PR TITLE
refactor: 💡 Rename Admin UI enterprise artifact

### DIFF
--- a/.github/workflows/build-admin-ui.yaml
+++ b/.github/workflows/build-admin-ui.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           name: admin-ui
           path: ./ui/admin/dist/
-      - name: Upload artifact admin-ui-oss
+      - name: Upload artifact Admin UI OSS
         uses: actions/upload-artifact@v3
         with:
           name: admin-ui-oss
@@ -69,8 +69,8 @@ jobs:
           node-version: '16.x'
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - run: yarn run build:ui:admin:enterprise
-      - name: Upload artifact admin-ui-enterprise
+      - name: Upload artifact Admin UI Enterprise
         uses: actions/upload-artifact@v3
         with:
-          name: admin-ui-enterprise
+          name: admin-ui-ent
           path: ./ui/admin/dist/


### PR DESCRIPTION
Rename Admin UI generated artifact for the enterprise edition.

The reason behind this change to be compliance within Hashicorp version schema.
