### PR TITLE
fix: 🐛 fix diagram width so explainer text stays below it

### DIFF
--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -635,6 +635,7 @@
     align-items: center;
     min-height: 11rem;
     margin-top: sizing.rems(xs) - sizing.rems(xxxxs); // 10
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-8022)

## Description

**NOTE: This is only to fix the UI bug. Not addressing any other style changes or refactors.**

We removed extra divs around the ordered-series-diagram and helper text component for the higher level `WorkerDiagram::DualFilter` and `WorkerDiagram::DualFilter::Hcp` components. This matched how we created the `WorkerDiagram::SingleFilter` component. However, we removed the div wrapper that was keeping the ordered-series-diagram and helper text component stacked on vertically. Now the helper text component has room to move next to the ordered-series-diagram while viewing in full screen. Solution is to give the ordered-series-diagram component full width of the form to prevent the helper text from moving up.

:technologist: [Admin preview](https://boundary-ui-git-icu-8022-target-form-worker-di-6fd3b0-hashicorp.vercel.app/scopes/s_1sheljmjgm/targets/t_h4m3u5vfzm)
You need to remove the egress filter or both to put the WorkerDiagram in the correct state to view fix. 

### Screenshots (if appropriate):
Before:
<img width="909" alt="Screen Shot 2023-02-08 at 5 04 28 PM" src="https://user-images.githubusercontent.com/29386339/217952484-8c0677aa-29c3-4508-ba05-0f7d73fdc049.png">
After:
<img width="909" alt="Screen Shot 2023-02-09 at 4 20 29 PM" src="https://user-images.githubusercontent.com/29386339/217952674-c1bae8d8-1234-4eb5-aff4-5479f4737adf.png">
