### PR TITLE
chore: 🤖 simplify importing of codemirror styles

### DIFF
--- a/addons/rose/index.js
+++ b/addons/rose/index.js
@@ -30,6 +30,10 @@ module.exports = {
         destDir: this.name,
         include: ['**/*'],
       }),
+      new Funnel(stylePath, {
+        destDir: this.name,
+        include: ['../../node_modules/codemirror/lib'],
+      }),
     ]);
 
     // Setup default sassOptions on the running application

--- a/ui/admin/ember-cli-build.js
+++ b/ui/admin/ember-cli-build.js
@@ -34,9 +34,6 @@ module.exports = function (defaults) {
     app.import('node_modules/clipboard/dist/clipboard.min.js');
   }
 
-  app.import('node_modules/codemirror/lib/codemirror.css');
-  app.import('node_modules/codemirror/theme/monokai.css');
-
   // Use `app.import` to add additional libraries to the generated
   // output files.
   //


### PR DESCRIPTION
## Description

Simplifies codemirror style import so that consumer apps do not need to reimport it.