### PR TITLE
fix: 🐛 Fix mac intel cli download

### DIFF
--- a/ui/desktop/electron-app/config/cli.js
+++ b/ui/desktop/electron-app/config/cli.js
@@ -11,7 +11,10 @@ const downloadArtifact = (version) => {
   const archivePlatform = {};
   if (isMac()) {
     archivePlatform.name = 'darwin';
-    archivePlatform.arch = os.arch();
+    let arch = os.arch();
+    // Map x64 to amd64 cli artifact
+    if (arch.match(/(x64)/i)) arch = 'amd64';
+    archivePlatform.arch = arch;
   }
 
   if (isWindows()) {


### PR DESCRIPTION
Fix intel mac downloading the cli. It also names its arch `x64` instead of `amd64`