### PR TITLE
fix: 🐛 Sort workers when filtering is enabled as well

### DIFF
--- a/ui/admin/app/routes/scopes/scope/workers/index.js
+++ b/ui/admin/app/routes/scopes/scope/workers/index.js
@@ -38,7 +38,7 @@ export default class ScopesScopeWorkersIndexRoute extends Route {
   // =methods
 
   model() {
-    const workers = this.modelFor('scopes.scope.workers');
+    const workers = this.modelFor('scopes.scope.workers').sortBy('displayName');
 
     if (this.tags?.length) {
       // Return workers that have config tags that have at
@@ -57,7 +57,7 @@ export default class ScopesScopeWorkersIndexRoute extends Route {
         );
       });
     }
-    return workers.sortBy('displayName');
+    return workers;
   }
 
   /**


### PR DESCRIPTION
## Description
Quick change to make sure workers are also sorted when filtering. Currently only unfiltered workers are sorted. 
This change will allow filtered workers to also have a stable order when refreshing workers, the filter should preserve order.
