### PR TITLE
Icu 5335 add doc link for credential store screens

### DIFF
--- a/ui/admin/app/components/credential-stores/credential-store/header/index.hbs
+++ b/ui/admin/app/components/credential-stores/credential-store/header/index.hbs
@@ -1,4 +1,7 @@
-<h2>{{t 'resources.credential-store.title'}}</h2>
+<h2>
+  {{t 'resources.credential-store.title'}}
+  <DocLink @doc='credential-store' @iconSize='large' />
+</h2>
 <p>{{t 'resources.credential-store.description'}}</p>
 <Copyable
   @text={{@model.id}}

--- a/ui/admin/app/templates/scopes/scope/credential-stores/new.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/new.hbs
@@ -6,7 +6,10 @@
   </page.breadcrumbs>
 
   <page.header>
-    <h2>{{t 'titles.new'}}</h2>
+    <h2>
+      {{t 'titles.new'}}
+      <DocLink @doc='credential-store' @iconSize='large' />
+    </h2>
   </page.header>
 
   <page.body>

--- a/ui/admin/tests/acceptance/credential-store/create-test.js
+++ b/ui/admin/tests/acceptance/credential-store/create-test.js
@@ -119,4 +119,14 @@ module('Acceptance | credential-stores | create', function (hooks) {
       'Name is required.'
     );
   });
+
+  test('Users can link to docs page for new credential store', async function (assert) {
+    assert.expect(1);
+    await visit(urls.newCredentialStore);
+    assert.ok(
+      find(
+        `[href="https://boundaryproject.io/help/admin-ui/credential-stores"]`
+      )
+    );
+  });
 });

--- a/ui/admin/tests/acceptance/credential-store/list-test.js
+++ b/ui/admin/tests/acceptance/credential-store/list-test.js
@@ -81,4 +81,14 @@ module('Acceptance | credential-stores | list', function (hooks) {
     await visit(urls.projectScope);
     assert.ok(find(`[href="${urls.credentialStores}"]`));
   });
+
+  test('Users can link to docs page for credential stores', async function (assert) {
+    assert.expect(1);
+    await visit(urls.credentialStores);
+    assert.ok(
+      find(
+        `[href="https://boundaryproject.io/help/admin-ui/credential-stores"]`
+      )
+    );
+  });
 });

--- a/ui/admin/tests/acceptance/credential-store/read-test.js
+++ b/ui/admin/tests/acceptance/credential-store/read-test.js
@@ -81,4 +81,14 @@ module('Acceptance | credential-stores | read', function (hooks) {
       'Error 404'
     );
   });
+
+  test('Users can link to docs page for credential store', async function (assert) {
+    assert.expect(1);
+    await visit(urls.credentialStore);
+    assert.ok(
+      find(
+        `[href="https://boundaryproject.io/help/admin-ui/credential-stores"]`
+      )
+    );
+  });
 });


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-5335)

## Note for discussion
I added tests to verify that the docs link is present and referencing the correct URL. I would like to not have to use the full URL in the future, maybe create a helper test method but I wanted to get feedback about including these tests from the team first. Let me know your thoughts.

## Description
Add DocLink component to new Credential Screen and the read Credential Store screen.
<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

### Screenshots (if appropriate):
<img width="623" alt="Screen Shot 2022-07-21 at 5 33 22 PM" src="https://user-images.githubusercontent.com/29386339/180326323-ad0dc2cf-99bd-4f94-b23a-b48f3cfabebe.png">
<img width="623" alt="Screen Shot 2022-07-21 at 5 33 38 PM" src="https://user-images.githubusercontent.com/29386339/180326325-bd0fa965-dd87-497a-85d2-0e7ec7296a66.png">
