### PR TITLE
refactor: 💡 Disable read-only fields when editing worker

### DIFF
--- a/addons/core/addon/helpers/relative-datetime-live.js
+++ b/addons/core/addon/helpers/relative-datetime-live.js
@@ -46,7 +46,6 @@ export default class extends Helper {
 
   compute([date]) {
     const delta = date.valueOf() - this.clockTick.now;
-    console.log(delta);
     const greatestMeaningfulUnit = unitMappings.reduce(
       (currentValue, previousValue) => {
         return Math.abs(delta) >= previousValue.value

--- a/ui/admin/app/components/form/worker/index.hbs
+++ b/ui/admin/app/components/form/worker/index.hbs
@@ -6,15 +6,14 @@
   as |form|
 >
 
-  {{#unless form.isEditable}}
-    <form.input
-      @name='type'
-      @value={{@model.type}}
-      @label={{t 'form.type.label'}}
-      @helperText={{t 'form.worker_type.help'}}
-      readonly={{true}}
-    />
-  {{/unless}}
+  <form.input
+    @name='type'
+    @value={{@model.type}}
+    @label={{t 'form.type.label'}}
+    @helperText={{t 'form.worker_type.help'}}
+    @disabled={{true}}
+    readonly={{true}}
+  />
 
   <form.input
     @name='name'
@@ -54,30 +53,30 @@
     {{/if}}
   </form.textarea>
 
-  {{#unless form.isEditable}}
+  <form.input
+    @name='address'
+    @type='url'
+    @value={{@model.address}}
+    @label={{t 'form.address.label'}}
+    @helperText={{t 'form.worker_address.help'}}
+    @disabled={{true}}
+    readonly={{true}}
+  />
+  {{#let
+    (relative-datetime-live @model.last_status_time)
+    (format-date @model.last_status_time format='yymmddt')
+    as |relativeDate customFormat|
+  }}
     <form.input
-      @name='address'
-      @type='url'
-      @value={{@model.address}}
-      @label={{t 'form.address.label'}}
-      @helperText={{t 'form.worker_address.help'}}
+      @name='last seen'
+      @type='datetime'
+      @value={{concat relativeDate ', ' customFormat}}
+      @label={{t 'form.worker_last_seen.label'}}
+      @helperText={{t 'form.worker_last_seen.help'}}
+      @disabled={{true}}
       readonly={{true}}
     />
-    {{#let
-      (relative-datetime-live @model.last_status_time)
-      (format-date @model.last_status_time format='yymmddt')
-      as |relativeDate customFormat|
-    }}
-      <form.input
-        @name='last seen'
-        @type='datetime'
-        @value={{concat relativeDate ', ' customFormat}}
-        @label={{t 'form.worker_last_seen.label'}}
-        @helperText={{t 'form.worker_last_seen.help'}}
-        readonly={{true}}
-      />
-    {{/let}}
-  {{/unless}}
+  {{/let}}
 
   {{#if (can 'save worker' @model)}}
     <form.actions


### PR DESCRIPTION
Refactor detailed worker to not hide read-only fields when editing, but
leave them disabled

✅ Closes: ICU-5902

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER)
ICU-5902

## Description
Previous logic was  when user clicks on `edit` for `detailed-worker-view` it hides the `read-only` fields for the page and only displays the editable field. Current logic is when a user clicks on `edit` for `detailed-worker-view` it will no longer hide the `read-only` fields but they will keep their `disabled` state and stay on page.

<!--
Replace PATH_TO_FEATURE with Vercel link
https://boundary-ui-git-icu-5902-workers-detail-page-s-98f6df-hashicorp.vercel.app/scopes/global/authenticate/am_3enprm7y2t
-->

<!-- Add a brief description of changes here. Include any other necessary relevant links -->


### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/24277002/187454311-a393d3b5-b5ab-48dc-babe-a9bfaa31bfad.png)
