### PR TITLE
refactor: 💡 existing vault form field to radio group

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -319,6 +319,8 @@ credential-store:
   types:
     vault: Vault
     static: Static
+  help:
+    vault: The host details are brokered by a Vault server.
   form:
     address:
       label: Address
@@ -348,9 +350,6 @@ credential-store:
       help: A PEM-encoded private key matching the client certificate from Client Certificate.
     client_certificate_key_hmac:
       label: Client Certificate Key HMAC
-    type:
-      help:
-        vault: The host details are brokered by a Vault server.
 credential-library:
   title: Credential Library
   title_plural: Credential Libraries

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -348,6 +348,9 @@ credential-store:
       help: A PEM-encoded private key matching the client certificate from Client Certificate.
     client_certificate_key_hmac:
       label: Client Certificate Key HMAC
+    type:
+      help:
+        vault: The host details are brokered by a Vault server.
 credential-library:
   title: Credential Library
   title_plural: Credential Libraries

--- a/ui/admin/app/components/form/credential-store/index.hbs
+++ b/ui/admin/app/components/form/credential-store/index.hbs
@@ -6,12 +6,44 @@
   @showEditToggle={{if @model.isNew false true}}
   as |form|
 >
-  <form.input
-    @value={{@model.type}}
-    @label={{t 'form.type.label'}}
-    readonly={{true}}
-    @disabled={{true}}
-  />
+  {{#if (feature-flag 'static-credentials')}}
+    <form.fieldset>
+      <:title>{{t 'form.type.label'}}</:title>
+      <:body>
+        {{#if @model.isNew}}
+          {{! Code to allow option to select between cred. store types (vault or static) when it is first created goes here}}
+        {{else}}
+          <form.radioGroup
+            @name='types'
+            @selectedValue={{@model.type}}
+            as |radioGroup|
+          >
+            <radioGroup.card
+              @label={{t
+                (concat 'resources.credential-store.types.' @model.type)
+              }}
+              @helperText={{t
+                (concat
+                  'resources.credential-store.form.type.help.' @model.type
+                )
+              }}
+              @value={{@model.type}}
+              @layout='wide'
+              readonly={{true}}
+              @disabled={{true}}
+            />
+          </form.radioGroup>
+        {{/if}}
+      </:body>
+    </form.fieldset>
+  {{else}}
+    <form.input
+      @value={{@model.type}}
+      @label={{t 'form.type.label'}}
+      readonly={{true}}
+      @disabled={{true}}
+    />
+  {{/if}}
 
   <form.input
     @name='name'

--- a/ui/admin/app/components/form/credential-store/index.hbs
+++ b/ui/admin/app/components/form/credential-store/index.hbs
@@ -23,9 +23,7 @@
                 (concat 'resources.credential-store.types.' @model.type)
               }}
               @helperText={{t
-                (concat
-                  'resources.credential-store.form.type.help.' @model.type
-                )
+                (concat 'resources.credential-store.help.' @model.type)
               }}
               @value={{@model.type}}
               @layout='wide'

--- a/ui/admin/app/components/form/credential-store/index.hbs
+++ b/ui/admin/app/components/form/credential-store/index.hbs
@@ -12,6 +12,11 @@
       <:body>
         {{#if @model.isNew}}
           {{! Code to allow option to select between cred. store types (vault or static) when it is first created goes here}}
+          <form.input
+            @value={{@model.type}}
+            readonly={{true}}
+            @disabled={{true}}
+          />
         {{else}}
           <form.radioGroup
             @name='types'


### PR DESCRIPTION
✅ Closes: ICU-5171

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-5171)

🧑‍💻: [Admin preview](https://boundary-ui-git-icu-5171-refactor-existing-vau-37b194-hashicorp.vercel.app/scopes/s_1sheljmjgm/credential-stores/cs_ucau082vov)

## Description
Refactored existing vault form field to use radio card instead. This
change is seen on details tab of a static credential store.