### PR TITLE
chore: 🤖 update mout resolution to 1.2.4 for security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "ember-template-recast": "^6.0.0",
     "engine.io": "^5.2.1",
     "markdown-it": "^12.3.2",
-    "mout": "^1.2.3",
+    "mout": "^1.2.4",
     "nanoid": "^3.1.31",
     "plist": "^3.0.5",
     "lzma-native": "^8.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19861,10 +19861,10 @@ morgan@^1.10.0:
     on-finished "~2.3.0"
     on-headers "~1.0.2"
 
-mout@^1.0.0, mout@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/mout/-/mout-1.2.3.tgz#bd1477d8c7f2db5fcf43c91de30b6cc746b78e10"
-  integrity sha512-vtE+eZcSj/sBkIp6gxB87MznryWP+gHIp0XX9SKrzA5TAkvz6y7VTuNruBjYdJozd8NY5i9XVIsn8cn3SwNjzg==
+mout@^1.0.0, mout@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/mout/-/mout-1.2.4.tgz#9ffd261c4d6509e7ebcbf6b641a89b36ecdf8155"
+  integrity sha512-mZb9uOruMWgn/fw28DG4/yE3Kehfk1zKCLhuDU2O3vlKdnBBr4XaOCqVTflJ5aODavGUPqFHZgrFX3NJVuxGhQ==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Resolves this [high risk security issue](https://github.com/hashicorp/boundary-ui/security/dependabot/41).
