### PR TITLE
fix: 🐛 Change fields to optional as they get default by backend

### DIFF
--- a/ui/admin/app/components/form/credential-library/vault-ssh-certificate/index.hbs
+++ b/ui/admin/app/components/form/credential-library/vault-ssh-certificate/index.hbs
@@ -127,7 +127,7 @@
   </Hds::Form::TextInput::Field>
 
   <Hds::Form::Select::Field
-    @isRequired={{true}}
+    @isOptional={{true}}
     @width='100%'
     name='key_type'
     disabled={{form.disabled}}
@@ -160,7 +160,7 @@
 
   {{#if this.showKeyBits}}
     <Hds::Form::TextInput::Field
-      @isRequired={{true}}
+      @isOptional={{true}}
       @value={{@model.key_bits}}
       @isInvalid={{@model.errors.key_bits}}
       @type='text'


### PR DESCRIPTION
## Description
It seems like the `key_type` field and `key_bits` field are required in the backend but have [default values](https://github.com/hashicorp/boundary/blob/llb-vault-ssh-cert-injection/internal/credential/vault/repository_ssh_certificate_credential_library.go#L51) if we don't provide one so it's technically optional from our perspective.
