### PR TITLE
Icu 6896 upgrade ember data

### DIFF
--- a/addons/api/addon/models/base.js
+++ b/addons/api/addon/models/base.js
@@ -92,7 +92,6 @@ export default class BaseModel extends Model {
   /**
    * @type {boolean}
    */
-  @computed('hasDirtyAttributes', 'isSaving')
   get canSave() {
     return this.hasDirtyAttributes && !this.isSaving;
   }
@@ -100,7 +99,6 @@ export default class BaseModel extends Model {
   /**
    * @type {boolean}
    */
-  @computed('canSave')
   get cannotSave() {
     return !this.canSave;
   }

--- a/addons/api/addon/models/base.js
+++ b/addons/api/addon/models/base.js
@@ -54,6 +54,10 @@ export default class BaseModel extends Model {
     const id = this.scopeID;
     return this.store.peekRecord('scope', id);
   }
+
+  // Ember seems to have a bug with its internals and can't correctly set
+  // the `scopeModel` when passed in as part of the `inputProperties`
+  // of a `createRecord` call
   set scopeModel(model) {
     if (model) {
       const json = model.serialize();

--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -32,7 +32,7 @@
     "ember-cli-htmlbars": "^6.1.0",
     "ember-cli-mirage": "^2.2.0",
     "ember-copy": "^2.0.1",
-    "ember-data": "^3.20.0",
+    "ember-data": "^3.28.12",
     "ember-fetch": "^8.1.1"
   },
   "devDependencies": {

--- a/addons/api/tests/unit/models/base-test.js
+++ b/addons/api/tests/unit/models/base-test.js
@@ -91,14 +91,19 @@ module('Unit | Model | base', function (hooks) {
     assert.true(model.hasDirtyAttributes);
     assert.true(model.canSave);
     assert.false(model.cannotSave);
+
     // Should not be able to save while currently saving
-    model.save().then(() => {
-      assert.false(model.isSaving);
-      assert.false(model.canSave);
-    });
+    const savePromise = model.save();
+
+    // Verify conditions before save completes
     assert.true(model.isSaving);
     assert.false(model.canSave);
     assert.true(model.cannotSave);
+
+    // Verify conditions after save completes
+    await savePromise;
+    assert.false(model.isSaving);
+    assert.false(model.canSave);
   });
 
   test('it saves records to a scoped URL', async function (assert) {

--- a/ui/admin/app/routes/scopes/scope/auth-methods/new.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/new.js
@@ -22,9 +22,10 @@ export default class ScopesScopeAuthMethodsNewRoute extends Route {
    */
   model(params) {
     const scopeModel = this.modelFor('scopes.scope');
-    return this.store.createRecord('auth-method', {
-      scopeModel,
+    const record = this.store.createRecord('auth-method', {
       type: params.type,
     });
+    record.scopeModel = scopeModel;
+    return record;
   }
 }

--- a/ui/admin/app/routes/scopes/scope/credential-stores/new.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/new.js
@@ -34,12 +34,13 @@ export default class ScopesScopeCredentialStoresNewRoute extends Route {
     if (!this.features.isEnabled('static-credentials')) {
       type = 'vault';
     }
-    return this.store.createRecord('credential-store', {
+    const record = this.store.createRecord('credential-store', {
       type,
-      scopeModel,
       name,
       description,
     });
+    record.scopeModel = scopeModel;
+    return record;
   }
 
   /**

--- a/ui/admin/app/routes/scopes/scope/groups/new.js
+++ b/ui/admin/app/routes/scopes/scope/groups/new.js
@@ -14,6 +14,8 @@ export default class ScopesScopeGroupsNewRoute extends Route {
    */
   model() {
     const scopeModel = this.modelFor('scopes.scope');
-    return this.store.createRecord('group', { scopeModel });
+    const record = this.store.createRecord('group');
+    record.scopeModel = scopeModel;
+    return record;
   }
 }

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
@@ -34,13 +34,14 @@ export default class ScopesScopeHostCatalogsNewRoute extends Route {
     if (compositeType === 'azure') {
       disable_credential_rotation = true;
     }
-    return this.store.createRecord('host-catalog', {
-      scopeModel,
+    const record = this.store.createRecord('host-catalog', {
       compositeType,
       name,
       description,
       disable_credential_rotation,
     });
+    record.scopeModel = scopeModel;
+    return record;
   }
 
   /**

--- a/ui/admin/app/routes/scopes/scope/roles/new.js
+++ b/ui/admin/app/routes/scopes/scope/roles/new.js
@@ -14,6 +14,8 @@ export default class ScopesScopeRolesNewRoute extends Route {
    */
   model() {
     const scopeModel = this.modelFor('scopes.scope');
-    return this.store.createRecord('role', { scopeModel });
+    const record = this.store.createRecord('role');
+    record.scopeModel = scopeModel;
+    return record;
   }
 }

--- a/ui/admin/app/routes/scopes/scope/targets/new.js
+++ b/ui/admin/app/routes/scopes/scope/targets/new.js
@@ -31,12 +31,13 @@ export default class ScopesScopeTargetsNewRoute extends Route {
       this.currentModel.rollbackAttributes();
     }
 
-    return this.store.createRecord('target', {
-      scopeModel,
+    const record = this.store.createRecord('target', {
       type,
       name,
       description,
     });
+    record.scopeModel = scopeModel;
+    return record;
   }
 
   /**

--- a/ui/admin/app/routes/scopes/scope/users/new.js
+++ b/ui/admin/app/routes/scopes/scope/users/new.js
@@ -14,6 +14,8 @@ export default class ScopesScopeUsersNewRoute extends Route {
    */
   model() {
     const scopeModel = this.modelFor('scopes.scope');
-    return this.store.createRecord('user', { scopeModel });
+    const record = this.store.createRecord('user');
+    record.scopeModel = scopeModel;
+    return record;
   }
 }

--- a/ui/admin/app/routes/scopes/scope/workers/new.js
+++ b/ui/admin/app/routes/scopes/scope/workers/new.js
@@ -17,7 +17,9 @@ export default class ScopesScopeWorkersNewRoute extends Route {
    */
   model() {
     const scopeModel = this.modelFor('scopes.scope');
-    return this.store.createRecord('worker', { scopeModel });
+    const record = this.store.createRecord('worker');
+    record.scopeModel = scopeModel;
+    return record;
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3701,78 +3701,79 @@
     minimatch "^3.0.4"
     plist "^3.0.4"
 
-"@ember-data/adapter@3.27.1":
-  version "3.27.1"
-  resolved "https://registry.yarnpkg.com/@ember-data/adapter/-/adapter-3.27.1.tgz#4258b138ae43f1329995b8fce54e866d0b9b79a3"
-  integrity sha512-g9JPXn2QvV47xFWbY7xRiVp4LEbE4vkVo/qu3NtrvD+MLHNmfWn6VHhx2+v5mQB0pBe8lK8nPZGoS8PM/3CMuA==
+"@ember-data/adapter@3.28.12":
+  version "3.28.12"
+  resolved "https://registry.yarnpkg.com/@ember-data/adapter/-/adapter-3.28.12.tgz#0c77ba87b316acdab442240812a2504beb42b766"
+  integrity sha512-pG7ITjLnYcKFZ5XrQB2kUn2mf6vwxzocXOOmCtRSS2oNVp+iYBMqNOUk6I2v5WgjwzSSePzWuGdlcOYn/KPweg==
   dependencies:
-    "@ember-data/private-build-infra" "3.27.1"
-    "@ember-data/store" "3.27.1"
+    "@ember-data/private-build-infra" "3.28.12"
+    "@ember-data/store" "3.28.12"
     "@ember/edition-utils" "^1.2.0"
-    "@ember/string" "^1.0.0"
+    "@ember/string" "^3.0.0"
     ember-cli-babel "^7.26.6"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.0.0"
+    ember-cli-typescript "^4.1.0"
 
-"@ember-data/canary-features@3.27.1":
-  version "3.27.1"
-  resolved "https://registry.yarnpkg.com/@ember-data/canary-features/-/canary-features-3.27.1.tgz#fa589ff8a37f6dcc607f874303be024a4f7a186a"
-  integrity sha512-7RLYG1W1woBu116h4bE3zfEHCV+EVVzNZcgRD3tUH9cg/EvOfXfn3naAFNnoA7TIEl2ZShRPgNNi2SjkYYy52Q==
+"@ember-data/canary-features@3.28.12":
+  version "3.28.12"
+  resolved "https://registry.yarnpkg.com/@ember-data/canary-features/-/canary-features-3.28.12.tgz#d980ac9bae671fc8a4aec763de6af9377f1f1e29"
+  integrity sha512-+1ymzYYCX5hc/zHv/OjEPUoEP9J/cZRiC1VWvIWm1aAZXm+th1G3wtu9+BWYVVRhX3V3rNgP2f9ePR6wgSI5LQ==
   dependencies:
     ember-cli-babel "^7.26.6"
     ember-cli-typescript "^4.1.0"
 
-"@ember-data/debug@3.27.1":
-  version "3.27.1"
-  resolved "https://registry.yarnpkg.com/@ember-data/debug/-/debug-3.27.1.tgz#76ec39fd981ad9e97d140a30dfae6e3258144c0e"
-  integrity sha512-VWAzZFqKiheMc7Qx5yIekpdfamSBWURjNF5NKCQGGLRv7SsQe1eOjbW5iaq+gsnNr/gk4U95yLd225kUf6ubEQ==
+"@ember-data/debug@3.28.12":
+  version "3.28.12"
+  resolved "https://registry.yarnpkg.com/@ember-data/debug/-/debug-3.28.12.tgz#ef3389ab69405fbbfca928744c087092a6e5deef"
+  integrity sha512-uxBqJUMD6hxie6CazFlZ8Kca1Pi34sTKs2UmJaa3MviQ67mE+XVPoVe5Q8RFpA5aIGGWsS6SNgMMIjvuR36vUw==
   dependencies:
-    "@ember-data/private-build-infra" "3.27.1"
+    "@ember-data/private-build-infra" "3.28.12"
     "@ember/edition-utils" "^1.2.0"
-    "@ember/string" "^1.0.0"
+    "@ember/string" "^3.0.0"
     ember-cli-babel "^7.26.6"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.0.0"
+    ember-cli-typescript "^4.1.0"
 
-"@ember-data/model@3.27.1":
-  version "3.27.1"
-  resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-3.27.1.tgz#e35730da811c21e85f2bd334eb4a741f5368ce50"
-  integrity sha512-GC5bf2wAad6ePCoreOj4JknJaJ62FBwR9q+/zFxADU1Ns68kyVm/Xg7KD1sDvcXEwLJebH09j9sN7LkwZaN3Og==
+"@ember-data/model@3.28.12":
+  version "3.28.12"
+  resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-3.28.12.tgz#481dbf036e804ab64bd4fc54473838964156be26"
+  integrity sha512-tv1kPqJMAq37zbn/h3Vg6Y6aaWybXdqw0Z3KnOy8wcbi5qHKdhPbozVP7gp+uUyle8addiFZ85ckJMUe0COWAw==
   dependencies:
-    "@ember-data/canary-features" "3.27.1"
-    "@ember-data/private-build-infra" "3.27.1"
-    "@ember-data/store" "3.27.1"
+    "@ember-data/canary-features" "3.28.12"
+    "@ember-data/private-build-infra" "3.28.12"
+    "@ember-data/store" "3.28.12"
     "@ember/edition-utils" "^1.2.0"
-    "@ember/string" "^1.0.0"
+    "@ember/string" "^3.0.0"
+    ember-cached-decorator-polyfill "^0.1.4"
     ember-cli-babel "^7.26.6"
     ember-cli-string-utils "^1.1.0"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.0.0"
+    ember-cli-typescript "^4.1.0"
     ember-compatibility-helpers "^1.2.0"
-    inflection "1.12.0"
+    inflection "~1.13.1"
 
-"@ember-data/private-build-infra@3.27.1":
-  version "3.27.1"
-  resolved "https://registry.yarnpkg.com/@ember-data/private-build-infra/-/private-build-infra-3.27.1.tgz#040a9f646a1ca2764e67bf1108dc489d2008e7d5"
-  integrity sha512-Cox/CRovg1gFGuO2zn64JSAezbbO1XHP+tLWDXRIiB2Oqlk3CtNxEs9K02DxMCojK4C8itFDOVpBKLYCB5MbYQ==
+"@ember-data/private-build-infra@3.28.12":
+  version "3.28.12"
+  resolved "https://registry.yarnpkg.com/@ember-data/private-build-infra/-/private-build-infra-3.28.12.tgz#4a0f674ce865b41a7e4d28be25f6631b588367aa"
+  integrity sha512-Nn1ipcOcIvkS3cXjSrvey4obNjI56JpCjfMQTHrLj1m2lhYbZmiEuulbLs3Mn5y5EOZ6d5HJNK7fbhZRLoh3tQ==
   dependencies:
     "@babel/plugin-transform-block-scoping" "^7.8.3"
-    "@ember-data/canary-features" "3.27.1"
+    "@ember-data/canary-features" "3.28.12"
     "@ember/edition-utils" "^1.2.0"
     babel-plugin-debug-macros "^0.3.3"
     babel-plugin-filter-imports "^4.0.0"
     babel6-plugin-strip-class-callcheck "^6.0.0"
     broccoli-debug "^0.6.5"
     broccoli-file-creator "^2.1.1"
-    broccoli-funnel "^2.0.2"
+    broccoli-funnel "^3.0.3"
     broccoli-merge-trees "^4.2.0"
-    broccoli-rollup "^4.1.1"
+    broccoli-rollup "^5.0.0"
     calculate-cache-key-for-tree "^2.0.0"
     chalk "^4.0.0"
     ember-cli-babel "^7.26.6"
     ember-cli-path-utils "^1.0.0"
     ember-cli-string-utils "^1.1.0"
-    ember-cli-typescript "^3.1.3"
+    ember-cli-typescript "^4.1.0"
     ember-cli-version-checker "^5.1.1"
     esm "^3.2.25"
     git-repo-info "^2.1.1"
@@ -3783,49 +3784,48 @@
     semver "^7.1.3"
     silent-error "^1.1.1"
 
-"@ember-data/record-data@3.27.1":
-  version "3.27.1"
-  resolved "https://registry.yarnpkg.com/@ember-data/record-data/-/record-data-3.27.1.tgz#2d9e35e36404790adebc24890ca0eb8ee1ecfb65"
-  integrity sha512-QSY7vJIbfCCpVNhAXkGc73UiXqX7UyELq0Mc3URoVCKRYZJOCSnydPYARLgN/NM99HV0Mw1aa+KP8Nco8Z/gFg==
+"@ember-data/record-data@3.28.12":
+  version "3.28.12"
+  resolved "https://registry.yarnpkg.com/@ember-data/record-data/-/record-data-3.28.12.tgz#75cb865fca155eb8d8a0362db6e05b30b651db86"
+  integrity sha512-BUhabJqdgeh2kjKgCSn+K/D4lZww7jIFiATmmC5ecXJPPI3YSTAnYzGfxOdqd6F37DTkAwDJpdPR8OcOyTfmPg==
   dependencies:
-    "@ember-data/canary-features" "3.27.1"
-    "@ember-data/private-build-infra" "3.27.1"
-    "@ember-data/store" "3.27.1"
+    "@ember-data/canary-features" "3.28.12"
+    "@ember-data/private-build-infra" "3.28.12"
+    "@ember-data/store" "3.28.12"
     "@ember/edition-utils" "^1.2.0"
-    "@ember/ordered-set" "^4.0.0"
     ember-cli-babel "^7.26.6"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.0.0"
+    ember-cli-typescript "^4.1.0"
 
 "@ember-data/rfc395-data@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
   integrity sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==
 
-"@ember-data/serializer@3.27.1":
-  version "3.27.1"
-  resolved "https://registry.yarnpkg.com/@ember-data/serializer/-/serializer-3.27.1.tgz#17301698281e9d888f6c38b59c4b460c9ab27fd7"
-  integrity sha512-kJE+kiisk1d9KQYRcRK4BFQhhsZ3n7ADlyK5eCsaNEwJm4YsfvKgjUgaC16MJddX4LG9d7QORHNJT9rWcCL9fg==
+"@ember-data/serializer@3.28.12":
+  version "3.28.12"
+  resolved "https://registry.yarnpkg.com/@ember-data/serializer/-/serializer-3.28.12.tgz#4eb41aef80e453b29335c2ba4a77339e89204b9e"
+  integrity sha512-q6FjqL2VYmmcVdTLhENoBTpayhCnCCyWc/FPsuBO6knOuCd4vDlSK+y0BotSZ/Tadjmi6qjYrff7hpXbvnR/FQ==
   dependencies:
-    "@ember-data/private-build-infra" "3.27.1"
-    "@ember-data/store" "3.27.1"
+    "@ember-data/private-build-infra" "3.28.12"
+    "@ember-data/store" "3.28.12"
     ember-cli-babel "^7.26.6"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.0.0"
+    ember-cli-typescript "^4.1.0"
 
-"@ember-data/store@3.27.1":
-  version "3.27.1"
-  resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-3.27.1.tgz#2026adbeee893d3a71417b82095b4921fdd590fb"
-  integrity sha512-RL9OkNBB9DtT5nkYTmGuk46hbVs2avuvSggiPJU3iuQYD3dJ8jC2XGGs3Z4FHEzAVWwlCnFiwVT03GfYbuIbUw==
+"@ember-data/store@3.28.12":
+  version "3.28.12"
+  resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-3.28.12.tgz#896a8a4924ce0a47c191251d71d697e1b0980eb4"
+  integrity sha512-y1XmmWIW/vDJsNGu14QfsZzggktqip2lGmQI6gTZacRYl7reSMZHnM9veifhRT3uZHTxcRy7nhGMsBB5QUxeeQ==
   dependencies:
-    "@ember-data/canary-features" "3.27.1"
-    "@ember-data/private-build-infra" "3.27.1"
-    "@ember/string" "^1.0.0"
+    "@ember-data/canary-features" "3.28.12"
+    "@ember-data/private-build-infra" "3.28.12"
+    "@ember/string" "^3.0.0"
     "@glimmer/tracking" "^1.0.4"
+    ember-cached-decorator-polyfill "^0.1.4"
     ember-cli-babel "^7.26.6"
     ember-cli-path-utils "^1.0.0"
-    ember-cli-typescript "^4.0.0"
-    heimdalljs "^0.3.0"
+    ember-cli-typescript "^4.1.0"
 
 "@ember/edition-utils@^1.2.0":
   version "1.2.0"
@@ -3844,14 +3844,6 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
-"@ember/ordered-set@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@ember/ordered-set/-/ordered-set-4.0.0.tgz#c5ec021ab8d4734c6db92708a81edd499d45fd31"
-  integrity sha512-cUCcme4R5H37HyK8w0qzdG5+lpb3XVr2RQHLyWEP4JsKI66Ob4tizoJOs8rb/XdHCv+F5WeA321hfPMi3DrZbg==
-  dependencies:
-    ember-cli-babel "^7.22.1"
-    ember-compatibility-helpers "^1.1.1"
-
 "@ember/render-modifiers@^1.0.2 || ^2.0.0", "@ember/render-modifiers@^2.0.2", "@ember/render-modifiers@^2.0.4":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-2.0.4.tgz#0ac7af647cb736076dbfcd54ca71e090cd329d71"
@@ -3861,12 +3853,12 @@
     ember-cli-babel "^7.26.11"
     ember-modifier-manager-polyfill "^1.2.0"
 
-"@ember/string@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ember/string/-/string-1.0.0.tgz#3a2254caedacb95e09071204d36cad49e0f8b855"
-  integrity sha512-KZ+CcIXFdyIBMztxDMgza4SdLJgIeUgTjDAoHk6M50C2u1X/BK7KWUIN7MIK2LNTOMvbib9lWwEzKboxdI4lBw==
+"@ember/string@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@ember/string/-/string-3.0.0.tgz#e3a3cc7874c9f64eadfdac644d8b1238721ce289"
+  integrity sha512-T+7QYDp8ItlQseNveK2lL6OsOO5wg7aNQ/M2RpO8cGwM80oZOnr/Y35HmMfu4ejFEc+F1LPegvu7LGfeJOicWA==
   dependencies:
-    ember-cli-babel "^7.4.0"
+    ember-cli-babel "^7.26.6"
 
 "@ember/test-helpers@^2.1.4":
   version "2.4.0"
@@ -6616,10 +6608,12 @@
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.1.tgz#5a284d193cfc61abb2e5a50d36ebbc50d942a32b"
   integrity sha512-+euflG6ygo4bn0JHtn4pYqcXwRtLvElQ7/nnjDu7iYG56H0+OhCd7d6Ug0IE3WcFpZozBKW2+80FUbv5QGk5AQ==
 
-"@types/broccoli-plugin@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@types/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz#38f8462fecaebc4e09a32e4d4ed1b9808f75bbca"
-  integrity sha512-SLk4/hFc2kGvgwNFrpn2O1juxFOllcHAywvlo7VwxfExLzoz1GGJ0oIZCwj5fwSpvHw4AWpZjJ1fUvb62PDayQ==
+"@types/broccoli-plugin@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/broccoli-plugin/-/broccoli-plugin-3.0.0.tgz#290fda2270c47a568edfd0cefab8bb840d8bb7b2"
+  integrity sha512-f+TcsARR2PovfFRKFdCX0kfH/QoM3ZVD2h1rl2mNvrKO0fq2uBNCBsTU3JanfU4COCt5cXpTfARyUsERlC8vIw==
+  dependencies:
+    broccoli-plugin "*"
 
 "@types/cacheable-request@^6.0.1":
   version "6.0.2"
@@ -7514,7 +7508,7 @@ acorn@^6.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
-acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0, acorn@^7.4.1:
+acorn@^7.1.1, acorn@^7.4.0, acorn@^7.4.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
@@ -9358,6 +9352,19 @@ broccoli-persistent-filter@^3.1.2:
     symlink-or-copy "^1.0.1"
     sync-disk-cache "^2.0.0"
 
+broccoli-plugin@*, broccoli-plugin@^4.0.0, broccoli-plugin@^4.0.1, broccoli-plugin@^4.0.2, broccoli-plugin@^4.0.3, broccoli-plugin@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz#dd176a85efe915ed557d913744b181abe05047db"
+  integrity sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==
+  dependencies:
+    broccoli-node-api "^1.7.0"
+    broccoli-output-wrapper "^3.2.5"
+    fs-merger "^3.2.1"
+    promise-map-series "^0.3.0"
+    quick-temp "^0.1.8"
+    rimraf "^3.0.2"
+    symlink-or-copy "^1.3.1"
+
 broccoli-plugin@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz#73e2cfa05f8ea1e3fc1420c40c3d9e7dc724bf02"
@@ -9378,7 +9385,7 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-plugin@^2.0.0, broccoli-plugin@^2.1.0:
+broccoli-plugin@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz#2fab6c578219cfcc64f773e9616073313fc8b334"
   integrity sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==
@@ -9401,19 +9408,6 @@ broccoli-plugin@^3.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-plugin@^4.0.0, broccoli-plugin@^4.0.1, broccoli-plugin@^4.0.2, broccoli-plugin@^4.0.3, broccoli-plugin@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz#dd176a85efe915ed557d913744b181abe05047db"
-  integrity sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==
-  dependencies:
-    broccoli-node-api "^1.7.0"
-    broccoli-output-wrapper "^3.2.5"
-    fs-merger "^3.2.1"
-    promise-map-series "^0.3.0"
-    quick-temp "^0.1.8"
-    rimraf "^3.0.2"
-    symlink-or-copy "^1.3.1"
-
 broccoli-rollup@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-2.1.1.tgz#0b77dc4b7560a53e998ea85f3b56772612d4988d"
@@ -9431,20 +9425,20 @@ broccoli-rollup@^2.1.1:
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.1"
 
-broccoli-rollup@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-4.1.1.tgz#7531a24d88ddab9f1bace1c6ee6e6ca74a38d36f"
-  integrity sha512-hkp0dB5chiemi32t6hLe5bJvxuTOm1TU+SryFlZIs95KT9+94uj0C8w6k6CsZ2HuIdIZg6D252t4gwOlcTXrpA==
+broccoli-rollup@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-5.0.0.tgz#a77b53bcef1b70e988913fee82265c0a4ca530da"
+  integrity sha512-QdMuXHwsdz/LOS8zu4HP91Sfi4ofimrOXoYP/lrPdRh7lJYD87Lfq4WzzUhGHsxMfzANIEvl/7qVHKD3cFJ4tA==
   dependencies:
-    "@types/broccoli-plugin" "^1.3.0"
-    broccoli-plugin "^2.0.0"
+    "@types/broccoli-plugin" "^3.0.0"
+    broccoli-plugin "^4.0.7"
     fs-tree-diff "^2.0.1"
     heimdalljs "^0.2.6"
     node-modules-path "^1.0.1"
-    rollup "^1.12.0"
+    rollup "^2.50.0"
     rollup-pluginutils "^2.8.1"
     symlink-or-copy "^1.2.0"
-    walk-sync "^1.1.3"
+    walk-sync "^2.2.0"
 
 broccoli-sass-source-maps@^4.0.0:
   version "4.0.0"
@@ -12170,7 +12164,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, em
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^6.6.0, ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.5, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.10, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.26.8, ember-cli-babel@^7.4.0, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3:
+ember-cli-babel@^6.6.0, ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.5, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.10, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.26.8, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.3:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -12498,7 +12492,7 @@ ember-cli-typescript@^2.0.2:
     stagehand "^1.0.0"
     walk-sync "^1.0.0"
 
-ember-cli-typescript@^3.0.0, ember-cli-typescript@^3.1.3:
+ember-cli-typescript@^3.0.0:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz#21d6ccd670d1f2e34c9cce68c6e32c442f46806b"
   integrity sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==
@@ -12518,7 +12512,7 @@ ember-cli-typescript@^3.0.0, ember-cli-typescript@^3.1.3:
     stagehand "^1.0.0"
     walk-sync "^2.0.0"
 
-ember-cli-typescript@^4.0.0, ember-cli-typescript@^4.1.0:
+ember-cli-typescript@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz#54d08fc90318cc986f3ea562f93ce58a6cc4c24d"
   integrity sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==
@@ -12698,7 +12692,7 @@ ember-cli@^4.4.0:
     workerpool "^6.2.0"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.5.tgz#b8363b1d5b8725afa9a4fe2b2986ac28626c6f23"
   integrity sha512-7cddkQQp8Rs2Mqrj0xqZ0uO7eC9tBCKyZNcP2iE1RxQqOGPv8fiPkj1TUeidUB/Qe80lstoVXWMEuqqhW7Yy9A==
@@ -12774,21 +12768,20 @@ ember-copy@^2.0.1:
   dependencies:
     ember-cli-babel "^7.22.1"
 
-ember-data@^3.20.0:
-  version "3.27.1"
-  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.27.1.tgz#02d6b76c1d5de0f50d24274147b8711f6ca4f28d"
-  integrity sha512-36P8+7B6Z5ZjyITFbf2Wcub/fdE2DTsLoPPZK7It488fub5s90o85XC0WlwUQPvff39us2N4pzjwmCZ8Jj/gjg==
+ember-data@^3.28.12:
+  version "3.28.12"
+  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.28.12.tgz#8d63fcd18982323887c637f78bafbf6e8715da93"
+  integrity sha512-eVVhYf45WjLpq2j9jIFxlrh3DG8um2tuzVMlhCGz1l6mIocT6TOW2NTcS5Ue2Dz7VDd3DeBtgfzvV6DIdouHug==
   dependencies:
-    "@ember-data/adapter" "3.27.1"
-    "@ember-data/debug" "3.27.1"
-    "@ember-data/model" "3.27.1"
-    "@ember-data/private-build-infra" "3.27.1"
-    "@ember-data/record-data" "3.27.1"
-    "@ember-data/serializer" "3.27.1"
-    "@ember-data/store" "3.27.1"
+    "@ember-data/adapter" "3.28.12"
+    "@ember-data/debug" "3.28.12"
+    "@ember-data/model" "3.28.12"
+    "@ember-data/private-build-infra" "3.28.12"
+    "@ember-data/record-data" "3.28.12"
+    "@ember-data/serializer" "3.28.12"
+    "@ember-data/store" "3.28.12"
     "@ember/edition-utils" "^1.2.0"
-    "@ember/ordered-set" "^4.0.0"
-    "@ember/string" "^1.0.0"
+    "@ember/string" "^3.0.0"
     "@glimmer/env" "^0.1.7"
     broccoli-merge-trees "^4.2.0"
     ember-cli-babel "^7.26.6"
@@ -16082,13 +16075,6 @@ heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3, heimdalljs@^0.2.5, heim
   dependencies:
     rsvp "~3.2.1"
 
-heimdalljs@^0.3.0:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.3.3.tgz#e92d2c6f77fd46d5bf50b610d28ad31755054d0b"
-  integrity sha1-6S0sb3f9RtW/ULYQ0orTF1UFTQs=
-  dependencies:
-    rsvp "~3.2.1"
-
 highlight.js@^10.1.1, highlight.js@^10.4.1, highlight.js@~10.7.0:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
@@ -16527,15 +16513,15 @@ inflected@^2.0.4:
   resolved "https://registry.yarnpkg.com/inflected/-/inflected-2.1.0.tgz#2816ac17a570bbbc8303ca05bca8bf9b3f959687"
   integrity sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w==
 
-inflection@1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz#a200935656d6f5f6bc4dc7502e1aecb703228416"
-  integrity sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=
-
 inflection@^1.12.0, inflection@^1.13.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.13.1.tgz#c5cadd80888a90cf84c2e96e340d7edc85d5f0cb"
   integrity sha512-dldYtl2WlN0QDkIDtg8+xFwOS2Tbmp12t1cHa5/YClU6ZQjTFm7B66UcVbh9NQB+HvT5BAd2t5+yKsBkw5pcqA==
+
+inflection@~1.13.1:
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.13.4.tgz#65aa696c4e2da6225b148d7a154c449366633a32"
+  integrity sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==
 
 inflight@^1.0.4, inflight@~1.0.6:
   version "1.0.6"
@@ -23611,14 +23597,12 @@ rollup@^0.57.1:
     signal-exit "^3.0.2"
     sourcemap-codec "^1.4.1"
 
-rollup@^1.12.0:
-  version "1.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
-  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
-  dependencies:
-    "@types/estree" "*"
-    "@types/node" "*"
-    acorn "^7.1.0"
+rollup@^2.50.0:
+  version "2.79.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.1.tgz#bedee8faef7c9f93a2647ac0108748f497f081c7"
+  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 route-recognizer@^0.3.3:
   version "0.3.4"


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-6896)

## Description
This upgrades ember data to the latest `3.x` version. There was an error occurring after upgrading to `3.28.0` and any subsequent version (including the `4.x` versions).

It appears that ember-data had changed some of their internal state management and introduced a bug. Setting the `stateModel` (which is an object) as part of the `createRecord` call causes ember to error out (possibly because of their own ember run loop? seems like it assumes the model is ready before it's actually set, couldn't figure this out).

However setting the `stateModel` after creating the record works fine. As a workaround, that is what I do in this PR.

I also had to cherry-pick a fix from our ember 4 api upgrade branch. 