### PR TITLE
chore: 🤖 explicitly call @hashicorp/ember-flight-icons` contentFor hook

### DIFF
--- a/addons/rose/index.js
+++ b/addons/rose/index.js
@@ -17,6 +17,18 @@ module.exports = {
   },
 
   /**
+   * Due to a limitation in how ember treats nested addons (see https://github.com/ember-cli/ember-cli/issues/4475)
+   * this is neeeded to reach down in to @hashicorp/ember-flight-icons' contentFor hook to run the logic
+   * that injects the sprite into the DOM
+   */
+  contentFor(type, config) {
+    return this.findOwnAddonByName('@hashicorp/ember-flight-icons').contentFor(
+      type,
+      config
+    );
+  },
+
+  /**
    * Finds this addon's styles folder and includes it into the running
    * application's `sassOptions.includePaths`, such that the application needs
    * no further configuration to import the styles.

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@hashicorp/design-system-components": "^1.2.0",
+    "@hashicorp/ember-flight-icons": "^3.0.0",
     "codemirror": "5.65.7",
     "ember-auto-import": "^2.4.2",
     "ember-cli-babel": "^7.26.8",


### PR DESCRIPTION
## Description

This PR works around [a limitation](https://github.com/ember-cli/ember-cli/issues/4475) in how ember treats nested addons and their `contentFor` hooks by manually finding and running that hook as part of rose's `contentFor` hook. Note, it is also important for `@hashicorp/ember-flight-icons` to be listed in rose's `dependencies` otherwise `this. findOwnAddonByName()` can't see it.

For context, the way `@hashicorp/ember-flight-icons` inserts the sprite into the dom is by using the `contentFor` hook like [this](https://github.com/hashicorp/design-system/blob/954566adcb84900c949941530fc0f8bf757c1b84/packages/ember-flight-icons/index.js#L14). The problem here is that because `@hashicorp/ember-flight-icons` is a dependency of `@hashicorp/design-system-components` and not of rose directly, this hook is not run 😭 .

:technologist: [Admin preview](PATH_TO_FEATURE)

:rose: [Rose preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

<!-- Add a brief description of changes here. Include any other necessary relevant links -->

### Screenshots (if appropriate):
