### PR TITLE
refactor: 💡 Deprecate renderTemplate in header-nav

### DIFF
--- a/addons/core/addon/services/scope.js
+++ b/addons/core/addon/services/scope.js
@@ -16,5 +16,15 @@ export default class ScopeService extends Service {
   /**
    * @type {ScopeModel}
    */
+  @tracked orgsList;
+
+  /**
+   * @type {ScopeModel}
+   */
   @tracked project;
+
+  /**
+   * @type {ScopeModel}
+   */
+  @tracked projectsList;
 }

--- a/addons/core/addon/services/scope.js
+++ b/addons/core/addon/services/scope.js
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 
 /**
  * This simple non-functional service is used to retain references to
- * the current active scope(s).
+ * lists of scopes (orgs and projects) and selected scopes (orgs and projects).
  */
 export default class ScopeService extends Service {
   // =attributes

--- a/addons/core/tests/unit/services/scope-test.js
+++ b/addons/core/tests/unit/services/scope-test.js
@@ -12,7 +12,7 @@ module('Unit | Service | scope', function (hooks) {
 
   test('it can contain orgs list scope', function (assert) {
     let service = this.owner.lookup('service:scope');
-    service.orgsList = {};
+    service.orgsList = [];
     assert.ok(service.orgsList, 'Service contains orgs list scope');
   });
 
@@ -24,7 +24,7 @@ module('Unit | Service | scope', function (hooks) {
 
   test('it can contain projects list scope', function (assert) {
     let service = this.owner.lookup('service:scope');
-    service.projectsList = {};
+    service.projectsList = [];
     assert.ok(service.projectsList, 'Service contains projects list scope');
   });
 });

--- a/addons/core/tests/unit/services/scope-test.js
+++ b/addons/core/tests/unit/services/scope-test.js
@@ -10,9 +10,21 @@ module('Unit | Service | scope', function (hooks) {
     assert.ok(service.org, 'Service contains org scope');
   });
 
+  test('it can contain orgs list scope', function (assert) {
+    let service = this.owner.lookup('service:scope');
+    service.orgsList = {};
+    assert.ok(service.orgsList, 'Service contains orgs list scope');
+  });
+
   test('it can contain project scope', function (assert) {
     let service = this.owner.lookup('service:scope');
     service.project = {};
     assert.ok(service.project, 'Service contains project scope');
+  });
+
+  test('it can contain projects list scope', function (assert) {
+    let service = this.owner.lookup('service:scope');
+    service.projectsList = {};
+    assert.ok(service.projectsList, 'Service contains projects list scope');
   });
 });

--- a/ui/admin/app/components/header-nav/index.hbs
+++ b/ui/admin/app/components/header-nav/index.hbs
@@ -1,7 +1,7 @@
 <Rose::Dropdown
-  @text={{this.scopes.selectedOrg.displayName}}
+  @text={{this.scope.org.displayName}}
   @icon={{if
-    this.scopes.selectedOrg.isGlobal
+    this.scope.org.isGlobal
     'flight-icons/svg/globe-16'
     'flight-icons/svg/org-16'
   }}
@@ -13,22 +13,22 @@
     </dropdown.link>
     <dropdown.separator />
   {{/if}}
-  {{#each this.scopes.orgs as |scope|}}
-    <dropdown.link @route='scopes.scope' @model={{scope.id}}>
-      {{scope.displayName}}
+  {{#each this.scope.orgsList as |org|}}
+    <dropdown.link @route='scopes.scope' @model={{org.id}}>
+      {{org.displayName}}
     </dropdown.link>
   {{/each}}
 </Rose::Dropdown>
 
-{{#if this.scopes.selectedProject}}
+{{#if this.scope.project}}
   <Rose::Dropdown
-    @text={{this.scopes.selectedProject.displayName}}
+    @text={{this.scope.project.displayName}}
     @icon='flight-icons/svg/grid-16'
     as |dropdown|
   >
-    {{#each this.scopes.projects as |scope|}}
-      <dropdown.link @route='scopes.scope' @model={{scope.id}}>
-        {{scope.displayName}}
+    {{#each this.scope.projectsList as |project|}}
+      <dropdown.link @route='scopes.scope' @model={{project.id}}>
+        {{project.displayName}}
       </dropdown.link>
     {{/each}}
   </Rose::Dropdown>

--- a/ui/admin/app/components/header-nav/index.js
+++ b/ui/admin/app/components/header-nav/index.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class HeaderNavComponent extends Component {
+  // =services
+
+  @service session;
+  @service scope;
+  @service router;
+}

--- a/ui/admin/app/components/header-nav/index.js
+++ b/ui/admin/app/components/header-nav/index.js
@@ -6,5 +6,4 @@ export default class HeaderNavComponent extends Component {
 
   @service session;
   @service scope;
-  @service router;
 }

--- a/ui/admin/app/routes/application.js
+++ b/ui/admin/app/routes/application.js
@@ -14,6 +14,8 @@ export default class ApplicationRoute extends Route {
   @service session;
   @service confirm;
   @service router;
+  @service scope;
+  @service intl;
 
   // =attributes
 

--- a/ui/admin/app/routes/application.js
+++ b/ui/admin/app/routes/application.js
@@ -14,8 +14,6 @@ export default class ApplicationRoute extends Route {
   @service session;
   @service confirm;
   @service router;
-  @service scope;
-  @service intl;
 
   // =attributes
 

--- a/ui/admin/app/routes/scopes/scope.js
+++ b/ui/admin/app/routes/scopes/scope.js
@@ -68,6 +68,8 @@ export default class ScopesScopeRoute extends Route {
     // Update the scope service with the current scope(s);
     this.scope.org = selectedOrg;
     this.scope.project = selectedProject;
+    this.scope.orgsList = orgs;
+    this.scope.projectsList = projects;
     this.scopes = { orgs, projects, selectedOrg, selectedProject };
     // Update the controller (if exists), since setupController is only
     // called once the first time the route is activated.  It is not called
@@ -92,20 +94,6 @@ export default class ScopesScopeRoute extends Route {
   setControllerProperties(scopes) {
     /* eslint-disable-next-line ember/no-controller-access-in-routes */
     this.controller.setProperties({ scopes });
-  }
-
-  /**
-   * Renders the scope-specific header template.
-   * @override
-   * @param {object} controller
-   * @param {object} model
-   */
-  renderTemplate() {
-    super.renderTemplate(...arguments);
-    this.render('scopes/scope/-header-nav', {
-      into: 'application',
-      outlet: 'header-nav',
-    });
   }
 
   // =actions

--- a/ui/admin/app/templates/application.hbs
+++ b/ui/admin/app/templates/application.hbs
@@ -8,9 +8,7 @@
 
       {{#if this.session.isAuthenticated}}
         <header.nav>
-
-          {{outlet 'header-nav'}}
-
+          <HeaderNav />
         </header.nav>
 
         <header.utilities as |utilities|>


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-6017)

## Description

Deprecate the usage of `renderTemplate` in the application `header-nav`.

Created a `header-nav` component to get rid of named outlets and `renderTemplate`. Add Organizations list and Projects list to `scope` service, so the new `header-nav` component can consume the data.

[Link to Vercel deployment of this PR](https://boundary-ui-git-refactor-deprecate-rendertempl-db50f8-hashicorp.vercel.app/) free of `renderTemplate` deprecation messages in browser console.
