### PR TITLE
chore: 🤖 Add new component for handling info field text

### DIFF
--- a/addons/rose/addon/components/rose/info-field/index.hbs
+++ b/addons/rose/addon/components/rose/info-field/index.hbs
@@ -1,0 +1,10 @@
+<article class='rose-info-field' ...attributes>
+  <header class='rose-info-field-header'>
+    <p class='rose-info-field-title'>{{@title}}</p>
+    {{#if @icon}}
+      <Rose::Icon @name={{@icon}} @size='medium' />
+    {{/if}}
+    <p class='rose-info-field-subtitle'>{{@subtitle}}</p>
+  </header>
+  <p class='rose-info-field-description'>{{@description}}</p>
+</article>

--- a/addons/rose/addon/components/rose/info-field/index.stories.mdx
+++ b/addons/rose/addon/components/rose/info-field/index.stories.mdx
@@ -1,0 +1,81 @@
+import { Meta, Story, Preview } from '@storybook/addon-docs';
+import { hbs } from 'ember-cli-htmlbars';
+
+<Meta title="Rose/Info Field" component="InfoField" />
+
+# Info Field
+
+A information component containing a title, subtitle, description.
+Subtitle can be configured with optional icon.
+
+export const Template = (args) => ({
+  template: hbs`
+      <Rose::InfoField
+        @title={{title}}
+        @subtitle={{subtitle}}
+        @icon={{icon}}
+        @description={{description}}
+      />
+    `,
+  context: args,
+});
+
+<Preview>
+  <Story
+    name="Info Field with Icon"
+    height="12rem"
+    args={{
+      title: 'Type',
+      subtitle: 'Username & Key Pair',
+      description:
+        'This host requires a username, public key, and private key to connect',
+      icon: 'flight-icons/svg/keychain-16',
+    }}
+    argTypes={{
+      icon: {
+        control: 'select',
+        options: 'flight-icons/svg/keychain-16',
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Preview>
+
+```handlebars
+
+```
+
+Info Field can be configured without icons.
+
+export const BasicTemplate = (args) => ({
+  template: hbs`
+      <Rose::InfoField
+        @title={{title}}
+        @subtitle='JSON'
+        @description='Connect using a JSON blob containing the credentials'
+      />`,
+  context: args,
+});
+
+<Preview>
+  <Story
+    name="Basic"
+    height="8rem"
+    args={{
+      title: 'Type',
+      subtitle: 'JSON',
+      description: 'Connect using a JSON blob containing the credentials.',
+    }}
+  >
+    {BasicTemplate.bind({})}
+  </Story>
+</Preview>
+
+```handlebars
+<Rose::Message
+  @title='Type'
+  @subtitle='JSON'
+  @description='Connect using a JSON blob containing the credentials.'
+/>
+```

--- a/addons/rose/app/components/rose/info-field/index.js
+++ b/addons/rose/app/components/rose/info-field/index.js
@@ -1,0 +1,1 @@
+export { default } from 'rose/components/rose/info-field/index';

--- a/addons/rose/app/styles/rose/components/_index.scss
+++ b/addons/rose/app/styles/rose/components/_index.scss
@@ -20,3 +20,4 @@
 @import 'badge';
 @import 'toolbar';
 @import 'code-editor';
+@import 'info-field';

--- a/addons/rose/app/styles/rose/components/_info-field.scss
+++ b/addons/rose/app/styles/rose/components/_info-field.scss
@@ -1,0 +1,41 @@
+@use '../variables/sizing';
+
+.rose-info-field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: sizing.rems(m);
+
+  .rose-info-field-header {
+    display: grid;
+    grid-template-areas:
+      'title title'
+      'icon subtitle'
+      'description description';
+    grid-auto-columns: auto 1fr;
+    font-size: var(--token-typography-body-200-font-size);
+
+    .rose-info-field-title {
+      margin-bottom: sizing.rems(xxs);
+      grid-area: title;
+      font-weight: var(--token-typography-font-weight-semibold);
+    }
+
+    .rose-icon {
+      margin-right: sizing.rems(xxs);
+      grid-area: icon;
+    }
+
+    .rose-info-field-subtitle {
+      margin-bottom: 0;
+      grid-area: subtitle;
+      font-weight: var(--token-typography-font-weight-medium);
+    }
+  }
+
+  .rose-info-field-description {
+    margin-top: sizing.rems(xs);
+    grid-area: description;
+    font-size: var(--token-typography-body-100-font-size);
+    color: var(--token-form-helper-text-color);
+  }
+}

--- a/addons/rose/tests/integration/components/rose/info-field-test.js
+++ b/addons/rose/tests/integration/components/rose/info-field-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, find } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | rose/info-field', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    assert.expect(4);
+    await render(hbs`
+      <Rose::InfoField
+        @title="Title"
+        @subtitle="Subtitle"
+        @description="Description"
+      />
+    `);
+    assert.ok(find('.rose-info-field'));
+    assert.strictEqual(
+      find('.rose-info-field-title').textContent.trim(),
+      'Title'
+    );
+    assert.strictEqual(
+      find('.rose-info-field-subtitle').textContent.trim(),
+      'Subtitle'
+    );
+    assert.strictEqual(
+      find('.rose-info-field-description').textContent.trim(),
+      'Description'
+    );
+  });
+});


### PR DESCRIPTION
✅ Closes: ICU-6957

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-6957)

## Description
Added a new component called `<Rose::InfoField/>` that will help with readonly data for admin ui. 

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:rose: [Rose preview](PATH_TO_FEATURE)

<!-- Add a brief description of changes here. Include any other necessary relevant links -->

### Screenshots (if appropriate):
<img width="1502" alt="Screen Shot 2022-11-16 at 12 40 12" src="https://user-images.githubusercontent.com/24277002/202254220-4f31b660-8485-45c6-a1f8-af6b956f1ef5.png">
<img width="1502" alt="Screen Shot 2022-11-16 at 12 41 25" src="https://user-images.githubusercontent.com/24277002/202254232-b280c276-5436-45c5-b102-baf586a819f5.png">
