### PR TITLE
Change the way we declare icon color

### DIFF
--- a/ui/admin/app/templates/onboarding/success.hbs
+++ b/ui/admin/app/templates/onboarding/success.hbs
@@ -10,8 +10,8 @@
         <span class='create-resources-item-header'>
           <FlightIcon
             @name='check-circle'
-            @color='var(--token-color-foreground-success)'
             @size='24'
+            class='hds-foreground-success'
           />
           <h3>{{t 'onboarding.success.titles.creation-success'}}</h3>
         </span>


### PR DESCRIPTION
## Description

Change how we define color to an icon. We stop usign `@color` and passing a `--token-color` to use a class `ds-foreground-success`.