### PR TITLE
fix: 🐛 Fix raw api output not displaying codemirror properly

### DIFF
--- a/addons/rose/addon/modifiers/code-mirror.js
+++ b/addons/rose/addon/modifiers/code-mirror.js
@@ -8,6 +8,7 @@ import 'codemirror/mode/shell/shell';
 import 'codemirror/addon/edit/matchbrackets';
 import 'codemirror/addon/edit/closebrackets';
 import 'codemirror/addon/selection/active-line';
+import 'codemirror/addon/display/autorefresh';
 
 // Here we define default options for the editor.
 // These should follow the codemirror configuration types

--- a/ui/desktop/app/templates/scopes/scope/projects/targets.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets.hbs
@@ -135,6 +135,7 @@
                             lineNumbers=false
                             cursorBlinkRate=-1
                             styleActiveLine=false
+                            autoRefresh=true
                           }}
                         />
                       </Rose::CodeEditor>


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-6249)

## Description
Fixes the raw API output not displaying properly. The issue seems to be a quirk of `code-mirror`. Code mirror listens in on resizing the editor and will handle it accordingly but if it's initialized when the element is hidden initially, it won't know to refresh itself to display properly. Code mirror provides an [autorefresh addon](https://codemirror.net/5/doc/manual.html#addon_autorefresh) to help with this.

This could also have been handled by manually calling refresh whenever we reveal it, but this would require exposing the underlying editor and correctly calling it by knowing when it's visible from our `reveal` component. 