### PR TITLE
fix: 🐛 Fix claims map dropdown not having a default value

### DIFF
--- a/ui/admin/app/components/form/auth-method/oidc/index.js
+++ b/ui/admin/app/components/form/auth-method/oidc/index.js
@@ -16,5 +16,10 @@ export default class FormAuthMethodOidcComponent extends Component {
   /**
    * @type {string}
    */
+  newToClaim = options.oidc.account_claim_maps.to[0];
+
+  /**
+   * @type {string}
+   */
   newSigningAlgorithm = options.oidc.signing_algorithms[0];
 }


### PR DESCRIPTION
## Description
This fixes the claims map `to` field not having a default value when adding a claim map even though it looks like it's selected