### PR TITLE
chore: 🤖 display auth method names in auth form, if available

### DIFF
--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -489,7 +489,9 @@ $chevron-down: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%231
   .is-loading {
     .rose-icon {
       @keyframes hds-flight-icon-animation-rotation {
-        to {transform: rotate(360deg);}
+        to {
+          transform: rotate(360deg);
+        }
       }
 
       > svg {

--- a/ui/desktop/app/templates/scopes/scope/authenticate.hbs
+++ b/ui/desktop/app/templates/scopes/scope/authenticate.hbs
@@ -32,7 +32,11 @@
             @route='scopes.scope.authenticate.method'
             @model={{authMethod.id}}
           >
-            {{t (concat 'resources.auth-method.types.' authMethod.type)}}
+            {{#if authMethod.name}}
+              {{authMethod.name}}
+            {{else}}
+              {{t (concat 'resources.auth-method.types.' authMethod.type)}}
+            {{/if}}
           </nav.link>
         {{/each}}
       {{else}}
@@ -43,7 +47,11 @@
               @route='scopes.scope.authenticate.method'
               @model={{authMethod.id}}
             >
-              {{t (concat 'resources.auth-method.types.' authMethod.type)}}
+              {{#if authMethod.name}}
+                {{authMethod.name}}
+              {{else}}
+                {{t (concat 'resources.auth-method.types.' authMethod.type)}}
+              {{/if}}
             </nav.link>
           {{/unless}}
         {{/each}}

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -86,9 +86,7 @@ const createWindow = (partition, closeWindowCB) => {
 
   // If the user-specified origin changes, reload the page so that
   // the CSP can be refreshed with the this source allowed
-  runtimeSettings.onOriginChange(() =>
-    browserWindow.loadURL(emberAppURL)
-  );
+  runtimeSettings.onOriginChange(() => browserWindow.loadURL(emberAppURL));
 
   // Load the ember application
   browserWindow.loadURL(emberAppURL);


### PR DESCRIPTION
Simple PR to display auth method names in the Desktop login form, when available.  This is how admin UI has worked for some time, but Desktop only showed auth method type.

<img width="424" alt="Screenshot 2022-05-19 at 13 40 52" src="https://user-images.githubusercontent.com/8390120/169363541-ce208f5c-0301-442b-a294-80b1caa5a8aa.png">

