### PR TITLE
Refactor host-catalog/host-sets/host-set/hosts template

### DIFF
--- a/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/index.hbs
@@ -1,91 +1,104 @@
-{{#if @model.hosts}}
+<Rose::Layout::Page as |page|>
+  <page.breadcrumbs>
+    <BreadCrumbs />
+  </page.breadcrumbs>
 
-  <Rose::Table as |table|>
-    <table.header as |header|>
-      <header.row as |row|>
-        <row.headerCell>{{t 'form.name.label'}}</row.headerCell>
-        <row.headerCell>{{t 'form.type.label'}}</row.headerCell>
-        <row.headerCell>{{t 'form.id.label'}}</row.headerCell>
-        {{#if @model.isStatic}}
-          <row.headerCell>{{t 'titles.actions'}}</row.headerCell>
-        {{/if}}
-      </header.row>
-    </table.header>
-    <table.body as |body|>
-      {{#each @model.hosts as |host|}}
-        <body.row as |row|>
-          <row.headerCell>
-            {{#if host.isStatic}}
-              <LinkTo
-                @route='scopes.scope.host-catalogs.host-catalog.hosts.host'
-                @model={{host.id}}
-              >
-                {{host.displayName}}
-              </LinkTo>
-            {{else}}
-              {{! Link to a different subroute for dynamic/plugin hosts }}
-              <LinkTo
-                @route='scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts.host'
-                @model={{host.id}}
-              >
-                {{host.displayName}}
-              </LinkTo>
+  <page.header>
+    <HostCatalogs::HostCatalog::HostSets::HostSet::Header @model={{@model.hostSet}} />
+  </page.header>
+
+  <page.actions>
+    <HostCatalogs::HostCatalog::HostSets::HostSet::Actions @model={{@model}} />
+  </page.actions>
+
+  <page.navigation>
+    <HostCatalogs::HostCatalog::HostSets::HostSet::Navigation @model={{@model}} />
+  </page.navigation>
+
+  <page.body>
+    {{#if @model.hosts}}
+      <Rose::Table as |table|>
+        <table.header as |header|>
+          <header.row as |row|>
+            <row.headerCell>{{t 'form.name.label'}}</row.headerCell>
+            <row.headerCell>{{t 'form.type.label'}}</row.headerCell>
+            <row.headerCell>{{t 'form.id.label'}}</row.headerCell>
+            {{#if @model.isStatic}}
+              <row.headerCell>{{t 'titles.actions'}}</row.headerCell>
             {{/if}}
-            <p>{{host.description}}</p>
-          </row.headerCell>
-          <row.cell>
-            <HostCatalogTypeBadge @model={{host}} />
-          </row.cell>
-          <row.cell>
-            <Copyable
-              @text={{host.id}}
-              @buttonText={{t 'actions.copy-to-clipboard'}}
-              @acknowledgeText={{t 'states.copied'}}
-            >
-              <code>{{host.id}}</code>
-            </Copyable>
-          </row.cell>
-          <row.cell>
-            {{#if (can 'removeHosts hostSet' @model.hostSet)}}
-              <Rose::Dropdown
-                @icon='flight-icons/svg/more-horizontal-16'
-                @iconOnly={{true}}
-                @showCaret={{false}}
-                @dropdownRight={{true}}
-                @text={{t 'actions.manage'}}
-                as |dropdown|
-              >
-                <dropdown.button
-                  @style='danger'
-                  {{on 'click' (route-action 'removeHost' @model.hostSet host)}}
+          </header.row>
+        </table.header>
+
+        <table.body as |body|>
+          {{#each @model.hosts as |host|}}
+            <body.row as |row|>
+              <row.headerCell>
+                {{#if host.isStatic}}
+                  <LinkTo
+                    @route='scopes.scope.host-catalogs.host-catalog.hosts.host'
+                    @model={{host.id}}
+                  >
+                    {{host.displayName}}
+                  </LinkTo>
+                {{else}}
+                  {{! Link to a different subroute for dynamic/plugin hosts }}
+                  <LinkTo
+                    @route='scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts.host'
+                    @model={{host.id}}
+                  >
+                    {{host.displayName}}
+                  </LinkTo>
+                {{/if}}
+                <p>{{host.description}}</p>
+              </row.headerCell>
+              <row.cell>
+                <HostCatalogTypeBadge @model={{host}} />
+              </row.cell>
+              <row.cell>
+                <Copyable
+                  @text={{host.id}}
+                  @buttonText={{t 'actions.copy-to-clipboard'}}
+                  @acknowledgeText={{t 'states.copied'}}
                 >
-                  {{t 'actions.remove'}}
-                </dropdown.button>
-              </Rose::Dropdown>
-            {{/if}}
-          </row.cell>
-        </body.row>
-      {{/each}}
-    </table.body>
-  </Rose::Table>
+                  <code>{{host.id}}</code>
+                </Copyable>
+              </row.cell>
+              <row.cell>
+                {{#if (can 'removeHosts hostSet' @model.hostSet)}}
+                  <Rose::Dropdown
+                    @icon='flight-icons/svg/more-horizontal-16'
+                    @iconOnly={{true}}
+                    @showCaret={{false}}
+                    @dropdownRight={{true}}
+                    @text={{t 'actions.manage'}}
+                    as |dropdown|
+                  >
+                    <dropdown.button
+                      @style='danger'
+                      {{on 'click' (route-action 'removeHost' @model.hostSet host)}}
+                    >
+                      {{t 'actions.remove'}}
+                    </dropdown.button>
+                  </Rose::Dropdown>
+                {{/if}}
+              </row.cell>
+            </body.row>
+          {{/each}}
+        </table.body>
+      </Rose::Table>
+    {{/if}}
 
-{{/if}}
-
-{{#unless @model.hosts}}
-  <Rose::Layout::Centered>
-    <Rose::Message
-      @title={{t 'resources.host-set.host.messages.none.title'}}
-      as |message|
-    >
-      <message.description>
-        {{t 'resources.host-set.host.messages.none.description'}}
-      </message.description>
-      {{!--
-      <message.link @route="scopes.scope.host-catalogs.host-catalog.host-sets.host-set.create-and-add-host">
-        <Rose::Icon @name="flight-icons/svg/plus-circle-16" />
-        {{t "resources.host-set.actions.create-and-add-host"}}
-      </message.link>
-      --}}
-    </Rose::Message>
-  </Rose::Layout::Centered>
-{{/unless}}
+    {{#unless @model.hosts}}
+      <Rose::Layout::Centered>
+        <Rose::Message
+          @title={{t 'resources.host-set.host.messages.none.title'}}
+          as |message|
+        >
+          <message.description>
+            {{t 'resources.host-set.host.messages.none.description'}}
+          </message.description>
+        </Rose::Message>
+      </Rose::Layout::Centered>
+    {{/unless}}
+  </page.body>
+</Rose::Layout::Page>


### PR DESCRIPTION

## Description

This is a transitory PR while working on `refactor-deprecate-renderTemplate`.

PR Fixes template host-catalog/host-sets/host-set/hosts template.

## Why a PR that breaks stuff?

We are refactoring templates and the current implementation (named outlets) assumes some parent templates nesting parts of the child (like header, actions or navigation). 

With the new implementation, we need to refactor from top to bottom, so from parent to child. In the meantime, some child views (i.e. hosts/host/new) look broken for missing the mentioned nested parts.

Some Acceptance tests are not passing either due to side effects caused by the reasons mentioned above.

BE AWARE this will NOT be merge to `main` but to `refactor-deprecate-rendertemplate`.