### PR TITLE
fix: 🐛 Use more common hasOwnProperty and don't modify payload

### DIFF
--- a/addons/api/addon/serializers/application.js
+++ b/addons/api/addon/serializers/application.js
@@ -291,21 +291,23 @@ export default class ApplicationSerializer extends RESTSerializer {
     id,
     requestType
   ) {
+    const newPayload = copy(payload, true);
+
     primaryModelClass.attributes.forEach((attribute) => {
       const {
         name,
         options: { readOnly },
       } = attribute;
 
-      if (readOnly && !Object.hasOwn(payload, name)) {
-        payload[name] = null;
+      if (readOnly && !Object.prototype.hasOwnProperty.call(newPayload, name)) {
+        newPayload[name] = null;
       }
     });
 
     return super.normalizeUpdateRecordResponse(
       store,
       primaryModelClass,
-      payload,
+      newPayload,
       id,
       requestType
     );


### PR DESCRIPTION
## Description

Use `hasOwnProperty` instead of `hasOwn`. The latter only recently received support in some browsers such as Safari, take a look [here](https://caniuse.com/mdn-javascript_builtins_object_hasown). Probably too early to use as of right now.

Also stopped modifying the payload directly.
