### PR TITLE
fix: 🐛 infofield on host catalog plugin forms

### DIFF
--- a/ui/admin/app/components/form/host-catalog/aws/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/aws/index.hbs
@@ -101,14 +101,9 @@
       </:body>
     </form.fieldset>
   {{else}}
-    <InfoField
-      @value={{t 'resources.host-catalog.types.aws'}}
-      @icon='aws-color'
-      disabled={{form.disabled}}
-      as |F|
-    >
+    <InfoField @value={{t 'descriptions.provider'}} @icon='aws-color' as |F|>
       <F.Label>{{t 'titles.provider'}}</F.Label>
-      <F.HelperText>{{t 'descriptions.provider'}}
+      <F.HelperText>{{t 'resources.host-catalog.types.aws'}}
       </F.HelperText>
     </InfoField>
   {{/if}}

--- a/ui/admin/app/components/form/host-catalog/azure/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/azure/index.hbs
@@ -106,14 +106,9 @@
       </:body>
     </form.fieldset>
   {{else}}
-    <InfoField
-      @value={{t 'resources.host-catalog.types.azure'}}
-      @icon='azure-color'
-      disabled={{form.disabled}}
-      as |F|
-    >
+    <InfoField @value={{t 'descriptions.provider'}} @icon='azure-color' as |F|>
       <F.Label>{{t 'titles.provider'}}</F.Label>
-      <F.HelperText>{{t 'descriptions.provider'}}
+      <F.HelperText>{{t 'resources.host-catalog.types.azure'}}
       </F.HelperText>
     </InfoField>
   {{/if}}


### PR DESCRIPTION
the type and the helper text were flipped in the host catalog plugin forms


[azure](https://boundary-f4wwcezmk-hashicorp.vercel.app/scopes/s_1sheljmjgm/host-catalogs/hc_r9jfw7e4kg)

[aws](https://boundary-f4wwcezmk-hashicorp.vercel.app/scopes/s_1sheljmjgm/host-catalogs/hc_d035pwe9uu)