### PR TITLE
fix: 🐛 Fix electron appearance for desktop with mirage locally

### DIFF
--- a/addons/api/mirage/scenarios/ipc.js
+++ b/addons/api/mirage/scenarios/ipc.js
@@ -120,20 +120,6 @@ export default function initializeMockIPC(server, config) {
     }
 
     /**
-     * Check for window chrome on MacOS
-     */
-    hasMacOSChrome() {
-      return false;
-    }
-
-    /**
-     * Check for OS chrome state
-     */
-    showWindowActions() {
-      return true;
-    }
-
-    /**
      * Do nothing when attempting to minimize, toggle fullscreen,
      * and close a browser window
      */
@@ -151,6 +137,14 @@ export default function initializeMockIPC(server, config) {
    */
   if (config['ember-cli-mirage'].enabled && !isTesting) {
     const mockIPC = new MockIPC();
+
+    if (!config.isElectron) {
+      // Add these handlers for non electron environments, otherwise just
+      // pass through and use the actual electron handlers
+      mockIPC.hasMacOSChrome = () => false;
+      mockIPC.showWindowActions = () => true;
+    }
+
     window.addEventListener('message', async function (event) {
       if (event.origin !== window.location.origin) return;
       const { method, payload } = event?.data ?? {};

--- a/addons/api/mirage/scenarios/ipc.js
+++ b/addons/api/mirage/scenarios/ipc.js
@@ -6,8 +6,8 @@ export default function initializeMockIPC(server, config) {
   /**
    * We strive to make this application runnable in a regular web browser, since
    * it is a convenient environment for development and testing.  But only an
-   * Electron environment has true IPC.  Outside of Electron, we mock the handling
-   * of the message-based IPC requests originating from the
+   * Electron environment has true IPC.  Outside of Electron or with mirage,
+   * we mock the handling of the message-based IPC requests originating from the
    * renderer (the Ember app).
    */
   class MockIPC {
@@ -120,12 +120,19 @@ export default function initializeMockIPC(server, config) {
     }
 
     /**
+     * Check for OS chrome state
+     */
+    showWindowActions() {
+      return true;
+    }
+
+    /**
      * Do nothing when attempting to minimize, toggle fullscreen,
      * and close a browser window
      */
     minimizeWindow() {}
     closeWindow() {}
-    toggleFullScreenWindow() {}
+    toggleFullscreenWindow() {}
   }
 
   /**
@@ -142,7 +149,6 @@ export default function initializeMockIPC(server, config) {
       // Add these handlers for non electron environments, otherwise just
       // pass through and use the actual electron handlers
       mockIPC.hasMacOSChrome = () => false;
-      mockIPC.showWindowActions = () => true;
     }
 
     window.addEventListener('message', async function (event) {

--- a/addons/api/mirage/scenarios/ipc.js
+++ b/addons/api/mirage/scenarios/ipc.js
@@ -120,6 +120,13 @@ export default function initializeMockIPC(server, config) {
     }
 
     /**
+     * Check for window chrome on MacOS
+     */
+    hasMacOSChrome() {
+      return true;
+    }
+
+    /**
      * Check for OS chrome state
      */
     showWindowActions() {
@@ -141,15 +148,11 @@ export default function initializeMockIPC(server, config) {
    * preload.js script.
    *
    * Initializes mock IPC only in a non-testing context and when mirage is turned on.
+   * We mock certain functions even in electron (e.g. hasMacOSChrome) when running
+   * locally which will force a certain appearance regardless of platform
    */
   if (config['ember-cli-mirage'].enabled && !isTesting) {
     const mockIPC = new MockIPC();
-
-    if (!config.isElectron) {
-      // Add these handlers for non electron environments, otherwise just
-      // pass through and use the actual electron handlers
-      mockIPC.hasMacOSChrome = () => false;
-    }
 
     window.addEventListener('message', async function (event) {
       if (event.origin !== window.location.origin) return;


### PR DESCRIPTION
## Description
When using the desktop client locally with mirage enabled, the appearance is wonky due to us mocking functions that are needed to determine the appearance.

### Screenshots (if appropriate):
Before:
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/5783847/198334868-443ba309-2c7e-4825-a239-4d7f45a0140d.png">

After:
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/5783847/198335042-091ea1a6-ab8f-450f-b63c-9dfa81fde6f8.png">

