### PR TITLE
chore: 🤖 Allow retrieval of arm64 cli

### DIFF
--- a/ui/desktop/electron-app/config/cli.js
+++ b/ui/desktop/electron-app/config/cli.js
@@ -11,7 +11,7 @@ const downloadArtifact = (version) => {
   const archivePlatform = {};
   if (isMac()) {
     archivePlatform.name = 'darwin';
-    archivePlatform.arch = 'amd64';
+    archivePlatform.arch = os.arch();
   }
 
   if (isWindows()) {


### PR DESCRIPTION
## Description
This will allow using the arm64 cli for m1 macs. This can sometimes be a painpoint as using the `amd64` cli on m1 macs can sometimes return a rosetta error and if you're using the desktop client it will silently fail and you won't know what the issue is. 

See this [thread](https://hashicorp.slack.com/archives/C012GTH1C4E/p1664381734699799) for more info.

There was some hesitancy as this might enable building for arm64 but it looks like we're _already_ doing that with `electron-forge`. I was originally going to flag the arch for the boundary CLI based off of maybe a production env variable or flag but the default setting in `electron-forge` won't let us set the `arch` anyways so didn't see much point, see this [documentation](https://www.electronforge.io/configuration#packager-config). I can manually override it by setting it through the CLI but not through config it seems.

I would be interested in hearing why we use `electron-forge` over something like `electron-builder` which shouldn't require us to build on a specific platform in our CI and just generate all of the exectuables. I added this to tech time already.

