### PR TITLE
Icu 7490 UI add new address field to target

### DIFF
--- a/addons/api/addon/serializers/target.js
+++ b/addons/api/addon/serializers/target.js
@@ -18,6 +18,10 @@ export default class TargetSerializer extends ApplicationSerializer {
   serialize(snapshot) {
     let serialized = super.serialize(...arguments);
     const hostSourceIDs = snapshot?.adapterOptions?.hostSetIDs;
+    const useHostSources = snapshot?.adapterOptions?.useHostSources;
+    if (useHostSources) {
+      serialized.address = null;
+    }
     if (hostSourceIDs) {
       serialized = this.serializeWithHostSources(snapshot, hostSourceIDs);
     }

--- a/addons/api/tests/unit/serializers/target-test.js
+++ b/addons/api/tests/unit/serializers/target-test.js
@@ -227,6 +227,74 @@ module('Unit | Serializer | target', function (hooks) {
     });
   });
 
+  test('it serializes address when `adapterOptions.useHostSources` is false', function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('target');
+    const record = store.createRecord('target', {
+      name: 'User',
+      description: 'Description',
+      version: 1,
+      address: '0.0.0.0',
+      type: TYPE_TARGET_TCP,
+      default_port: 1234,
+    });
+    const snapshot = record._createSnapshot();
+    snapshot.adapterOptions = {
+      useHostSources: false,
+    };
+    const serializedRecord = serializer.serialize(snapshot);
+    assert.deepEqual(serializedRecord, {
+      name: 'User',
+      description: 'Description',
+      address: '0.0.0.0',
+      version: 1,
+      attributes: {
+        default_port: 1234,
+      },
+      session_connection_limit: null,
+      session_max_seconds: 28800,
+      type: TYPE_TARGET_TCP,
+      egress_worker_filter: null,
+      ingress_worker_filter: null,
+      worker_filter: null,
+    });
+  });
+
+  test('it sets address to null when `adapterOptions.useHostSources` is true', function (assert) {
+    assert.expect(1);
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('target');
+    const record = store.createRecord('target', {
+      name: 'User',
+      description: 'Description',
+      version: 1,
+      address: '0.0.0.0',
+      type: TYPE_TARGET_TCP,
+      default_port: 1234,
+    });
+    const snapshot = record._createSnapshot();
+    snapshot.adapterOptions = {
+      useHostSources: true,
+    };
+    const serializedRecord = serializer.serialize(snapshot);
+    assert.deepEqual(serializedRecord, {
+      name: 'User',
+      description: 'Description',
+      address: null,
+      version: 1,
+      attributes: {
+        default_port: 1234,
+      },
+      session_connection_limit: null,
+      session_max_seconds: 28800,
+      type: TYPE_TARGET_TCP,
+      egress_worker_filter: null,
+      ingress_worker_filter: null,
+      worker_filter: null,
+    });
+  });
+
   test('it normalizes records with array fields', function (assert) {
     assert.expect(1);
     const store = this.owner.lookup('service:store');

--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -165,3 +165,6 @@ tags:
 secret-editor:
   details: This secret is saved but won't be displayed
   edit: Click to replace this secret
+host-source-toggle:
+  label: Use host sources
+  help: Enable this option to attach a host source instead of using a static address.

--- a/ui/admin/app/components/form/target/details/index.hbs
+++ b/ui/admin/app/components/form/target/details/index.hbs
@@ -150,6 +150,42 @@
     {{/if}}
   </Hds::Form::TextInput::Field>
 
+  {{#if (feature-flag 'target-network-address')}}
+    <Hds::Form::Toggle::Field
+      name='use_host_sources'
+      disabled={{form.disabled}}
+      checked={{this.useHostSources}}
+      {{on 'change' this.toggleUseHostSources}}
+      as |F|
+    >
+      <F.Label>{{t 'form.host-source-toggle.label'}}</F.Label>
+      <F.HelperText>{{t 'form.host-source-toggle.help'}}</F.HelperText>
+    </Hds::Form::Toggle::Field>
+    {{#unless this.useHostSources}}
+      <Hds::Form::TextInput::Field
+        @isRequired={{true}}
+        @isOptional={{false}}
+        @value={{@model.address}}
+        @isInvalid={{@model.errors.address}}
+        @type='text'
+        name='address'
+        disabled={{form.disabled}}
+        {{on 'input' (set-from-event @model 'address')}}
+        as |F|
+      >
+        <F.Label>{{t 'form.address.label'}}</F.Label>
+        <F.HelperText>{{t 'form.address.help'}}</F.HelperText>
+        {{#if @model.errors.address}}
+          <F.Error as |E|>
+            {{#each @model.errors.address as |error|}}
+              <E.Message>{{error.message}}</E.Message>
+            {{/each}}
+          </F.Error>
+        {{/if}}
+      </Hds::Form::TextInput::Field>
+    {{/unless}}
+  {{/if}}
+
   {{#if (feature-flag 'target-worker-filters-v2')}}
     <Hds::Form::Fieldset
       class='target-workers'
@@ -217,41 +253,6 @@
         </F.Error>
       {{/if}}
     </Hds::Form::TextInput::Field>
-  {{/if}}
-
-  {{#if (feature-flag 'target-network-address')}}
-    <Hds::Form::Toggle::Field
-      disabled={{form.disabled}}
-      checked={{this.useHostSources}}
-      {{on 'change' this.toggleUseHostSources}}
-      as |F|
-    >
-      <F.Label>{{t 'form.host-source-toggle.label'}}</F.Label>
-      <F.HelperText>{{t 'form.host-source-toggle.help'}}</F.HelperText>
-    </Hds::Form::Toggle::Field>
-    {{#unless this.useHostSources}}
-      <Hds::Form::TextInput::Field
-        @isRequired={{true}}
-        @isOptional={{false}}
-        @value={{@model.address}}
-        @isInvalid={{@model.errors.address}}
-        @type='text'
-        name='address'
-        disabled={{form.disabled}}
-        {{on 'input' (set-from-event @model 'address')}}
-        as |F|
-      >
-        <F.Label>{{t 'form.address.label'}}</F.Label>
-        <F.HelperText>{{t 'form.address.help'}}</F.HelperText>
-        {{#if @model.errors.address}}
-          <F.Error as |E|>
-            {{#each @model.errors.address as |error|}}
-              <E.Message>{{error.message}}</E.Message>
-            {{/each}}
-          </F.Error>
-        {{/if}}
-      </Hds::Form::TextInput::Field>
-    {{/unless}}
   {{/if}}
 
   {{#if (can 'save model' @model)}}

--- a/ui/admin/app/components/form/target/details/index.hbs
+++ b/ui/admin/app/components/form/target/details/index.hbs
@@ -1,6 +1,6 @@
 <Rose::Form
-  @onSubmit={{@submit}}
-  @cancel={{@cancel}}
+  @onSubmit={{this.submit}}
+  @cancel={{this.cancel}}
   @disabled={{@model.isSaving}}
   @showEditToggle={{if @model.isNew false true}}
   as |form|
@@ -217,6 +217,41 @@
         </F.Error>
       {{/if}}
     </Hds::Form::TextInput::Field>
+  {{/if}}
+
+  {{#if (feature-flag 'target-network-address')}}
+    <Hds::Form::Toggle::Field
+      disabled={{form.disabled}}
+      checked={{this.useHostSources}}
+      {{on 'change' this.toggleUseHostSources}}
+      as |F|
+    >
+      <F.Label>{{t 'form.host-source-toggle.label'}}</F.Label>
+      <F.HelperText>{{t 'form.host-source-toggle.help'}}</F.HelperText>
+    </Hds::Form::Toggle::Field>
+    {{#unless this.useHostSources}}
+      <Hds::Form::TextInput::Field
+        @isRequired={{true}}
+        @isOptional={{false}}
+        @value={{@model.address}}
+        @isInvalid={{@model.errors.address}}
+        @type='text'
+        name='address'
+        disabled={{form.disabled}}
+        {{on 'input' (set-from-event @model 'address')}}
+        as |F|
+      >
+        <F.Label>{{t 'form.address.label'}}</F.Label>
+        <F.HelperText>{{t 'form.address.help'}}</F.HelperText>
+        {{#if @model.errors.address}}
+          <F.Error as |E|>
+            {{#each @model.errors.address as |error|}}
+              <E.Message>{{error.message}}</E.Message>
+            {{/each}}
+          </F.Error>
+        {{/if}}
+      </Hds::Form::TextInput::Field>
+    {{/unless}}
   {{/if}}
 
   {{#if (can 'save model' @model)}}

--- a/ui/admin/app/components/form/target/details/index.js
+++ b/ui/admin/app/components/form/target/details/index.js
@@ -1,5 +1,7 @@
 import Component from '@glimmer/component';
 import { TYPES_TARGET } from 'api/models/target';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 // NOTE: this is all a temporary solution till we have a resource type helper.
 const types = [...TYPES_TARGET].reverse();
@@ -10,6 +12,9 @@ const icons = {
 
 export default class FormTargetComponent extends Component {
   // =properties
+  @tracked
+  useHostSources = this.initialUseHostSourcesValue;
+
   /**
    * maps resource type with icon
    * @type {object}
@@ -36,5 +41,34 @@ export default class FormTargetComponent extends Component {
    */
   get showDeprecationMessage() {
     return !this.args.model.isNew && this.args.model.worker_filter;
+  }
+
+  /**
+   * Gets the initial value for whether the target is using host sources
+   * @returns {boolean}
+   */
+  get initialUseHostSourcesValue() {
+    return !this.args.model.address && !this.args.model.isNew;
+  }
+
+  // =actions
+
+  @action
+  submit() {
+    this.args.submit({
+      adapterOptions: { useHostSources: this.useHostSources },
+    });
+  }
+
+  @action
+  cancel() {
+    this.args.cancel();
+    // Reset the tracked variables for toggles after rollback
+    this.useHostSources = this.initialUseHostSourcesValue;
+  }
+
+  @action
+  toggleUseHostSources() {
+    this.useHostSources = !this.useHostSources;
   }
 }

--- a/ui/admin/app/routes/scopes/scope/targets.js
+++ b/ui/admin/app/routes/scopes/scope/targets.js
@@ -51,11 +51,11 @@ export default class ScopesScopeTargetsRoute extends Route {
   /**
    * Handle save.
    * @param {TargetModel} target
-   * @param {Event} e
+   * @param {object} options
    */
   @action
   @loading
-  @notifyError(({ message }) => message)
+  @notifyError(({ message }) => message, { catch: true })
   @notifySuccess(({ isNew }) =>
     isNew ? 'notifications.create-success' : 'notifications.save-success'
   )

--- a/ui/admin/app/routes/scopes/scope/targets.js
+++ b/ui/admin/app/routes/scopes/scope/targets.js
@@ -59,8 +59,13 @@ export default class ScopesScopeTargetsRoute extends Route {
   @notifySuccess(({ isNew }) =>
     isNew ? 'notifications.create-success' : 'notifications.save-success'
   )
-  async save(target) {
-    await target.save();
+  async save(target, options = { adapterOptions: {} }) {
+    await target.save({
+      ...options,
+      adapterOptions: {
+        ...options.adapterOptions,
+      },
+    });
     if (this.can.can('read model', target)) {
       await this.router.transitionTo('scopes.scope.targets.target', target);
     } else {

--- a/ui/admin/tests/acceptance/targets/create-test.js
+++ b/ui/admin/tests/acceptance/targets/create-test.js
@@ -136,13 +136,13 @@ module('Acceptance | targets | create', function (hooks) {
     );
   });
 
-  test('defualt port is not marked required for SSH targets', async function (assert) {
+  test('default port is not marked required for SSH targets', async function (assert) {
     assert.expect(1);
     await visit(urls.newTarget);
     assert.dom('[data-test-default-port-label]').includesText('Optional');
   });
 
-  test('defualt port is marked required for TCP targets', async function (assert) {
+  test('default port is marked required for TCP targets', async function (assert) {
     assert.expect(1);
     await visit(urls.newTarget);
     await click('[value="tcp"]');
@@ -284,5 +284,43 @@ module('Acceptance | targets | create', function (hooks) {
 
     assert.dom('[role="alert"] div').hasText('The request was invalid.');
     assert.dom('.hds-form-error__message').hasText('Name is required.');
+  });
+
+  test('can save address', async function (assert) {
+    assert.expect(2);
+    const targetCount = getTargetCount();
+    await visit(urls.targets);
+
+    await click(`[href="${urls.newTarget}"]`);
+    await fillIn('[name="name"]', 'random string');
+    await fillIn('[name="address"]', '0.0.0.0');
+    await click('[type="submit"]');
+
+    assert.strictEqual(getTargetCount(), targetCount + 1);
+    assert.strictEqual(
+      this.server.schema.targets.all().models[getTargetCount() - 1].address,
+      '0.0.0.0'
+    );
+  });
+
+  test('having useHostSources toggle on removes address field', async function (assert) {
+    assert.expect(1);
+    await visit(urls.targets);
+
+    await click(`[href="${urls.newTarget}"]`);
+    await click('[name="use_host_sources"]');
+
+    assert.dom('[name="address"]').doesNotExist();
+  });
+
+  test('toggle and address field do not exist when target address feature is disabled', async function (assert) {
+    assert.expect(2);
+    featuresService.disable('target-network-address');
+    await visit(urls.targets);
+
+    await click(`[href="${urls.newTarget}"]`);
+
+    assert.dom('[name="address"]').doesNotExist();
+    assert.dom('[name="use_host_sources"]').doesNotExist();
   });
 });

--- a/ui/admin/tests/acceptance/targets/update-test.js
+++ b/ui/admin/tests/acceptance/targets/update-test.js
@@ -199,4 +199,28 @@ module('Acceptance | targets | update', function (hooks) {
 
     assert.dom('form [type="button"]').doesNotExist();
   });
+
+  test('setting useHostSources toggle on sets address to null', async function (assert) {
+    assert.expect(2);
+    const target = this.server.create('target', {
+      scope: instances.scopes.project,
+      address: '1.2.3.4.5',
+    });
+    assert.strictEqual(
+      this.server.schema.targets.find(target.id).address,
+      '1.2.3.4.5'
+    );
+    const url = `${urls.targets}/${target.id}`;
+    await visit(urls.targets);
+    await click(`[href="${url}"]`);
+
+    await click('form [type="button"]', 'Activate edit mode');
+    await click('[name="use_host_sources"]');
+    await click('[type="submit"]');
+
+    assert.strictEqual(
+      this.server.schema.targets.find(target.id).address,
+      null
+    );
+  });
 });


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-7490)

## Description
Added an address field to support targets having a static address instead of a host. See the [figma](https://www.figma.com/file/gVJWQN2IWbsCBrS3ggknox/Assign-address-to-targets?node-id=1844%3A5779&t=i3ruNtWHaY4qWJyD-0).

The toggle is `Use Host Sources` instead of `Use Static Addresses`, but either one could be used and the default when creating could be checked or not either way, let me know which wording you prefer. 

There also has been a suggestion to move the address and port fields up, let me know if that would be better.

### Screenshots (if appropriate):

### Toggle Off:
<img width="774" alt="image" src="https://user-images.githubusercontent.com/5783847/211925630-ac58e006-0de5-432f-ac64-27b777e79ccb.png">

### Toggle On:
<img width="740" alt="image" src="https://user-images.githubusercontent.com/5783847/211925667-327cf49e-e0b9-41a5-8fa8-0dfb853351ec.png">

### Error States:
<img width="1461" alt="image" src="https://user-images.githubusercontent.com/5783847/211925975-adcd8572-0110-4489-95fe-480b861bbf50.png">

<img width="1461" alt="image" src="https://user-images.githubusercontent.com/5783847/211926617-8c40a728-403d-44f6-96b8-c1b5a7b09f10.png">

