### PR TITLE
Chore/cleanup rose

### DIFF
--- a/addons/rose/addon/components/rose/button/index.hbs
+++ b/addons/rose/addon/components/rose/button/index.hbs
@@ -2,8 +2,7 @@
   ...attributes
   type={{if @submit 'submit' 'button'}}
   disabled={{if @disabled 'disabled'}}
-  class='{{@classNames}}
-    {{if @style (concat 'rose-button-' @style)}}
+  class='{{if @style (concat 'rose-button-' @style)}}
     {{if @iconLeft 'has-icon-left'}}
     {{if @iconRight 'has-icon-right'}}
     {{if @iconOnly 'has-icon-only'}}'

--- a/addons/rose/addon/components/rose/code-editor/field-editor/index.hbs
+++ b/addons/rose/addon/components/rose/code-editor/field-editor/index.hbs
@@ -1,6 +1,6 @@
 <div
   data-test-code-editor-field-editor
   ...attributes
-  class='{{@classNames}} rose-codemirror-container'
+  class='rose-codemirror-container'
   {{code-mirror value=@value onInput=@onInput options=@options}}
 ></div>

--- a/addons/rose/addon/components/rose/code-editor/index.stories.mdx
+++ b/addons/rose/addon/components/rose/code-editor/index.stories.mdx
@@ -57,7 +57,7 @@ export const codeValue =
       template: hbs`
       <Rose::CodeEditor @codeValue={{codeValue}} as |c|>
         <c.toolbar />
-        <c.fieldEditor @classNames='rose-autosize' @options={{options}} />
+        <c.fieldEditor class='rose-autosize' @options={{options}} />
       </Rose::CodeEditor>`,
       context: {
         codeValue: 'mkdir /home/ubuntu/boundary/',
@@ -76,7 +76,7 @@ export const codeValue =
       template: hbs`
       <Rose::CodeEditor @codeValue={{codeValue}} as |c|>
         <c.toolbar />
-        <c.fieldEditor @classNames='autosize' @options={{options}} />
+        <c.fieldEditor class='autosize' @options={{options}} />
       </Rose::CodeEditor>`,
       context: {
         codeValue: 'mkdir /home/ubuntu/boundary/',

--- a/addons/rose/addon/components/rose/form/actions/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/actions/index.stories.mdx
@@ -8,35 +8,38 @@ import { text, boolean } from '@storybook/addon-knobs';
 # Form Actions
 
 A simple collection of buttons for performing common actions like submit/save
-and cancel.  Form actions should always be used in the context of a form element
-where the form has a submit action handler.  The submit button does not directly
-support actions.  The cancel button supports a cancel action.
+and cancel. Form actions should always be used in the context of a form element
+where the form has a submit action handler. The submit button does not directly
+support actions. The cancel button supports a cancel action.
 
 ```html
 <Rose::Form::Actions
   @submitText="Save"
   @cancelText="Cancel"
   @showCancel={{true}}
-  @disabled={{false}}
-  @cancel=(fn @cancel) />
+  @submitDisabled={{false}}
+  @cancel=(fn @cancel)
+/>
 ```
 
 <Preview>
-  <Story name="Basic Form Actions">{{
-    template: hbs`
+  <Story name="Basic Form Actions">
+    {{
+      template: hbs`
       <Rose::Form::Actions
         @submitText={{submitText}}
         @cancelText={{cancelText}}
         @showCancel={{showCancel}}
-        @disabled={{disabled}}
+        @submitDisabled={{submitDisabled}}
         @cancel={{onCancel}} />
     `,
-    context: {
-      submitText: text('submitText', 'Save'),
-      cancelText: text('cancelText', 'Cancel'),
-      showCancel: boolean('showCancel', true),
-      disabled: boolean('disabled', false),
-      onCancel: action('cancel'),
-    },
-  }}</Story>
+      context: {
+        submitText: text('submitText', 'Save'),
+        cancelText: text('cancelText', 'Cancel'),
+        showCancel: boolean('showCancel', true),
+        submitDisabled: boolean('submitDisabled', false),
+        onCancel: action('cancel'),
+      },
+    }}
+  </Story>
 </Preview>


### PR DESCRIPTION
## Description
Fixed a few things in rose:
- Removed unused `@classNames` variables
- Fixed form action story not using correct `disabled` boolean
