### PR TITLE
fix: 🐛 Fix styling for header icon CSS

### DIFF
--- a/addons/rose/app/styles/rose/components/header/_dropdown.scss
+++ b/addons/rose/app/styles/rose/components/header/_dropdown.scss
@@ -22,8 +22,10 @@ $chevron: "data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%23bac1cc' xm
         }
 
         .rose-icon {
+          --size: #{sizing.rems(l)};
+
           display: inline-block;
-          height: sizing.rems(l);
+          height: var(--size);
 
           > svg {
             vertical-align: top;


### PR DESCRIPTION
## Description
Fixes the small header icon CSS
