### PR TITLE
Fix runtime-settings to not access directly the private variable

### DIFF
--- a/ui/desktop/electron-app/src/models/runtime-settings.js
+++ b/ui/desktop/electron-app/src/models/runtime-settings.js
@@ -46,7 +46,7 @@ class RuntimeSettings {
    * Sets the clusterUrl to null.
    */
   async resetClusterUrl() {
-    this.#clusterUrl = null;
+    this.clusterUrl = null;
   }
 
   // Quick and dirty event handler pattern to enable the application to respond


### PR DESCRIPTION
## Description

Fix a bug introduced with the `origin` to `clusterURL` refactor. We should NOT access the private var directly