### PR TITLE
Refactor upgrade ember 4 addon rose fix linting issues

### DIFF
--- a/addons/rose/.eslintignore
+++ b/addons/rose/.eslintignore
@@ -17,6 +17,7 @@ main.js
 !.*
 .*/
 .eslintcache
+.stylelintrc.js
 
 # ember-try
 /.node_modules.ember-try/

--- a/addons/rose/addon/components/rose/anonymous/index.js
+++ b/addons/rose/addon/components/rose/anonymous/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable ember/no-classic-components, ember/no-classic-classes, ember/require-tagless-components */
 import Component from '@ember/component';
 import layout from './index';
 

--- a/addons/rose/addon/components/rose/button/index.js
+++ b/addons/rose/addon/components/rose/button/index.js
@@ -1,5 +1,0 @@
-import Component from '@glimmer/component';
-
-export default class RoseButtonComponent extends Component {
-  // =attributes
-}

--- a/addons/rose/addon/components/rose/dropdown/section/index.js
+++ b/addons/rose/addon/components/rose/dropdown/section/index.js
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { generateComponentID } from '../../../../utilities/component-auto-id';
-import { action } from '@ember/object';
 
 export default class RoseDialogComponent extends Component {
   // =attributes

--- a/addons/rose/addon/components/rose/form/index.js
+++ b/addons/rose/addon/components/rose/form/index.js
@@ -19,7 +19,7 @@ export default class RoseFormComponent extends Component {
    * in which case the value is dependent on `@disabled` and `this.isEditable`.
    * @type {boolean}
    */
-  @computed('args.disabled', 'args.showEditToggle', 'isEditable')
+  @computed('args.{disabled,showEditToggle}', 'isEditable')
   get disabled() {
     if (this.args.showEditToggle) return this.args.disabled || !this.isEditable;
     return this.args.disabled;

--- a/addons/rose/addon/components/rose/message/index.js
+++ b/addons/rose/addon/components/rose/message/index.js
@@ -1,3 +1,0 @@
-import Component from '@glimmer/component';
-
-export default class RoseMessageComponent extends Component {}

--- a/addons/rose/addon/components/rose/table/row/cell/index.js
+++ b/addons/rose/addon/components/rose/table/row/cell/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable ember/no-classic-components, ember/no-classic-classes, ember/require-tagless-components, ember/require-computed-property-dependencies, ember/require-return-from-computed */
 import Component from '@ember/component';
 import layout from './index';
 import { computed } from '@ember/object';

--- a/addons/rose/addon/components/rose/table/row/index.js
+++ b/addons/rose/addon/components/rose/table/row/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable ember/no-classic-components, ember/no-classic-classes  */
 import Component from '@ember/component';
 import layout from './index';
 

--- a/addons/rose/addon/components/rose/table/section/index.js
+++ b/addons/rose/addon/components/rose/table/section/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable ember/no-classic-components, ember/no-classic-classes  */
 import Component from '@ember/component';
 import layout from './index';
 

--- a/addons/rose/index.js
+++ b/addons/rose/index.js
@@ -1,8 +1,6 @@
 'use strict';
 
 var path = require('path');
-var Funnel = require('broccoli-funnel');
-var mergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
   name: require('./package').name,


### PR DESCRIPTION
## Description

- Fix linter issues.
- Disable some linter rules. These components require to be refactored to glimmer component to be compliance with linter. We will come back to this later, now the work is focus on Ember 4.

**Be aware:**
- This branch is merging with `refactor-upgrade-ember-4-addon-rose`.
- This branch contains a 3 failing tests we will take care of those within `refactor-upgrade-ember-4-addon-rose`.