### PR TITLE
refactor: 💡 update onSubmit for add-credential-sources

### DIFF
--- a/ui/admin/app/components/form/target/add-credential-sources/index.hbs
+++ b/ui/admin/app/components/form/target/add-credential-sources/index.hbs
@@ -1,6 +1,6 @@
 <Rose::Form
   class='full-width'
-  @onSubmit={{fn this.submit @submit}}
+  @onSubmit={{fn @submit this.selectedCredentialSourceIDs}}
   @cancel={{@cancel}}
   @disabled={{@model.isSaving}}
   @error={{@model.errors.base}}
@@ -26,7 +26,7 @@
             <form.checkbox
               @label={{credentialSource.id}}
               @description={{credentialSource.description}}
-              @onChange={{fn this.toggleCredentialSource credentialSource}}
+              @onChange={{fn this.toggleCredentialSource credentialSource.id}}
             />
           </row.headerCell>
           <row.cell>{{credentialSource.name}}</row.cell>

--- a/ui/admin/app/components/form/target/add-credential-sources/index.js
+++ b/ui/admin/app/components/form/target/add-credential-sources/index.js
@@ -15,22 +15,14 @@ export default class FormTargetAddCredentialSourcesIndexComponent extends Compon
 
   /**
    * Add/Remove credential source to current selection
-   * @param {CredentialLibraryModel, CredentialModel} credentialSource
+   * @param {string} credentialSourceId
    */
   @action
-  toggleCredentialSource(credentialSource) {
-    if (!this.selectedCredentialSourceIDs.includes(credentialSource.id)) {
-      this.selectedCredentialSourceIDs.addObject(credentialSource.id);
+  toggleCredentialSource(credentialSourceId) {
+    if (!this.selectedCredentialSourceIDs.includes(credentialSourceId)) {
+      this.selectedCredentialSourceIDs.addObject(credentialSourceId);
     } else {
-      this.selectedCredentialSourceIDs.removeObject(credentialSource.id);
+      this.selectedCredentialSourceIDs.removeObject(credentialSourceId);
     }
-  }
-
-  /**
-   * Submit selected credential source ids
-   */
-  @action
-  submit(fn) {
-    fn(this.selectedCredentialSourceIDs);
   }
 }


### PR DESCRIPTION
## Description
Remove submit action from form component and pass selected credential IDs directly to the submit method
Update toggle action to accept the credential source ID instead of the whole model.

:technologist: [Admin preview](https://boundary-ui-git-refactor-add-credential-source-submit-hashicorp.vercel.app/scopes/s_1sheljmjgm/targets/t_4uga1n9zdm/add-credential-sources)