### PR TITLE
refactor: 💡 refactor series diagram

### DIFF
--- a/ui/admin/app/components/ordered-series-diagram/group/index.hbs
+++ b/ui/admin/app/components/ordered-series-diagram/group/index.hbs
@@ -1,4 +1,25 @@
-<div class='ordered-series-diagram-group {{if @highlight "highlight"}}'>
-  <span>{{@title}}</span>
-  {{yield}}
-</div>
+<li class='ordered-series-diagram-group'>
+
+  <div
+    class='ordered-series-diagram-group-content
+      {{if @color (concat "hds-surface-" @color)}}'
+  >
+    <div
+      class='ordered-series-diagram-group-title
+        {{if @color (concat "hds-foreground-" @color "-on-surface")}}'
+    >
+      {{@title}}
+    </div>
+    <ol class='ordered-series-diagram-group-items'>
+      {{yield}}
+    </ol>
+  </div>
+
+  <div class='ordered-series-diagram-separator-icon'>
+    {{!
+      Separator icon is not configurable, but potentially could be.
+    }}
+    <FlightIcon @name='arrow-right' @size='24' />
+  </div>
+
+</li>

--- a/ui/admin/app/components/ordered-series-diagram/index.hbs
+++ b/ui/admin/app/components/ordered-series-diagram/index.hbs
@@ -1,8 +1,8 @@
-<div class='ordered-series-diagram'>
+<ol class='ordered-series-diagram'>
   {{yield
     (hash
-      item=(component 'ordered-series-diagram/item')
-      group=(component 'ordered-series-diagram/group')
+      Item=(component 'ordered-series-diagram/item')
+      Group=(component 'ordered-series-diagram/group')
     )
   }}
-</div>
+</ol>

--- a/ui/admin/app/components/ordered-series-diagram/item/index.hbs
+++ b/ui/admin/app/components/ordered-series-diagram/item/index.hbs
@@ -1,7 +1,15 @@
-<div class='ordered-series-diagram-item'>
-  <Hds::IconTile @icon={{@icon}} @size='large' />
-  {{#if @arrow}}
+<li class='ordered-series-diagram-item'>
+
+  <div class='ordered-series-diagram-item-content'>
+    <Hds::IconTile @icon={{@icon}} @size='large' @color='hcp' />
+    <span class='ordered-series-diagram-item-title'>{{yield}}</span>
+  </div>
+
+  <div class='ordered-series-diagram-separator-icon'>
+    {{!
+      Separator icon is not configurable, but potentially could be.
+    }}
     <FlightIcon @name='arrow-right' @size='24' />
-  {{/if}}
-  <span>{{yield}}</span>
-</div>
+  </div>
+
+</li>

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -599,58 +599,67 @@
 }
 
 .ordered-series-diagram {
+  --group-title-line-height: 2.25rem;
+
   display: flex;
-  flex-direction: row;
-  align-items: flex-end;
+  margin-bottom: 1rem;
 
-  .ordered-series-diagram-item {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, 75px);
-    grid-template-rows: repeat(2, 1fr);
-    gap: sizing.rems(xs) 0;
-    grid-template-areas:
-      'icon arrow'
-      'description ...';
+  &-item {
+    display: flex;
+    margin-top: var(--group-title-line-height);
 
-    .hds-icon-tile {
-      grid-area: icon;
-      justify-self: center;
-    }
-
-    > span {
+    &-content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
       text-align: center;
-      grid-area: description;
     }
 
-    .flight-icon-arrow-right {
-      grid-area: arrow;
-      place-self: center;
+    &-title {
+      font-weight: var(--token-typography-font-weight-semibold);
+      margin-top: 0.5rem;
+      width: 4rem;
+    }
+
+    &:last-child {
+      > .ordered-series-diagram-separator-icon {
+        display: none;
+      }
     }
   }
 
-  .ordered-series-diagram-group {
-    border-radius: sizing.rems(xs);
-    display: grid;
-    grid-template-areas:
-      'title title'
-      'primary secondary';
+  &-group {
+    display: flex;
 
-    > span {
-      font-size: sizing.rems(s);
-      color: var(--token-color-foreground-highlight-on-surface);
-      padding-bottom: sizing.rems(s);
-      padding-top: sizing.rems(xxs);
-      grid-area: title;
-      place-self: center;
+    &-content {
+      border-radius: 0.5rem;
+      padding: 0 0.75rem 0.75rem;
     }
 
-    .ordered-series-diagram-item {
-      grid-area: primary;
+    &-items {
+      display: flex;
 
-      &:last-child {
-        grid-area: secondary;
+      & .ordered-series-diagram-item {
+        margin-top: 0;
       }
     }
+
+    &-title {
+      font-size: var(--token-typography-display-100-font-size);
+      line-height: var(--group-title-line-height);
+      text-align: center;
+    }
+
+    &:last-child {
+      > .ordered-series-diagram-separator-icon {
+        display: none;
+      }
+    }
+  }
+
+  &-separator-icon {
+    color: var(--token-color-foreground-faint);
+    margin: 0.75rem 0.5rem;
   }
 }
 


### PR DESCRIPTION
Refactor ordered series diagram to better conform to HDS and to support arbitrary HDS semantic colors in groups.

Usage:
```hbs
<OrderedSeriesDiagram as |D|>
  <D.Item @icon='user'>Client</D.Item>
  <D.Item @icon='settings'>Ingress Worker</D.Item>
  <D.Group @title='Private Network' @color='highlight'>
    <D.Item @icon='settings'>Egress Worker</D.Item>
    <D.Item @icon='server'>Host</D.Item>
  </D.Group>
</OrderedSeriesDiagram>
```

<img width="481" alt="Screenshot 2023-01-12 at 15 09 18" src="https://user-images.githubusercontent.com/8390120/212201194-71fb5942-7cd3-468c-bdf9-3ac345c8d6e0.png">
