### PR TITLE
chore: 🤖 JSON credential data modeling

### DIFF
--- a/addons/api/addon/generated/models/credential.js
+++ b/addons/api/addon/generated/models/credential.js
@@ -79,4 +79,12 @@ export default class GeneratedCredentialModel extends BaseModel {
     description: 'The private key passphrase for credential.',
   })
   private_key_passphrase;
+
+  @attr('string', {
+    for: 'json',
+    isNestedAttribute: true,
+    isSecret: true,
+    description: 'The secret associated with credential.',
+  })
+  json_object;
 }

--- a/addons/api/addon/models/credential.js
+++ b/addons/api/addon/models/credential.js
@@ -3,7 +3,7 @@ import GeneratedCredentialModel from '../generated/models/credential';
 /**
  * Supported Credential types.
  */
-export const types = ['username_password', 'ssh_private_key'];
+export const types = ['username_password', 'ssh_private_key', 'json'];
 
 export default class CredentialModel extends GeneratedCredentialModel {
   // =attributes

--- a/addons/api/addon/models/credential.js
+++ b/addons/api/addon/models/credential.js
@@ -3,7 +3,7 @@ import GeneratedCredentialModel from '../generated/models/credential';
 /**
  * Supported Credential types.
  */
-export const types = ['username_password', 'ssh_private_key', 'json'];
+export const types = ['username_password', 'ssh_private_key'];
 
 export default class CredentialModel extends GeneratedCredentialModel {
   // =attributes

--- a/addons/api/addon/serializers/credential.js
+++ b/addons/api/addon/serializers/credential.js
@@ -13,6 +13,20 @@ export default class CredentialSerializer extends ApplicationSerializer {
    */
   serializeScopeID = false;
 
+  serialize() {
+    const serialized = super.serialize(...arguments);
+
+    if (serialized.type === 'json') {
+      delete serialized.attributes.username;
+
+      serialized.attributes.object = serialized.attributes.json_object;
+      delete serialized.attributes.json_object;
+      let parsedSecret = JSON.parse(serialized.attributes.object);
+      serialized.attributes.object = parsedSecret;
+    }
+
+    return serialized;
+  }
 
   normalize(typeClass, hash, ...rest) {
     const normalizedHash = copy(hash, true);
@@ -21,6 +35,7 @@ export default class CredentialSerializer extends ApplicationSerializer {
     normalized.data.attributes.password = '';
     normalized.data.attributes.private_key = '';
     normalized.data.attributes.private_key_passphrase = '';
+    normalized.data.attributes.json_object = '';
     return normalized;
   }
 }

--- a/addons/api/addon/serializers/credential.js
+++ b/addons/api/addon/serializers/credential.js
@@ -19,10 +19,12 @@ export default class CredentialSerializer extends ApplicationSerializer {
     if (serialized.type === 'json') {
       delete serialized.attributes.username;
 
-      serialized.attributes.object = serialized.attributes.json_object;
-      delete serialized.attributes.json_object;
-      let parsedSecret = JSON.parse(serialized.attributes.object);
-      serialized.attributes.object = parsedSecret;
+      if (serialized?.attributes?.json_object) {
+        serialized.attributes.object = serialized.attributes.json_object;
+        const parsedSecret = JSON.parse(serialized.attributes.object);
+        delete serialized.attributes.json_object;
+        serialized.attributes.object = parsedSecret;
+      }
     }
 
     return serialized;

--- a/addons/api/addon/serializers/credential.js
+++ b/addons/api/addon/serializers/credential.js
@@ -20,10 +20,8 @@ export default class CredentialSerializer extends ApplicationSerializer {
       delete serialized.attributes.username;
 
       if (serialized?.attributes?.json_object) {
-        serialized.attributes.object = serialized.attributes.json_object;
-        const parsedSecret = JSON.parse(serialized.attributes.object);
+        serialized.attributes.object = JSON.parse(serialized.attributes.json_object);
         delete serialized.attributes.json_object;
-        serialized.attributes.object = parsedSecret;
       }
     }
 

--- a/addons/api/mirage/serializers/credential.js
+++ b/addons/api/mirage/serializers/credential.js
@@ -15,7 +15,7 @@ export default ApplicationSerializer.extend({
     delete json.attributes?.password;
     delete json.attributes?.private_key;
     delete json.attributes?.private_key_passphrase;
-
+    delete json.attributes?.json_object;
     return json;
   },
 });

--- a/addons/api/tests/unit/serializers/credential-test.js
+++ b/addons/api/tests/unit/serializers/credential-test.js
@@ -92,6 +92,37 @@ module('Unit | Serializer | credential', function (hooks) {
     });
   });
 
+  test('it serializes json_object type correctly on create', async function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('credential');
+    const record = store.createRecord('credential', {
+      credential_store_id: 'csst_i7p1eu0Nw8',
+      json_object:
+        '{"secret_key": "QWERTYUIOP", "secret_access_key": "QWERT.YUIOP234567890"}',
+      type: 'json',
+      name: 'Name',
+      description: 'Description',
+      version: 1,
+    });
+    const snapshot = record._createSnapshot();
+    const serializedRecord = serializer.serialize(snapshot);
+
+    assert.deepEqual(serializedRecord, {
+      attributes: {
+        object: {
+          secret_key: 'QWERTYUIOP',
+          secret_access_key: 'QWERT.YUIOP234567890',
+        },
+      },
+      credential_store_id: 'csst_i7p1eu0Nw8',
+      type: 'json',
+      name: 'Name',
+      description: 'Description',
+      version: 1,
+    });
+  });
+
   test('it serializes ssh_private_key type correctly when only the username is updated', function (assert) {
     assert.expect(1);
     const store = this.owner.lookup('service:store');
@@ -146,6 +177,7 @@ module('Unit | Serializer | credential', function (hooks) {
           private_key_passphrase: '',
           private_key: '',
           password: '',
+          json_object: '',
         },
         type: 'credential',
         id: 'credup_123',
@@ -180,9 +212,39 @@ module('Unit | Serializer | credential', function (hooks) {
           private_key_passphrase: '',
           private_key: '',
           password: '',
+          json_object: '',
         },
         type: 'credential',
         id: 'credspk_123',
+        relationships: {},
+      },
+    });
+  });
+
+  test('it normalizes "json" type credential record', async function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('credential');
+    const credentialModelClass = store.createRecord('credential').constructor;
+    const payload = {
+      id: 'credjson_123',
+      version: 1,
+      type: 'json',
+    };
+    const normalized = serializer.normalize(credentialModelClass, payload);
+
+    assert.deepEqual(normalized, {
+      data: {
+        attributes: {
+          type: 'json',
+          version: 1,
+          private_key_passphrase: '',
+          private_key: '',
+          password: '',
+          json_object: '',
+        },
+        type: 'credential',
+        id: 'credjson_123',
         relationships: {},
       },
     });

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -439,9 +439,9 @@ credential:
     json: JSON
     unknown: Unknown
   help:
-    username_password: This host requires a username and password to connect.
-    ssh_private_key: This host requires a username, public key, and private key to connect.
-    json: This host requires JSON blob to connect.
+    username_password: Connect using the provided username and password.
+    ssh_private_key: Connect using a username, public key, and private key.
+    json: Connect using a JSON blob containing the credentials.
   form:
     username:
       label: Username

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -441,7 +441,7 @@ credential:
   help:
     username_password: This host requires a username and password to connect.
     ssh_private_key: This host requires a username, public key, and private key to connect.
-    json: This host requires JSON blog to connect.
+    json: This host requires JSON blob to connect.
   form:
     username:
       label: Username

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -436,10 +436,12 @@ credential:
   types:
     username_password: Username & Password
     ssh_private_key: Username & Key Pair
+    json: JSON
     unknown: Unknown
   help:
     username_password: This host requires a username and password to connect.
     ssh_private_key: This host requires a username, public key, and private key to connect.
+    json: This host requires JSON blog to connect.
   form:
     username:
       label: Username


### PR DESCRIPTION
✅ Closes: ICU-6653, ICU-6684, ICU-6685, ICU-6802, ICU-6803

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-6653) [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-6684) [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-6685) [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-6802) [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-6803) 

## Description
Added json type to credential model, created `json_object` attribute for `json` type, updated credential serializer to handle `json_object` attribute data being sent to backend and updated normalizer to handlle secret untracked 'json_object'.
