### PR TITLE
ICU 6044 Update detailed worker view

### DIFF
--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -41,8 +41,9 @@ session_max_seconds:
 session_connection_limit:
   label: Maximum Connections
   help: The maximum number of connections allowed per session.  For unlimited, specify "-1".
-worker_version:
-  label: Version
+worker_release_version:
+  label: Release Version
+  help: The version of the Boundary binary the worker is running.
 worker_authorized_actions:
   label: Authorized Actions
 worker_last_seen:

--- a/ui/admin/app/components/form/worker/index.hbs
+++ b/ui/admin/app/components/form/worker/index.hbs
@@ -78,6 +78,15 @@
     />
   {{/let}}
 
+  <form.input
+      @name='release version'
+      @value={{@model.release_version}}
+      @label={{t 'form.worker_release_version.label'}}
+      @helperText={{t 'form.worker_release_version.help'}}
+      @disabled={{true}}
+      readonly={{true}}
+    />
+
   {{#if (can 'save worker' @model)}}
     <form.actions
       @enableEditText={{t 'actions.edit-form'}}


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-6046)

## Description
- Update `detailed-worker-view` to show Boundary resource `release_version` in a read-only input field

<!-- Add a brief description of changes here. Include any other necessary relevant links -->

### Screenshots (if appropriate):

<img width="1480" alt="Screen Shot 2022-09-13 at 13 55 22" src="https://user-images.githubusercontent.com/24277002/189976355-87367d81-6c52-4201-ab78-1238f5899df0.png">
