### PR TITLE
refactor: 💡 use constants for target types

### DIFF
--- a/addons/api/addon/models/target.js
+++ b/addons/api/addon/models/target.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 
 export const TYPE_TARGET_TCP = 'tcp';
 export const TYPE_TARGET_SSH = 'ssh';
-export const types = [TYPE_TARGET_TCP, TYPE_TARGET_SSH];
+export const TYPES_TARGET = Object.freeze([TYPE_TARGET_TCP, TYPE_TARGET_SSH]);
 
 export default class TargetModel extends GeneratedTargetModel {
   // =services

--- a/addons/api/addon/models/target.js
+++ b/addons/api/addon/models/target.js
@@ -2,7 +2,9 @@ import GeneratedTargetModel from '../generated/models/target';
 import { attr } from '@ember-data/model';
 import { inject as service } from '@ember/service';
 
-export const types = ['tcp', 'ssh'];
+export const TYPE_TARGET_TCP = 'tcp';
+export const TYPE_TARGET_SSH = 'ssh';
+export const types = [TYPE_TARGET_TCP, TYPE_TARGET_SSH];
 
 export default class TargetModel extends GeneratedTargetModel {
   // =services
@@ -321,7 +323,7 @@ export default class TargetModel extends GeneratedTargetModel {
    * @type {boolean}
    */
   get isTCP() {
-    return this.type === 'tcp';
+    return this.type === TYPE_TARGET_TCP;
   }
 
   /**
@@ -329,6 +331,6 @@ export default class TargetModel extends GeneratedTargetModel {
    * @type {boolean}
    */
   get isSSH() {
-    return this.type === 'ssh';
+    return this.type === TYPE_TARGET_SSH;
   }
 }

--- a/addons/api/mirage/factories/target.js
+++ b/addons/api/mirage/factories/target.js
@@ -3,11 +3,11 @@ import { trait } from 'ember-cli-mirage';
 import { faker } from '@faker-js/faker';
 import permissions from '../helpers/permissions';
 import generateId from '../helpers/id';
-import { types as targetTypes } from 'api/models/target';
+import { TYPES_TARGET } from 'api/models/target';
 
 const randomBoolean = (chance = 0.5) => Math.random() < chance;
 const hostSetChance = 0.3;
-const types = [...targetTypes];
+const types = [...TYPES_TARGET];
 
 export default factory.extend({
   authorized_actions: () =>

--- a/addons/api/mirage/factories/target.js
+++ b/addons/api/mirage/factories/target.js
@@ -3,11 +3,11 @@ import { trait } from 'ember-cli-mirage';
 import { faker } from '@faker-js/faker';
 import permissions from '../helpers/permissions';
 import generateId from '../helpers/id';
-import * as targetTypes from 'api/models/target';
+import { types as targetTypes } from 'api/models/target';
 
 const randomBoolean = (chance = 0.5) => Math.random() < chance;
 const hostSetChance = 0.3;
-const types = Object.values(targetTypes);
+const types = [...targetTypes];
 
 export default factory.extend({
   authorized_actions: () =>

--- a/addons/api/mirage/factories/target.js
+++ b/addons/api/mirage/factories/target.js
@@ -3,10 +3,11 @@ import { trait } from 'ember-cli-mirage';
 import { faker } from '@faker-js/faker';
 import permissions from '../helpers/permissions';
 import generateId from '../helpers/id';
+import * as targetTypes from 'api/models/target';
 
 const randomBoolean = (chance = 0.5) => Math.random() < chance;
 const hostSetChance = 0.3;
-const types = ['tcp', 'ssh'];
+const types = Object.values(targetTypes);
 
 export default factory.extend({
   authorized_actions: () =>
@@ -35,13 +36,11 @@ export default factory.extend({
    * Generates attributes fields by type.
    */
   afterCreate(target) {
-    if (target.type === 'tcp' || target.type === 'ssh') {
-      target.update({
-        attributes: {
-          default_port: faker.datatype.number(),
-        },
-      });
-    }
+    target.update({
+      attributes: {
+        default_port: faker.datatype.number(),
+      },
+    });
   },
 
   /**

--- a/addons/api/mirage/generated/factories/target.js
+++ b/addons/api/mirage/generated/factories/target.js
@@ -1,11 +1,12 @@
 import { Factory } from 'ember-cli-mirage';
 import { faker } from '@faker-js/faker';
+import { TYPE_TARGET_TCP } from 'api/models/target';
 
 /**
  * GeneratedTargetModelFactory
  */
 export default Factory.extend({
-  type: 'tcp',
+  type: TYPE_TARGET_TCP,
   name: () => faker.random.words(),
   session_max_seconds: () => faker.datatype.number(),
   session_connection_limit: () => faker.datatype.number(),

--- a/addons/api/tests/unit/models/target-test.js
+++ b/addons/api/tests/unit/models/target-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { TYPE_TARGET_TCP, TYPE_TARGET_SSH } from 'api/models/target';
 
 module('Unit | Model | target', function (hooks) {
   setupTest(hooks);
@@ -383,7 +384,7 @@ module('Unit | Model | target', function (hooks) {
     assert.expect(2);
     const store = this.owner.lookup('service:store');
     const modelSSH = store.createRecord('target', {
-      type: 'ssh',
+      type: TYPE_TARGET_SSH,
     });
     assert.true(modelSSH.isSSH);
     assert.false(modelSSH.isTCP);
@@ -393,7 +394,7 @@ module('Unit | Model | target', function (hooks) {
     assert.expect(2);
     const store = this.owner.lookup('service:store');
     const modelTCP = store.createRecord('target', {
-      type: 'tcp',
+      type: TYPE_TARGET_TCP,
     });
     assert.true(modelTCP.isTCP);
     assert.false(modelTCP.isSSH);

--- a/addons/api/tests/unit/serializers/auth-method-test.js
+++ b/addons/api/tests/unit/serializers/auth-method-test.js
@@ -182,7 +182,6 @@ module('Unit | Serializer | auth method', function (hooks) {
       signing_algorithms,
       idp_ca_certs,
     } = record;
-    console.log(record);
     assert.deepEqual(account_claim_maps, [
       { from: 'from', to: 'to' },
       { from: 'foo', to: 'bar' },

--- a/addons/api/tests/unit/serializers/target-test.js
+++ b/addons/api/tests/unit/serializers/target-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { TYPE_TARGET_TCP, TYPE_TARGET_SSH } from 'api/models/target';
 
 module('Unit | Serializer | target', function (hooks) {
   setupTest(hooks);
@@ -26,7 +27,7 @@ module('Unit | Serializer | target', function (hooks) {
       },
       default_port: 1234,
       version: 1,
-      type: 'tcp',
+      type: TYPE_TARGET_TCP,
     });
     const snapshot = record._createSnapshot();
     snapshot.adapterOptions = {};
@@ -35,7 +36,7 @@ module('Unit | Serializer | target', function (hooks) {
       name: 'User',
       description: 'Description',
       version: 1,
-      type: 'tcp',
+      type: TYPE_TARGET_TCP,
       scope_id: 'org_1',
       session_max_seconds: 28800,
       session_connection_limit: null,
@@ -124,7 +125,7 @@ module('Unit | Serializer | target', function (hooks) {
       name: 'User',
       description: 'Description',
       version: 1,
-      type: 'ssh',
+      type: TYPE_TARGET_SSH,
       worker_filter: 'worker',
       default_port: 1234,
       scope: {
@@ -137,7 +138,7 @@ module('Unit | Serializer | target', function (hooks) {
       name: 'User',
       description: 'Description',
       version: 1,
-      type: 'ssh',
+      type: TYPE_TARGET_SSH,
       scope_id: 'org_1',
       session_max_seconds: 28800,
       session_connection_limit: null,

--- a/ui/admin/app/components/form/target/details/index.js
+++ b/ui/admin/app/components/form/target/details/index.js
@@ -1,7 +1,8 @@
 import Component from '@glimmer/component';
-import { types } from 'api/models/target';
+import { TYPES_TARGET } from 'api/models/target';
 
-//Note: this is a temporary solution till we have resource type helper in place
+// NOTE: this is all a temporary solution till we have a resource type helper.
+const types = [...TYPES_TARGET].reverse();
 const icons = {
   ssh: 'terminal-screen',
   tcp: 'network',
@@ -14,8 +15,7 @@ export default class FormTargetComponent extends Component {
    * @type {object}
    */
   get typeMetas() {
-    const reversedTypes = [...types].reverse();
-    return reversedTypes.map((type) => ({
+    return types.map((type) => ({
       type,
       icon: icons[type],
     }));

--- a/ui/admin/app/routes/onboarding/quick-setup/create-resources.js
+++ b/ui/admin/app/routes/onboarding/quick-setup/create-resources.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifyError } from 'core/decorators/notify';
+import { TYPE_TARGET_TCP } from 'api/models/target';
 
 export default class OnboardingQuickSetupCreateResourcesRoute extends Route {
   // =services
@@ -40,7 +41,7 @@ export default class OnboardingQuickSetupCreateResourcesRoute extends Route {
         description: 'Sample host created by quick setup',
       }),
       target: this.store.createRecord('target', {
-        type: 'tcp',
+        type: TYPE_TARGET_TCP,
         name: 'EC2 Instances',
         description: 'Sample target created by quick setup',
       }),

--- a/ui/admin/app/routes/scopes/scope/targets/new.js
+++ b/ui/admin/app/routes/scopes/scope/targets/new.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { TYPE_TARGET_TCP, TYPE_TARGET_SSH } from 'api/models/target';
 
 export default class ScopesScopeTargetsNewRoute extends Route {
   // =services
@@ -29,7 +30,10 @@ export default class ScopesScopeTargetsNewRoute extends Route {
     const scopeModel = this.modelFor('scopes.scope');
 
     // default type is SSH if the feature is enabled, otherwise TCP
-    if (!type) type = this.features.isEnabled('ssh-target') ? 'ssh' : 'tcp';
+    if (!type)
+      type = this.features.isEnabled('ssh-target')
+        ? TYPE_TARGET_SSH
+        : TYPE_TARGET_TCP;
 
     if (this.currentModel?.isNew) {
       ({ name, description } = this.currentModel);

--- a/ui/admin/tests/acceptance/targets/create-test.js
+++ b/ui/admin/tests/acceptance/targets/create-test.js
@@ -16,6 +16,7 @@ import {
   //currentSession,
   //invalidateSession,
 } from 'ember-simple-auth/test-support';
+import { TYPE_TARGET_TCP, TYPE_TARGET_SSH } from 'api/models/target';
 
 module('Acceptance | targets | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -71,16 +72,16 @@ module('Acceptance | targets | create', function (hooks) {
     // Generate resource counter
     getTargetCount = () => this.server.schema.targets.all().models.length;
     getSSHTargetCount = () =>
-      this.server.schema.targets.where({ type: 'ssh' }).models.length;
+      this.server.schema.targets.where({ type: TYPE_TARGET_SSH }).models.length;
     getTCPTargetCount = () =>
-      this.server.schema.targets.where({ type: 'tcp' }).models.length;
+      this.server.schema.targets.where({ type: TYPE_TARGET_TCP }).models.length;
     authenticateSession({});
   });
 
   test('defaults to type `ssh` when no query param provided', async function (assert) {
     assert.expect(1);
     await visit(urls.newTarget);
-    assert.strictEqual(find('[name="type"]:checked').value, 'ssh');
+    assert.strictEqual(find('[name="type"]:checked').value, TYPE_TARGET_SSH);
   });
 
   test('can create type `ssh`', async function (assert) {

--- a/ui/admin/tests/acceptance/targets/injected-application-credential-sources-test.js
+++ b/ui/admin/tests/acceptance/targets/injected-application-credential-sources-test.js
@@ -5,6 +5,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import { TYPE_TARGET_SSH } from 'api/models/target';
 
 module(
   'Acceptance | targets | injected application credential sources',
@@ -78,7 +79,7 @@ module(
       instances.credential = instances.credentials[0];
       instances.target = this.server.create('target', {
         scope: instances.scopes.project,
-        type: 'ssh',
+        type: TYPE_TARGET_SSH,
       });
       randomlySelectedCredentials = this.server.schema.credentials
         .all()

--- a/ui/admin/tests/acceptance/targets/read-test.js
+++ b/ui/admin/tests/acceptance/targets/read-test.js
@@ -9,6 +9,7 @@ import {
   //currentSession,
   //invalidateSession,
 } from 'ember-simple-auth/test-support';
+import { TYPE_TARGET_TCP, TYPE_TARGET_SSH } from 'api/models/target';
 
 module('Acceptance | targets | read', function (hooks) {
   setupApplicationTest(hooks);
@@ -44,11 +45,11 @@ module('Acceptance | targets | read', function (hooks) {
       scope: { id: instances.scopes.org.id, type: 'org' },
     });
     instances.sshTarget = this.server.create('target', {
-      type: 'ssh',
+      type: TYPE_TARGET_SSH,
       scope: instances.scopes.project,
     });
     instances.tcpTarget = this.server.create('target', {
-      type: 'tcp',
+      type: TYPE_TARGET_TCP,
       scope: instances.scopes.project,
     });
     // Generate route URLs for resources

--- a/ui/desktop/tests/acceptance/projects/targets-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets-test.js
@@ -10,6 +10,7 @@ import {
   authenticateSession,
   invalidateSession,
 } from 'ember-simple-auth/test-support';
+import { TYPE_TARGET_SSH } from 'api/models/target';
 
 module('Acceptance | projects | targets', function (hooks) {
   setupApplicationTest(hooks);
@@ -247,7 +248,7 @@ module('Acceptance | projects | targets', function (hooks) {
   test('displays the correct target type (SSH) in the success dialog body', async function (assert) {
     assert.expect(1);
     instances.target.update({
-      type: 'ssh',
+      type: TYPE_TARGET_SSH,
     });
     stubs.ipcService.withArgs('cliExists').returns(true);
     stubs.ipcService.withArgs('connect').returns({


### PR DESCRIPTION
This pr introduces constants to represent available target types, as opposed to strings.  This is an improvement over duplicated strings for several reasons:

- Ties all instances of a resource type to a single source of truth:  its constant.
- Eliminates duplication of identical string values.
- Strings are error prone, since many tests may silently accept strings which are not valid types.
- This is a step toward the formalization of resource types, resulting in greater convenience and reliability of resource typing in the future (beginning with targets).
- Simplifies future refactors of resource types.  Where previously a search for an ambiguous string was required `'tcp'`, an unambiguous search may now be used `TYPE_TARGET_TCP`.

For example, in cases where target type previously was represented as a string:

```js
{ type: 'tcp' }
```

the type may now be represented as a constant, which is reusable everywhere the type is needed:

```js
import { TYPE_TARGET_TCP } from 'api/models/target';

{ type: TYPE_TARGET_TCP }
```

This is slightly more code.  But it reduces the proliferation of duplicate strings throughout the codebase and ties every use of a type back to a single source of truth.