### PR TITLE
feat: 🎸 Show worker version UI

### DIFF
--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -43,6 +43,7 @@ session_connection_limit:
   help: The maximum number of connections allowed per session.  For unlimited, specify "-1".
 worker_version:
   label: Version
+  help: The version number of the worker.
 worker_authorized_actions:
   label: Authorized Actions
 worker_last_seen:

--- a/ui/admin/app/components/form/worker/index.hbs
+++ b/ui/admin/app/components/form/worker/index.hbs
@@ -77,6 +77,21 @@
       readonly={{true}}
     />
   {{/let}}
+  <form.select
+    @name='version'
+    @value={{@model.version}}
+    @label={{t 'form.worker_version.label'}}
+    @helperText='Set your desired color'
+    @disabled={{false}}
+    @error={{false}}
+    as |field|
+  >
+   <field.field as |select|>
+      {{#each @model.version as |version|}}
+        <select.option @value={{version}}>{{version}}</select.option>
+      {{/each}}
+    </field.field>
+  </form.select>
 
   {{#if (can 'save worker' @model)}}
     <form.actions

--- a/ui/admin/app/components/form/worker/index.hbs
+++ b/ui/admin/app/components/form/worker/index.hbs
@@ -77,21 +77,16 @@
       readonly={{true}}
     />
   {{/let}}
-  <form.select
+
+  <form.input
     @name='version'
+    @type='text'
     @value={{@model.version}}
     @label={{t 'form.worker_version.label'}}
-    @helperText='Set your desired color'
-    @disabled={{false}}
-    @error={{false}}
-    as |field|
-  >
-   <field.field as |select|>
-      {{#each @model.version as |version|}}
-        <select.option @value={{version}}>{{version}}</select.option>
-      {{/each}}
-    </field.field>
-  </form.select>
+    @helperText={{t 'form.worker_version.help'}}
+    @disabled={{true}}
+    readonly={{true}}
+  />
 
   {{#if (can 'save worker' @model)}}
     <form.actions

--- a/ui/admin/app/templates/scopes/scope/workers/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/index.hbs
@@ -84,6 +84,7 @@
             <row.headerCell>{{t
                 'resources.worker.table.session_count'
               }}</row.headerCell>
+            <row.headerCell>{{t 'form.worker_version.label'}}</row.headerCell>
             <row.headerCell>{{t
                 'resources.worker.table.ip_address'
               }}</row.headerCell>
@@ -125,6 +126,7 @@
 
               <row.cell>{{worker.type}}</row.cell>
               <row.cell>{{worker.active_connection_count}}</row.cell>
+              <row.cell>{{worker.version}}</row.cell>
               <row.cell>{{worker.address}} </row.cell>
             </body.row>
           {{/each}}


### PR DESCRIPTION
Show worker version in `admin/ui`

✅ Closes: ICU-4156

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-4156)

## Description
- Adding read-only version of worker to admin-ui as a column on the `list-view` and as a read-only input field on `detailed-worker-view`

:computer: [Vercel](https://boundary-ui-git-icu-5682-show-worker-version-in-ui-hashicorp.vercel.app/)

### Screenshots (if appropriate):

