### PR TITLE
fix: 🐛 Add back div to fix tag icon badge layout

### DIFF
--- a/ui/admin/app/templates/scopes/scope/workers/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/index.hbs
@@ -120,12 +120,14 @@
                   <p>{{worker.description}}</p>
                 {{/if}}
                 {{#if worker.tagCount}}
-                  <Rose::Badge @icon='flight-icons/svg/tag-16'>
-                    {{t
-                      'resources.worker.table.tag_count'
-                      tagCount=worker.tagCount
-                    }}
-                  </Rose::Badge>
+                  <div>
+                    <Rose::Badge @icon='flight-icons/svg/tag-16'>
+                      {{t
+                        'resources.worker.table.tag_count'
+                        tagCount=worker.tagCount
+                      }}
+                    </Rose::Badge>
+                  </div>
                 {{/if}}
               </row.headerCell>
               <row.cell>


### PR DESCRIPTION
## Description

Fix an issue with the tag badge not correctly wrapping to a new line. Removed a div by accident which caused the tag to become inline when there's no description for the worker. 

### Screenshots (if appropriate):

<img width="266" alt="image" src="https://user-images.githubusercontent.com/5783847/191854629-f0e4e16a-b189-4a7d-88d2-b8391bc833a5.png">

<img width="224" alt="image" src="https://user-images.githubusercontent.com/5783847/191854597-d6bd209b-62d5-49c3-a719-92e504d747e4.png">
