### PR TITLE
fix: 🐛 Forgotten session setup method in core

### DIFF
--- a/addons/core/ember-cli-build.js
+++ b/addons/core/ember-cli-build.js
@@ -5,6 +5,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function (defaults) {
   let app = new EmberAddon(defaults, {
     // Add options here
+    'ember-simple-auth': {
+      useSessionSetupMethod: true,
+    },
   });
 
   /*


### PR DESCRIPTION
## Description

Forgotten ember auth session setup method

### Screenshots (if appropriate):

Deprecation message in browser console before changes:
<img width="1680" alt="Screen Shot 2022-10-17 at 6 43 36 PM" src="https://user-images.githubusercontent.com/9775006/196238602-2b00acf3-5ed3-4ee3-b64d-93ec55175557.png">


NO Deprecation message in browser console after changes:
<img width="1680" alt="Screen Shot 2022-10-17 at 6 47 49 PM" src="https://user-images.githubusercontent.com/9775006/196238620-b8cea86b-45b4-4b2f-8bfd-d341b1d3410c.png">
