### PR TITLE
Icu 5646 serializer

### DIFF
--- a/addons/api/addon/serializers/credential.js
+++ b/addons/api/addon/serializers/credential.js
@@ -19,8 +19,7 @@ export default class CredentialSerializer extends ApplicationSerializer {
 
   serializeUsernamePassword() {
     const serialized = super.serialize(...arguments);
-    // Remove password_hmac and non-username_password type attributes
-    delete serialized['attributes']['password_hmac'];
+    // Remove non-username_password type attributes
     delete serialized['attributes']['private_key'];
     delete serialized['attributes']['passphrase'];
     return serialized;
@@ -28,8 +27,7 @@ export default class CredentialSerializer extends ApplicationSerializer {
 
   serializeSSHPrivateKey() {
     const serialized = super.serialize(...arguments);
-    // Remove private_key_hmac and non-ssh_private_key type attributes
-    delete serialized['attributes']['private_key_hmac'];
+    // Remove non-ssh_private_key type attributes
     delete serialized['attributes']['password'];
     return serialized;
   }

--- a/addons/api/addon/serializers/credential.js
+++ b/addons/api/addon/serializers/credential.js
@@ -2,13 +2,35 @@ import ApplicationSerializer from './application';
 import { copy } from 'ember-copy';
 
 export default class CredentialSerializer extends ApplicationSerializer {
-  serialize() {
-    const serialized = super.serialize(...arguments);
-    delete serialized['attributes']['password_hmac'];
-    if (serialized.type === 'username_password') {
-      delete serialized['attributes']['private_key'];
-      delete serialized['attributes']['passphrase'];
+  /**
+   * @override
+   * @method serialize
+   * @param {Snapshot} snapshot
+   */
+  serialize(snapshot) {
+    switch (snapshot.record.type) {
+      case 'username_password':
+        return this.serializeUsernamePassword(...arguments);
+      case 'ssh_private_key':
+      default:
+        return this.serializeSSHPrivateKey(...arguments);
     }
+  }
+
+  serializeUsernamePassword() {
+    const serialized = super.serialize(...arguments);
+    // Remove password_hmac and non-username_password type attributes
+    delete serialized['attributes']['password_hmac'];
+    delete serialized['attributes']['private_key'];
+    delete serialized['attributes']['passphrase'];
+    return serialized;
+  }
+
+  serializeSSHPrivateKey() {
+    const serialized = super.serialize(...arguments);
+    // Remove private_key_hmac and non-ssh_private_key type attributes
+    delete serialized['attributes']['private_key_hmac'];
+    delete serialized['attributes']['password'];
     return serialized;
   }
 

--- a/addons/api/addon/serializers/credential.js
+++ b/addons/api/addon/serializers/credential.js
@@ -37,7 +37,8 @@ export default class CredentialSerializer extends ApplicationSerializer {
   normalize(typeClass, hash, ...rest) {
     const normalizedHash = copy(hash, true);
     const normalized = super.normalize(typeClass, normalizedHash, ...rest);
-    normalized['data']['attributes']['password'] = '';
+    // Remove passphrase as we don't track it after being created/updated
+    delete normalized['data']['attributes']['passphrase'];
     return normalized;
   }
 }

--- a/addons/api/tests/unit/serializers/credential-test.js
+++ b/addons/api/tests/unit/serializers/credential-test.js
@@ -4,17 +4,18 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Serializer | credential', function (hooks) {
   setupTest(hooks);
 
-  test('it serializes correctly on create', function (assert) {
+  test('it serializes username_password type correctly on create', function (assert) {
     assert.expect(1);
     const store = this.owner.lookup('service:store');
     const serializer = store.serializerFor('credential');
     const record = store.createRecord('credential', {
       password: 'pass',
       username: 'user',
-      credential_store_id: 'cs_i7p1eu0Nw8',
+      credential_store_id: 'csst_i7p1eu0Nw8',
       type: 'username_password',
       name: 'Name',
       description: 'Description',
+      version: 1,
     });
     const snapshot = record._createSnapshot();
     const serializedRecord = serializer.serialize(snapshot);
@@ -24,10 +25,42 @@ module('Unit | Serializer | credential', function (hooks) {
         password: 'pass',
         username: 'user',
       },
-      credential_store_id: 'cs_i7p1eu0Nw8',
+      credential_store_id: 'csst_i7p1eu0Nw8',
       type: 'username_password',
       name: 'Name',
       description: 'Description',
+      version: 1,
+    });
+  });
+
+  test('it serializes ssh_private_key type correctly on create', function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('credential');
+    const record = store.createRecord('credential', {
+      passphrase: 'passphrasesaresosecure',
+      private_key: 'superPriveKey',
+      username: 'user',
+      credential_store_id: 'csst_i7p1eu0Nw8',
+      type: 'ssh_private_key',
+      name: 'Name',
+      description: 'Description',
+      version: 1,
+    });
+    const snapshot = record._createSnapshot();
+    const serializedRecord = serializer.serialize(snapshot);
+
+    assert.deepEqual(serializedRecord, {
+      attributes: {
+        passphrase: 'passphrasesaresosecure',
+        private_key: 'superPriveKey',
+        username: 'user',
+      },
+      credential_store_id: 'csst_i7p1eu0Nw8',
+      type: 'ssh_private_key',
+      name: 'Name',
+      description: 'Description',
+      version: 1,
     });
   });
 
@@ -42,7 +75,7 @@ module('Unit | Serializer | credential', function (hooks) {
       type: 'username_password',
       attributes: {
         username: 'username',
-        password: '12345678',
+        password_hmac: 'completenonsense',
       },
     };
     const normalized = serializer.normalize(credentialModelClass, payload);
@@ -55,9 +88,9 @@ module('Unit | Serializer | credential', function (hooks) {
           username: 'username',
           version: 1,
         },
+        type: 'credential',
         id: 'cred_123',
         relationships: {},
-        type: 'credential',
       },
     });
   });

--- a/addons/api/tests/unit/serializers/credential-test.js
+++ b/addons/api/tests/unit/serializers/credential-test.js
@@ -64,13 +64,13 @@ module('Unit | Serializer | credential', function (hooks) {
     });
   });
 
-  test('it normalizes credential record', async function (assert) {
+  test('it normalizes "username_password" type credential record', async function (assert) {
     assert.expect(1);
     const store = this.owner.lookup('service:store');
     const serializer = store.serializerFor('credential');
     const credentialModelClass = store.createRecord('credential').constructor;
     const payload = {
-      id: 'cred_123',
+      id: 'credup_123',
       version: 1,
       type: 'username_password',
       attributes: {
@@ -83,13 +83,43 @@ module('Unit | Serializer | credential', function (hooks) {
     assert.deepEqual(normalized, {
       data: {
         attributes: {
-          password: '',
           type: 'username_password',
           username: 'username',
           version: 1,
         },
         type: 'credential',
-        id: 'cred_123',
+        id: 'credup_123',
+        relationships: {},
+      },
+    });
+  });
+
+  test('it normalizes "ssh_private_key" type credential record', async function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('credential');
+    const credentialModelClass = store.createRecord('credential').constructor;
+    const payload = {
+      id: 'credspk_123',
+      version: 1,
+      type: 'ssh_private_key',
+      attributes: {
+        username: 'username',
+        passphrase: 'random',
+        private_key_hmac: 'completenonsense',
+      },
+    };
+    const normalized = serializer.normalize(credentialModelClass, payload);
+
+    assert.deepEqual(normalized, {
+      data: {
+        attributes: {
+          type: 'ssh_private_key',
+          username: 'username',
+          version: 1,
+        },
+        type: 'credential',
+        id: 'credspk_123',
         relationships: {},
       },
     });


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-5646)

## Description
Updated serialize/normalize for static credentials.
Username & Password: After creation, we don't keep track of the `password` field. We only display the `username` when reading.
SSH Private Key: After creation, we don't keep track of the `private key` or `passphrase` field. We only display the `username` when reading.

Mirage updates will be in the next PR.