### PR TITLE
fix: 🐛 stop sending scope_id on cred libraries - ICU-6159

### DIFF
--- a/addons/api/addon/serializers/credential-library.js
+++ b/addons/api/addon/serializers/credential-library.js
@@ -1,6 +1,13 @@
 import ApplicationSerializer from './application';
 
 export default class CredentialLibrarySerializer extends ApplicationSerializer {
+  // =properties
+
+  /**
+   * @type {boolean}
+   */
+  serializeScopeID = false;
+
   /**
    * @override
    * @method serialize


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-6159)

## Description

Fixes a bug where credential libraries incorrectly serialize a `scope_id` on save.