### PR TITLE
Chore/upgrade ember data to 4

### DIFF
--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -1,4 +1,7 @@
-import { discoverEmberDataModels, applyEmberDataSerializers } from 'ember-cli-mirage';
+import {
+  discoverEmberDataModels,
+  applyEmberDataSerializers,
+} from 'ember-cli-mirage';
 import { createServer, Response } from 'miragejs';
 import environmentConfig from '../config/environment';
 import { authHandler, deauthHandler } from './route-handlers/auth';
@@ -7,12 +10,11 @@ import { pickRandomStatusString } from './factories/session';
 import initializeMockIPC from './scenarios/ipc';
 import makeBooleanFilter from './helpers/bexpr-filter';
 
-
 const isTesting = environmentConfig.environment === 'test';
 
 // Main function
 // More info about server configuration https://www.ember-cli-mirage.com/docs/advanced/server-configuration
-export default function(mirageConfig) {
+export default function (mirageConfig) {
   let finalConfig = {
     ...mirageConfig,
     models: { ...discoverEmberDataModels(), ...mirageConfig.models },
@@ -23,7 +25,7 @@ export default function(mirageConfig) {
 }
 
 // Only routes are defined here
-function routes () {
+function routes() {
   initializeMockIPC(this, environmentConfig);
 
   // make this `http://localhost:8080`, for example, if your API is on a different server

--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -28,7 +28,7 @@
     "ember-cli-htmlbars": "^6.1.0",
     "ember-cli-mirage": "^2.4.0",
     "ember-copy": "^2.0.1",
-    "ember-data": "^3.28.12",
+    "ember-data": "~4.4.0",
     "ember-fetch": "^8.1.1"
   },
   "devDependencies": {
@@ -63,7 +63,6 @@
     "eslint-plugin-qunit": "^7.3.0",
     "js-bexpr": "hashicorp/js-bexpr#9b4a4b54d85eba67fdfc0990133d1518d890b1e1",
     "loader.js": "^4.7.0",
-    "miragejs": "^0.1.46",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.2",
     "qunit": "^2.19.1",

--- a/addons/api/tests/dummy/mirage/config.js
+++ b/addons/api/tests/dummy/mirage/config.js
@@ -1,22 +1,5 @@
-export default function () {
-  // These comments are here to help you get started. Feel free to delete them.
-  /*
-    Config (with defaults).
+import { createServer } from 'miragejs';
 
-    Note: these only affect routes defined *after* them!
-  */
-  // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
-  // this.namespace = '';    // make this `/api`, for example, if your API is namespaced
-  // this.timing = 400;      // delay for each request, automatically set to 0 during testing
-  /*
-    Shorthand cheatsheet:
-
-    this.get('/posts');
-    this.post('/posts');
-    this.get('/posts/:id');
-    this.put('/posts/:id'); // or this.patch
-    this.del('/posts/:id');
-
-    https://www.ember-cli-mirage.com/docs/route-handlers/shorthands
-  */
+export default function (config) {
+  return createServer({ ...config });
 }

--- a/addons/api/tests/unit/models/base-test.js
+++ b/addons/api/tests/unit/models/base-test.js
@@ -120,10 +120,11 @@ module('Unit | Model | base', function (hooks) {
       return {};
     });
     await model.save();
-    this.server.delete('/v1/users', () => {
+    this.server.delete('/v1/users/u_123', () => {
       assert.ok(true, 'Correctly scoped delete record URL was requested.');
       return {};
     });
+    model.id = 'u_123';
     await model.destroyRecord();
   });
 
@@ -143,10 +144,11 @@ module('Unit | Model | base', function (hooks) {
       return {};
     });
     await model.save({ adapterOptions: { scopeID: customScopeID } });
-    this.server.delete('/v1/users', () => {
+    this.server.delete('/v1/users/u_123', () => {
       assert.ok(true, 'Correctly scoped delete record URL was requested.');
       return {};
     });
+    model.id = 'u_123';
     await model.destroyRecord({ adapterOptions: { scopeID: customScopeID } });
   });
 

--- a/addons/api/tests/unit/serializers/auth-method-test.js
+++ b/addons/api/tests/unit/serializers/auth-method-test.js
@@ -182,7 +182,6 @@ module('Unit | Serializer | auth method', function (hooks) {
       signing_algorithms,
       idp_ca_certs,
     } = record;
-    console.log(record);
     assert.deepEqual(account_claim_maps, [
       { from: 'from', to: 'to' },
       { from: 'foo', to: 'bar' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3850,66 +3850,69 @@
     minimatch "^3.0.4"
     plist "^3.0.4"
 
-"@ember-data/adapter@3.28.12":
-  version "3.28.12"
-  resolved "https://registry.yarnpkg.com/@ember-data/adapter/-/adapter-3.28.12.tgz#0c77ba87b316acdab442240812a2504beb42b766"
-  integrity sha512-pG7ITjLnYcKFZ5XrQB2kUn2mf6vwxzocXOOmCtRSS2oNVp+iYBMqNOUk6I2v5WgjwzSSePzWuGdlcOYn/KPweg==
+"@ember-data/adapter@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/adapter/-/adapter-4.4.1.tgz#1c61fcb0392cb9b04479f7886f8373e89f71e163"
+  integrity sha512-VIEusESLxpe/M7DGcmb7KTFLB3Joi+x5fbx6mywvYDhzTzsq/U5RCuIkxs9G/PNSlXD3z691GnZVd4T8GtcJXA==
   dependencies:
-    "@ember-data/private-build-infra" "3.28.12"
-    "@ember-data/store" "3.28.12"
+    "@ember-data/private-build-infra" "4.4.1"
+    "@ember-data/store" "4.4.1"
     "@ember/edition-utils" "^1.2.0"
     "@ember/string" "^3.0.0"
-    ember-cli-babel "^7.26.6"
+    ember-auto-import "^2.2.4"
+    ember-cli-babel "^7.26.11"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.1.0"
+    ember-cli-typescript "^5.0.0"
 
-"@ember-data/canary-features@3.28.12":
-  version "3.28.12"
-  resolved "https://registry.yarnpkg.com/@ember-data/canary-features/-/canary-features-3.28.12.tgz#d980ac9bae671fc8a4aec763de6af9377f1f1e29"
-  integrity sha512-+1ymzYYCX5hc/zHv/OjEPUoEP9J/cZRiC1VWvIWm1aAZXm+th1G3wtu9+BWYVVRhX3V3rNgP2f9ePR6wgSI5LQ==
+"@ember-data/canary-features@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/canary-features/-/canary-features-4.4.1.tgz#2e169c235ee095e84040fb01f6ebe171b986a464"
+  integrity sha512-st/MA0DuN/HX2JsE6jabS/ry9oE0tB4kkOqDmu6+uCcgup8gXK85Y9SYUvTKv/v5AlpGa06+ATIFxSVOUQDBtw==
   dependencies:
-    ember-cli-babel "^7.26.6"
-    ember-cli-typescript "^4.1.0"
+    ember-cli-babel "^7.26.11"
+    ember-cli-typescript "^5.0.0"
 
-"@ember-data/debug@3.28.12":
-  version "3.28.12"
-  resolved "https://registry.yarnpkg.com/@ember-data/debug/-/debug-3.28.12.tgz#ef3389ab69405fbbfca928744c087092a6e5deef"
-  integrity sha512-uxBqJUMD6hxie6CazFlZ8Kca1Pi34sTKs2UmJaa3MviQ67mE+XVPoVe5Q8RFpA5aIGGWsS6SNgMMIjvuR36vUw==
+"@ember-data/debug@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/debug/-/debug-4.4.1.tgz#848c32e05f91f6e975c9c7af53f9d3c2d49d1da8"
+  integrity sha512-x5LeVyYSPZQkieJUU26c9mP4Y2Jo+kTBehh6+RgLOkCuNLfJdU5/YIB56IgWPFV0SmEMSoZtWh1rB+SBWAHWgg==
   dependencies:
-    "@ember-data/private-build-infra" "3.28.12"
+    "@ember-data/private-build-infra" "4.4.1"
     "@ember/edition-utils" "^1.2.0"
     "@ember/string" "^3.0.0"
-    ember-cli-babel "^7.26.6"
+    ember-auto-import "^2.2.4"
+    ember-cli-babel "^7.26.11"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.1.0"
+    ember-cli-typescript "^5.0.0"
 
-"@ember-data/model@3.28.12":
-  version "3.28.12"
-  resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-3.28.12.tgz#481dbf036e804ab64bd4fc54473838964156be26"
-  integrity sha512-tv1kPqJMAq37zbn/h3Vg6Y6aaWybXdqw0Z3KnOy8wcbi5qHKdhPbozVP7gp+uUyle8addiFZ85ckJMUe0COWAw==
+"@ember-data/model@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-4.4.1.tgz#cd5018579c6648dd40de5c8defc93bf84a342fde"
+  integrity sha512-yLTX6lFOotAYgHB+zD9VRHuVxyrxH9bqBO/+rtL88QpHKixtZZjknLL6DXzkjejgom58PXmXulGcnopiicbd6w==
   dependencies:
-    "@ember-data/canary-features" "3.28.12"
-    "@ember-data/private-build-infra" "3.28.12"
-    "@ember-data/store" "3.28.12"
+    "@ember-data/canary-features" "4.4.1"
+    "@ember-data/private-build-infra" "4.4.1"
+    "@ember-data/store" "4.4.1"
     "@ember/edition-utils" "^1.2.0"
     "@ember/string" "^3.0.0"
+    ember-auto-import "^2.2.4"
     ember-cached-decorator-polyfill "^0.1.4"
-    ember-cli-babel "^7.26.6"
+    ember-cli-babel "^7.26.11"
     ember-cli-string-utils "^1.1.0"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.1.0"
+    ember-cli-typescript "^5.0.0"
     ember-compatibility-helpers "^1.2.0"
     inflection "~1.13.1"
 
-"@ember-data/private-build-infra@3.28.12":
-  version "3.28.12"
-  resolved "https://registry.yarnpkg.com/@ember-data/private-build-infra/-/private-build-infra-3.28.12.tgz#4a0f674ce865b41a7e4d28be25f6631b588367aa"
-  integrity sha512-Nn1ipcOcIvkS3cXjSrvey4obNjI56JpCjfMQTHrLj1m2lhYbZmiEuulbLs3Mn5y5EOZ6d5HJNK7fbhZRLoh3tQ==
+"@ember-data/private-build-infra@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/private-build-infra/-/private-build-infra-4.4.1.tgz#cd9ed50072f71b5aaac72946abc44fc6043047b0"
+  integrity sha512-Yg50CZCU1Xll/6N+iUzzG+hqxK3BtiVJziRmWnOapSvExA6HxzD1hnxd/AB9+wECprHElBxLEKo85oNgFtC7zg==
   dependencies:
-    "@babel/plugin-transform-block-scoping" "^7.8.3"
-    "@ember-data/canary-features" "3.28.12"
+    "@babel/plugin-transform-block-scoping" "^7.16.7"
+    "@ember-data/canary-features" "4.4.1"
     "@ember/edition-utils" "^1.2.0"
-    babel-plugin-debug-macros "^0.3.3"
+    babel-plugin-debug-macros "^0.3.4"
     babel-plugin-filter-imports "^4.0.0"
     babel6-plugin-strip-class-callcheck "^6.0.0"
     broccoli-debug "^0.6.5"
@@ -3919,10 +3922,10 @@
     broccoli-rollup "^5.0.0"
     calculate-cache-key-for-tree "^2.0.0"
     chalk "^4.0.0"
-    ember-cli-babel "^7.26.6"
+    ember-cli-babel "^7.26.11"
     ember-cli-path-utils "^1.0.0"
     ember-cli-string-utils "^1.1.0"
-    ember-cli-typescript "^4.1.0"
+    ember-cli-typescript "^5.0.0"
     ember-cli-version-checker "^5.1.1"
     esm "^3.2.25"
     git-repo-info "^2.1.1"
@@ -3933,48 +3936,51 @@
     semver "^7.1.3"
     silent-error "^1.1.1"
 
-"@ember-data/record-data@3.28.12":
-  version "3.28.12"
-  resolved "https://registry.yarnpkg.com/@ember-data/record-data/-/record-data-3.28.12.tgz#75cb865fca155eb8d8a0362db6e05b30b651db86"
-  integrity sha512-BUhabJqdgeh2kjKgCSn+K/D4lZww7jIFiATmmC5ecXJPPI3YSTAnYzGfxOdqd6F37DTkAwDJpdPR8OcOyTfmPg==
+"@ember-data/record-data@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/record-data/-/record-data-4.4.1.tgz#1524d361e2d1f8c8b24e5f5e7417a82b9b0f51ed"
+  integrity sha512-5wmvcdxuVbA449UJzaMW/jovL3Sca/Yu+nVwiShic0GWcV72hbdO26/6Ii2dDCXqCf9WVXAl30egCGz/mGZgKQ==
   dependencies:
-    "@ember-data/canary-features" "3.28.12"
-    "@ember-data/private-build-infra" "3.28.12"
-    "@ember-data/store" "3.28.12"
+    "@ember-data/canary-features" "4.4.1"
+    "@ember-data/private-build-infra" "4.4.1"
+    "@ember-data/store" "4.4.1"
     "@ember/edition-utils" "^1.2.0"
-    ember-cli-babel "^7.26.6"
+    ember-auto-import "^2.2.4"
+    ember-cli-babel "^7.26.11"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.1.0"
+    ember-cli-typescript "^5.0.0"
 
 "@ember-data/rfc395-data@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
   integrity sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==
 
-"@ember-data/serializer@3.28.12":
-  version "3.28.12"
-  resolved "https://registry.yarnpkg.com/@ember-data/serializer/-/serializer-3.28.12.tgz#4eb41aef80e453b29335c2ba4a77339e89204b9e"
-  integrity sha512-q6FjqL2VYmmcVdTLhENoBTpayhCnCCyWc/FPsuBO6knOuCd4vDlSK+y0BotSZ/Tadjmi6qjYrff7hpXbvnR/FQ==
+"@ember-data/serializer@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/serializer/-/serializer-4.4.1.tgz#0699bd08e76d298776663d783f819380fe818700"
+  integrity sha512-ffzHcWDJlX5epM8SzQMirRkBU2/N/enJwnJV28DzcxQcrbVfUWZqaPgQWpg8wADLETfumERzy7WIJlcSCGR5ow==
   dependencies:
-    "@ember-data/private-build-infra" "3.28.12"
-    "@ember-data/store" "3.28.12"
-    ember-cli-babel "^7.26.6"
+    "@ember-data/private-build-infra" "4.4.1"
+    "@ember-data/store" "4.4.1"
+    ember-auto-import "^2.2.4"
+    ember-cli-babel "^7.26.11"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.1.0"
+    ember-cli-typescript "^5.0.0"
 
-"@ember-data/store@3.28.12":
-  version "3.28.12"
-  resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-3.28.12.tgz#896a8a4924ce0a47c191251d71d697e1b0980eb4"
-  integrity sha512-y1XmmWIW/vDJsNGu14QfsZzggktqip2lGmQI6gTZacRYl7reSMZHnM9veifhRT3uZHTxcRy7nhGMsBB5QUxeeQ==
+"@ember-data/store@4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-4.4.1.tgz#07c49e9228d56e63dcaba793aa4061ba28633e32"
+  integrity sha512-lfEQmm/xaqPdG6S4fSwm3XG/3g1s9R9ir5OcOytng/UNw7wZxDZnUA+wOiFup1gN3ZO/q5y4nCg8B6dC3NEFgA==
   dependencies:
-    "@ember-data/canary-features" "3.28.12"
-    "@ember-data/private-build-infra" "3.28.12"
+    "@ember-data/canary-features" "4.4.1"
+    "@ember-data/private-build-infra" "4.4.1"
     "@ember/string" "^3.0.0"
     "@glimmer/tracking" "^1.0.4"
+    ember-auto-import "^2.2.4"
     ember-cached-decorator-polyfill "^0.1.4"
-    ember-cli-babel "^7.26.6"
+    ember-cli-babel "^7.26.11"
     ember-cli-path-utils "^1.0.0"
-    ember-cli-typescript "^4.1.0"
+    ember-cli-typescript "^5.0.0"
 
 "@ember/edition-utils@^1.2.0":
   version "1.2.0"
@@ -8433,7 +8439,7 @@ babel-plugin-debug-macros@^0.2.0:
   dependencies:
     semver "^5.3.0"
 
-babel-plugin-debug-macros@^0.3.3, babel-plugin-debug-macros@^0.3.4:
+babel-plugin-debug-macros@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.4.tgz#22961d0cb851a80654cece807a8b4b73d85c6075"
   integrity sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==
@@ -12177,6 +12183,42 @@ ember-auto-import@^2.2.3, ember-auto-import@^2.4.1, ember-auto-import@^2.4.2:
     typescript-memoize "^1.0.0-alpha.3"
     walk-sync "^3.0.0"
 
+ember-auto-import@^2.2.4:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-2.5.0.tgz#627607648e87d154f75cd3f70c435355ef7cced9"
+  integrity sha512-fKERUmpZLn4RJiCwTjS7D5zJxgnbF4E6GiSp1GYh53K96S+5UBs06r7ScDI52rq34z0+qdSrA6qiDJ3i/lWqKg==
+  dependencies:
+    "@babel/core" "^7.16.7"
+    "@babel/plugin-proposal-class-properties" "^7.16.7"
+    "@babel/plugin-proposal-decorators" "^7.16.7"
+    "@babel/preset-env" "^7.16.7"
+    "@embroider/macros" "^1.0.0"
+    "@embroider/shared-internals" "^2.0.0"
+    babel-loader "^8.0.6"
+    babel-plugin-ember-modules-api-polyfill "^3.5.0"
+    babel-plugin-htmlbars-inline-precompile "^5.2.1"
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^3.0.8"
+    broccoli-merge-trees "^4.2.0"
+    broccoli-plugin "^4.0.0"
+    broccoli-source "^3.0.0"
+    css-loader "^5.2.0"
+    debug "^4.3.1"
+    fs-extra "^10.0.0"
+    fs-tree-diff "^2.0.0"
+    handlebars "^4.3.1"
+    js-string-escape "^1.0.1"
+    lodash "^4.17.19"
+    mini-css-extract-plugin "^2.5.2"
+    parse5 "^6.0.1"
+    resolve "^1.20.0"
+    resolve-package-path "^4.0.3"
+    semver "^7.3.4"
+    style-loader "^2.0.0"
+    typescript-memoize "^1.0.0-alpha.3"
+    walk-sync "^3.0.0"
+
 ember-auto-import@^2.4.0, ember-auto-import@^2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-2.4.3.tgz#0ff8ebe37a2016dbad2ccc10c0ef2dfbd0289b55"
@@ -13015,24 +13057,25 @@ ember-copy@^2.0.1:
   dependencies:
     ember-cli-babel "^7.22.1"
 
-ember-data@^3.28.12:
-  version "3.28.12"
-  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.28.12.tgz#8d63fcd18982323887c637f78bafbf6e8715da93"
-  integrity sha512-eVVhYf45WjLpq2j9jIFxlrh3DG8um2tuzVMlhCGz1l6mIocT6TOW2NTcS5Ue2Dz7VDd3DeBtgfzvV6DIdouHug==
+ember-data@~4.4.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-4.4.1.tgz#86e56d55b49986dff8ae1cc98a740c829e53961e"
+  integrity sha512-Jc8a2OTX3rcnbmVwBjdeOYPSKUHWYRH+RMyDSLN3fpLp/A8pZp1Lkn3b5/ZEi9DmBRirxIDSSSPPZ6RDTMBYlQ==
   dependencies:
-    "@ember-data/adapter" "3.28.12"
-    "@ember-data/debug" "3.28.12"
-    "@ember-data/model" "3.28.12"
-    "@ember-data/private-build-infra" "3.28.12"
-    "@ember-data/record-data" "3.28.12"
-    "@ember-data/serializer" "3.28.12"
-    "@ember-data/store" "3.28.12"
+    "@ember-data/adapter" "4.4.1"
+    "@ember-data/debug" "4.4.1"
+    "@ember-data/model" "4.4.1"
+    "@ember-data/private-build-infra" "4.4.1"
+    "@ember-data/record-data" "4.4.1"
+    "@ember-data/serializer" "4.4.1"
+    "@ember-data/store" "4.4.1"
     "@ember/edition-utils" "^1.2.0"
     "@ember/string" "^3.0.0"
     "@glimmer/env" "^0.1.7"
     broccoli-merge-trees "^4.2.0"
-    ember-cli-babel "^7.26.6"
-    ember-cli-typescript "^4.1.0"
+    ember-auto-import "^2.2.4"
+    ember-cli-babel "^7.26.11"
+    ember-cli-typescript "^5.0.0"
     ember-inflector "^4.0.1"
 
 ember-destroyable-polyfill@^2.0.1, ember-destroyable-polyfill@^2.0.2, ember-destroyable-polyfill@^2.0.3:
@@ -20061,7 +20104,7 @@ minizlib@^2.0.0, minizlib@^2.1.1:
     minipass "^3.0.0"
     yallist "^4.0.0"
 
-miragejs@^0.1.43, miragejs@^0.1.46:
+miragejs@^0.1.43:
   version "0.1.46"
   resolved "https://registry.yarnpkg.com/miragejs/-/miragejs-0.1.46.tgz#0b27edcdfc7f0df06e5779334d452c2250cc9cbf"
   integrity sha512-xmWiFaGamslyUqZt7tDd0kkjWa8Ow4I7ID/Gi8c+iCVibZyU+SAiIZNmUynnDGD1Q8g8nlydtzADnb5+21gwww==


### PR DESCRIPTION
## Description
Upgrade `ember-data` to 4.4.1.

~~Still getting deprecation messages from mirage but should have been fixed by #1504, will look a bit more into it.~~
The issue was when running tests, mirage was also looking at the dummy config
