### PR TITLE
refactor: 💡 logically separate save steps for targets

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -321,7 +321,7 @@ target:
   questions:
     delete-host-sources:
       title: Remove associated host sources?
-      message: You have {numHostSources, plural, one {# host source} other {# host sources}} associated with this target. Adding an address will remove these host sources when you save your changes.
+      message: You have {hostSourceCount, plural, one {# host source} other {# host sources}} associated with this target. Adding an address will remove these host sources when you save your changes.
   host-source:
     title: Host Source
     title_plural: Host Sources

--- a/ui/admin/app/routes/scopes/scope/targets.js
+++ b/ui/admin/app/routes/scopes/scope/targets.js
@@ -115,7 +115,9 @@ export default class ScopesScopeTargetsRoute extends Route {
     const hostSourceCount = target.host_sources?.length;
 
     if (hostSourceCount) {
-      const ids = target.host_sources.map(({ host_source_id: id }) => id);
+      const hostSourceIDs = target.host_sources.map(
+        ({ host_source_id }) => host_source_id
+      );
       const confirmMessage = this.intl.t(
         'resources.target.questions.delete-host-sources.message',
         { hostSourceCount }
@@ -127,7 +129,7 @@ export default class ScopesScopeTargetsRoute extends Route {
         confirm: 'actions.remove-resources',
       });
       // Remove host sources.  This step is reached only if the user accepts.
-      await target.removeHostSources(ids);
+      await target.removeHostSources(hostSourceIDs);
     }
   }
 


### PR DESCRIPTION
This PR separates `saveWithAddress` into two steps:  one to remove host sources and another to save as normal.