### PR TITLE
chore: 🤖 Update git hook to not use commitizen on merges

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,5 +1,14 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+SHA1=$3
+
+# Don't run commitizen for merge or squash commits
+if [ "${COMMIT_SOURCE}" = merge ] || [ "${COMMIT_SOURCE}" = squash ];then
+    exit 0
+fi
+
 # This is to allow interaction with the terminal for commitizen
 exec < /dev/tty && npx git-cz --hook || true


### PR DESCRIPTION
## Description

Update the git hook to not run commitizen on merge commits or squashes.

You can test this by checking out an older commit and merging another branch or main back in. Or doing a rebase -i
