### PR TITLE
refactor: 💡 Refactor default values for target creation

### DIFF
--- a/addons/api/addon/generated/models/target.js
+++ b/addons/api/addon/generated/models/target.js
@@ -30,7 +30,6 @@ export default class GeneratedTargetModel extends BaseModel {
 
   @attr('number', {
     description: '',
-    defaultValue: 1,
   })
   session_connection_limit;
 

--- a/addons/api/tests/unit/serializers/target-test.js
+++ b/addons/api/tests/unit/serializers/target-test.js
@@ -34,7 +34,7 @@ module('Unit | Serializer | target', function (hooks) {
       type: 'tcp',
       scope_id: 'org_1',
       session_max_seconds: 28800,
-      session_connection_limit: 1,
+      session_connection_limit: null,
       worker_filter: null,
       attributes: {
         default_port: 1234,
@@ -111,7 +111,7 @@ module('Unit | Serializer | target', function (hooks) {
       type: 'ssh',
       scope_id: 'org_1',
       session_max_seconds: 28800,
-      session_connection_limit: 1,
+      session_connection_limit: null,
       worker_filter: 'worker',
       attributes: {
         default_port: 1234,


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-5127)

## Description

Refactor default value of `session_connection_limit`.

New behaviour: if the user does not specify a limit, at creation time the backend will assign `-1` (unlimited) as default. So the UI does not deal with default values anymore for this field.

### How I test this PR?

With the latest `0.9.1` binary, I used `BOUNDARY_DEV_UI_PASSTHROUGH_DIR` to passthrough the UI in my local env to the binary running, [here more info how to use it](https://github.com/hashicorp/boundary#ui-development).

### Screenshots (if appropriate):

New target form before being send, no value specified for `session_connection_limit`:
![Screen Shot 2022-07-08 at 11 58 42 AM](https://user-images.githubusercontent.com/9775006/178055610-05af753b-6e01-4ba6-bc87-a6c6c6721118.png)


New target form after being created with the response from BE, notice now it shows `-1` in `session_connection_limit`:
![Screen Shot 2022-07-08 at 11 59 02 AM](https://user-images.githubusercontent.com/9775006/178055589-9c5e18c1-1293-400a-8398-d7f6730340d3.png)
 
