### PR TITLE
fix: 🐛 add translation for the new credential type within target route

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -300,6 +300,7 @@ target:
     types:
       vault: Vault
       username_password: Username & Password
+      ssh_private_key: Username & Key Pair
     messages:
       welcome:
         title: Welcome to brokered credentials


### PR DESCRIPTION
Add missing translation for the new credential type within the target route

Before:
<img width="1468" alt="Screen Shot 2022-08-18 at 3 30 05 PM" src="https://user-images.githubusercontent.com/15043878/185506396-552d7b93-6939-4b31-bf28-bb7658642d78.png">

After:
<img width="1203" alt="Screen Shot 2022-08-18 at 3 28 39 PM" src="https://user-images.githubusercontent.com/15043878/185506440-155aad56-4038-4d3b-8b17-41baf6e60151.png">
 