### PR TITLE
Chore update ember cli dependency checker addon

### DIFF
--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -45,7 +45,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "doctoc": "^2.2.0",
     "ember-cli": "^4.4.0",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",

--- a/addons/auth/package.json
+++ b/addons/auth/package.json
@@ -37,7 +37,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "doctoc": "^2.2.0",
     "ember-cli": "^4.4.0",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",

--- a/addons/core/package.json
+++ b/addons/core/package.json
@@ -55,7 +55,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "doctoc": "^2.2.0",
     "ember-cli": "^4.4.0",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -69,7 +69,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "doctoc": "^2.2.0",
     "ember-cli": "^4.4.0",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -59,7 +59,7 @@
     "ember-cli-babel": "^7.26.8",
     "ember-cli-code-coverage": "^1.0.3",
     "ember-cli-content-security-policy": "^2.0.3",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-flash": "^4.0.0",
     "ember-cli-htmlbars": "^6.1.0",
     "ember-cli-inject-live-reload": "^2.1.0",

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -77,7 +77,7 @@
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.8",
     "ember-cli-code-coverage": "^1.0.3",
-    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-flash": "^4.0.0",
     "ember-cli-htmlbars": "^6.1.0",
     "ember-cli-inject-live-reload": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12020,6 +12020,17 @@ ember-cli-dependency-checker@^3.2.0:
     resolve "^1.5.0"
     semver "^5.3.0"
 
+ember-cli-dependency-checker@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-dependency-checker/-/ember-cli-dependency-checker-3.3.1.tgz#16b44d7a1a1e946f59859fad97f32e616d78323a"
+  integrity sha512-Tg6OeijjXNKWkDm6057Tr0N9j9Vlz/ITewXWpn1A/+Wbt3EowBx5ZKfvoupqz05EznKgL1B/ecG0t+JN7Qm6MA==
+  dependencies:
+    chalk "^2.3.0"
+    find-yarn-workspace-root "^1.1.0"
+    is-git-url "^1.0.0"
+    resolve "^1.5.0"
+    semver "^5.3.0"
+
 ember-cli-flash@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-flash/-/ember-cli-flash-4.0.0.tgz#e6886a9a76718c7740942eb812d3f5427f15760d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12009,17 +12009,6 @@ ember-cli-content-security-policy@^2.0.3:
     ember-cli-babel "^7.26.3"
     ember-cli-version-checker "^5.0.2"
 
-ember-cli-dependency-checker@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-dependency-checker/-/ember-cli-dependency-checker-3.2.0.tgz#9202ad9e14d6fda33cffc22a11c343c2a8885330"
-  integrity sha512-dkSmcJ/jY/2ms/S6ph2jXSfOW5VfOpLfg5DFEbra0SaMNgYkNDFF1o0U4OdTsG37L5h/AXWNuVtnOa4TMabz9Q==
-  dependencies:
-    chalk "^2.3.0"
-    find-yarn-workspace-root "^1.1.0"
-    is-git-url "^1.0.0"
-    resolve "^1.5.0"
-    semver "^5.3.0"
-
 ember-cli-dependency-checker@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-dependency-checker/-/ember-cli-dependency-checker-3.3.1.tgz#16b44d7a1a1e946f59859fad97f32e616d78323a"


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-6330)

## Description

Update `ember-cli-dependency-checker` to the latest version, so it does not use `bowerDependencies` anymore and we do not get any more deprecation messages.

### Screenshots (if appropriate):

Addon/api deprecation message before the changes:
<img width="1654" alt="addons-api-before" src="https://user-images.githubusercontent.com/9775006/194002849-7b2aa201-0736-4620-8981-7eac705fd973.png">

Addon/api with no more deprecation message after the changes:
<img width="1672" alt="addons-api-after" src="https://user-images.githubusercontent.com/9775006/194002955-84b69605-e49f-43bd-80d7-af132f03c6c5.png">

Addon/auth deprecation message before the changes:
<img width="1680" alt="addons-auth-before" src="https://user-images.githubusercontent.com/9775006/194003177-9618357e-6f1f-48d3-b31c-21daa64f68ba.png">

Addon/auth with no more deprecation message after the changes:
<img width="1680" alt="addons-auth-after" src="https://user-images.githubusercontent.com/9775006/194003253-892dc689-414c-4957-9505-82d155f5b25a.png">

Addon/core deprecation message before the changes:
<img width="1490" alt="addons-core-before" src="https://user-images.githubusercontent.com/9775006/194003427-9a57a33a-6846-4c49-aa87-4c3abf3299fa.png">

Addon/core with no more deprecation message after the changes:
<img width="1499" alt="addons-core-after" src="https://user-images.githubusercontent.com/9775006/194003460-5b6db9f1-5373-4483-a255-21ca855eda26.png">


Addon/rose deprecation message before the changes:
<img width="1668" alt="addons-rose-before" src="https://user-images.githubusercontent.com/9775006/194003488-26a5d0ad-cca0-4697-bff9-b627606917d0.png">

Addon/rose with no more deprecation message after the changes:
<img width="1467" alt="addons-rose-after" src="https://user-images.githubusercontent.com/9775006/194003514-e3ab55bf-d104-4137-971d-a91e8605f992.png">


Admin UI deprecation message before the changes:
<img width="1680" alt="adminui-before" src="https://user-images.githubusercontent.com/9775006/194003537-e99defce-aa2d-4ab7-9d98-4ce0f0708a8d.png">

Admin UI with no more deprecation message after the changes:
<img width="1483" alt="admin-ui-after" src="https://user-images.githubusercontent.com/9775006/194003559-488cbbc1-77a2-49d2-9144-521799590af3.png">


Desktop UI deprecation message before the changes:
<img width="1680" alt="desktopui-before" src="https://user-images.githubusercontent.com/9775006/194003589-ec18d742-85f0-4ac0-af80-205e69f16de6.png">

Desktop UI with no more deprecation message after the changes:
<img width="1675" alt="desktopui-after" src="https://user-images.githubusercontent.com/9775006/194003614-ee7a25ae-496d-41f0-95ff-0e973bed3521.png">



