### PR TITLE
chore: 🤖 Add feature flags for dev and test environments

### DIFF
--- a/ui/admin/config/environment.js
+++ b/ui/admin/config/environment.js
@@ -125,7 +125,10 @@ module.exports = function (environment) {
     };
 
     // Enable features in development
+    ENV.featureFlags['search'] = true;
+    ENV.featureFlags['static-credentials'] = true;
     ENV.featureFlags['byow'] = true;
+    ENV.featureFlags['ssh-target'] = true;
   }
 
   if (environment === 'test') {
@@ -145,7 +148,10 @@ module.exports = function (environment) {
     ENV.enableConfirmService = false;
 
     // Enable tests for development features
+    ENV.featureFlags['search'] = true;
+    ENV.featureFlags['static-credentials'] = true;
     ENV.featureFlags['byow'] = true;
+    ENV.featureFlags['ssh-target'] = true;
   }
 
   if (environment === 'production') {

--- a/ui/admin/config/environment.js
+++ b/ui/admin/config/environment.js
@@ -7,7 +7,6 @@ const EDITION = process.env.EDITION || 'oss'; // Default edition is OSS
 // Object that defines edition features.
 const featureEditions = {
   oss: {
-    search: false,
     'static-credentials': true,
     byow: false,
   },
@@ -125,7 +124,6 @@ module.exports = function (environment) {
     };
 
     // Enable features in development
-    ENV.featureFlags['search'] = true;
     ENV.featureFlags['static-credentials'] = true;
     ENV.featureFlags['byow'] = true;
     ENV.featureFlags['ssh-target'] = true;
@@ -148,7 +146,6 @@ module.exports = function (environment) {
     ENV.enableConfirmService = false;
 
     // Enable tests for development features
-    ENV.featureFlags['search'] = true;
     ENV.featureFlags['static-credentials'] = true;
     ENV.featureFlags['byow'] = true;
     ENV.featureFlags['ssh-target'] = true;


### PR DESCRIPTION
Add feature flags for development and test environments.

## Description

### Context:
Feature flags gives us the avility to turn `ON` or `OFF` different feature flags depending on the Boundary UI edition (OSS, enterprise and HCP) we want to build/deploy.

### Problem:
Within development and test environments not all the feature flags are turned `ON`.

This makes more difficult some of the development tasks. 

Also makes Admin UI Vercel deployment to not show all the features. Remember Vercel deployment reflects a development environment.

### Solution:
Override all the new feature flags: `static-credentials`, `byow` and `ssh-target` within `development` and `test` environments.

This way ALL features will be available at development and test time. Also Admin UI Vercel deployment will have all these features available.

### Screenshots:

On the screenshots you can see the `featureFlags` values:

Vercel deployment BEFORE this PR (so NOT all featureFlags are turned on):
<img width="1680" alt="vercel-before-changes" src="https://user-images.githubusercontent.com/9775006/189353926-9476b47b-8a97-4e7b-9fcd-305b33d37657.png">

Vercel deployment AFTER this PR (so ALL featureFlags are turned on):
<img width="1680" alt="Screen Shot 2022-09-09 at 2 17 32 PM" src="https://user-images.githubusercontent.com/9775006/189354254-6467466f-5227-4ba5-89ed-e38995769f77.png">

