### PR TITLE
fix: 🐛 Fix null date time erroring out

### DIFF
--- a/addons/core/addon/helpers/relative-datetime-live.js
+++ b/addons/core/addon/helpers/relative-datetime-live.js
@@ -45,6 +45,10 @@ export default class extends Helper {
   // =methods
 
   compute([date]) {
+    if (!date) {
+      return;
+    }
+
     const delta = date.valueOf() - this.clockTick.now;
     const greatestMeaningfulUnit = unitMappings.reduce(
       (currentValue, previousValue) => {

--- a/addons/core/addon/helpers/relative-datetime-live.js
+++ b/addons/core/addon/helpers/relative-datetime-live.js
@@ -45,9 +45,7 @@ export default class extends Helper {
   // =methods
 
   compute([date]) {
-    if (!date) {
-      return;
-    }
+    if (!date) return;
 
     const delta = date.valueOf() - this.clockTick.now;
     const greatestMeaningfulUnit = unitMappings.reduce(

--- a/addons/core/tests/integration/helpers/relative-datetime-live-test.js
+++ b/addons/core/tests/integration/helpers/relative-datetime-live-test.js
@@ -53,4 +53,12 @@ module('Integration | Helper | relative-datetime-live', function (hooks) {
     await render(hbs`{{relative-datetime-live this.date}}`);
     assert.dom(this.element).hasText('in 22 years');
   });
+
+  test('it renders nothing when there is no date', async function (assert) {
+    assert.expect(1);
+
+    this.date = null;
+    await render(hbs`{{relative-datetime-live this.date}}`);
+    assert.dom(this.element).hasText('');
+  });
 });

--- a/ui/admin/app/components/form/worker/index.hbs
+++ b/ui/admin/app/components/form/worker/index.hbs
@@ -99,7 +99,10 @@
     <form.input
       @name='last seen'
       @type='datetime'
-      @value={{concat relativeDate ', ' customFormat}}
+      @value={{if
+        @model.last_status_time
+        (concat relativeDate ', ' customFormat)
+      }}
       @label={{t 'form.worker_last_seen.label'}}
       @helperText={{t 'form.worker_last_seen.help'}}
       @disabled={{true}}


### PR DESCRIPTION
## Description
This fixes when a worker doesn't properly connect and you try to view the details page for the worker and it errors out due to not having a date time.

