### PR TITLE
Chore rose storybook deprecations

### DIFF
--- a/addons/rose/.storybook/main.js
+++ b/addons/rose/.storybook/main.js
@@ -2,7 +2,7 @@ const namedBlockPolyfill = require('ember-named-blocks-polyfill/lib/named-blocks
 
 module.exports = {
   stories: [
-    '../addon/components/**/*.stories.(js|mdx)',
+    '../addon/components/**/*.stories.@(js|mdx)',
     '../stories/**/*.stories.mdx',
   ],
   addons: [

--- a/addons/rose/.storybook/main.js
+++ b/addons/rose/.storybook/main.js
@@ -14,4 +14,7 @@ module.exports = {
   emberOptions: {
     polyfills: [namedBlockPolyfill],
   },
+  features: {
+    postcss: false,
+  },
 };

--- a/addons/rose/addon/components/rose/anonymous/index.stories.mdx
+++ b/addons/rose/addon/components/rose/anonymous/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Anonymous" component="Anonymous" />
+<Meta title="Rose/Anonymous" component="Anonymous" />
 
 # Anonymous
 
@@ -15,11 +15,19 @@ For example, layout components may yield an anonymous component to configure
 various layout regions:
 
 ```htmlbars
-<div ...attributes class="rose-layout-global">
-  {{yield (hash
-    header=(component "rose/anonymous" tagName="header" class="rose-layout-global-header")
-    sidebar=(component "rose/anonymous" tagName="aside" class="rose-layout-global-sidebar")
-    body=(component "rose/anonymous" tagName="main" class="rose-layout-global-body")
-  )}}
+<div ...attributes class='rose-layout-global'>
+  {{yield
+    (hash
+      header=(component
+        'rose/anonymous' tagName='header' class='rose-layout-global-header'
+      )
+      sidebar=(component
+        'rose/anonymous' tagName='aside' class='rose-layout-global-sidebar'
+      )
+      body=(component
+        'rose/anonymous' tagName='main' class='rose-layout-global-body'
+      )
+    )
+  }}
 </div>
 ```

--- a/addons/rose/addon/components/rose/badge/index.stories.mdx
+++ b/addons/rose/addon/components/rose/badge/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Badge" component="Badge" />
+<Meta title="Rose/Badge" component="Badge" />
 
 # Badge
 
@@ -13,47 +13,56 @@ When style definition isn't supplied, a default style will be supplied.
 Styles: outline, dark, informational, informational-outline, success, success-outline, error, error-outline, warning, warning-outline, alert, alert-outline
 
 ```html
-<Rose::Badge @style="outline" @icon="flight-icons/svg/org-16">Badge</Rose::Badge>
+<Rose::Badge @style="outline" @icon="flight-icons/svg/org-16"
+  >Badge</Rose::Badge
+>
 ```
 
 <Preview>
-  <Story name="Basic">{{
-    template: hbs`<Rose::Badge
+  <Story name="Basic">
+    {{
+      template: hbs`<Rose::Badge
       @style={{style}}
       @icon={{icon}}>
       {{text}}
       </Rose::Badge>`,
-    context: {
-      text: text('text', 'Badge'),
-      style: select('style', {
-          'none': 'none',
-          'outline': 'outline',
-          'dark': 'dark',
-          'informational': 'informational',
-          'informational-outline': 'informational-outline',
-          'success': 'success',
-          'success-outline': 'success-outline',
-          'alert': 'alert',
-          'alert-outline': 'alert-outline',
-          'error': 'error',
-          'error-outline': 'error-outline',
-          'warning': 'warning',
-          'warning-outline': 'warning-outline',
-        },
-        'none'
-      ),
-      icon: select('icon', {
-          'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
-        },
-        'flight-icons/svg/org-16'
-      ),
-    }
-  }}</Story>
+      context: {
+        text: text('text', 'Badge'),
+        style: select(
+          'style',
+          {
+            none: 'none',
+            outline: 'outline',
+            dark: 'dark',
+            informational: 'informational',
+            'informational-outline': 'informational-outline',
+            success: 'success',
+            'success-outline': 'success-outline',
+            alert: 'alert',
+            'alert-outline': 'alert-outline',
+            error: 'error',
+            'error-outline': 'error-outline',
+            warning: 'warning',
+            'warning-outline': 'warning-outline',
+          },
+          'none'
+        ),
+        icon: select(
+          'icon',
+          {
+            'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
+          },
+          'flight-icons/svg/org-16'
+        ),
+      },
+    }}
+  </Story>
 </Preview>
 
 <Preview>
-  <Story name="Style legend">{{
-    template: hbs`
+  <Story name="Style legend">
+    {{
+      template: hbs`
     <Rose::Badge>default style</Rose::Badge>
     <Rose::Badge @style="outline">outline</Rose::Badge>
     <Rose::Badge @icon="flight-icons/svg/org-16">default style with icon</Rose::Badge>
@@ -69,5 +78,6 @@ Styles: outline, dark, informational, informational-outline, success, success-ou
     <Rose::Badge @style="warning">warning</Rose::Badge>
     <Rose::Badge @style="warning-outline">warning-outline</Rose::Badge>
     `,
-  }}</Story>
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/button/index.stories.mdx
+++ b/addons/rose/addon/components/rose/button/index.stories.mdx
@@ -1,25 +1,26 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Button" component="Button" />
+<Meta title="Rose/Button" component="Button" />
 
 # Button
 
-A simple button component that renders an HTML `<button>` element.  May be used
-to trigger actions or to submit forms.  Avoid using buttons as simple links to
-other routes.  For accessibility, use links instead.
+A simple button component that renders an HTML `<button>` element. May be used
+to trigger actions or to submit forms. Avoid using buttons as simple links to
+other routes. For accessibility, use links instead.
 
 ```htmlbars
-<Rose::Button @style="primary" @iconRight="flight-icons/svg/entry-point-16">
+<Rose::Button @style='primary' @iconRight='flight-icons/svg/entry-point-16'>
   Action
 </Rose::Button>
 ```
 
 <Preview>
-  <Story name="Advanced">{{
-    template: hbs`
+  <Story name="Advanced">
+    {{
+      template: hbs`
       <Rose::Button
         @submit={{submit}}
         @disabled={{disabled}}
@@ -31,61 +32,70 @@ other routes.  For accessibility, use links instead.
         {{text}}
       </Rose::Button>
     `,
-    context: {
-      text: text('text', 'Action'),
-      submit: boolean('submit', true),
-      disabled: boolean('disabled', false),
-      style: select(
-        'style',
-        {
-          primary: 'primary',
-          secondary: 'secondary',
-          warning: 'warning',
-          ghost: 'ghost',
-          'inline-link-action': 'inline-link-action',
-        },
-        'primary'
-      ),
-      iconLeft: select(
-        'iconLeft',
-        {
-          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
-          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
-        },
-        'flight-icons/svg/check-circle-16'
-      ),
-      iconRight: select(
-        'iconRight',
-        {
-          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
-          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
-        },
-        'flight-icons/svg/clipboard-copy-16'
-      ),
-      onClick: action('clicked'),
-    },
-  }}</Story>
+      context: {
+        text: text('text', 'Action'),
+        submit: boolean('submit', true),
+        disabled: boolean('disabled', false),
+        style: select(
+          'style',
+          {
+            primary: 'primary',
+            secondary: 'secondary',
+            warning: 'warning',
+            ghost: 'ghost',
+            'inline-link-action': 'inline-link-action',
+          },
+          'primary'
+        ),
+        iconLeft: select(
+          'iconLeft',
+          {
+            'flight-icons/svg/check-circle-16':
+              'flight-icons/svg/check-circle-16',
+            'flight-icons/svg/clipboard-copy-16':
+              'flight-icons/svg/clipboard-copy-16',
+          },
+          'flight-icons/svg/check-circle-16'
+        ),
+        iconRight: select(
+          'iconRight',
+          {
+            'flight-icons/svg/check-circle-16':
+              'flight-icons/svg/check-circle-16',
+            'flight-icons/svg/clipboard-copy-16':
+              'flight-icons/svg/clipboard-copy-16',
+          },
+          'flight-icons/svg/clipboard-copy-16'
+        ),
+        onClick: action('clicked'),
+      },
+    }}
+  </Story>
 </Preview>
 
-Buttons may show only an icon.  You should still pass block content into the
+Buttons may show only an icon. You should still pass block content into the
 button in this case for accessibility.
 
 <Preview>
-  <Story name="Icon Only">{{
-    template: hbs`
+  <Story name="Icon Only">
+    {{
+      template: hbs`
       <Rose::Button @style="secondary" @iconOnly={{iconOnly}}>
         Icon Only
       </Rose::Button>
     `,
-    context: {
-      iconOnly: select(
-        'iconOnly',
-        {
-          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
-          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
-        },
-        'flight-icons/svg/check-circle-16'
-      ),
-    },
-  }}</Story>
+      context: {
+        iconOnly: select(
+          'iconOnly',
+          {
+            'flight-icons/svg/check-circle-16':
+              'flight-icons/svg/check-circle-16',
+            'flight-icons/svg/clipboard-copy-16':
+              'flight-icons/svg/clipboard-copy-16',
+          },
+          'flight-icons/svg/check-circle-16'
+        ),
+      },
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/card/link/index.stories.mdx
+++ b/addons/rose/addon/components/rose/card/link/index.stories.mdx
@@ -1,8 +1,8 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { text, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Card|Link" component="Link" />
+<Meta title="Rose/Card/Link" component="Link" />
 
 # Card Link
 
@@ -10,16 +10,18 @@ Card link component wraps content with `LinkTo` component. Supports title and de
 
 ```html
 <Rose::Card::Link
-  @title='Card title'
-  @description='Card description'
-  @id='resource_id_1234'
-  @icon='flight-icons/svg/org-16'
-  @route='about'/>
+  @title="Card title"
+  @description="Card description"
+  @id="resource_id_1234"
+  @icon="flight-icons/svg/org-16"
+  @route="about"
+/>
 ```
 
 <Preview>
-  <Story name="Basic">{{
-    template: hbs`
+  <Story name="Basic">
+    {{
+      template: hbs`
       <Rose::Card::Link
         @title={{title}}
         @description={{description}}
@@ -27,17 +29,20 @@ Card link component wraps content with `LinkTo` component. Supports title and de
         @icon={{icon}}
       />
     `,
-    context: {
-      title: text('title', 'Card title'),
-      description: text('description', 'Card description'),
-      id: text('id', 'resource_id_1234'),
-      icon: select('icon', {
-          'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
-        },
-        'flight-icons/svg/org-16'
-      ),
-    },
-  }}</Story>
+      context: {
+        title: text('title', 'Card title'),
+        description: text('description', 'Card description'),
+        id: text('id', 'resource_id_1234'),
+        icon: select(
+          'icon',
+          {
+            'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
+          },
+          'flight-icons/svg/org-16'
+        ),
+      },
+    }}
+  </Story>
 </Preview>
 
 `@route` defaults to 'index' when not supplied.

--- a/addons/rose/addon/components/rose/cards/index.stories.mdx
+++ b/addons/rose/addon/components/rose/cards/index.stories.mdx
@@ -1,17 +1,18 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Cards" component="Cards" />
+<Meta title="Rose/Cards" component="Cards" />
 
 # Cards
 
 A set of cards arranged side-by-side.
 
 <Preview>
-  <Story name="Basic Cards" height="20rem">{{
-    template: hbs`
+  <Story name="Basic Cards" height="20rem">
+    {{
+      template: hbs`
       <Rose::Cards as |cards|>
         <cards.link
           @route="index"
@@ -50,26 +51,26 @@ A set of cards arranged side-by-side.
         />
       </Rose::Cards>
     `,
-    context: {}
-  }}</Story>
+      context: {},
+    }}
+  </Story>
 </Preview>
-
 
 ```htmlbars
 <Rose::Cards as |cards|>
   <cards.link
-    @route="index"
-    @title="Card Title"
-    @description="Description"
-    @id="resource_id_1234"
-    @icon="flight-icons/svg/org-16"
+    @route='index'
+    @title='Card Title'
+    @description='Description'
+    @id='resource_id_1234'
+    @icon='flight-icons/svg/org-16'
   />
   <cards.link
-    @route="index"
-    @title="Card Title"
-    @description="Description"
-    @id="resource_id_1234"
-    @icon="flight-icons/svg/org-16"
+    @route='index'
+    @title='Card Title'
+    @description='Description'
+    @id='resource_id_1234'
+    @icon='flight-icons/svg/org-16'
   />
 </Rose::Cards>
 ```

--- a/addons/rose/addon/components/rose/code-editor/index.stories.mdx
+++ b/addons/rose/addon/components/rose/code-editor/index.stories.mdx
@@ -1,7 +1,7 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 
-<Meta title="Rose|Code Editor" component="CodeEditor" />
+<Meta title="Rose/Code Editor" component="CodeEditor" />
 
 # Code Editor
 

--- a/addons/rose/addon/components/rose/dialog/cover/index.stories.mdx
+++ b/addons/rose/addon/components/rose/dialog/cover/index.stories.mdx
@@ -1,9 +1,8 @@
-
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
-<Meta title="Rose|Dialog|Cover" component="Cover" />
+<Meta title="Rose/Dialog/Cover" component="Cover" />
 
 # Dialog Cover
 
@@ -11,12 +10,13 @@ A template-only dialog component that covers the viewport and accepts arbitrary
 content. Note that this component is unique to Boundary and is not part of the
 Structure design system.
 
-Prerequisite:  `ember-named-blocks-polyfill` must be installed in your app's
+Prerequisite: `ember-named-blocks-polyfill` must be installed in your app's
 `dependencies` rather than `devDependencies`.
 
 <Preview>
-  <Story name="Cover" height="15rem">{{
-    template: hbs`
+  <Story name="Cover" height="15rem">
+    {{
+      template: hbs`
     <Rose::Dialog::Cover>
       <:header>
         <h1>Cover Header</h1>
@@ -25,10 +25,10 @@ Prerequisite:  `ember-named-blocks-polyfill` must be installed in your app's
         <p>Cover body</p>
       </:body>
     </Rose::Dialog::Cover>
-    `
-  }}</Story>
+    `,
+    }}
+  </Story>
 </Preview>
-
 
 ```htmlbars
 <Rose::Dialog::Cover>

--- a/addons/rose/addon/components/rose/dialog/index.stories.mdx
+++ b/addons/rose/addon/components/rose/dialog/index.stories.mdx
@@ -1,18 +1,18 @@
-
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Dialog" component="Dialog" />
+<Meta title="Rose/Dialog" component="Dialog" />
 
 # Dialog
 
 A dialog component with optional modal capabilities.
 
 <Preview>
-  <Story name="Dialog" height="15rem">{{
-    template: hbs`
+  <Story name="Dialog" height="15rem">
+    {{
+      template: hbs`
       <Rose::Dialog
         @modal={{modal}}
         @dismiss={{dismiss}}
@@ -29,39 +29,39 @@ A dialog component with optional modal capabilities.
         </dialog.footer>
       </Rose::Dialog>
     `,
-    context: {
-      modal: boolean('modal', false),
-      heading: text('heading', 'Dialog Heading Text'),
-      dismissButtonText: text('dismissButtonText', 'Dismiss'),
-      icon: select(
-        'icon',
-        {
-          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
-          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
-        },
-        'flight-icons/svg/check-circle-16'
-      ),
-      style: select(
-        'style',
-        {
-          'default': '',
-          'warning': 'warning'
-        }
-      ),
-      dismiss: action('dismiss')
-    }
-  }}</Story>
+      context: {
+        modal: boolean('modal', false),
+        heading: text('heading', 'Dialog Heading Text'),
+        dismissButtonText: text('dismissButtonText', 'Dismiss'),
+        icon: select(
+          'icon',
+          {
+            'flight-icons/svg/check-circle-16':
+              'flight-icons/svg/check-circle-16',
+            'flight-icons/svg/clipboard-copy-16':
+              'flight-icons/svg/clipboard-copy-16',
+          },
+          'flight-icons/svg/check-circle-16'
+        ),
+        style: select('style', {
+          default: '',
+          warning: 'warning',
+        }),
+        dismiss: action('dismiss'),
+      },
+    }}
+  </Story>
 </Preview>
-
 
 ```htmlbars
 <Rose::Dialog
   @modal={{true}}
   @dismiss={{@dismissFn}}
-  @icon="flight-icons/svg/check-circle-16"
-  @heading="Heading"
-  @dismissButtonText="Dismiss"
-as |dialog|>
+  @icon='flight-icons/svg/check-circle-16'
+  @heading='Heading'
+  @dismissButtonText='Dismiss'
+  as |dialog|
+>
   <dialog.body>
     Dialog Body
   </dialog.body>

--- a/addons/rose/addon/components/rose/dropdown/index.stories.mdx
+++ b/addons/rose/addon/components/rose/dropdown/index.stories.mdx
@@ -1,17 +1,18 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { number, boolean, object } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
-<Meta title="Rose|Dropdown" component="Dropdown" />
+<Meta title="Rose/Dropdown" component="Dropdown" />
 
 # Dropdown
 
 A simple dropdown component with support for links and buttons.
 
 <Preview>
-  <Story name="Basic Dropdown" height="7rem">{{
-    template: hbs`
+  <Story name="Basic Dropdown" height="7rem">
+    {{
+      template: hbs`
       <Rose::Dropdown @text="Choose One&hellip;" @count={{count}} @icon="flight-icons/svg/org-16" @showCaret={{showCaret}} as |dropdown|>
         <dropdown.link @route="index">Menu item</dropdown.link>
         <dropdown.link @route="about">Menu item</dropdown.link>
@@ -23,16 +24,18 @@ A simple dropdown component with support for links and buttons.
         </dropdown.section>
       </Rose::Dropdown>
     `,
-    context: {
-      count: number('count', 0),
-      showCaret: boolean('showCaret', true),
-    },
-  }}</Story>
+      context: {
+        count: number('count', 0),
+        showCaret: boolean('showCaret', true),
+      },
+    }}
+  </Story>
 </Preview>
 
 <Preview>
-  <Story name="Icon-only Dropdown" height="5rem">{{
-    template: hbs`
+  <Story name="Icon-only Dropdown" height="5rem">
+    {{
+      template: hbs`
       <Rose::Dropdown @text="Choose One&hellip;" @icon="flight-icons/svg/org-16" @iconOnly={{true}} as |dropdown|>
         <dropdown.link @route="index">Menu item</dropdown.link>
         <dropdown.link @route="about">Menu item</dropdown.link>
@@ -40,12 +43,14 @@ A simple dropdown component with support for links and buttons.
         <dropdown.button>Button menu item</dropdown.button>
       </Rose::Dropdown>
     `,
-  }}</Story>
+    }}
+  </Story>
 </Preview>
 
 <Preview>
-  <Story name="Dropdown with Radio Buttons" height="13rem">{{
-    template: hbs`
+  <Story name="Dropdown with Radio Buttons" height="13rem">
+    {{
+      template: hbs`
       <Rose::Form as |form|>
         <form.radioGroup @name="color" @selectedValue="red" as |radioGroup|>
           <Rose::Dropdown @text="Color" as |dropdown|>
@@ -62,12 +67,14 @@ A simple dropdown component with support for links and buttons.
         </form.radioGroup>
       </Rose::Form>
     `,
-  }}</Story>
+    }}
+  </Story>
 </Preview>
 
 <Preview>
-  <Story name="Dropdown with Key Value Items" height="13rem">{{
-    template: hbs`
+  <Story name="Dropdown with Key Value Items" height="13rem">
+    {{
+      template: hbs`
       <Rose::Dropdown @text="View details" @showCaret={{showCaret}} @ignoreClickInside={{true}} as |dropdown|>
         <dropdown.key-value>
           <:key>Name</:key>
@@ -80,31 +87,40 @@ A simple dropdown component with support for links and buttons.
         </dropdown.key-value>
       </Rose::Dropdown>
     `,
-  }}</Story>
+    }}
+  </Story>
 </Preview>
 
-
 ```html
-  <Rose::Dropdown @text="Choose One&hellip;" as |dropdown|>
+<Rose::Dropdown @text="Choose One&hellip;" as |dropdown|>
+  <dropdown.link @route="index">Menu item</dropdown.link>
+  <dropdown.link @route="about">Menu item</dropdown.link>
+  <dropdown.button>Button menu item</dropdown.button>
+  <dropdown.separator />
+  <dropdown.section
+    @title="Dropdown Section Title"
+    @icon="flight-icons/svg/tag-16"
+  >
     <dropdown.link @route="index">Menu item</dropdown.link>
-    <dropdown.link @route="about">Menu item</dropdown.link>
-    <dropdown.button>Button menu item</dropdown.button>
-    <dropdown.separator />
-    <dropdown.section @title="Dropdown Section Title" @icon="flight-icons/svg/tag-16">
-      <dropdown.link @route="index">Menu item</dropdown.link>
-    </dropdown.section>
-  </Rose::Dropdown>
+  </dropdown.section>
+</Rose::Dropdown>
 ```
 
 Dropdown content can be aligned to right edge of the component instead of the default left edge, which is the default setting. The following example floats the component to right edge of the page inorder to provide enough space to display right aligned dropdown content.
 
 ```html
-  <Rose::Dropdown @text="Choose One&hellip;" style="float: right" @dropdownRight={{true}} as |dropdown|>
-    <dropdown.link @route="index">Menu item</dropdown.link>
-    <dropdown.link @route="about">Menu item</dropdown.link>
-    <dropdown.separator />
-    <dropdown.button>Button menu item</dropdown.button>
-  </Rose::Dropdown>
+<Rose::Dropdown
+  @text="Choose One&hellip;"
+  style="float: right"
+  @dropdownRight="{{true}}"
+  as
+  |dropdown|
+>
+  <dropdown.link @route="index">Menu item</dropdown.link>
+  <dropdown.link @route="about">Menu item</dropdown.link>
+  <dropdown.separator />
+  <dropdown.button>Button menu item</dropdown.button>
+</Rose::Dropdown>
 ```
 
 Dropdown supports `danger` styling through `style` attribute.
@@ -119,13 +135,18 @@ Dropdown supports `danger` styling through `style` attribute.
 Dropdown indicator can be hidden using `showCaret` attribute.
 
 ```html
-<Rose::Dropdown @showCaret={{true}} @icon="flight-icons/svg/more-horizontal-16" as |dropdown|>
-    <dropdown.link @route="index">Menu item</dropdown.link>
-    <dropdown.button>Button menu item</dropdown.button>
+<Rose::Dropdown
+  @showCaret="{{true}}"
+  @icon="flight-icons/svg/more-horizontal-16"
+  as
+  |dropdown|
+>
+  <dropdown.link @route="index">Menu item</dropdown.link>
+  <dropdown.button>Button menu item</dropdown.button>
 </Rose::Dropdown>
 ```
 
-Dropdowns also support radio buttons and checkboxes.  Currently, radio buttons and checkboxes are the only supported
+Dropdowns also support radio buttons and checkboxes. Currently, radio buttons and checkboxes are the only supported
 form fields.
 
 ```html
@@ -148,30 +169,31 @@ form fields.
 
 ```html
 <Rose::Form as |form|>
-  <Rose::Dropdown @text="Items" @ignoreClickInside={{true}} as |dropdown|>
-<Rose::Form::Checkbox::Group
-  @name='checkbox-group'
-  @items={{this.items}}
-  @selectedItems={{this.selectedItems}}
-  @onChange={{fn this.onChange}}
-  as |group|
->
-<dropdown.item>
-  <group.checkbox
-    @label={{group.item.name}}
-    value={{group.item.id}}
-    />
-    </dropdown.item>
-</Rose::Form::Checkbox::Group>
-
- </Rose::Dropdown>
+  <Rose::Dropdown @text="Items" @ignoreClickInside="{{true}}" as |dropdown|>
+    <Rose::Form::Checkbox::Group
+      @name="checkbox-group"
+      @items="{{this.items}}"
+      @selectedItems="{{this.selectedItems}}"
+      @onChange="{{fn"
+      this.onChange}}
+      as
+      |group|
+    >
+      <dropdown.item>
+        <group.checkbox
+          @label="{{group.item.name}}"
+          value="{{group.item.id}}"
+        />
+      </dropdown.item>
+    </Rose::Form::Checkbox::Group>
+  </Rose::Dropdown>
 </Rose::Form>
 ```
 
-
 <Preview>
-  <Story name="Dropdown with Checkboxes" height="10rem">{{
-  template: hbs`
+  <Story name="Dropdown with Checkboxes" height="10rem">
+    {{
+      template: hbs`
   <Rose::Form as |form|>
    <Rose::Dropdown   @ignoreClickInside={{true}} @text="Items" as |dropdown|>
     <Rose::Form::Checkbox::Group
@@ -192,20 +214,19 @@ form fields.
      </Rose::Dropdown>
     </Rose::Form>
   `,
-  context: {
-    disabled: boolean('disabled', false),
-    items: object('items', [
-      { id: 1, name: 'Foo' },
-      { id: 2, name: 'Bar' },
-      { id: 3, name: 'Baz' },
-    ]),
-    selectedItems: object('selectedItems', []),
-    onChange: action('changed'),
-  }
-  }}</Story>
+      context: {
+        disabled: boolean('disabled', false),
+        items: object('items', [
+          { id: 1, name: 'Foo' },
+          { id: 2, name: 'Bar' },
+          { id: 3, name: 'Baz' },
+        ]),
+        selectedItems: object('selectedItems', []),
+        onChange: action('changed'),
+      },
+    }}
+  </Story>
 </Preview>
-
-
 
 Closing dropdown after clicking inside it's content can be ignored using `ignoreClickInside`. This is useful when dropdown contains keyvalue items that users need to select/copy/interact with.
 

--- a/addons/rose/addon/components/rose/footer/index.stories.mdx
+++ b/addons/rose/addon/components/rose/footer/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Footer" component="Footer" />
+<Meta title="Rose/Footer" component="Footer" />
 
 # Footer
 
@@ -21,8 +21,9 @@ A footer component that allows four distinct sections to be configured: brand, n
 ```
 
 <Preview>
-  <Story name="Basic">{{
-    template: hbs`
+  <Story name="Basic">
+    {{
+      template: hbs`
       <Rose::Footer as |footer|>
         <footer.brand @logo="logo" @text={{brandName}} />
         <footer.text>{{footerText}}</footer.text>
@@ -32,9 +33,10 @@ A footer component that allows four distinct sections to be configured: brand, n
         </footer.nav>
       </Rose::Footer>
     `,
-    context: {
-      brandName: text('brandName', 'Brand Name'),
-      footerText: text('footerText', 'Text'),
-    },
-  }}</Story>
+      context: {
+        brandName: text('brandName', 'Brand Name'),
+        footerText: text('footerText', 'Text'),
+      },
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/form/actions/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/actions/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/Actions" component="Form/Actions" />
+<Meta title="Rose/Form/Actions" component="Form/Actions" />
 
 # Form Actions
 
@@ -16,9 +16,10 @@ support actions. The cancel button supports a cancel action.
 <Rose::Form::Actions
   @submitText="Save"
   @cancelText="Cancel"
-  @showCancel={{true}}
-  @submitDisabled={{false}}
-  @cancel=(fn @cancel)
+  @showCancel="{{true}}"
+  @submitDisabled="{{false}}"
+  @cancel="(fn"
+  @cancel)
 />
 ```
 

--- a/addons/rose/addon/components/rose/form/checkbox/group/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/checkbox/group/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select, object } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/Checkbox/Group" component="Form/Checkbox/Group" />
+<Meta title="Rose/Form/Checkbox/Group" component="Form/Checkbox/Group" />
 
 # Form checkboxfield group
 

--- a/addons/rose/addon/components/rose/form/checkbox/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/checkbox/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/Checkbox" component="Form/Checkbox" />
+<Meta title="Rose/Form/Checkbox" component="Form/Checkbox" />
 
 # Form Checkbox
 
@@ -11,17 +11,18 @@ Renders a form input checkbox.
 
 ```htmlbars
 <Rose::Form::Checkbox
-  @name="boolean-value"
-  @label="Yes?"
+  @name='boolean-value'
+  @label='Yes?'
   @checked={{false}}
   @error={{false}}
   @disabled={{false}}
-  />
+/>
 ```
 
 <Preview>
-  <Story name="Basic Checkbox" height="10rem">{{
-    template: hbs`
+  <Story name="Basic Checkbox" height="10rem">
+    {{
+      template: hbs`
       <Rose::Form::Checkbox
         @name={{name}}
         @label={{label}}
@@ -32,21 +33,23 @@ Renders a form input checkbox.
         @disabled={{disabled}}
         />
     `,
-    context: {
-      label: text('text', 'Checkbox 🛎'),
-      description: text('description', 'Short description in label'),
-      helperText: text('helperText', 'This is an optional help text.'),
-      name: text('name', 'checkbox-1'),
-      checked: boolean('checked', false),
-      error: boolean('error', false),
-      disabled: boolean('disabled', false),
-    }
-  }}</Story>
+      context: {
+        label: text('text', 'Checkbox 🛎'),
+        description: text('description', 'Short description in label'),
+        helperText: text('helperText', 'This is an optional help text.'),
+        name: text('name', 'checkbox-1'),
+        checked: boolean('checked', false),
+        error: boolean('error', false),
+        disabled: boolean('disabled', false),
+      },
+    }}
+  </Story>
 </Preview>
 
 <Preview>
-  <Story name="Checkbox with errors" height="10rem">{{
-    template: hbs`
+  <Story name="Checkbox with errors" height="10rem">
+    {{
+      template: hbs`
       <Rose::Form::Checkbox
         @name={{name}}
         @label={{label}}
@@ -60,30 +63,31 @@ Renders a form input checkbox.
         </field.errors>
       </Rose::Form::Checkbox>
     `,
-    context: {
-      label: text('text', 'Checkbox 🛎'),
-      name: text('name', 'checkbox-1'),
-      checked: boolean('checked', false),
-      disabled: boolean('disabled', false),
-    }
-  }}</Story>
+      context: {
+        label: text('text', 'Checkbox 🛎'),
+        name: text('name', 'checkbox-1'),
+        checked: boolean('checked', false),
+        disabled: boolean('disabled', false),
+      },
+    }}
+  </Story>
 </Preview>
-
 
 ```htmlbars
 <Rose::Form::Checkbox
-  @name="boolean-value"
-  @label="Yes?"
+  @name='boolean-value'
+  @label='Yes?'
   @checked={{false}}
   @error={{false}}
   @disabled={{false}}
   @inline={{false}}
-  />
+/>
 ```
 
 <Preview>
-  <Story name="Checkbox with inline style" height="10rem">{{
-    template: hbs`
+  <Story name="Checkbox with inline style" height="10rem">
+    {{
+      template: hbs`
       <Rose::Form::Checkbox
         @name='checkbox-1'
         @label='Checkbox1 🛎'
@@ -115,14 +119,14 @@ Renders a form input checkbox.
         @inline={{inline}}
         />
     `,
-    context: {
-      description: text('description', 'Short description in label'),
-      helperText: text('helperText', 'This is an optional help text.'),
-      checked: boolean('checked', false),
-      error: boolean('error', false),
-      disabled: boolean('disabled', false),
-      inline: boolean('inline', false)
-    }
-  }}</Story>
-  
+      context: {
+        description: text('description', 'Short description in label'),
+        helperText: text('helperText', 'This is an optional help text.'),
+        checked: boolean('checked', false),
+        error: boolean('error', false),
+        disabled: boolean('disabled', false),
+        inline: boolean('inline', false),
+      },
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/form/errors/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/errors/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/Errors" component="Form/Errors" />
+<Meta title="Rose/Form/Errors" component="Form/Errors" />
 
 # Form Errors
 
@@ -17,13 +17,15 @@ Use this component to display one or more error messages.
 ```
 
 <Preview>
-  <Story name="Basic Form Errors">{{
-    template: hbs`
+  <Story name="Basic Form Errors">
+    {{
+      template: hbs`
       <Rose::Form::Errors as |errors|>
         <errors.message>An error message goes here.</errors.message>
         <errors.message>Another message goes here.</errors.message>
       </Rose::Form::Errors>
     `,
-    context: {},
-  }}</Story>
+      context: {},
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/form/errors/message/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/errors/message/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/Errors/Message" component="Form/Errors/Message" />
+<Meta title="Rose/Form/Errors/Message" component="Form/Errors/Message" />
 
 # Form Error Message
 
@@ -18,12 +18,14 @@ of the `Rose::Form::Errors` component.
 ```
 
 <Preview>
-  <Story name="Basic Form Error Message">{{
-    template: hbs`
+  <Story name="Basic Form Error Message">
+    {{
+      template: hbs`
       <Rose::Form::Errors::Message>
         An error message goes here.
       </Rose::Form::Errors::Message>
     `,
-    context: {},
-  }}</Story>
+      context: {},
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/form/fieldset/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/fieldset/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/Fieldset" component="Form/Fieldset" />
+<Meta title="Rose/Form/Fieldset" component="Form/Fieldset" />
 
 # Form Fieldset
 

--- a/addons/rose/addon/components/rose/form/helper-text/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/helper-text/index.stories.mdx
@@ -1,32 +1,38 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/HelperText" component="Form/HelperText" />
+<Meta title="Rose/Form/HelperText" component="Form/HelperText" />
 
 # Form Helper Text
 
-Displays helpful messages related to a form field.  This component is used
+Displays helpful messages related to a form field. This component is used
 by form fields and should not be used directly.
 
 ```html
-<Rose::Form::HelperText @id="helper-text-{{field.id}}" @link='link' @linkText='link text goes here'>
+<Rose::Form::HelperText
+  @id="helper-text-{{field.id}}"
+  @link="link"
+  @linkText="link text goes here"
+>
   Helper text
 </Rose::Form::HelperText>
 ```
 
 <Preview>
-  <Story name="HelperText">{{
-    template: hbs`
+  <Story name="HelperText">
+    {{
+      template: hbs`
       <Rose::Form::HelperText @error={{this.error}} @link={{this.link}} @linkText={{this.linkText}}>
         Helper text
       </Rose::Form::HelperText>
     `,
-    context: {
-      error: boolean('error', false),
-      link: text('link', 'http://www.example.net/'),
-      linkText: text('linkText', 'sample link text')
-    },
-  }}</Story>
+      context: {
+        error: boolean('error', false),
+        link: text('link', 'http://www.example.net/'),
+        linkText: text('linkText', 'sample link text'),
+      },
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/form/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/index.stories.mdx
@@ -1,18 +1,19 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form" component="Form" />
+<Meta title="Rose/Form" component="Form" />
 
 # Form
 
-A component for building accessible forms.  Yields contextual fields
+A component for building accessible forms. Yields contextual fields
 and actions.
 
 <Preview>
-  <Story name="Form" height="35rem">{{
-    template: hbs`
+  <Story name="Form" height="35rem">
+    {{
+      template: hbs`
       <Rose::Form
         @onSubmit={{submit}}
         @cancel={{cancel}}
@@ -67,16 +68,16 @@ and actions.
           @showCancel={{true}} />
       </Rose::Form>
     `,
-    context: {
-      showEditToggle: boolean('showEditToggle', false),
-      disabled: boolean('disabled', false),
-      submit: action('submit'),
-      cancel: action('cancel'),
-      selectChange: action('selectChange'),
-    },
-  }}</Story>
+      context: {
+        showEditToggle: boolean('showEditToggle', false),
+        disabled: boolean('disabled', false),
+        submit: action('submit'),
+        cancel: action('cancel'),
+        selectChange: action('selectChange'),
+      },
+    }}
+  </Story>
 </Preview>
-
 
 ```htmlbars
 <Rose::Form
@@ -84,51 +85,34 @@ and actions.
   @cancel={{this.cancel}}
   @disabled={{false}}
   @showEditToggle={{true}}
-  as |form|>
-  <form.input
-    @label="Label"
-    @helperText="Helper text"
-    @value="Text"
-    />
-  <form.textarea
-    @label="Label"
-    @helperText="Helper text"
-    @value="Text"
-    />
+  as |form|
+>
+  <form.input @label='Label' @helperText='Helper text' @value='Text' />
+  <form.textarea @label='Label' @helperText='Helper text' @value='Text' />
   <form.select
-    @label="Label"
-    @helperText="Helper text"
+    @label='Label'
+    @helperText='Helper text'
     @onChange={{fn this.actionHandler}}
     as |field|
   >
     <field.field as |select|>
       <select.option>Choose an option</select.option>
-      <select.option @value="value-1">Value 1</select.option>
-      <select.option @value="value-2">Value 2</select.option>
-      <select.option @value="value-3">Value 3</select.option>
+      <select.option @value='value-1'>Value 1</select.option>
+      <select.option @value='value-2'>Value 2</select.option>
+      <select.option @value='value-3'>Value 3</select.option>
     </field.field>
   </form.select>
-  <form.radioGroup @name="color" @selectedValue="green" as |radioGroup|>
-    <radioGroup.radio
-      @label="Red"
-      @value="red"
-    />
-    <radioGroup.radio
-      @label="Green"
-      @value="green"
-    />
-    <radioGroup.radio
-      @label="Blue"
-      @value="blue"
-    />
+  <form.radioGroup @name='color' @selectedValue='green' as |radioGroup|>
+    <radioGroup.radio @label='Red' @value='red' />
+    <radioGroup.radio @label='Green' @value='green' />
+    <radioGroup.radio @label='Blue' @value='blue' />
   </form.radioGroup>
-  <form.checkbox
-    @label="Label"
-    />
+  <form.checkbox @label='Label' />
   <form.actions
-    @submitText="Save"
-    @cancelText="Cancel"
-    @enableEditText="Edit"
-    @showCancel={{true}} />
+    @submitText='Save'
+    @cancelText='Cancel'
+    @enableEditText='Edit'
+    @showCancel={{true}}
+  />
 </Rose::Form>
 ```

--- a/addons/rose/addon/components/rose/form/input/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/input/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/Input" component="Form/Input" />
+<Meta title="Rose/Form/Input" component="Form/Input" />
 
 # Form Input
 
@@ -11,11 +11,11 @@ Renders a simple form input.
 
 ```htmlbars
 <Rose::Form::Input
-  @type="email"
-  @name="email"
-  @value="info@example.com"
-  @label="Email"
-  @helperText="Enter your email"
+  @type='email'
+  @name='email'
+  @value='info@example.com'
+  @label='Email'
+  @helperText='Enter your email'
   @link='www.example.net'
   @linkText='sample link text'
   @error={{false}}
@@ -30,24 +30,23 @@ Or a fully contextual component without a wrapper, for maximum flexibility.
 ```htmlbars
 <Rose::Form::Input
   @contextual={{true}}
-  @type="email"
-  @name="email"
-  @value="info@example.com"
-  @label="Email"
-  @helperText="Enter your email"
+  @type='email'
+  @name='email'
+  @value='info@example.com'
+  @label='Email'
+  @helperText='Enter your email'
   @link='www.example.net'
   @linkText='sample link text'
   @error={{false}}
   @disabled={{false}}
   readonly={{false}}
->
-
-</Rose::Form::Input>
+/>
 ```
 
 <Preview>
-  <Story name="Basic Field">{{
-    template: hbs`
+  <Story name="Basic Field">
+    {{
+      template: hbs`
       <Rose::Form::Input
         @type={{type}}
         @name={{type}}
@@ -62,39 +61,41 @@ Or a fully contextual component without a wrapper, for maximum flexibility.
         @icon={{icon}}
         />
     `,
-    context: {
-      type: select(
-        'type',
-        {
-          text: 'text',
-          email: 'email',
-          number: 'number',
-          password: 'password',
-        },
-        'text'
-      ),
-      value: text('value', 'Value'),
-      label: text('label', 'Label'),
-      helperText: text('helperText', 'Helper text'),
-      link: text('link', 'link goes here'),
-      linkText: text('linkText', 'link text'),
-      disabled: boolean('disabled', false),
-      'read-only': boolean('readonly', false),
-      icon: select(
-        'icon',
-        {
-          'none': null,
-          'flight-icons/svg/search-16': 'flight-icons/svg/search-16',
-        },
-        'flight-icons/svg/search-16',
-      ),
-    }
-  }}</Story>
+      context: {
+        type: select(
+          'type',
+          {
+            text: 'text',
+            email: 'email',
+            number: 'number',
+            password: 'password',
+          },
+          'text'
+        ),
+        value: text('value', 'Value'),
+        label: text('label', 'Label'),
+        helperText: text('helperText', 'Helper text'),
+        link: text('link', 'link goes here'),
+        linkText: text('linkText', 'link text'),
+        disabled: boolean('disabled', false),
+        'read-only': boolean('readonly', false),
+        icon: select(
+          'icon',
+          {
+            none: null,
+            'flight-icons/svg/search-16': 'flight-icons/svg/search-16',
+          },
+          'flight-icons/svg/search-16'
+        ),
+      },
+    }}
+  </Story>
 </Preview>
 
 <Preview>
-  <Story name="Field with Errors">{{
-    template: hbs`
+  <Story name="Field with Errors">
+    {{
+      template: hbs`
       <Rose::Form::Input
         @type={{type}}
         @name={{type}}
@@ -113,31 +114,33 @@ Or a fully contextual component without a wrapper, for maximum flexibility.
         </field.errors>
       </Rose::Form::Input>
     `,
-    context: {
-      type: select(
-        'type',
-        {
-          text: 'text',
-          email: 'email',
-          number: 'number',
-          password: 'password',
-        },
-        'text'
-      ),
-      value: text('value', 'Value'),
-      label: text('label', 'Label'),
-      helperText: text('helperText', 'Helper text'),
-      link: text('link', 'link goes here'),
-      linkText: text('linkText', 'link text'),
-      disabled: boolean('disabled', false),
-      'read-only': boolean('readonly', false),
-    }
-  }}</Story>
+      context: {
+        type: select(
+          'type',
+          {
+            text: 'text',
+            email: 'email',
+            number: 'number',
+            password: 'password',
+          },
+          'text'
+        ),
+        value: text('value', 'Value'),
+        label: text('label', 'Label'),
+        helperText: text('helperText', 'Helper text'),
+        link: text('link', 'link goes here'),
+        linkText: text('linkText', 'link text'),
+        disabled: boolean('disabled', false),
+        'read-only': boolean('readonly', false),
+      },
+    }}
+  </Story>
 </Preview>
 
 <Preview>
-  <Story name="Fully Contextual Input">{{
-    template: hbs`
+  <Story name="Fully Contextual Input">
+    {{
+      template: hbs`
       <Rose::Form::Input @value="Text" @error={{true}} @contextual={{true}} as |field|>
         <hr />
         <field.label>Label</field.label>
@@ -152,6 +155,7 @@ Or a fully contextual component without a wrapper, for maximum flexibility.
         <hr />
       </Rose::Form::Input>
     `,
-    context: {},
-  }}</Story>
+      context: {},
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/form/label/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/label/index.stories.mdx
@@ -1,30 +1,32 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/Label" component="Form/Label" />
+<Meta title="Rose/Form/Label" component="Form/Label" />
 
 # Form Label
 
-Renders a simple form label.  This componet is used and yielded by form fields
+Renders a simple form label. This componet is used and yielded by form fields
 and should not be used directly.
 
 ```htmlbars
-<Rose::Form::Label @for="my-field-id">
+<Rose::Form::Label @for='my-field-id'>
   Form Label
 </Rose::Form::Label>
 ```
 
 <Preview>
-  <Story name="Form Label">{{
-    template: hbs`
+  <Story name="Form Label">
+    {{
+      template: hbs`
       <Rose::Form::Label @for="my-field-id" @error={{this.error}}>
         Form Label
       </Rose::Form::Label>
     `,
-    context: {
-      error: boolean('error', false)
-    },
-  }}</Story>
+      context: {
+        error: boolean('error', false),
+      },
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/form/radio/card/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/radio/card/index.stories.mdx
@@ -1,8 +1,8 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/Radio/Radio/Card" component="Form/Radio/Radio/Card" />
+<Meta title="Rose/Form/Radio/Radio/Card" component="Form/Radio/Radio/Card" />
 
 # Form Radiofield in a wide format
 
@@ -10,19 +10,20 @@ Renders a form radiofield in a Wide format.
 
 ```htmlbars
 <Rose::Form::Radio::Card
-  @label="Yes"
+  @label='Yes'
   @error={{false}}
-  @value="yes-agree"
-  @selectedValue="yes-agree"
+  @value='yes-agree'
+  @selectedValue='yes-agree'
   @disabled={{false}}
   @changed={{fn}}
   @layout='wide'
-  />
+/>
 ```
 
 <Preview>
-  <Story name="Wide" height="10rem">{{
-    template: hbs`
+  <Story name="Wide" height="10rem">
+    {{
+      template: hbs`
       <Rose::Form::Radio::Card
         @label={{label}}
         @error={{error}}
@@ -34,38 +35,42 @@ Renders a form radiofield in a Wide format.
         @layout='wide'
         />
     `,
-    context: {
-      label: text('text', 'Azure'),
-      error: boolean('error', false),
-      value: text('value', 'value and selectedValue must match to select radiofield'),
-      selectedValue: text(
-        'selectedValue',
-        'value and selectedValue must match to select radiofield'
-      ),
-      helperText: text('helperText', 'Record financial transactions using'),
-      disabled: boolean('disabled', false),
-    }
-  }}</Story>
+      context: {
+        label: text('text', 'Azure'),
+        error: boolean('error', false),
+        value: text(
+          'value',
+          'value and selectedValue must match to select radiofield'
+        ),
+        selectedValue: text(
+          'selectedValue',
+          'value and selectedValue must match to select radiofield'
+        ),
+        helperText: text('helperText', 'Record financial transactions using'),
+        disabled: boolean('disabled', false),
+      },
+    }}
+  </Story>
 </Preview>
-
 
 Renders a form radiofield in a tile format.
 
 ```htmlbars
 <Rose::Form::Radio::Card
-  @label="Yes"
+  @label='Yes'
   @error={{false}}
-  @value="yes-agree"
-  @selectedValue="yes-agree"
+  @value='yes-agree'
+  @selectedValue='yes-agree'
   @disabled={{false}}
   @changed={{fn}}
   @layout='tile'
-  />
+/>
 ```
 
 <Preview>
-  <Story name="Tile" height="10rem">{{
-    template: hbs`
+  <Story name="Tile" height="10rem">
+    {{
+      template: hbs`
       <Rose::Form::Radio::Card
         @label={{label}}
         @error={{error}}
@@ -77,24 +82,29 @@ Renders a form radiofield in a tile format.
         @layout='tile'
         />
     `,
-    context: {
-      label: text('text', 'Azure'),
-      error: boolean('error', false),
-      value: text('value', 'value and selectedValue must match to select radiofield'),
-      selectedValue: text(
-        'selectedValue',
-        'value and selectedValue must match to select radiofield'
-      ),
-      helperText: text('helperText', 'Record financial transactions using'),
-      disabled: boolean('disabled', false),
-      icon: select(
-        'icon',
-        {
-          'none': null,
-          'flight-icons/svg/azure-color-16': 'flight-icons/svg/azure-color-16',
-        },
-        null
-      ),
-    }
-  }}</Story>
+      context: {
+        label: text('text', 'Azure'),
+        error: boolean('error', false),
+        value: text(
+          'value',
+          'value and selectedValue must match to select radiofield'
+        ),
+        selectedValue: text(
+          'selectedValue',
+          'value and selectedValue must match to select radiofield'
+        ),
+        helperText: text('helperText', 'Record financial transactions using'),
+        disabled: boolean('disabled', false),
+        icon: select(
+          'icon',
+          {
+            none: null,
+            'flight-icons/svg/azure-color-16':
+              'flight-icons/svg/azure-color-16',
+          },
+          null
+        ),
+      },
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/form/radio/group/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/radio/group/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/Radio/Group" component="Form/Radio/Group" />
+<Meta title="Rose/Form/Radio/Group" component="Form/Radio/Group" />
 
 # Form radiofield group
 
@@ -13,28 +13,21 @@ Renders a form radiofield group.
 <Rose::Form::Radio::Group
   @disabled={{false}}
   @name={{name}}
-  @selectedValue="disagree"
+  @selectedValue='disagree'
   @changed={{fn}}
   @inline={{false}}
   as |radioGroup|
 >
-  <radioGroup.radio
-    @label="Agree"
-    @value="agree"
-  />
-  <radioGroup.radio
-    @label="disagree"
-    @value="disagree"
-  />
-  <radioGroup.radio
-    @label="maybe"
-    @value="maybe"
-  />
+  <radioGroup.radio @label='Agree' @value='agree' />
+  <radioGroup.radio @label='disagree' @value='disagree' />
+  <radioGroup.radio @label='maybe' @value='maybe' />
 </Rose::Form::Radio::Group>
 ```
+
 <Preview>
-  <Story name="Basic" height="10rem">{{
-  template: hbs`
+  <Story name="Basic" height="10rem">
+    {{
+      template: hbs`
     <Rose::Form::Radio::Group
       @disabled={{disabled}}
       @name={{name}}
@@ -58,62 +51,66 @@ Renders a form radiofield group.
       />
     </Rose::Form::Radio::Group>
   `,
-  context: {
-    name: text('name', 'mustagree'),
-    disabled: boolean('disabled', false),
-    inline: boolean('inline', true),
-    selectedValue: text('selectedValue', 'disagree'),
-    firstFieldLabel: text('first label', 'Agree'),
-    firstFieldValue: text('first value', 'agree'),
-    firstFieldIcon: select(
-      'first icon',
-      {
-        'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
-        'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
+      context: {
+        name: text('name', 'mustagree'),
+        disabled: boolean('disabled', false),
+        inline: boolean('inline', true),
+        selectedValue: text('selectedValue', 'disagree'),
+        firstFieldLabel: text('first label', 'Agree'),
+        firstFieldValue: text('first value', 'agree'),
+        firstFieldIcon: select(
+          'first icon',
+          {
+            'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
+            'flight-icons/svg/clipboard-copy-16':
+              'flight-icons/svg/clipboard-copy-16',
+          },
+          'flight-icons/svg/org-16'
+        ),
+        secondFieldLabel: text('second label', 'Maybe'),
+        secondFieldValue: text('second value', 'maybe'),
+        thirdFieldLabel: text('third label', 'Disagree'),
+        thirdFieldValue: text('third value', 'disagree'),
+        changed: action('changed'),
       },
-      'flight-icons/svg/org-16'
-    ),
-    secondFieldLabel: text('second label', 'Maybe'),
-    secondFieldValue: text('second value', 'maybe'),
-    thirdFieldLabel: text('third label', 'Disagree'),
-    thirdFieldValue: text('third value', 'disagree'),
-    changed: action('changed')
-  }
-  }}</Story>
+    }}
+  </Story>
 </Preview>
 
 ```htmlbars
 <Rose::Form::Radio::Group
   @disabled={{false}}
   @name={{name}}
-  @selectedValue="disagree"
+  @selectedValue='disagree'
   @changed={{fn}}
   @inline={{false}}
   as |radioGroup|
 >
   <radioGroup.Card
-    @label="Agree"
-    @value="agree"
+    @label='Agree'
+    @value='agree'
     @layout='tile'
-       @helperText="dwsd"
+    @helperText='dwsd'
   />
   <radioGroup.Card
-    @label="disagree"
-    @value="disagree"
+    @label='disagree'
+    @value='disagree'
     @layout='tile'
-       @helperText="dwsd"
+    @helperText='dwsd'
   />
   <radioGroup.Card
-    @label="maybe"
-    @value="maybe"
+    @label='maybe'
+    @value='maybe'
     @layout='tile'
-    @helperText="dwsd"
+    @helperText='dwsd'
   />
 </Rose::Form::Radio::Group>
 ```
+
 <Preview>
-  <Story name="Card:  Tile" height="10rem">{{
-  template: hbs`
+  <Story name="Card:  Tile" height="10rem">
+    {{
+      template: hbs`
     <Rose::Form::Radio::Group
       @disabled={{disabled}}
       @name={{name}}
@@ -141,69 +138,67 @@ Renders a form radiofield group.
       />
     </Rose::Form::Radio::Group>
   `,
-  context: {
-    name: text('name', 'mustagree'),
-    disabled: boolean('disabled', false),
-    selectedValue: text('selectedValue', 'disagree'),
-    firstFieldLabel: text('first label', 'Agree'),
-    firstFieldValue: text('first value', 'agree'),
-    firstFieldIcon: select(
-        'firstFieldIcon',
-        {
-          'none': null,
-          'flight-icons/svg/azure-color-16': 'flight-icons/svg/azure-color-16',
-        },
-        null
-      ),
-         secondFieldIcon: select(
-        'secondFieldIcon',
-        {
-          'none': null,
-          'flight-icons/svg/azure-color-16': 'flight-icons/svg/azure-color-16',
-        },
-        null
-      ),
-         thirdFieldIcon: select(
-        'thirdFieldIcon',
-        {
-          'none': null,
-          'flight-icons/svg/azure-color-16': 'flight-icons/svg/azure-color-16',
-        },
-        null
-      ),
-    secondFieldLabel: text('second label', 'Maybe'),
-    secondFieldValue: text('second value', 'maybe'),
-    thirdFieldLabel: text('third label', 'Disagree'),
-    thirdFieldValue: text('third value', 'disagree'),
-    changed: action('changed')
-  }
-  }}</Story>
+      context: {
+        name: text('name', 'mustagree'),
+        disabled: boolean('disabled', false),
+        selectedValue: text('selectedValue', 'disagree'),
+        firstFieldLabel: text('first label', 'Agree'),
+        firstFieldValue: text('first value', 'agree'),
+        firstFieldIcon: select(
+          'firstFieldIcon',
+          {
+            none: null,
+            'flight-icons/svg/azure-color-16':
+              'flight-icons/svg/azure-color-16',
+          },
+          null
+        ),
+        secondFieldIcon: select(
+          'secondFieldIcon',
+          {
+            none: null,
+            'flight-icons/svg/azure-color-16':
+              'flight-icons/svg/azure-color-16',
+          },
+          null
+        ),
+        thirdFieldIcon: select(
+          'thirdFieldIcon',
+          {
+            none: null,
+            'flight-icons/svg/azure-color-16':
+              'flight-icons/svg/azure-color-16',
+          },
+          null
+        ),
+        secondFieldLabel: text('second label', 'Maybe'),
+        secondFieldValue: text('second value', 'maybe'),
+        thirdFieldLabel: text('third label', 'Disagree'),
+        thirdFieldValue: text('third value', 'disagree'),
+        changed: action('changed'),
+      },
+    }}
+  </Story>
 </Preview>
 
 ```htmlbars
 <Rose::Form::Radio::Group
   @disabled={{false}}
   @name={{name}}
-  @selectedValue="disagree"
+  @selectedValue='disagree'
   @changed={{fn}}
   @inline={{false}}
   as |radioGroup|
 >
-  <radioGroup.Card
-    @label="Agree"
-    @value="agree"
-    @layout='wide'
-  />
-  <radioGroup.Card
-    @label="disagree"
-    @value="disagree"
-    @layout='wide'
-  />
+  <radioGroup.Card @label='Agree' @value='agree' @layout='wide' />
+  <radioGroup.Card @label='disagree' @value='disagree' @layout='wide' />
 </Rose::Form::Radio::Group>
 ```
+
 <Preview>
-  <Story name="Card:  Wide" height="10rem">{{
-  template: hbs`
+  <Story name="Card:  Wide" height="10rem">
+    {{
+      template: hbs`
     <Rose::Form::Radio::Group
       @disabled={{disabled}}
       @name={{name}}
@@ -229,25 +224,27 @@ Renders a form radiofield group.
       />
     </Rose::Form::Radio::Group>
   `,
-  context: {
-    name: text('name', 'mustagree'),
-    disabled: boolean('disabled', false),
-    selectedValue: text('selectedValue', 'disagree'),
-    firstFieldLabel: text('first label', 'Agree'),
-    firstFieldValue: text('first value', 'agree'),
-    firstFieldIcon: select(
-        'firstFieldIcon',
-        {
-          'none': null,
-          'flight-icons/svg/azure-color-16': 'flight-icons/svg/azure-color-16',
-        },
-        null
-      ),
-    secondFieldLabel: text('second label', 'Maybe'),
-    secondFieldValue: text('second value', 'maybe'),
-    thirdFieldLabel: text('third label', 'Disagree'),
-    thirdFieldValue: text('third value', 'disagree'),
-    changed: action('changed')
-  }
-  }}</Story>
+      context: {
+        name: text('name', 'mustagree'),
+        disabled: boolean('disabled', false),
+        selectedValue: text('selectedValue', 'disagree'),
+        firstFieldLabel: text('first label', 'Agree'),
+        firstFieldValue: text('first value', 'agree'),
+        firstFieldIcon: select(
+          'firstFieldIcon',
+          {
+            none: null,
+            'flight-icons/svg/azure-color-16':
+              'flight-icons/svg/azure-color-16',
+          },
+          null
+        ),
+        secondFieldLabel: text('second label', 'Maybe'),
+        secondFieldValue: text('second value', 'maybe'),
+        thirdFieldLabel: text('third label', 'Disagree'),
+        thirdFieldValue: text('third value', 'disagree'),
+        changed: action('changed'),
+      },
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/form/radio/radio/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/radio/radio/index.stories.mdx
@@ -1,8 +1,8 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/Radio/Radio" component="Form/Radio/Radio" />
+<Meta title="Rose/Form/Radio/Radio" component="Form/Radio/Radio" />
 
 # Form Radiofield
 
@@ -10,18 +10,19 @@ Renders a form radiofield.
 
 ```htmlbars
 <Rose::Form::Radio::Radio
-  @label="Yes"
+  @label='Yes'
   @error={{false}}
-  @value="yes-agree"
-  @selectedValue="yes-agree"
+  @value='yes-agree'
+  @selectedValue='yes-agree'
   @disabled={{false}}
   @changed={{fn}}
-  />
+/>
 ```
 
 <Preview>
-  <Story name="Basic" height="10rem">{{
-    template: hbs`
+  <Story name="Basic" height="10rem">
+    {{
+      template: hbs`
       <Rose::Form::Radio::Radio
         @label={{label}}
         @error={{error}}
@@ -32,46 +33,51 @@ Renders a form radiofield.
         @helperText={{helperText}}
         />
     `,
-    context: {
-      label: text('text', 'Radiofield'),
-      error: boolean('error', false),
-      value: text('value', 'value and selectedValue must match to select radiofield'),
-      helperText: text('helperText', 'Helper text'),
-      selectedValue: text(
-        'selectedValue',
-        'value and selectedValue must match to select radiofield'
-      ),
-      disabled: boolean('disabled', false),
-      icon: select(
-        'icon',
-        {
-          'none': null,
-          'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
-          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
-        },
-        null
-      ),
-    }
-  }}</Story>
+      context: {
+        label: text('text', 'Radiofield'),
+        error: boolean('error', false),
+        value: text(
+          'value',
+          'value and selectedValue must match to select radiofield'
+        ),
+        helperText: text('helperText', 'Helper text'),
+        selectedValue: text(
+          'selectedValue',
+          'value and selectedValue must match to select radiofield'
+        ),
+        disabled: boolean('disabled', false),
+        icon: select(
+          'icon',
+          {
+            none: null,
+            'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
+            'flight-icons/svg/clipboard-copy-16':
+              'flight-icons/svg/clipboard-copy-16',
+          },
+          null
+        ),
+      },
+    }}
+  </Story>
 </Preview>
-
 
 ```htmlbars
 <Rose::Form::Radio::Radio
-  @label="Yes"
+  @label='Yes'
   @error={{false}}
-  @value="yes-agree"
-  @selectedValue="yes-agree"
+  @value='yes-agree'
+  @selectedValue='yes-agree'
   @disabled={{false}}
   @changed={{fn}}
   @inline={{true}}
   @helperText={{helperText}}
-  />
+/>
 ```
 
 <Preview>
-  <Story name="Radio with inline style" height="10rem">{{
-    template: hbs`
+  <Story name="Radio with inline style" height="10rem">
+    {{
+      template: hbs`
       <Rose::Form::Radio::Radio
         @label='Radiofield1'
         @error={{error}}
@@ -103,25 +109,30 @@ Renders a form radiofield.
         @helperText={{helperText}}
         />
     `,
-    context: {
-      error: boolean('error', false),
-      value: text('value', 'value and selectedValue must match to select radiofield'),
-      selectedValue: text(
-        'selectedValue',
-        'value and selectedValue must match to select radiofield'
-      ),
-      helperText: text('helperText', 'Helper text'),
-      disabled: boolean('disabled', false),
-      icon: select(
-        'icon',
-        {
-          'none': null,
-          'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
-          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
-        },
-        null
-      ),
-      inline: boolean('inline', false)
-    }
-  }}</Story>
+      context: {
+        error: boolean('error', false),
+        value: text(
+          'value',
+          'value and selectedValue must match to select radiofield'
+        ),
+        selectedValue: text(
+          'selectedValue',
+          'value and selectedValue must match to select radiofield'
+        ),
+        helperText: text('helperText', 'Helper text'),
+        disabled: boolean('disabled', false),
+        icon: select(
+          'icon',
+          {
+            none: null,
+            'flight-icons/svg/org-16': 'flight-icons/svg/org-16',
+            'flight-icons/svg/clipboard-copy-16':
+              'flight-icons/svg/clipboard-copy-16',
+          },
+          null
+        ),
+        inline: boolean('inline', false),
+      },
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/form/select/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/select/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/Select" component="Form/Select" />
+<Meta title="Rose/Form/Select" component="Form/Select" />
 
 # Form Select
 
@@ -11,26 +11,27 @@ Renders a form select element.
 
 ```htmlbars
 <Rose::Form::Select
-  @name="select-name"
-  @value="green"
-  @label="Color"
-  @helperText="Set your desired color"
+  @name='select-name'
+  @value='green'
+  @label='Color'
+  @helperText='Set your desired color'
   @disabled={{false}}
   @error={{false}}
   as |field|
 >
   <field.field as |select|>
     <select.option>Choose a color</select.option>
-    <select.option @value="red">Red</select.option>
-    <select.option @value="green">Green</select.option>
-    <select.option @value="blue">Blue</select.option>
+    <select.option @value='red'>Red</select.option>
+    <select.option @value='green'>Green</select.option>
+    <select.option @value='blue'>Blue</select.option>
   </field.field>
 </Rose::Form::Select>
 ```
 
 <Preview>
-  <Story name="Basic" height="10rem">{{
-    template: hbs`
+  <Story name="Basic" height="10rem">
+    {{
+      template: hbs`
       <Rose::Form::Select
         @name={{name}}
         @value={{value}}
@@ -49,29 +50,31 @@ Renders a form select element.
         </field.field>
       </Rose::Form::Select>
     `,
-    context: {
-      value: select(
-        'value',
-        {
-          null: null,
-          'value-1': 'value-1',
-          'value-2': 'value-2',
-          'value-3': 'value-3',
-        },
-        null
-      ),
-      name: text('name', 'select-name'),
-      label: text('label', 'Label'),
-      helperText: text('helperText', 'Helper text'),
-      disabled: boolean('disabled', false),
-      onChange: action('changed'),
-    }
-  }}</Story>
+      context: {
+        value: select(
+          'value',
+          {
+            null: null,
+            'value-1': 'value-1',
+            'value-2': 'value-2',
+            'value-3': 'value-3',
+          },
+          null
+        ),
+        name: text('name', 'select-name'),
+        label: text('label', 'Label'),
+        helperText: text('helperText', 'Helper text'),
+        disabled: boolean('disabled', false),
+        onChange: action('changed'),
+      },
+    }}
+  </Story>
 </Preview>
 
 <Preview>
-  <Story name="Select with Errors" height="10rem">{{
-    template: hbs`
+  <Story name="Select with Errors" height="10rem">
+    {{
+      template: hbs`
       <Rose::Form::Select
         @name={{name}}
         @value={{value}}
@@ -93,29 +96,31 @@ Renders a form select element.
         </field.errors>
       </Rose::Form::Select>
     `,
-    context: {
-      value: select(
-        'value',
-        {
-          null: null,
-          'value-1': 'value-1',
-          'value-2': 'value-2',
-          'value-3': 'value-3',
-        },
-        null
-      ),
-      name: text('name', 'select-name'),
-      label: text('label', 'Label'),
-      helperText: text('helperText', 'Helper text'),
-      disabled: boolean('disabled', false),
-      onChange: action('changed'),
-    }
-  }}</Story>
+      context: {
+        value: select(
+          'value',
+          {
+            null: null,
+            'value-1': 'value-1',
+            'value-2': 'value-2',
+            'value-3': 'value-3',
+          },
+          null
+        ),
+        name: text('name', 'select-name'),
+        label: text('label', 'Label'),
+        helperText: text('helperText', 'Helper text'),
+        disabled: boolean('disabled', false),
+        onChange: action('changed'),
+      },
+    }}
+  </Story>
 </Preview>
 
 <Preview>
-  <Story name="Fully Contextual Select">{{
-    template: hbs`
+  <Story name="Fully Contextual Select">
+    {{
+      template: hbs`
       <Rose::Form::Select @value="value-3" @error={{true}} @contextual={{true}} as |field|>
         <hr />
         <field.label>Label</field.label>
@@ -134,6 +139,7 @@ Renders a form select element.
         <hr />
       </Rose::Form::Select>
     `,
-    context: {},
-  }}</Story>
+      context: {},
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/form/textarea/index.stories.mdx
+++ b/addons/rose/addon/components/rose/form/textarea/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Form/Textarea" component="Form/Textarea" />
+<Meta title="Rose/Form/Textarea" component="Form/Textarea" />
 
 # Form Textarea
 
@@ -11,10 +11,10 @@ Renders a simple form textarea.
 
 ```htmlbars
 <Rose::Form::Textarea
-  @name="field"
-  @value="Descriptive content"
-  @label="Description"
-  @helperText="Enter a description"
+  @name='field'
+  @value='Descriptive content'
+  @label='Description'
+  @helperText='Enter a description'
   @error={{false}}
   @disabled={{false}}
   readonly={{false}}
@@ -24,8 +24,9 @@ Renders a simple form textarea.
 ```
 
 <Preview>
-  <Story name="Basic Textarea" height="10rem">{{
-    template: hbs`
+  <Story name="Basic Textarea" height="10rem">
+    {{
+      template: hbs`
       <Rose::Form::Textarea
         @name="field"
         @value={{value}}
@@ -38,21 +39,23 @@ Renders a simple form textarea.
         @linkText='link text goes here'
         />
     `,
-    context: {
-      value: text('value', 'Value'),
-      label: text('label', 'Label'),
-      helperText: text('helperText', 'Helper text'),
-      link: text('link', 'link'),
-      linkText: text('linkText', 'link text goes here'),
-      disabled: boolean('disabled', false),
-      'read-only': boolean('readonly', false),
-    }
-  }}</Story>
+      context: {
+        value: text('value', 'Value'),
+        label: text('label', 'Label'),
+        helperText: text('helperText', 'Helper text'),
+        link: text('link', 'link'),
+        linkText: text('linkText', 'link text goes here'),
+        disabled: boolean('disabled', false),
+        'read-only': boolean('readonly', false),
+      },
+    }}
+  </Story>
 </Preview>
 
 <Preview>
-  <Story name="Textarea with Errors" height="10rem">{{
-    template: hbs`
+  <Story name="Textarea with Errors" height="10rem">
+    {{
+      template: hbs`
       <Rose::Form::Textarea
         @name="field"
         @value={{value}}
@@ -67,19 +70,21 @@ Renders a simple form textarea.
         </field.errors>
       </Rose::Form::Textarea>
     `,
-    context: {
-      value: text('value', 'Value'),
-      label: text('label', 'Label'),
-      helperText: text('helperText', 'Helper text'),
-      disabled: boolean('disabled', false),
-      'read-only': boolean('readonly', false),
-    }
-  }}</Story>
+      context: {
+        value: text('value', 'Value'),
+        label: text('label', 'Label'),
+        helperText: text('helperText', 'Helper text'),
+        disabled: boolean('disabled', false),
+        'read-only': boolean('readonly', false),
+      },
+    }}
+  </Story>
 </Preview>
 
 <Preview>
-  <Story name="Fully Contextual Textarea">{{
-    template: hbs`
+  <Story name="Fully Contextual Textarea">
+    {{
+      template: hbs`
       <Rose::Form::Textarea @value="Text" @error={{true}} @contextual={{true}} as |field|>
         <hr />
         <field.label>Label</field.label>
@@ -94,6 +99,7 @@ Renders a simple form textarea.
         <hr />
       </Rose::Form::Textarea>
     `,
-    context: {},
-  }}</Story>
+      context: {},
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/frame/index.stories.mdx
+++ b/addons/rose/addon/components/rose/frame/index.stories.mdx
@@ -1,22 +1,22 @@
-
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
-<Meta title="Rose|Frame" component="Frame" />
+<Meta title="Rose/Frame" component="Frame" />
 
 # Frame
 
-A simple frame component with named blocks `:header` and `:body`.  Note that
+A simple frame component with named blocks `:header` and `:body`. Note that
 this component is unique to Boundary and is not part of the Structure design
 system.
 
-Prerequisite:  `ember-named-blocks-polyfill` must be installed in your app's
+Prerequisite: `ember-named-blocks-polyfill` must be installed in your app's
 `dependencies` rather than `devDependencies`.
 
 <Preview>
-  <Story name="Frame" height="15rem">{{
-    template: hbs`
+  <Story name="Frame" height="15rem">
+    {{
+      template: hbs`
     <Rose::Frame>
       <:header>
         <h2>Frame Header</h2>
@@ -25,10 +25,10 @@ Prerequisite:  `ember-named-blocks-polyfill` must be installed in your app's
         <p>Frame body</p>
       </:body>
     </Rose::Frame>
-    `
-  }}</Story>
+    `,
+    }}
+  </Story>
 </Preview>
-
 
 ```htmlbars
 <Rose::Frame>

--- a/addons/rose/addon/components/rose/header/index.stories.mdx
+++ b/addons/rose/addon/components/rose/header/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Header" component="Header" />
+<Meta title="Rose/Header" component="Header" />
 
 # Header
 
@@ -11,26 +11,27 @@ A header component that allows three distinct sections to be configured: brand, 
 
 ```htmlbars
 <Rose::Header as |header|>
-  <header.brand @logo="logo" @text="Product Name" />
+  <header.brand @logo='logo' @text='Product Name' />
 
   <header.nav as |nav|>
-    <nav.dropdown @text="org-name" as |dropdown|>
-      <dropdown.link @route="index">Menu item</dropdown.link>
-      <dropdown.link @route="about">Menu item</dropdown.link>
+    <nav.dropdown @text='org-name' as |dropdown|>
+      <dropdown.link @route='index'>Menu item</dropdown.link>
+      <dropdown.link @route='about'>Menu item</dropdown.link>
       <dropdown.button>Button menu item</dropdown.button>
     </nav.dropdown>
-    <nav.link @route="index">Section</nav.link>
-    <nav.link @route="about">Section</nav.link>
+    <nav.link @route='index'>Section</nav.link>
+    <nav.link @route='about'>Section</nav.link>
   </header.nav>
 
   <header.utilities as |utilities|>
     <utilities.dropdown
-      @text="user@example.net"
+      @text='user@example.net'
       @iconOnly={{true}}
-      @icon="flight-icons/svg/user-circle-16" as |dropdown|
+      @icon='flight-icons/svg/user-circle-16'
+      as |dropdown|
     >
-      <dropdown.link @route="index">Menu item</dropdown.link>
-      <dropdown.link @route="about">Menu item</dropdown.link>
+      <dropdown.link @route='index'>Menu item</dropdown.link>
+      <dropdown.link @route='about'>Menu item</dropdown.link>
       <dropdown.button>Button menu item</dropdown.button>
     </utilities.dropdown>
   </header.utilities>
@@ -38,8 +39,9 @@ A header component that allows three distinct sections to be configured: brand, 
 ```
 
 <Preview>
-  <Story name="Basic">{{
-    template: hbs`
+  <Story name="Basic">
+    {{
+      template: hbs`
     <Rose::Header as |header|>
       <header.brand @logo="logo" @text={{brandName}} />
       <header.nav as |nav|>
@@ -64,17 +66,21 @@ A header component that allows three distinct sections to be configured: brand, 
       </header.utilities>
     </Rose::Header>
     `,
-    context: {
-      brandName: text('brandName', 'Brand Name'),
-      dropdownIcon: select(
-        'dropdownIcon',
-        {
-          'flight-icons/svg/user-circle-16': 'flight-icons/svg/user-circle-16',
-          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
-          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
-        },
-        'flight-icons/svg/user-circle-16'
-      ),
-    },
-  }}</Story>
+      context: {
+        brandName: text('brandName', 'Brand Name'),
+        dropdownIcon: select(
+          'dropdownIcon',
+          {
+            'flight-icons/svg/user-circle-16':
+              'flight-icons/svg/user-circle-16',
+            'flight-icons/svg/check-circle-16':
+              'flight-icons/svg/check-circle-16',
+            'flight-icons/svg/clipboard-copy-16':
+              'flight-icons/svg/clipboard-copy-16',
+          },
+          'flight-icons/svg/user-circle-16'
+        ),
+      },
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/icon/index.stories.mdx
+++ b/addons/rose/addon/components/rose/icon/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Icon" component="Icon" />
+<Meta title="Rose/Icon" component="Icon" />
 
 # Icon
 
@@ -14,19 +14,23 @@ Renders a simple icon.
 ```
 
 <Preview>
-  <Story name="Basic">{{
-    template: hbs`
+  <Story name="Basic">
+    {{
+      template: hbs`
       <Rose::Icon @name={{name}} @size={{size}} />
     `,
-    context: {
-      name: select(
-        'name',
-        {
-          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
-          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
-        },
-        'flight-icons/svg/check-circle-16'
-      ),
-    }
-  }}</Story>
+      context: {
+        name: select(
+          'name',
+          {
+            'flight-icons/svg/check-circle-16':
+              'flight-icons/svg/check-circle-16',
+            'flight-icons/svg/clipboard-copy-16':
+              'flight-icons/svg/clipboard-copy-16',
+          },
+          'flight-icons/svg/check-circle-16'
+        ),
+      },
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/layout/centered/index.stories.mdx
+++ b/addons/rose/addon/components/rose/layout/centered/index.stories.mdx
@@ -1,8 +1,8 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
-<Meta title="Rose|Layout|Centered" component="Centered" />
+<Meta title="Rose/Layout/Centered" component="Centered" />
 
 # Layout|Centered
 
@@ -15,11 +15,13 @@ A left and right centered layout/positioning component.
 ```
 
 <Preview>
-  <Story name="Centered">{{
-    template: hbs`
+  <Story name="Centered">
+    {{
+      template: hbs`
     <Rose::Layout::Centered style="background: var(--brand-gray-7);">
       Centered
     </Rose::Layout::Centered>
     `,
-  }}</Story>
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/layout/global/index.stories.mdx
+++ b/addons/rose/addon/components/rose/layout/global/index.stories.mdx
@@ -1,7 +1,7 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 
-<Meta title="Rose|Layout|Global" component="Global" />
+<Meta title="Rose/Layout/Global" component="Global" />
 
 # Layout|Global
 
@@ -17,13 +17,15 @@ be configured: header, body, and footer.
 ```
 
 <Preview>
-  <Story name="Global">{{
-    template: hbs`
+  <Story name="Global">
+    {{
+      template: hbs`
       <Rose::Layout::Global as |layout|>
         <layout.header style="background: var(--brand-gray-5);">Header</layout.header>
         <layout.body style="background: var(--brand-gray-7);">Body</layout.body>
         <layout.footer style="background: var(--brand-gray-5);">Footer</layout.footer>
       </Rose::Layout::Global>
     `,
-  }}</Story>
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/layout/page/index.stories.mdx
+++ b/addons/rose/addon/components/rose/layout/page/index.stories.mdx
@@ -1,8 +1,8 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
-<Meta title="Rose|Layout|Page" component="Page" />
+<Meta title="Rose/Layout/Page" component="Page" />
 
 # Layout|Page
 
@@ -19,8 +19,9 @@ A page layout/positioning component that allows five distinct sections to be con
 ```
 
 <Preview>
-  <Story name="Page">{{
-    template: hbs`
+  <Story name="Page">
+    {{
+      template: hbs`
     <Rose::Layout::Page as |page|>
       <page.breadcrumbs style="background: var(--brand-gray-4);">Breadcrumbs</page.breadcrumbs>
       <page.header style="background: var(--brand-gray-5);">Header</page.header>
@@ -29,5 +30,6 @@ A page layout/positioning component that allows five distinct sections to be con
       <page.body style="background: var(--brand-gray-7);">Body</page.body>
     </Rose::Layout::Page>
     `,
-  }}</Story>
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/layout/sidebar/index.stories.mdx
+++ b/addons/rose/addon/components/rose/layout/sidebar/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Layout|Sidebar" component="SidebarLayout" />
+<Meta title="Rose/Layout/Sidebar" component="SidebarLayout" />
 
 # Layout|Sidebar
 
@@ -22,12 +22,14 @@ be configured: sidebar and body.
 ```
 
 <Preview>
-  <Story name="SidebarLayout">{{
-    template: hbs`
+  <Story name="SidebarLayout">
+    {{
+      template: hbs`
       <Rose::Layout::Sidebar as |layout|>
         <layout.sidebar style="background: var(--brand-gray-7);">Body</layout.sidebar>
         <layout.body style="background: var(--brand-gray-5);">Sidebar</layout.body>
       </Rose::Layout::Sidebar>
     `,
-  }}</Story>
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/link-button/index.stories.mdx
+++ b/addons/rose/addon/components/rose/link-button/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|LinkButton" component="LinkButton" />
+<Meta title="Rose/LinkButton" component="LinkButton" />
 
 # LinkButton
 
@@ -12,14 +12,19 @@ Styles supported: primary, secondary, warning, and ghost.
 Disabling link button is not supported as it is an action on form components only.
 
 ```html
-<Rose::LinkButton @route="index" @style="primary" @iconRight="flight-icons/svg/entry-point-16">
+<Rose::LinkButton
+  @route="index"
+  @style="primary"
+  @iconRight="flight-icons/svg/entry-point-16"
+>
   Content
 </Rose::LinkButton>
 ```
 
 <Preview>
-  <Story name="Advanced">{{
-    template: hbs`
+  <Story name="Advanced">
+    {{
+      template: hbs`
       <Rose::LinkButton
         @route="index"
         @style={{style}}
@@ -29,70 +34,82 @@ Disabling link button is not supported as it is an action on form components onl
         {{text}}
       </Rose::LinkButton>
     `,
-    context: {
-      text: text('text', 'Content'),
-      style: select(
-        'style',
-        {
-          primary: 'primary',
-          secondary: 'secondary',
-          warning: 'warning',
-          ghost: 'ghost',
-          'inline-link-action': 'inline-link-action',
-        },
-        'primary'
-      ),
-      iconLeft: select(
-        'iconLeft',
-        {
-          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
-          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
-        },
-        'flight-icons/svg/clipboard-copy-16'
-      ),
-      iconRight: select(
-        'iconRight',
-        {
-          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
-          'flight-icons/svg/clipboard-copy-16': 'flight-icons/svg/clipboard-copy-16',
-        },
-        'flight-icons/svg/clipboard-copy-16'
-      ),
-    },
-  }}</Story>
+      context: {
+        text: text('text', 'Content'),
+        style: select(
+          'style',
+          {
+            primary: 'primary',
+            secondary: 'secondary',
+            warning: 'warning',
+            ghost: 'ghost',
+            'inline-link-action': 'inline-link-action',
+          },
+          'primary'
+        ),
+        iconLeft: select(
+          'iconLeft',
+          {
+            'flight-icons/svg/check-circle-16':
+              'flight-icons/svg/check-circle-16',
+            'flight-icons/svg/clipboard-copy-16':
+              'flight-icons/svg/clipboard-copy-16',
+          },
+          'flight-icons/svg/clipboard-copy-16'
+        ),
+        iconRight: select(
+          'iconRight',
+          {
+            'flight-icons/svg/check-circle-16':
+              'flight-icons/svg/check-circle-16',
+            'flight-icons/svg/clipboard-copy-16':
+              'flight-icons/svg/clipboard-copy-16',
+          },
+          'flight-icons/svg/clipboard-copy-16'
+        ),
+      },
+    }}
+  </Story>
 </Preview>
 
 Similar to `Rose::Button`, icon only link button is supported.
 
 ```html
-<Rose::LinkButton @route="index" @style="primary" @iconOnly="flight-icons/svg/help-16" />
+<Rose::LinkButton
+  @route="index"
+  @style="primary"
+  @iconOnly="flight-icons/svg/help-16"
+/>
 ```
 
 <Preview>
-  <Story name="Icon Only">{{
-    template: hbs`
+  <Story name="Icon Only">
+    {{
+      template: hbs`
     <Rose::LinkButton @route="" @style={{style}} @iconOnly={{iconOnly}} />
     `,
-    context: {
-      style: select(
-        'style',
-        {
-          primary: 'primary',
-          secondary: 'secondary',
-          warning: 'warning',
-          ghost: 'ghost',
-          'inline-link-action': 'inline-link-action',
-        },
-        'primary'
-      ),
-      iconOnly: select(
-        'iconOnly',
-        {
-          'flight-icons/svg/check-circle-16': 'flight-icons/svg/check-circle-16',
-          'flight-icons/svg/help-16': 'flight-icons/svg/help-16',
-        },
-        'flight-icons/svg/help-16'
-      ),
-    },
-  }}</Story>
+      context: {
+        style: select(
+          'style',
+          {
+            primary: 'primary',
+            secondary: 'secondary',
+            warning: 'warning',
+            ghost: 'ghost',
+            'inline-link-action': 'inline-link-action',
+          },
+          'primary'
+        ),
+        iconOnly: select(
+          'iconOnly',
+          {
+            'flight-icons/svg/check-circle-16':
+              'flight-icons/svg/check-circle-16',
+            'flight-icons/svg/help-16': 'flight-icons/svg/help-16',
+          },
+          'flight-icons/svg/help-16'
+        ),
+      },
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/list/key-value/index.stories.mdx
+++ b/addons/rose/addon/components/rose/list/key-value/index.stories.mdx
@@ -1,16 +1,17 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
-<Meta title="Rose|List|KeyValue" component="List/KeyValue" />
+<Meta title="Rose/List/KeyValue" component="List/KeyValue" />
 
 # Key/Value List
 
 A simple key/value list with support for embedded form fields and buttons.
 
 <Preview>
-  <Story name="Basic Key/Value List" height="17rem">{{
-    template: hbs`
+  <Story name="Basic Key/Value List" height="17rem">
+    {{
+      template: hbs`
     <Rose::List::KeyValue as |list|>
       <list.item as |item|>
         <item.key>Key</item.key>
@@ -52,7 +53,8 @@ A simple key/value list with support for embedded form fields and buttons.
       </Rose::Form::Input>
     </Rose::List::KeyValue>
     `,
-  }}</Story>
+    }}
+  </Story>
 </Preview>
 
 ```html
@@ -70,8 +72,9 @@ A simple key/value list with support for embedded form fields and buttons.
     <item.cell>Value</item.cell>
   </list.item>
 
-  {{!-- In actual use, form fields should be yielded from an outer form component --}}
-  <Rose::Form::Input @contextual={{true}} as |input|>
+  {{!-- In actual use, form fields should be yielded from an outer form
+  component --}}
+  <Rose::Form::Input @contextual="{{true}}" as |input|>
     <list.item as |item|>
       <item.key>
         <input.label>Key</input.label>
@@ -85,7 +88,7 @@ A simple key/value list with support for embedded form fields and buttons.
     </list.item>
   </Rose::Form::Input>
 
-  <Rose::Form::Input @contextual={{true}} as |input|>
+  <Rose::Form::Input @contextual="{{true}}" as |input|>
     <list.item as |item|>
       <item.key>
         <input.label>Key</input.label>
@@ -94,10 +97,14 @@ A simple key/value list with support for embedded form fields and buttons.
         <input.field />
       </item.cell>
       <item.cell>
-        <Rose::Button @style="secondary" @iconOnly="flight-icons/svg/trash-16" title="Remove">Remove</Rose::Button>
+        <Rose::Button
+          @style="secondary"
+          @iconOnly="flight-icons/svg/trash-16"
+          title="Remove"
+          >Remove</Rose::Button
+        >
       </item.cell>
     </list.item>
   </Rose::Form::Input>
-
 </Rose::List::KeyValue>
 ```

--- a/addons/rose/addon/components/rose/message/index.stories.mdx
+++ b/addons/rose/addon/components/rose/message/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Message" component="Message" />
+<Meta title="Rose/Message" component="Message" />
 
 # Message
 
@@ -11,8 +11,9 @@ A message component containing a title, description, and nav links.
 Title can be configured with optional icon and subtitle.
 
 <Preview>
-  <Story name="Advanced Message" height="12rem">{{
-    template: hbs`
+  <Story name="Advanced Message" height="12rem">
+    {{
+      template: hbs`
     <Rose::Message @title={{title}} @subtitle={{subtitle}} @icon={{icon}} as |message|>
       <message.description>
         {{description}}
@@ -26,27 +27,38 @@ Title can be configured with optional icon and subtitle.
       </message.link>
     </Rose::Message>
     `,
-    context: {
-      title: text('title', 'Page not found'),
-      subtitle: text('subtitle', 'Error 404'),
-      description: text('description', 'Sorry, we could not find the page you were looking for.  Navigate to another page with the links below.'),
-      icon: select(
-        'icon',
-        {
-          'flight-icons/svg/alert-circle-16': 'flight-icons/svg/alert-circle-16',
-          'flight-icons/svg/help-16': 'flight-icons/svg/help-16',
-        },
-        'flight-icons/svg/help-16'
-      ),
-    },
-  }}</Story>
+      context: {
+        title: text('title', 'Page not found'),
+        subtitle: text('subtitle', 'Error 404'),
+        description: text(
+          'description',
+          'Sorry, we could not find the page you were looking for.  Navigate to another page with the links below.'
+        ),
+        icon: select(
+          'icon',
+          {
+            'flight-icons/svg/alert-circle-16':
+              'flight-icons/svg/alert-circle-16',
+            'flight-icons/svg/help-16': 'flight-icons/svg/help-16',
+          },
+          'flight-icons/svg/help-16'
+        ),
+      },
+    }}
+  </Story>
 </Preview>
 
 ```html
-<Rose::Message @title="Page not found" @subtitle="Error 404" @icon="flight-icons/svg/alert-circle-16" as |message|>
+<Rose::Message
+  @title="Page not found"
+  @subtitle="Error 404"
+  @icon="flight-icons/svg/alert-circle-16"
+  as
+  |message|
+>
   <message.description>
-      You must be granted permissions to view this data. Ask your administrator
-      if you think you should have access.
+    You must be granted permissions to view this data. Ask your administrator if
+    you think you should have access.
   </message.description>
   <message.link @route="index">
     <Rose::Icon @name="flight-icons/svg/chevron-left-16" />
@@ -59,25 +71,28 @@ Title can be configured with optional icon and subtitle.
 Message can be configured without icons and navigation links.
 
 <Preview>
-  <Story name="Basic Message" height="8rem">{{
-    template: hbs`
+  <Story name="Basic Message" height="8rem">
+    {{
+      template: hbs`
     <Rose::Message @title="No logs received yet" as |message|>
       <message.description>
         {{description}}
       </message.description>
     </Rose::Message>
     `,
-    context: {
-      title: text('title', 'No logs received yet'),
-      description: text('description', 'Sorry, we could not find the page you were looking for.  Navigate to another page with the links below.'),
-    },
-  }}</Story>
+      context: {
+        title: text('title', 'No logs received yet'),
+        description: text(
+          'description',
+          'Sorry, we could not find the page you were looking for.  Navigate to another page with the links below.'
+        ),
+      },
+    }}
+  </Story>
 </Preview>
 
 ```html
 <Rose::Message @title="No logs received yet" as |message|>
-  <message.description>
-    Description.
-  </message.description>
+  <message.description> Description. </message.description>
 </Rose::Message>
 ```

--- a/addons/rose/addon/components/rose/nav/breadcrumbs/index.stories.mdx
+++ b/addons/rose/addon/components/rose/nav/breadcrumbs/index.stories.mdx
@@ -1,8 +1,8 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
-<Meta title="Rose|Nav|Breadcrumbs" component="Nav/Breadcrumbs" />
+<Meta title="Rose/Nav/Breadcrumbs" component="Nav/Breadcrumbs" />
 
 # Breadcrumbs Navigation
 
@@ -16,12 +16,14 @@ A breadcrumbs component with links as crumbs.
 ```
 
 <Preview>
-  <Story name="Basic Breadcrumbs">{{
-    template: hbs`
+  <Story name="Basic Breadcrumbs">
+    {{
+      template: hbs`
       <Rose::Nav::Breadcrumbs as |breadcrumbs|>
         <breadcrumbs.link @route="about">Level 1</breadcrumbs.link>
         <breadcrumbs.link @route="index">Level 2</breadcrumbs.link>
       </Rose::Nav::Breadcrumbs>
     `,
-  }}</Story>
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/nav/link/index.stories.mdx
+++ b/addons/rose/addon/components/rose/nav/link/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Nav|Link" component="Nav/Link" />
+<Meta title="Rose/Nav/Link" component="Nav/Link" />
 
 # Generic Navigation Link
 

--- a/addons/rose/addon/components/rose/nav/sidebar/sidebar.stories.mdx
+++ b/addons/rose/addon/components/rose/nav/sidebar/sidebar.stories.mdx
@@ -1,34 +1,36 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Nav|Sidebar" component="Nav/Sidebar" />
+<Meta title="Rose/Nav/Sidebar" component="Nav/Sidebar" />
 
 # Sidebar Navigation
 
 A simple navigation component intended for use in the sidebar layout region.
 
 <Preview>
-  <Story name="Basic Sidebar Nav" height="8rem">{{
-    template: hbs`
+  <Story name="Basic Sidebar Nav" height="8rem">
+    {{
+      template: hbs`
       <Rose::Nav::Sidebar @title={{title}} as |nav|>
         <nav.link @route="index" class="active">Item Name</nav.link>
         <nav.link @route="index">Item Name</nav.link>
       </Rose::Nav::Sidebar>
     `,
-    context: {
-      title: text('title', 'Title'),
-    },
-  }}</Story>
+      context: {
+        title: text('title', 'Title'),
+      },
+    }}
+  </Story>
 </Preview>
 
-_Note_:  do not assign the `active` class directly.  This is done by the link
-component automatically.  We use it in this story for illustrative purposes.
+_Note_: do not assign the `active` class directly. This is done by the link
+component automatically. We use it in this story for illustrative purposes.
 
 ```htmlbars
-<Rose::Nav::Sidebar @title="Title" as |nav|>
-  <nav.link @route="index">Item Name</nav.link>
-  <nav.link @route="about">Item Name</nav.link>
+<Rose::Nav::Sidebar @title='Title' as |nav|>
+  <nav.link @route='index'>Item Name</nav.link>
+  <nav.link @route='about'>Item Name</nav.link>
 </Rose::Nav::Sidebar>
 ```

--- a/addons/rose/addon/components/rose/nav/tabs/index.stories.mdx
+++ b/addons/rose/addon/components/rose/nav/tabs/index.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Nav|Tabs" component="Nav/Tabs" />
+<Meta title="Rose/Nav/Tabs" component="Nav/Tabs" />
 
 # Tabs Navigation
 
@@ -11,21 +11,23 @@ A simple tabbed navigation component.
 
 ```html
 <Rose::Nav::Tabs as |nav|>
-  <nav.link @route='index' class="active">Text</nav.link>
-  <nav.link @route='index'>Text</nav.link>
-  <nav.link @route='index'>Text</nav.link>
+  <nav.link @route="index" class="active">Text</nav.link>
+  <nav.link @route="index">Text</nav.link>
+  <nav.link @route="index">Text</nav.link>
 </Rose::Nav::Tabs>
 ```
 
 <Preview>
-  <Story name="Basic Tabs">{{
-    template: hbs`
+  <Story name="Basic Tabs">
+    {{
+      template: hbs`
       <Rose::Nav::Tabs as |nav|>
         <nav.link @route='index' class="active">Text</nav.link>
         <nav.link @route='index'>Text</nav.link>
         <nav.link @route='index'>Text</nav.link>
       </Rose::Nav::Tabs>
     `,
-    context: {},
-  }}</Story>
+      context: {},
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/notification/index.stories.mdx
+++ b/addons/rose/addon/components/rose/notification/index.stories.mdx
@@ -1,35 +1,36 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Notification" component="Notification" />
+<Meta title="Rose/Notification" component="Notification" />
 
 # Notification
 
-Notifications come in four semantic styles:  `info` (default), `success`,
-`warning`, and `error`.  Heading text is required.  Additional block content
+Notifications come in four semantic styles: `info` (default), `success`,
+`warning`, and `error`. Heading text is required. Additional block content
 is optional.
 
 Notifications may be made dismissible by passing a `@dismiss` function into
-the component.  Dismissible notifications _must_ also have `@dismissText`.
-This component does not handle dismissal though.  Be sure your `@dismiss`
+the component. Dismissible notifications _must_ also have `@dismissText`.
+This component does not handle dismissal though. Be sure your `@dismiss`
 handler takes appropriate action and hides the notification.
 
 ```htmlbars
 <Rose::Notification
-  @style="info"
-  @heading="Alert Notification"
+  @style='info'
+  @heading='Alert Notification'
   @dismiss={{dismissHandler}}
-  @dismissText="Dismiss"
+  @dismissText='Dismiss'
 >
   An error occurred.
 </Rose::Notification>
 ```
 
 <Preview>
-  <Story name="Basic Notification">{{
-    template: hbs`
+  <Story name="Basic Notification">
+    {{
+      template: hbs`
       <Rose::Notification
         @style="info"
         @heading="Notification without dismissal"
@@ -37,13 +38,15 @@ handler takes appropriate action and hides the notification.
         Some useful information.
       </Rose::Notification>
     `,
-    context: {}
-  }}</Story>
+      context: {},
+    }}
+  </Story>
 </Preview>
 
 <Preview>
-  <Story name="Basic Notifications with Dismissal" height="30rem">{{
-    template: hbs`
+  <Story name="Basic Notifications with Dismissal" height="30rem">
+    {{
+      template: hbs`
       <Rose::Notification
         @style="info"
         @heading="Dismissible Notification"
@@ -77,8 +80,9 @@ handler takes appropriate action and hides the notification.
         An error occurred.
       </Rose::Notification>
     `,
-    context: {
-      dismiss: action('dismiss'),
-    }
-  }}</Story>
+      context: {
+        dismiss: action('dismiss'),
+      },
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/separator/index.stories.mdx
+++ b/addons/rose/addon/components/rose/separator/index.stories.mdx
@@ -1,21 +1,23 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Separator" component="Separator" />
+<Meta title="Rose/Separator" component="Separator" />
 
 # Separator
 
 A simple styled `<hr>` element.
 
 <Preview>
-  <Story name="Basic Separator">{{
-    template: hbs`
+  <Story name="Basic Separator">
+    {{
+      template: hbs`
       <Rose::Separator />
     `,
-    context: {}
-  }}</Story>
+      context: {},
+    }}
+  </Story>
 </Preview>
 
 ```htmlbars

--- a/addons/rose/addon/components/rose/table/index.stories.mdx
+++ b/addons/rose/addon/components/rose/table/index.stories.mdx
@@ -1,8 +1,8 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Rose|Table" component="Table" />
+<Meta title="Rose/Table" component="Table" />
 
 # Table
 
@@ -11,32 +11,34 @@ A table component to display data in structure of rows and columns. It supports 
 Cell shrink should be applied to all the cells in a row. Otherwise the bigger cell with shrink applied will determinate the width of the row.
 
 ```html
-<Rose::Table @style={{style}} as |table|>
+<Rose::Table @style="{{style}}" as |table|>
   <table.header as |header|>
-    <header.row @hidden={{hideHeaderRow}} as |row|>
+    <header.row @hidden="{{hideHeaderRow}}" as |row|>
       <row.headerCell>Address</row.headerCell>
       <row.headerCell>Host Set</row.headerCell>
       <row.headerCell>Name</row.headerCell>
-      <row.headerCell @alignCenter={{true}}>Description</row.headerCell>
+      <row.headerCell @alignCenter="{{true}}">Description</row.headerCell>
     </header.row>
   </table.header>
   <table.body as |body|>
     <body.row as |row|>
       <row.cell>1.1.1.1</row.cell>
       <row.cell>host-set-1, host-set-2</row.cell>
-      <row.cell @shrink={{true}}>optional name</row.cell>
-      <row.cell @alignCenter={{true}}>description</row.cell>
+      <row.cell @shrink="{{true}}">optional name</row.cell>
+      <row.cell @alignCenter="{{true}}">description</row.cell>
     </body.row>
     <body.row as |row|>
       <row.cell>1.1.1.1</row.cell>
       <row.cell>host-set-2</row.cell>
-      <row.cell @shrink={{true}} @alignCenter={{true}}>optional name</row.cell>
-      <row.cell @alignRight={{true}}>description</row.cell>
+      <row.cell @shrink="{{true}}" @alignCenter="{{true}}"
+        >optional name</row.cell
+      >
+      <row.cell @alignRight="{{true}}">description</row.cell>
     </body.row>
     <body.row as |row|>
       <row.cell>1.1.1.1</row.cell>
       <row.cell>host-set-1</row.cell>
-      <row.cell @shrink={{true}}>optional name</row.cell>
+      <row.cell @shrink="{{true}}">optional name</row.cell>
       <row.cell>description</row.cell>
     </body.row>
   </table.body>
@@ -49,8 +51,9 @@ Cell shrink should be applied to all the cells in a row. Otherwise the bigger ce
 ```
 
 <Preview>
-  <Story name="Basic">{{
-    template: hbs`
+  <Story name="Basic">
+    {{
+      template: hbs`
     <Rose::Table @style={{style}} as |table|>
       <table.header as |header|>
         <header.row @hidden={{hideHeaderRow}} as |row|>
@@ -87,25 +90,24 @@ Cell shrink should be applied to all the cells in a row. Otherwise the bigger ce
       </table.footer>
     </Rose::Table>
     `,
-    context: {
-      hideHeaderRow: boolean('hideHeaderRow', false),
-      cellShrink: boolean('cellShrink', false),
-      style: select(
-        'style',
-        {
-          'default': '',
-          'condensed': 'condensed'
-        }
-      ),
-      cellAlignmentCenter: boolean('cellAlignmentCenter', false),
-      cellAlignmentRight: boolean('cellAlignmentRight', false),
-    },
-  }}</Story>
+      context: {
+        hideHeaderRow: boolean('hideHeaderRow', false),
+        cellShrink: boolean('cellShrink', false),
+        style: select('style', {
+          default: '',
+          condensed: 'condensed',
+        }),
+        cellAlignmentCenter: boolean('cellAlignmentCenter', false),
+        cellAlignmentRight: boolean('cellAlignmentRight', false),
+      },
+    }}
+  </Story>
 </Preview>
 
 <Preview>
-  <Story name="Basic Key/Value Table">{{
-    template: hbs`
+  <Story name="Basic Key/Value Table">
+    {{
+      template: hbs`
       <Rose::Table @style={{style}} as |table|>
         <table.header as |header|>
           <header.row  as |row|>
@@ -175,14 +177,12 @@ Cell shrink should be applied to all the cells in a row. Otherwise the bigger ce
         </table.footer>
       </Rose::Table>
     `,
-    context: {
-      style: select(
-        'style',
-        {
-          'condensed': 'condensed',
-          'default': ''
-        }
-      )
-    }
-  }}</Story>
+      context: {
+        style: select('style', {
+          condensed: 'condensed',
+          default: '',
+        }),
+      },
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/toolbar/index.stories.mdx
+++ b/addons/rose/addon/components/rose/toolbar/index.stories.mdx
@@ -1,12 +1,12 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
-<Meta title="Rose|Toolbar" component="Toolbar" />
+<Meta title="Rose/Toolbar" component="Toolbar" />
 
 # Toolbar
 
-Renders a toolbar.  Items may be added directly into the toolbar, or within
+Renders a toolbar. Items may be added directly into the toolbar, or within
 predefined "regions" for left and right alignment, respectively.
 
 ```htmlbars
@@ -22,11 +22,13 @@ predefined "regions" for left and right alignment, respectively.
 ```
 
 <Preview>
-  <Story name="Toolbar">{{
-    template: hbs`
+  <Story name="Toolbar">
+    {{
+      template: hbs`
     <Rose::Toolbar as |toolbar|>
     toolbar
      </Rose::Toolbar>
     `,
-  }}</Story>
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/addon/components/rose/toolbar/info/index.stories.mdx
+++ b/addons/rose/addon/components/rose/toolbar/info/index.stories.mdx
@@ -1,8 +1,8 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
-<Meta title="Rose|Toolbar|Info" component="Toolbar Info" />
+<Meta title="Rose/Toolbar/Info" component="Toolbar Info" />
 
 # Toolbar Info
 
@@ -15,11 +15,13 @@ Used to display non-interactive information in a toolbar.
 ```
 
 <Preview>
-  <Story name="Toolbar Info">{{
-    template: hbs`
+  <Story name="Toolbar Info">
+    {{
+      template: hbs`
     <Rose::Toolbar>
       <Rose::Toolbar::Info>30 seconds ago</Rose::Toolbar::Info>
     </Rose::Toolbar>
     `,
-  }}</Story>
+    }}
+  </Story>
 </Preview>

--- a/addons/rose/stories/colors.stories.mdx
+++ b/addons/rose/stories/colors.stories.mdx
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Style Guide|Colors" />
+<Meta title="Style Guide/Colors" />
 
 # Colors
 

--- a/addons/rose/stories/colors.stories.mdx
+++ b/addons/rose/stories/colors.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';

--- a/addons/rose/stories/sizing.stories.mdx
+++ b/addons/rose/stories/sizing.stories.mdx
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Style Guide|Sizing" />
+<Meta title="Style Guide/Sizing" />
 
 # Sizing
 

--- a/addons/rose/stories/sizing.stories.mdx
+++ b/addons/rose/stories/sizing.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';

--- a/addons/rose/stories/typography.stories.mdx
+++ b/addons/rose/stories/typography.stories.mdx
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
 
-<Meta title="Style Guide|Typography" />
+<Meta title="Style Guide/Typography" />
 
 # Typography
 

--- a/addons/rose/stories/typography.stories.mdx
+++ b/addons/rose/stories/typography.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs';
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';


### PR DESCRIPTION
## Description

More context on this [work here](https://hashicorp.atlassian.net/browse/ICU-6367)

This PR fixes 4 deprecations for rose/storybook:
- [Deprecated implicit PostCSS loader](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-implicit-postcss-loader).
- [Correct globs in mainjs](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#correct-globs-in-mainjs).
- [Deprecated hierarchy separator (hierarchy-separator)](https://github.com/storybookjs/eslint-plugin-storybook/blob/main/docs/rules/hierarchy-separator.md)
- [Deprecated scoped blocks imports](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-scoped-blocks-imports)

### Screenshots (if appropriate):

PostCSS deprecation message before changes:
<img width="1674" alt="postcss-before" src="https://user-images.githubusercontent.com/9775006/195092962-5b517830-c1b4-4eb3-b91c-8df33204ba93.png">

No PostCSS deprecation message after changes:
<img width="1680" alt="postcss-after" src="https://user-images.githubusercontent.com/9775006/195093089-827c4170-2def-44e2-b773-5da5d09a4dba.png">

Glob in main deprecation message before changes:
<img width="1680" alt="glob-before" src="https://user-images.githubusercontent.com/9775006/195093147-d9efdd0e-3d1d-462c-ba60-b6bcc115bda9.png">

No Glob in main deprecation message after changes:
<img width="1680" alt="glob-after" src="https://user-images.githubusercontent.com/9775006/195093253-a37048b7-7f21-40c6-8d4e-fc03f411b5c6.png">

Hierarchy separators deprecation message before:
![hierarchy-separators-before](https://user-images.githubusercontent.com/9775006/195093314-8a1d64b8-48bd-4b8b-a5a7-167ea580a995.jpg)

No Hierarchy separators deprecation message after:
![hierarchy-separators-after](https://user-images.githubusercontent.com/9775006/195093509-ed1f826a-74a0-43aa-b923-19ab2d0d060d.jpg)

**As a side effect of Hierarchy separators, the menu has changed:**

Old version:
<img width="676" alt="Screen Shot 2022-10-11 at 2 43 16 PM" src="https://user-images.githubusercontent.com/9775006/195094097-34b1ecc9-8496-4e51-b3f1-e8c6c3604a4a.png">

New version:
<img width="951" alt="Screen Shot 2022-10-11 at 2 42 15 PM" src="https://user-images.githubusercontent.com/9775006/195094142-8903e938-8fbe-46f9-8389-cbc90e80b4eb.png">



