### PR TITLE
fix: 🐛 Fix undefined values from resource filter

### DIFF
--- a/addons/api/addon/services/resource-filter-store.js
+++ b/addons/api/addon/services/resource-filter-store.js
@@ -61,9 +61,7 @@ export class ResourceFilter {
    * @return {string}
    */
   equals(key, value) {
-    return value !== null && value !== undefined
-      ? `"/item/${key}" == "${value}"`
-      : null;
+    return value !== null ? `"/item/${key}" == "${value}"` : null;
   }
 
   /**

--- a/addons/api/addon/services/resource-filter-store.js
+++ b/addons/api/addon/services/resource-filter-store.js
@@ -61,7 +61,9 @@ export class ResourceFilter {
    * @return {string}
    */
   equals(key, value) {
-    return value !== null ? `"/item/${key}" == "${value}"` : null;
+    return value !== null && value !== undefined
+      ? `"/item/${key}" == "${value}"`
+      : null;
   }
 
   /**

--- a/addons/core/addon/decorators/resource-filter.js
+++ b/addons/core/addon/decorators/resource-filter.js
@@ -66,7 +66,10 @@ class RouteResourceFilter extends EmberObject {
           )
         )
       : null;
-    return deserializedValue;
+
+    // Filter out any possible undefined values that come from not finding the decoded value
+    // e.g. the query parameter filter was persisted after a resource was removed from the model
+    return deserializedValue?.filter((value) => value !== undefined);
   }
   set value(value) {
     const queryParams = {};

--- a/addons/core/addon/decorators/resource-filter.js
+++ b/addons/core/addon/decorators/resource-filter.js
@@ -60,16 +60,16 @@ class RouteResourceFilter extends EmberObject {
       JSON.stringify(this.defaultValue);
     const value = decodedValue ? JSON.parse(decodedValue) : null;
     const deserializedValue = value
-      ? value.map((serializedValue) =>
-          this.allowedValues.find((item) =>
-            this.deserializeValue(item, serializedValue)
+      ? value
+          .map((serializedValue) =>
+            this.allowedValues.find((item) =>
+              this.deserializeValue(item, serializedValue)
+            )
           )
-        )
+          .filter((value) => value !== undefined)
       : null;
 
-    // Filter out any possible undefined values that come from not finding the decoded value
-    // e.g. the query parameter filter was persisted after a resource was removed from the model
-    return deserializedValue?.filter((value) => value !== undefined);
+    return deserializedValue;
   }
   set value(value) {
     const queryParams = {};


### PR DESCRIPTION
## Description
There can be a bug in workers when you have an active filter on a worker that is deleted and it is the only worker with the active tag being filtered. When we return to the workers route, the `resource-filter` tries to find that tag from the list of tags from the workers but it doesn't find it anymore. 

This aims to fix it by filtering out the `undefined` tags that result from not finding the resources. 