### PR TITLE
Chore not override feature flags on vercel

### DIFF
--- a/ui/admin/config/environment.js
+++ b/ui/admin/config/environment.js
@@ -3,6 +3,7 @@
 const APP_NAME = process.env.APP_NAME || 'Boundary';
 const API_HOST = process.env.API_HOST || '';
 const EDITION = process.env.EDITION || 'oss'; // Default edition is OSS
+const IS_VERCEL = process.env.VERCEL || false; // To know is is a Vercel deployment
 
 // Object that defines edition features.
 const featureEditions = {
@@ -144,8 +145,14 @@ module.exports = function (environment) {
     // be explicit.
     if (API_HOST) ENV.contentSecurityPolicy['connect-src'].push(API_HOST);
 
-    // Enable features in development
-    ENV.featureFlags['ssh-target'] = true;
+    /**
+     * We need to know if this build/deployment is for Vercel.
+     * If is for Vercel we should NOT override any featureFlag.
+     */
+    if (!IS_VERCEL) {
+      // Enable features in development when NOT in Vercel
+      ENV.featureFlags['ssh-target'] = true;
+    }
   }
 
   if (environment === 'test') {

--- a/ui/admin/config/environment.js
+++ b/ui/admin/config/environment.js
@@ -3,7 +3,7 @@
 const APP_NAME = process.env.APP_NAME || 'Boundary';
 const API_HOST = process.env.API_HOST || '';
 const EDITION = process.env.EDITION || 'oss'; // Default edition is OSS
-const IS_VERCEL = process.env.VERCEL || false; // To know is is a Vercel deployment
+const IS_VERCEL = process.env.VERCEL || false; // To know if running on Vercel
 
 // Object that defines edition features.
 const featureEditions = {


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-4329)

## Description

### Assumptions to review this PR:
- You are  aware of how we are managing `featureFlags` and `EDITION`.
- You are aware of Ember CLI environments.
- You are aware of Vercel deployments.
- You are aware of the Mirage mocks.
- This change just affects Admin UI.

### Context:
We define a set of `featureFlags` depending on the `EDITION` (OSS or Enterprise) we are deploying or building.
Depending on what ember CLI environment we are working on, it is convenient to override some of those `featureFlags` for development purposes. I.E: if we are on development environment, I want all the `featureFlags` on, regardless of the `EDITION`, so on development stage there is no `EDITION` distinction.

We are using Vercel to integrate with our CI so we can preview a development version of every branch we are working on. At the moment we have 2 Vercel deployments for the Admin UI, OSS and Enterprie edition. We deploy in Vercel using the ember CLI `development` environment flag.

### Problem:
When deploying in Vercel with the ember CLI environment flag `development`, as explained in the context section, the `featureFlags` are override. So there is no distinction between Editions and that make's both of our deployments (OSS and Enterprise) serve the exact same code.
Deploying on Vercel using the ember CLI environment flag `development`is a MUST because we need the Mirage Mocks running and those are just available for `development`.

### Solution:
Using Environment variable on Vercel's, so our code can have a simple conditional to know when is being used by Vercel and NOT override any of the `featureFlags` with ember CLI environment flag set to `development`.

After reading [Vercel's documentation about Environment Variables](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables), I figure they are already exposing a variable `VERCEL`. Such variable has a value of `1` or `true` and we will not have such variable in our local development environments, so seems the perfect one to being use.

To not couple our code to this, by default it will ALWAYS assume it is running in a local dev environment unless the environment varible `VERCEL` is present with a `true` value.

This check is done at building time, so adding this extra conditional will be unperceivable from building times perspective and will not affect development on that matter.

### Screenshots:

Screenshot of boundary-ui (OSS Edition) deployed in Vercel with Ember CLI environment flag set to `development` and just the `featureFlags` that belong to OSS:
![oss](https://user-images.githubusercontent.com/9775006/169623473-285d7ba7-e470-4711-8c05-8c711e8ce4af.png)


Screenshot of boundary-ui-enterprise (Enterprise edition) deployed in Vercel with Ember CLI environment flag set to `development` and just the `featureFlags` that belong to Enterprise:
![enterprise](https://user-images.githubusercontent.com/9775006/169623487-437a1b5c-4473-4fbc-a4f9-19958f17f90a.png)


