### PR TITLE
refactor: 💡 Update IPC mock for desktop client

### DIFF
--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -18,11 +18,6 @@ export default function () {
   // delay for each request, automatically set to 0 during testing
   this.timing = 1;
 
-  // Allow any configured API host to passthrough, which is useful in
-  // development for testing against a locally running backend.
-  if (config.api.host) this.passthrough(`${config.api.host}/**`);
-  this.passthrough();
-
   // Scope resources
 
   this.get(

--- a/addons/api/mirage/scenarios/ipc.js
+++ b/addons/api/mirage/scenarios/ipc.js
@@ -147,9 +147,9 @@ export default function initializeMockIPC(server, config) {
    * main process, and routes messages to it in a way similar to our
    * preload.js script.
    *
-   * Initializes mock IPC only in a non-Electron non-testing context.
+   * Initializes mock IPC only in a non-testing context and when mirage is turned on.
    */
-  if (!config.isElectron && !isTesting) {
+  if (config['ember-cli-mirage'].enabled && !isTesting) {
     const mockIPC = new MockIPC();
     window.addEventListener('message', async function (event) {
       if (event.origin !== window.location.origin) return;

--- a/ui/admin/config/environment.js
+++ b/ui/admin/config/environment.js
@@ -123,6 +123,10 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
 
+    ENV['ember-cli-mirage'].enabled = process.env.ENABLE_MIRAGE
+      ? JSON.parse(process.env.ENABLE_MIRAGE)
+      : true;
+
     ENV['ember-a11y-testing'] = {
       componentOptions: {
         axeOptions: {

--- a/ui/desktop/config/environment.js
+++ b/ui/desktop/config/environment.js
@@ -63,10 +63,6 @@ module.exports = function (environment) {
     },
   };
 
-  if (process.env.ENABLE_MIRAGE) {
-    ENV['ember-cli-mirage'].enabled = JSON.parse(process.env.ENABLE_MIRAGE);
-  }
-
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
@@ -78,6 +74,10 @@ module.exports = function (environment) {
     // of the UI, which only makes sense in development where the origin is
     // usually the same as the application origin.
     ENV.autoOrigin = true;
+
+    ENV['ember-cli-mirage'].enabled = process.env.ENABLE_MIRAGE
+      ? JSON.parse(process.env.ENABLE_MIRAGE)
+      : true;
 
     // Enable features in development
   }


### PR DESCRIPTION
## Description
The goal of this PR is to enable the IPC mock for desktop client as right now if you run the DC locally with electron, there's no way to use the IPC mock and have target connection be mocked.

However, there is some interesting behavior I found a bit perplexing which I changed to be consistent across desktop and admin:
- The `ENABLE_MIRAGE` env variable isn't actually being used at all in admin, it's solely the `API_HOST` which determines if we will use mirage. I found this a bit misleading as our README implies that `ENABLE_MIRAGE` needs to be false alongside `API_HOST`.
  - This is half true as there's no actual way to turn off mirage in admin, we just have requests passthrough
- In development for both admin and desktop, I parse the `ENABLE_MIRAGE` env variable and if there's no variable set, default it to true
  - I want  `ember-cli-mirage`  to always have a value of `true` or `false` in dev so we can check it correctly to determine if we're using mirage, i.e. no undefined or null from not setting `ENABLE_MIRAGE`
- I removed the passthroughs completely
  - Using an `API_HOST` should require mirage to be off and therefore no passthroughs should be needed. 

Nothing should change for production environments. 
