### PR TITLE
[ICU-6448] Update CSP to add frame-ancestors: self

### DIFF
--- a/ui/admin/config/content-security-policy.js
+++ b/ui/admin/config/content-security-policy.js
@@ -15,6 +15,7 @@ module.exports = function (environment) {
     'media-src': ["'self'"],
     'manifest-src': ["'self'"],
     'style-src-attr': ["'self'"],
+    'frame-ancestors': ["'self'"],
   };
 
   // Unsafe policy is necessary in development and test environments, but should

--- a/ui/desktop/electron-app/src/config/content-security-policy.js
+++ b/ui/desktop/electron-app/src/config/content-security-policy.js
@@ -11,6 +11,7 @@ const csp = {
   'style-src': ["'self'"],
   'media-src': ["'self'"],
   'manifest-src': ["'self'"],
+  'frame-ancestors': ["'self'"],
 };
 
 // Dev policy is necessary for Ember live reload.


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-6348)

Adds [frame-ancestors directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) to the CSP headers.
