### PR TITLE
docs: ✏️ Add how to debug binary to docs

### DIFF
--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -6,21 +6,23 @@ The desktop client UI for Boundary.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Prerequisites](#prerequisites)
-- [Installation](#installation)
-- [Yarn Commands](#yarn-commands)
-- [Running / Development](#running--development)
-  - [Developing Using Non-Release Versions of Boundary](#developing-using-non-release-versions-of-boundary)
-  - [Environment Variables](#environment-variables)
-  - [Building for Production](#building-for-production)
-    - [Environment Variables](#environment-variables-1)
-  - [Running Tests](#running-tests)
-  - [Running end to end Tests](#running-end-to-end-tests)
-  - [Deploying](#deploying)
-- [Debug desktop client](#debug-desktop-client)
-  - [Debug `renderer` process](#debug-renderer-process)
-  - [Debug `main` process ](#debug-main-process)
-- [Further Reading / Useful Links](#further-reading--useful-links)
+- [Desktop client UI](#desktop-client-ui)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Yarn Commands](#yarn-commands)
+  - [Running / Development](#running--development)
+    - [Developing Using Non-Release Versions of Boundary](#developing-using-non-release-versions-of-boundary)
+    - [Environment Variables](#environment-variables)
+    - [Building for Production](#building-for-production)
+      - [Environment Variables](#environment-variables-1)
+    - [Running Tests](#running-tests)
+    - [Running end to end Tests](#running-end-to-end-tests)
+    - [Deploying](#deploying)
+  - [Debug desktop client](#debug-desktop-client)
+    - [Debug `renderer` process](#debug-renderer-process)
+    - [Debug `main` process ](#debug-main-process)
+    - [Debug `binary`](#debug-binary)
+  - [Further Reading / Useful Links](#further-reading--useful-links)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -218,6 +220,13 @@ If you start the inspector with the `-brk` (breakpoint) code will not execute un
 
 More information on [debugging the main process](https://www.electronjs.org/docs/latest/tutorial/debugging-main-process).
 More information on [Node debugging guide](https://nodejs.org/en/docs/guides/debugging-getting-started/).
+
+### Debug `binary`
+
+The desktop client binary is the end artifact we deliver to customers. More information on how to build such binary in the [Building for Production](#building-for-production).
+
+We use [Debugtron](https://github.com/pd4d10/debugtron) for debug the production binary. Debugtron let you inspect the Electron app as if you were on a dev environment. Also provides debug options for the node process running Electron.
+
 
 ## Further Reading / Useful Links
 

--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -223,7 +223,7 @@ More information on [Node debugging guide](https://nodejs.org/en/docs/guides/deb
 
 ### Debug `binary`
 
-The desktop client binary is the end artifact we deliver to customers. More information on how to build such binary in the [Building for Production](#building-for-production).
+The desktop client binary is the end artifact we deliver to customers. More information on how to build the binary in [Building for Production](#building-for-production).
 
 We use [Debugtron](https://github.com/pd4d10/debugtron) for debug the production binary. Debugtron let you inspect the Electron app as if you were on a dev environment. Also provides debug options for the node process running Electron.
 

--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -225,7 +225,7 @@ More information on [Node debugging guide](https://nodejs.org/en/docs/guides/deb
 
 The desktop client binary is the end artifact we deliver to customers. More information on how to build the binary in [Building for Production](#building-for-production).
 
-We use [Debugtron](https://github.com/pd4d10/debugtron) for debug the production binary. Debugtron let you inspect the Electron app as if you were on a dev environment. Also provides debug options for the node process running Electron.
+We use [Debugtron](https://github.com/pd4d10/debugtron) to debug the production binary. Debugtron let's you inspect the Electron app as if you were in a dev environment. It also provides debug options for the node process running Electron.
 
 
 ## Further Reading / Useful Links


### PR DESCRIPTION
## Description

_Be aware changes on table of contents are result of running doc:toc, not manual changes._

Add how to debug the Desktop Client binary to the debug documentation.