### PR TITLE
refactor: 💡 Remove default value for IP address and port

### DIFF
--- a/ui/admin/app/routes/onboarding/quick-setup/create-resources.js
+++ b/ui/admin/app/routes/onboarding/quick-setup/create-resources.js
@@ -53,7 +53,7 @@ export default class OnboardingQuickSetupCreateResourcesRoute extends Route {
   @notifyError(function () {
     return this.intl.t('errors.quick-setup-failed.description');
   })
-  async createResources(hostAddress = '1234', targetPort = '42') {
+  async createResources(hostAddress, targetPort) {
     try {
       await this.createOnboardingResourcesAndRedirect(hostAddress, targetPort);
     } catch (e) {

--- a/ui/admin/tests/acceptance/onboarding/create-resource-test.js
+++ b/ui/admin/tests/acceptance/onboarding/create-resource-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit, currentURL, find, click } from '@ember/test-helpers';
+import { visit, currentURL, find, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateSession } from 'ember-simple-auth/test-support';
@@ -11,6 +11,7 @@ module('Acceptance | onboarding | create-resources', function (hooks) {
   const urls = {
     createResources: '/onboarding/quick-setup/create-resources',
     successPath: '/onboarding/quick-setup/create-resources/success',
+    hostCatalogPath: '/scopes/1/host-catalogs/1/hosts',
   };
 
   hooks.beforeEach(function () {
@@ -28,7 +29,17 @@ module('Acceptance | onboarding | create-resources', function (hooks) {
   test('redirects user to success screen when next is clicked', async function (assert) {
     assert.expect(1);
     await visit(urls.createResources);
+    await click('[type="checkbox"]');
+    await fillIn('[name="hostAddress"]', '0.0.0.0');
+    await fillIn('[name="targetPort"]', '22');
     await click('[type="submit"]');
     assert.equal(currentURL(), urls.successPath);
+  });
+
+  test('redirects user to host catalog screen when next is clicked', async function (assert) {
+    assert.expect(1);
+    await visit(urls.createResources);
+    await click('[type="submit"]');
+    assert.equal(currentURL(), urls.hostCatalogPath);
   });
 });

--- a/ui/admin/tests/acceptance/onboarding/create-resource-test.js
+++ b/ui/admin/tests/acceptance/onboarding/create-resource-test.js
@@ -11,7 +11,7 @@ module('Acceptance | onboarding | create-resources', function (hooks) {
   const urls = {
     createResources: '/onboarding/quick-setup/create-resources',
     successPath: '/onboarding/quick-setup/create-resources/success',
-    hostCatalogPath: '/scopes/1/host-catalogs/1/hosts',
+    hostCatalogPath: null,
   };
 
   hooks.beforeEach(function () {
@@ -40,6 +40,10 @@ module('Acceptance | onboarding | create-resources', function (hooks) {
     assert.expect(1);
     await visit(urls.createResources);
     await click('[type="submit"]');
+    const projectScopeId = this.server.schema.scopes.where({ type: 'project' })
+      .models[0].scopeId;
+    const hostCatalogId = this.server.schema.hostCatalogs.all().models[0].id;
+    urls.hostCatalogPath = `/scopes/${projectScopeId}/host-catalogs/${hostCatalogId}/hosts`;
     assert.equal(currentURL(), urls.hostCatalogPath);
   });
 });


### PR DESCRIPTION
## Description

This allows the user to be directed to the Host Catalog page if they do not provide an IP or port for the target. If we do not need this we can just close this PR.