### PR TITLE
refactor: 💡 Simplify template for confirmation dialog

### DIFF
--- a/ui/admin/app/routes/application.js
+++ b/ui/admin/app/routes/application.js
@@ -38,7 +38,10 @@ export default class ApplicationRoute extends Route {
       if (fromName !== toName && maybeModel?.hasDirtyAttributes) {
         transition.abort();
         try {
-          await this.confirm.confirm('abandon', { isAbandonConfirm: true });
+          await this.confirm.confirm(this.intl.t('questions.abandon-confirm'), {
+            title: 'titles.abandon-confirm',
+            confirm: 'actions.discard',
+          });
           maybeModel?.rollbackAttributes();
           transition.retry();
         } catch (e) {

--- a/ui/admin/app/templates/application.hbs
+++ b/ui/admin/app/templates/application.hbs
@@ -91,57 +91,33 @@
 {{/if}}
 
 <PendingConfirmations as |confirmation accept deny|>
-  {{#if confirmation.options.isAbandonConfirm}}
-    <Rose::Dialog
-      @heading={{t 'titles.abandon-confirm'}}
-      @dismissButtonText={{t 'actions.cancel'}}
-      @icon='flight-icons/svg/alert-triangle-16'
-      @style='warning'
-      @modal={{true}}
-      @dismiss={{deny}}
-      as |dialog|
-    >
-      <dialog.body>
-        <p>{{t 'questions.abandon-confirm'}}</p>
-      </dialog.body>
-      <dialog.footer>
-        <Rose::Button @style='primary' {{on 'click' accept}}>
-          {{t 'actions.discard'}}
-        </Rose::Button>
-        <Rose::Button @style='secondary' {{on 'click' deny}}>
-          {{t 'actions.cancel'}}
-        </Rose::Button>
-      </dialog.footer>
-    </Rose::Dialog>
-  {{else}}
-    <Rose::Dialog
-      @heading={{if
-        confirmation.options.title
-        (t confirmation.options.title)
-        (t 'actions.confirm')
-      }}
-      @dismissButtonText={{t 'actions.cancel'}}
-      @icon='flight-icons/svg/alert-triangle-16'
-      @style='warning'
-      @modal={{true}}
-      @dismiss={{deny}}
-      as |dialog|
-    >
-      <dialog.body>
-        <p>{{confirmation.text}}</p>
-      </dialog.body>
-      <dialog.footer>
-        <Rose::Button @style='primary' {{on 'click' accept}}>
-          {{if
-            confirmation.options.confirm
-            (t confirmation.options.confirm)
-            (t 'actions.ok')
-          }}
-        </Rose::Button>
-        <Rose::Button @style='secondary' {{on 'click' deny}}>
-          {{t 'actions.cancel'}}
-        </Rose::Button>
-      </dialog.footer>
-    </Rose::Dialog>
-  {{/if}}
+  <Rose::Dialog
+    @heading={{if
+      confirmation.options.title
+      (t confirmation.options.title)
+      (t 'actions.confirm')
+    }}
+    @dismissButtonText={{t 'actions.cancel'}}
+    @icon='flight-icons/svg/alert-triangle-16'
+    @style='warning'
+    @modal={{true}}
+    @dismiss={{deny}}
+    as |dialog|
+  >
+    <dialog.body>
+      <p>{{confirmation.text}}</p>
+    </dialog.body>
+    <dialog.footer>
+      <Rose::Button @style='primary' {{on 'click' accept}}>
+        {{if
+          confirmation.options.confirm
+          (t confirmation.options.confirm)
+          (t 'actions.ok')
+        }}
+      </Rose::Button>
+      <Rose::Button @style='secondary' {{on 'click' deny}}>
+        {{t 'actions.cancel'}}
+      </Rose::Button>
+    </dialog.footer>
+  </Rose::Dialog>
 </PendingConfirmations>


### PR DESCRIPTION
## Description
While working on the network address feature in targets, I noticed our `application` template has unnecessary duplication of the dialog after adding the ability to change the confirmation button wording.
The goal of this PR is to simplify the template. 

