### PR TITLE
chore: 🤖 add role readPrincipal ability

### DIFF
--- a/addons/api/addon/abilities/managed-group.js
+++ b/addons/api/addon/abilities/managed-group.js
@@ -1,0 +1,8 @@
+import ModelAbility from './model';
+
+/**
+ * Provides abilities for managed groups.
+ */
+export default class ManagedGroupAbility extends ModelAbility {
+  // no op
+}

--- a/addons/api/addon/abilities/role.js
+++ b/addons/api/addon/abilities/role.js
@@ -1,9 +1,18 @@
 import ModelAbility from './model';
+import { inject as service } from '@ember/service';
+
+class InvalidRolePrincipalTypeError extends Error {
+  name = 'InvalidRolePrincipalTypeError';
+}
 
 /**
  * Provides abilities for roles.
  */
 export default class RoleAbility extends ModelAbility {
+  // =services
+
+  @service can;
+
   // =permissions
 
   /**
@@ -25,5 +34,23 @@ export default class RoleAbility extends ModelAbility {
    */
   get canRemovePrincipals() {
     return this.hasAuthorizedAction('remove-principals');
+  }
+
+  /**
+   * Returns the ability check for a principal model instance.
+   * Valid role principal models are: User, Group, and ManagedGroup.
+   * Throws an error if the principal type is invalid.
+   * @type {boolean}
+   * @throws {InvalidRolePrincipalTypeError}
+   */
+  get canReadPrincipal() {
+    const type = this.model.constructor.modelName;
+    const typeIsValid =
+      type === 'user' || type === 'group' || type === 'managed-group';
+    if (!typeIsValid)
+      throw new InvalidRolePrincipalTypeError(
+        `Expected a role principal of type 'user', 'group', or 'managed-group'.  Got '${type}'.`
+      );
+    return this.can.can(`read ${type}`, this.model);
   }
 }

--- a/addons/api/app/abilities/managed-group.js
+++ b/addons/api/app/abilities/managed-group.js
@@ -1,0 +1,1 @@
+export { default } from 'api/abilities/managed-group';


### PR DESCRIPTION
Introduces a convenience ability for roles, `readPrincipal`.  The ability accepts Role, Group, or ManagedGroup models and returns the `read` ability check for that model.

Since principals are polymorphic, the benefit of this ability is that it allows a read check without knowing the principal type ahead of time.

For example, these checks on the `role` resource:
`can('readPrincipal role', principal1)  // principal1 is a user`
`can('readPrincipal role', principal2)  // principal2 is a group`
`can('readPrincipal role', principal3)  // principal3 is a managed group`

Are equivalent to these checks when the resource type is known:
`can('read user', user)`
`can('read group', group)`
`can('read managedGroup', managedGroup)`