### PR TITLE
[CI-only] Add build job for HCPb variant

### DIFF
--- a/.github/workflows/build-admin-ui.yaml
+++ b/.github/workflows/build-admin-ui.yaml
@@ -94,8 +94,8 @@ jobs:
           node-version: '16.x'
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
       - run: yarn run build:ui:admin:enterprise
-      - name: Upload artifact Admin UI Enterprise
+      - name: Upload artifact Admin UI Enterprise for HCP
         uses: actions/upload-artifact@v3
         with:
-          name: admin-ui-ent
+          name: admin-ui-hcp
           path: ./ui/admin/dist/

--- a/.github/workflows/build-admin-ui.yaml
+++ b/.github/workflows/build-admin-ui.yaml
@@ -74,3 +74,28 @@ jobs:
         with:
           name: admin-ui-ent
           path: ./ui/admin/dist/
+
+  build-admin-ui-hcp:
+    name: Build Admin UI HCP
+    needs: [dependencies]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        id: node-modules-cache
+        with:
+          path: '**/node_modules'
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            node-modules-
+      - name: Build
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      - run: yarn run build:ui:admin:enterprise
+      - name: Upload artifact Admin UI Enterprise
+        uses: actions/upload-artifact@v3
+        with:
+          name: admin-ui-ent
+          path: ./ui/admin/dist/


### PR DESCRIPTION
## Description

This new job mirrors the enterprise build job, but lets us keep the existing logic laid out in https://github.com/hashicorp/boundary/blob/main/.github/workflows/build.yml#L136 to download the right UI artifacts based on the boundary variant/edition. This is needed for the release on August 1st. 🙏  Thanks
