### PR TITLE
refactor: 💡 Remove helper text for Username & Password

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -390,8 +390,6 @@ credential:
     username_password: Username & Password
   help:
     username_password: This host requires a username and password to connect.
-    username: The username to use when signing in with this credential store.
-    password: The password to use when signing in with this credential store.
 scope:
   title: Scope
   title_plural: Scopes

--- a/ui/admin/app/components/form/credential/index.hbs
+++ b/ui/admin/app/components/form/credential/index.hbs
@@ -71,7 +71,6 @@
     @value={{@model.username}}
     @label={{t 'form.username.label'}}
     @error={{@model.errors.username}}
-    @helperText={{t 'resources.credential.help.username'}}
     disabled={{@model.isSaving}}
     readonly={{false}}
     as |field|
@@ -84,36 +83,14 @@
       </field.errors>
     {{/if}}
   </form.input>
-  {{#if @model.isNew}}
-    <form.input
-      @name='password'
-      @type='password'
-      @value={{@model.password}}
-      @label={{t 'form.password.label'}}
-      @error={{@model.errors.password}}
-      @helperText={{t 'resources.credential.help.password'}}
-      disabled={{@model.isSaving}}
-      readonly={{false}}
-      as |field|
-    >
-      {{#if @model.errors.password}}
-        <field.errors as |errors|>
-          {{#each @model.errors.password as |error|}}
-            <errors.message>{{error.message}}</errors.message>
-          {{/each}}
-        </field.errors>
-      {{/if}}
-    </form.input>
-  {{/if}}
 
-  {{#if form.isEditable}}
+  {{#if (or @model.isNew form.isEditable)}}
     <form.input
       @name='password'
       @type='password'
       @value={{@model.password}}
       @label={{t 'form.password.label'}}
       @error={{@model.errors.password}}
-      @helperText={{t 'resources.credential.help.password'}}
       disabled={{@model.isSaving}}
       readonly={{false}}
       as |field|


### PR DESCRIPTION
✅ Closes: ICU-5459

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-5459)

:technologist: [Admin preview](https://boundary-ui-git-icu-5459-remove-helper-text-fo-f7e341-hashicorp.vercel.app/scopes/s_1sheljmjgm/credential-stores/cs_20nu3mgl4y/credentials/cred_hzrxf5z5za)

## Description
Remove helper text for username and password fields in Credential form
as requested in a previous conversation.


