### PR TITLE
chore: 🤖 update to credential source

### DIFF
--- a/addons/api/addon/models/session.js
+++ b/addons/api/addon/models/session.js
@@ -13,7 +13,7 @@ class SessionCredential {
   /**
    *
    */
-  static Library = class Library {
+  static Source = class Source {
     id;
     name;
     description;
@@ -42,7 +42,7 @@ class SessionCredential {
 
   // =attributes
   rawCredential;
-  library;
+  source;
   #payloadSecret;
 
   /**
@@ -72,8 +72,8 @@ class SessionCredential {
   // =methods
 
   constructor(cred) {
-    const { id, name, description, type } = cred.credential_library;
-    this.library = new SessionCredential.Library(id, name, description, type);
+    const { id, name, description, type } = cred.credential_source;
+    this.source = new SessionCredential.Source(id, name, description, type);
     this.#payloadSecret = cred.secret;
     this.rawCredential = cred;
   }

--- a/addons/api/mirage/scenarios/ipc.js
+++ b/addons/api/mirage/scenarios/ipc.js
@@ -66,10 +66,10 @@ export default function initializeMockIPC(server, config) {
         session_id: newSession.id,
         credentials: [
           {
-            credential_library: {
+            credential_source: {
               id: 'clvlt_4cvscMTl0N',
-              name: 'Library Name',
-              description: 'Library Description',
+              name: 'Source Name',
+              description: 'Source Description',
               credential_store_id: 'csvlt_Q1HFGt7Jpm',
               type: 'vault',
             },
@@ -78,10 +78,10 @@ export default function initializeMockIPC(server, config) {
             },
           },
           {
-            credential_library: {
+            credential_source: {
               id: 'clvlt_4cvscMTl0N',
-              name: 'Library Name',
-              description: 'Library Description',
+              name: 'Source Name',
+              description: 'Source Description',
               credential_store_id: 'csvlt_Q1HFGt7Jpm',
               type: 'vault',
             },
@@ -91,10 +91,10 @@ export default function initializeMockIPC(server, config) {
             },
           },
           {
-            credential_library: {
+            credential_source: {
               id: 'clvlt_9KWscxpcY7',
-              name: 'Library Name',
-              description: 'Library Description',
+              name: 'Source Name',
+              description: 'Source Description',
               credential_store_id: 'csvlt_Q1HFGt7Jpm',
               type: 'vault',
             },
@@ -103,10 +103,10 @@ export default function initializeMockIPC(server, config) {
             },
           },
           {
-            credential_library: {
+            credential_source: {
               id: 'clvlt_9KWscxpcY7',
-              name: 'Library Name',
-              description: 'Library Description',
+              name: 'Source Name',
+              description: 'Source Description',
               credential_store_id: 'csvlt_Q1HFGt7Jpm',
               type: 'vault',
             },

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -172,8 +172,8 @@ session:
     title_plural: Credentials
     secret:
       label: Secret
-    credential_library:
-      title: Credential Library
+    credential_source:
+      title: Credential Source
     actions:
       raw-api:
         show: View raw API output

--- a/ui/desktop/app/templates/scopes/scope/projects/targets.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets.hbs
@@ -41,15 +41,15 @@
                 <Card
                   @heading='{{t 'resources.session.credential.title'}}
                     {{if
-                    credential.library.name
-                    (concat ' (' credential.library.name ')')
+                    credential.source.name
+                    (concat ' (' credential.source.name ')')
                   }}'
                   @icon='flight-icons/svg/key-16'
                 >
                   <:header>
                     <Rose::Dropdown
                       @text={{t
-                        'resources.session.credential.credential_library.title'
+                        'resources.session.credential.credential_source.title'
                       }}
                       @style='condensed'
                       @dropdownRight={{true}}
@@ -60,28 +60,28 @@
                         <:key>{{t 'form.id.label'}}</:key>
                         <:value>
                           <Copyable
-                            @text={{credential.library.id}}
+                            @text={{credential.source.id}}
                             @buttonText={{t 'actions.copy-to-clipboard'}}
                             @acknowledgeText={{t 'states.copied'}}
                           >
-                            <code>{{credential.library.id}}</code>
+                            <code>{{credential.source.id}}</code>
                           </Copyable>
                         </:value>
                       </dropdown.key-value>
                       <dropdown.key-value>
                         <:key>{{t 'form.type.label'}}</:key>
-                        <:value>{{credential.library.type}}</:value>
+                        <:value>{{credential.source.type}}</:value>
                       </dropdown.key-value>
-                      {{#if credential.library.name}}
+                      {{#if credential.source.name}}
                         <dropdown.key-value>
                           <:key>{{t 'form.name.label'}}</:key>
-                          <:value>{{credential.library.name}}</:value>
+                          <:value>{{credential.source.name}}</:value>
                         </dropdown.key-value>
                       {{/if}}
-                      {{#if credential.library.description}}
+                      {{#if credential.source.description}}
                         <dropdown.key-value>
                           <:key>{{t 'form.description.label'}}</:key>
-                          <:value>{{credential.library.description}}</:value>
+                          <:value>{{credential.source.description}}</:value>
                         </dropdown.key-value>
                       {{/if}}
                     </Rose::Dropdown>


### PR DESCRIPTION
This pr updates `credential library` to `credential sources`

tested this against the latest 0.9 staged binary and set up credentials using the vault brokering guide
https://hashicorp.atlassian.net/browse/ICU-4874 

## Description
 

:desktop_computer: [Desktop preview](https://boundary-ui-desktop-fnijuxf9w-hashicorp.vercel.app/scopes/global/projects/targets)

<!-- Add a brief description of changes here. Include any other necessary relevant links -->

### Screenshots (if appropriate):
<img width="1285" alt="Screen Shot 2022-06-18 at 4 50 46 PM" src="https://user-images.githubusercontent.com/15043878/174460440-f7b5c34e-82ab-48bb-8586-efb3532c03d9.png">