### PR TITLE
Add mirage support principal managed groups

### DIFF
--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -267,7 +267,10 @@ export default function () {
   this.del('/roles/:id');
   this.post(
     '/roles/:idMethod',
-    function ({ roles, users, groups }, { params: { idMethod } }) {
+    function (
+      { roles, users, groups, managedGroups },
+      { params: { idMethod } }
+    ) {
       const attrs = this.normalizedRequestAttrs();
       const id = idMethod.split(':')[0];
       const method = idMethod.split(':')[1];
@@ -283,15 +286,20 @@ export default function () {
           version: attrs.version,
           userIds: role.userIds,
           groupIds: role.groupIds,
+          managedGroupIds: role.managedGroupIds,
         };
         attrs.principalIds.forEach((id) => {
           const isUser = users.find(id);
           const isGroup = groups.find(id);
+          const isManagedGroup = managedGroups.find(id);
           if (isUser && !updatedAttrs.userIds.includes(id)) {
             updatedAttrs.userIds.push(id);
           }
           if (isGroup && !updatedAttrs.groupIds.includes(id)) {
             updatedAttrs.groupIds.push(id);
+          }
+          if (isManagedGroup && !updatedAttrs.managedGroupIds.includes(id)) {
+            updatedAttrs.managedGroupIds.push(id);
           }
         });
       }
@@ -302,6 +310,7 @@ export default function () {
           version: attrs.version,
           userIds: role.userIds,
           groupIds: role.groupIds,
+          managedGroupIds: role.managedGroupIds,
         };
         updatedAttrs.userIds = updatedAttrs.userIds.filter((id) => {
           return !attrs.principalIds.includes(id);
@@ -309,6 +318,11 @@ export default function () {
         updatedAttrs.groupIds = updatedAttrs.groupIds.filter((id) => {
           return !attrs.principalIds.includes(id);
         });
+        updatedAttrs.managedGroupIds = updatedAttrs.managedGroupIds.filter(
+          (id) => {
+            return !attrs.principalIds.includes(id);
+          }
+        );
       }
 
       if (method === 'set-grants') {

--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -274,7 +274,7 @@ export default function () {
       const role = roles.find(id);
       let updatedAttrs = {};
 
-      // Principals is a combined list of users and groups, but in Mirage we've
+      // Principals is a combined list of users, groups and managed groups, but in Mirage we've
       // internally modelled them as separate lists.  Therefore we must check
       // the type by looking up the user or group first, then determine which
       // list to add the principal to.
@@ -295,7 +295,7 @@ export default function () {
           }
         });
       }
-      // If deleting principals, filter them out of both users and groups,
+      // If deleting principals, filter the ids out of users, groups and managed group lists,
       // and in this case don't care about the type
       if (method === 'remove-principals') {
         updatedAttrs = {
@@ -580,8 +580,17 @@ export default function () {
   // managed-groups
   this.get(
     '/managed-groups',
-    ({ managedGroups }, { queryParams: { auth_method_id: authMethodId } }) => {
-      return managedGroups.where({ authMethodId });
+    (
+      { managedGroups },
+      { queryParams: { auth_method_id: authMethodId, filter } }
+    ) => {
+      let resultSet;
+      if (authMethodId) {
+        resultSet = managedGroups.where({ authMethodId });
+      } else {
+        resultSet = managedGroups.all();
+      }
+      return resultSet.filter(makeBooleanFilter(filter));
     }
   );
   this.post('/managed-groups');

--- a/addons/api/mirage/factories/role.js
+++ b/addons/api/mirage/factories/role.js
@@ -28,9 +28,13 @@ export default factory.extend({
   withPrincipals: trait({
     afterCreate(role, server) {
       const { scope } = role;
+      const { id: scopeId } = scope;
       const users = server.createList('user', 2, { scope });
       const groups = server.createList('group', 2, { scope });
-      role.update({ users, groups });
+      const managedGroups = server.schema.managedGroups
+        .where({ scopeId })
+        .models.map((model) => model);
+      role.update({ users, groups, managedGroups });
     },
   }),
 

--- a/addons/api/mirage/factories/role.js
+++ b/addons/api/mirage/factories/role.js
@@ -31,9 +31,9 @@ export default factory.extend({
       const { id: scopeId } = scope;
       const users = server.createList('user', 2, { scope });
       const groups = server.createList('group', 2, { scope });
-      const managedGroups = server.schema.managedGroups
-        .where({ scopeId })
-        .models.map((model) => model);
+      const managedGroups = server.schema.managedGroups.where({
+        scopeId,
+      }).models;
       role.update({ users, groups, managedGroups });
     },
   }),

--- a/addons/api/mirage/models/role.js
+++ b/addons/api/mirage/models/role.js
@@ -5,4 +5,5 @@ export default Model.extend({
   scope: belongsTo(),
   users: hasMany(),
   groups: hasMany(),
+  managedGroups: hasMany(),
 });

--- a/addons/api/mirage/scenarios/default.js
+++ b/addons/api/mirage/scenarios/default.js
@@ -65,7 +65,7 @@ export default function (server) {
     )[0];
     const managedGroups = server.createList('managed-group', 2, {
       scope,
-      authMethodId: oidcAuthMethod[0].id,
+      authMethodId: oidcAuthMethod.id,
     });
     role.update({ managedGroups });
   });

--- a/addons/api/mirage/scenarios/default.js
+++ b/addons/api/mirage/scenarios/default.js
@@ -78,10 +78,12 @@ export default function (server) {
   );
   //create managed groups for role/principals in orgScope
   orgScopeRoles.forEach((role) => {
+    const { scope } = role;
     const oidcAuthMethod = orgAuthMethods.filter(
       (auth) => auth.type === 'oidc'
     )[0];
     const managedGroups = server.createList('managed-group', 2, {
+      scope,
       authMethodId: oidcAuthMethod.id,
     });
     role.update({ managedGroups });

--- a/addons/api/mirage/scenarios/default.js
+++ b/addons/api/mirage/scenarios/default.js
@@ -53,7 +53,7 @@ export default function (server) {
   // Role
   const globalScopeRoles = server.createList(
     'role',
-    5,
+    1,
     { scope: globalScope },
     'withPrincipals'
   );

--- a/addons/api/mirage/scenarios/default.js
+++ b/addons/api/mirage/scenarios/default.js
@@ -62,7 +62,7 @@ export default function (server) {
     const { scope } = role;
     const oidcAuthMethod = globalAuthMethods.filter(
       (auth) => auth.type === 'oidc'
-    );
+    )[0];
     const managedGroups = server.createList('managed-group', 2, {
       scope,
       authMethodId: oidcAuthMethod[0].id,

--- a/addons/api/mirage/scenarios/default.js
+++ b/addons/api/mirage/scenarios/default.js
@@ -70,21 +70,19 @@ export default function (server) {
     role.update({ managedGroups });
   });
 
-  const OrgScopeRoles = server.createList(
+  const orgScopeRoles = server.createList(
     'role',
     5,
     { scope: orgScope },
     'withPrincipals'
   );
   //create managed groups for role/principals in orgScope
-  OrgScopeRoles.forEach((role) => {
-    const { scope } = role;
+  orgScopeRoles.forEach((role) => {
     const oidcAuthMethod = orgAuthMethods.filter(
       (auth) => auth.type === 'oidc'
-    );
+    )[0];
     const managedGroups = server.createList('managed-group', 2, {
-      scope,
-      authMethodId: oidcAuthMethod[0].id,
+      authMethodId: oidcAuthMethod.id,
     });
     role.update({ managedGroups });
   });

--- a/addons/api/mirage/scenarios/default.js
+++ b/addons/api/mirage/scenarios/default.js
@@ -20,7 +20,7 @@ export default function (server) {
   // Auth
   const globalAuthMethods = server.createList(
     'auth-method',
-    1,
+    5,
     { scope: globalScope },
     'withAccountsAndUsersAndManagedGroups'
   );
@@ -51,8 +51,43 @@ export default function (server) {
   server.createList('group', 1, { scope: globalScope }, 'withMembers');
   server.createList('group', 5, { scope: orgScope }, 'withMembers');
   // Role
-  server.createList('role', 1, { scope: globalScope }, 'withPrincipals');
-  server.createList('role', 5, { scope: orgScope }, 'withPrincipals');
+  const globalScopeRoles = server.createList(
+    'role',
+    5,
+    { scope: globalScope },
+    'withPrincipals'
+  );
+  //create managed groups for role/principals in globalScope
+  globalScopeRoles.forEach((role) => {
+    const { scope } = role;
+    const oidcAuthMethod = globalAuthMethods.filter(
+      (auth) => auth.type === 'oidc'
+    );
+    const managedGroups = server.createList('managed-group', 2, {
+      scope,
+      authMethodId: oidcAuthMethod[0].id,
+    });
+    role.update({ managedGroups });
+  });
+
+  const OrgScopeRoles = server.createList(
+    'role',
+    5,
+    { scope: orgScope },
+    'withPrincipals'
+  );
+  //create managed groups for role/principals in orgScope
+  OrgScopeRoles.forEach((role) => {
+    const { scope } = role;
+    const oidcAuthMethod = orgAuthMethods.filter(
+      (auth) => auth.type === 'oidc'
+    );
+    const managedGroups = server.createList('managed-group', 2, {
+      scope,
+      authMethodId: oidcAuthMethod[0].id,
+    });
+    role.update({ managedGroups });
+  });
 
   // Other resources
   server.schema.scopes.where({ type: 'project' }).models.forEach((scope) => {

--- a/addons/api/mirage/serializers/role.js
+++ b/addons/api/mirage/serializers/role.js
@@ -18,7 +18,19 @@ export default ApplicationSerializer.extend({
       id: group.id,
       type: 'group',
     }));
-    json.principals = [...serializedUsers, ...serializedGroups];
+    const serializedManagedGroups = model.managedGroups.models.map(
+      (managedGroup) => ({
+        scope_id: model.scope.id,
+        id: managedGroup.id,
+        type: 'managed group',
+      })
+    );
+    json.principals = [
+      ...serializedUsers,
+      ...serializedGroups,
+      ...serializedManagedGroups,
+    ];
+
     if (!json.principals.length) delete json.principals;
 
     // default grant scope

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -271,6 +271,7 @@ role:
     types:
       user: User
       group: Group
+      managed-group: Managed Group
     actions:
       add-principals: Add Principals
   grant:

--- a/ui/admin/tests/acceptance/roles/principals-test.js
+++ b/ui/admin/tests/acceptance/roles/principals-test.js
@@ -46,7 +46,8 @@ module('Acceptance | roles | principals', function (hooks) {
     );
     principalsCount =
       this.server.db.roles[0].userIds.length +
-      this.server.db.roles[0].groupIds.length;
+      this.server.db.roles[0].groupIds.length +
+      this.server.db.roles[0].managedGroupIds.length;
     urls.roles = `/scopes/${instances.scopes.org.id}/roles`;
     urls.role = `${urls.roles}/${instances.role.id}`;
     urls.rolePrincipals = `${urls.role}/principals`;
@@ -111,7 +112,7 @@ module('Acceptance | roles | principals', function (hooks) {
 
   test('select and save principals to add', async function (assert) {
     assert.expect(3);
-    instances.role.update({ userIds: [], groupIds: [] });
+    instances.role.update({ userIds: [], groupIds: [], managedGroupIds: [] });
     await visit(urls.rolePrincipals);
     assert.strictEqual(findAll('tbody tr').length, 0);
     await click('.rose-layout-page-actions a');
@@ -154,7 +155,7 @@ module('Acceptance | roles | principals', function (hooks) {
         }
       );
     });
-    instances.role.update({ userIds: [], groupIds: [] });
+    instances.role.update({ userIds: [], groupIds: [], managedGroupIds: [] });
     await visit(urls.addPrincipals);
     await click('tbody label');
     await click('form [type="submit"]');


### PR DESCRIPTION
This PR adds mocks for managed groups in `role/principals list` and `add to principals` view for both global and org-level scope. 

This is part of https://hashicorp.atlassian.net/browse/ICU-7102 


global scope: 
<img width="836" alt="Screen Shot 2022-12-20 at 1 37 24 PM" src="https://user-images.githubusercontent.com/15043878/208790709-c42589c1-5c68-4a8c-98c9-101ace0343e4.png">

org Scope: 
<img width="931" alt="Screen Shot 2022-12-20 at 1 36 50 PM" src="https://user-images.githubusercontent.com/15043878/208790725-4fa07e77-271a-403f-90bc-659fdfb3e5e4.png">
