### PR TITLE
feat: 🎸 Add doc link to Credential screens

### DIFF
--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/credential/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/credential/index.hbs
@@ -7,6 +7,7 @@
   <page.header>
     <h2>
       {{t 'resources.credential.title'}}
+      <DocLink @doc='credential' @iconSize='large' />
     </h2>
     <p>{{t 'resources.credential.description'}}</p>
     <Copyable

--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/new.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/new.hbs
@@ -9,6 +9,7 @@
   <page.header>
     <h2>
       {{t 'titles.new'}}
+      <DocLink @doc='credential' @iconSize='large' />
     </h2>
   </page.header>
 

--- a/ui/admin/config/environment.js
+++ b/ui/admin/config/environment.js
@@ -79,6 +79,7 @@ module.exports = function (environment) {
         'host-set.add-hosts': '/host-sets/add-hosts',
         'credential-store': '/credential-stores',
         'credential-library': '/credential-libraries',
+        credential: '/credentials',
         host: '/hosts',
         'host.new': '/hosts/new',
         role: '/roles',


### PR DESCRIPTION
✅ Closes: ICU-5317

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-5317)

## Description

The redirect for Credential does not work right now. This is a brand new redirect on the boundaryproject.io website as well so the redirect will not work until our next release when those changes are pushed to production.
Here is the [PR](https://github.com/hashicorp/boundary/pull/2272) that added the redirect to the boundaryproject.io website.

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](https://boundary-ui-git-icu-5317-create-a-new-doc-link-cccbec-hashicorp.vercel.app/scopes/s_1sheljmjgm/credential-stores/cs_20nu3mgl4y/credentials/cred_hzrxf5z5za)

### Screenshots (if appropriate):
<img width="620" alt="Screen Shot 2022-07-25 at 5 43 52 PM" src="https://user-images.githubusercontent.com/29386339/180886524-e8d54181-8597-4e5d-ad95-d449f995f5ab.png">
<img width="962" alt="Screen Shot 2022-07-25 at 5 44 08 PM" src="https://user-images.githubusercontent.com/29386339/180886527-c11e0035-38d5-4a0e-a001-7534cd4b154c.png">
