### PR TITLE
fix: 🐛 spelling error in getting started on desktop redirect

### DIFF
--- a/ui/admin/config/environment.js
+++ b/ui/admin/config/environment.js
@@ -90,7 +90,7 @@ module.exports = function (environment) {
         'target.worker-filters': '/targets/worker-filters',
         user: '/users',
         downloads: '/downloads',
-        'getting-started.desktop': '/gettting-started/desktop',
+        'getting-started.desktop': '/getting-started/desktop',
         'api-client.cli': '/api-client/cli',
         'api-client.api': '/api-client/api',
       },


### PR DESCRIPTION
## Description
Fixes the redirect for the "Learn about Boundary Desktop app" link.

### Screenshots (if appropriate):
<img width="535" alt="Screen Shot 2022-07-26 at 10 52 25 AM" src="https://user-images.githubusercontent.com/29386339/181052476-8d4caea1-fceb-4323-8c06-9fbf6d340d91.png">
