### PR TITLE
fix: 🐛 overflow dropdown ui issue

### DIFF
--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -33,7 +33,6 @@
 
     main {
       flex-grow: 1;
-      overflow: auto;
     }
   }
 


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-4894)

## Description

This pr fixes the dropdown being cut off by removing `overflow: auto`. This change doesn't seem to affect anywhere on the desktop CLI UI on Mac OS. 

Help needed to test on Win and Linux: 

1. run a boundary instance to connect to target and sessions, and check if the project/sessions dropdown is displayed without being cut off 
2. create around 10-15 sessions, and ensure that there are no overflow issues when the dropdown is open/closed on the target page when you scroll the page

**Tested on mac OS:** 

**Dropdown with just single session:**  
<img width="1246" alt="Screen Shot 2022-06-28 at 10 02 40 AM" src="https://user-images.githubusercontent.com/15043878/176241156-64eaa1a6-e2aa-4412-81fc-de606933d076.png">


**Dropdown open when there are multiple sessions:**
<img width="1014" alt="Screen Shot 2022-06-28 at 10 03 16 AM" src="https://user-images.githubusercontent.com/15043878/176241388-35233837-d90f-4d22-a0ba-6a34119a93c0.png">

