### PR TITLE
chore: 🤖 disable csp meta for prod

### DIFF
--- a/ui/admin/config/content-security-policy.js
+++ b/ui/admin/config/content-security-policy.js
@@ -25,9 +25,10 @@ module.exports = function (environment) {
     if (API_HOST) policy['connect-src'].push(API_HOST);
   }
 
+  //enable csp meta tag only in dev env
   return {
     delivery: ['meta'],
-    enabled: environment !== 'test',
+    enabled: environment === 'development',
     policy,
     reportOnly: false,
   };


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-7038)

**Tested with a prod build locally**

 
when CSP meta is disabled in prod env: 
(meta tag with CSP is removed)

<img width="1385" alt="Screen Shot 2023-01-09 at 4 44 25 PM" src="https://user-images.githubusercontent.com/15043878/211437765-20bad1ff-1821-4690-950d-8d0c065bc68d.png">

 
when CSP meta is enabled in prod env: 
 (meta tag with CSP can be seen)
<img width="1363" alt="Screen Shot 2023-01-09 at 4 42 36 PM" src="https://user-images.githubusercontent.com/15043878/211437851-d30d2a83-8715-40b4-adbf-d61af08bca18.png">

