### PR TITLE
chore: 🤖 create enable and disable feature test helpers

### DIFF
--- a/ui/admin/tests/acceptance/credential-library/create-test.js
+++ b/ui/admin/tests/acceptance/credential-library/create-test.js
@@ -13,6 +13,7 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { Response } from 'miragejs';
 import { TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE } from 'api/models/credential-library';
+import { disableFeature } from '../../helpers/features-service';
 
 module('Acceptance | credential-libraries | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -219,8 +220,7 @@ module('Acceptance | credential-libraries | create', function (hooks) {
   });
 
   test('cannot select vault ssh cert when feature is disabled', async function (assert) {
-    const featuresService = this.owner.lookup('service:features');
-    featuresService.disable('credential-library-vault-ssh-certificate');
+    disableFeature('credential-library-vault-ssh-certificate');
     assert.expect(1);
     await visit(urls.newCredentialLibrary);
 

--- a/ui/admin/tests/acceptance/targets/create-test.js
+++ b/ui/admin/tests/acceptance/targets/create-test.js
@@ -1,12 +1,5 @@
 import { module, test } from 'qunit';
-import {
-  visit,
-  currentURL,
-  find,
-  click,
-  fillIn,
-  getContext,
-} from '@ember/test-helpers';
+import { visit, currentURL, find, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
@@ -17,6 +10,7 @@ import {
   //invalidateSession,
 } from 'ember-simple-auth/test-support';
 import { TYPE_TARGET_TCP, TYPE_TARGET_SSH } from 'api/models/target';
+import { disableFeature, enableFeature } from '../../helpers/features-service';
 
 module('Acceptance | targets | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -25,7 +19,6 @@ module('Acceptance | targets | create', function (hooks) {
   let getTargetCount;
   let getTCPTargetCount;
   let getSSHTargetCount;
-  let featuresService;
 
   const instances = {
     scopes: {
@@ -46,8 +39,6 @@ module('Acceptance | targets | create', function (hooks) {
   };
 
   hooks.beforeEach(function () {
-    const { owner } = getContext();
-    featuresService = owner.lookup('service:features');
     instances.scopes.global = this.server.create('scope', { id: 'global' });
     instances.scopes.org = this.server.create('scope', {
       type: 'org',
@@ -85,7 +76,7 @@ module('Acceptance | targets | create', function (hooks) {
   });
 
   test('can create type `ssh` when `target-worker-filters-v2` is disabled', async function (assert) {
-    featuresService.disable('target-worker-filters-v2');
+    disableFeature('target-worker-filters-v2');
     assert.expect(4);
     const targetCount = getTargetCount();
     const sshTargetCount = getSSHTargetCount();
@@ -111,7 +102,7 @@ module('Acceptance | targets | create', function (hooks) {
   });
 
   test('can create type `ssh` when `target-worker-filters-v2` is enabled', async function (assert) {
-    featuresService.enable('target-worker-filters-v2');
+    enableFeature('target-worker-filters-v2');
     assert.expect(4);
     const targetCount = getTargetCount();
     const sshTargetCount = getSSHTargetCount();
@@ -138,7 +129,7 @@ module('Acceptance | targets | create', function (hooks) {
   });
 
   test('can create type `tcp` when `target-worker-filters-v2` is disabled', async function (assert) {
-    featuresService.disable('target-worker-filters-v2');
+    disableFeature('target-worker-filters-v2');
     assert.expect(4);
     const targetCount = getTargetCount();
     const tcpTargetCount = getTCPTargetCount();
@@ -164,7 +155,7 @@ module('Acceptance | targets | create', function (hooks) {
   });
 
   test('can create type `tcp` when `target-worker-filters-v2` is enabled', async function (assert) {
-    featuresService.enable('target-worker-filters-v2');
+    enableFeature('target-worker-filters-v2');
     assert.expect(4);
     const targetCount = getTargetCount();
     const tcpTargetCount = getTCPTargetCount();
@@ -192,8 +183,8 @@ module('Acceptance | targets | create', function (hooks) {
   });
 
   test('can create type `tcp` when `target-worker-filters-v2` and `target-worker-filters-v2-ingress` is enabled', async function (assert) {
-    featuresService.enable('target-worker-filters-v2');
-    featuresService.enable('target-worker-filters-v2-ingress');
+    enableFeature('target-worker-filters-v2');
+    enableFeature('target-worker-filters-v2-ingress');
     assert.expect(4);
     const targetCount = getTargetCount();
     const tcpTargetCount = getTCPTargetCount();
@@ -274,7 +265,7 @@ module('Acceptance | targets | create', function (hooks) {
 
   test('cannot navigate to new SSH targets route when ssh feature is disabled', async function (assert) {
     assert.expect(3);
-    featuresService.disable('ssh-target');
+    disableFeature('ssh-target');
     await visit(urls.targets);
 
     await click(`[href="${urls.newTarget}"]`);
@@ -398,7 +389,7 @@ module('Acceptance | targets | create', function (hooks) {
 
   test('address field does not exist when target network address feature is disabled', async function (assert) {
     assert.expect(1);
-    featuresService.disable('target-network-address');
+    disableFeature('target-network-address');
     await visit(urls.targets);
 
     await click(`[href="${urls.newTarget}"]`);

--- a/ui/admin/tests/helpers/features-service.js
+++ b/ui/admin/tests/helpers/features-service.js
@@ -1,0 +1,13 @@
+import { getContext } from '@ember/test-helpers';
+
+export function enableFeature(flag) {
+  const { owner } = getContext();
+  const featuresService = owner.lookup('service:features');
+  featuresService.enable(flag);
+}
+
+export function disableFeature(flag) {
+  const { owner } = getContext();
+  const featuresService = owner.lookup('service:features');
+  featuresService.disable(flag);
+}

--- a/ui/admin/tests/integration/components/worker-diagram/index-test.js
+++ b/ui/admin/tests/integration/components/worker-diagram/index-test.js
@@ -3,19 +3,25 @@ import { setupRenderingTest } from 'admin/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
+import {
+  disableFeature,
+  enableFeature,
+} from '../../../helpers/features-service';
 
 module('Integration | Component | worker-diagram/index', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  let featuresService;
+  // let featuresService;
   const targetWorkerFilterIngress = 'target-worker-filters-v2-ingress';
   const targetWorkerFilterHCP = 'target-worker-filters-v2-hcp';
 
   test('it renders a single filter diagram', async function (assert) {
-    featuresService = this.owner.lookup('service:features');
-    featuresService.disable(targetWorkerFilterIngress);
-    featuresService.disable(targetWorkerFilterHCP);
+    // featuresService = this.owner.lookup('service:features');
+    // featuresService.disable(targetWorkerFilterIngress);
+    // featuresService.disable(targetWorkerFilterHCP);
+    disableFeature(targetWorkerFilterIngress);
+    disableFeature(targetWorkerFilterHCP);
     assert.expect(1);
     await render(hbs`<WorkerDiagram />`);
 
@@ -23,9 +29,11 @@ module('Integration | Component | worker-diagram/index', function (hooks) {
   });
 
   test('it renders a dual filter diagram when `target-worker-filters-v2-ingress` is enabled', async function (assert) {
-    featuresService = this.owner.lookup('service:features');
-    featuresService.enable(targetWorkerFilterIngress);
-    featuresService.disable(targetWorkerFilterHCP);
+    // featuresService = this.owner.lookup('service:features');
+    // featuresService.enable(targetWorkerFilterIngress);
+    // featuresService.disable(targetWorkerFilterHCP);
+    enableFeature(targetWorkerFilterIngress);
+    disableFeature(targetWorkerFilterHCP);
     assert.expect(1);
     await render(hbs`<WorkerDiagram />`);
 
@@ -33,9 +41,11 @@ module('Integration | Component | worker-diagram/index', function (hooks) {
   });
 
   test('it renders a HCP dual filter diagram when `target-worker-filters-v2-hcp` is enabled', async function (assert) {
-    featuresService = this.owner.lookup('service:features');
-    featuresService.enable(targetWorkerFilterIngress);
-    featuresService.enable(targetWorkerFilterHCP);
+    // featuresService = this.owner.lookup('service:features');
+    // featuresService.enable(targetWorkerFilterIngress);
+    // featuresService.enable(targetWorkerFilterHCP);
+    enableFeature(targetWorkerFilterIngress);
+    enableFeature(targetWorkerFilterHCP);
     assert.expect(1);
     await render(hbs`<WorkerDiagram />`);
 

--- a/ui/admin/tests/unit/abilities/credential-test.js
+++ b/ui/admin/tests/unit/abilities/credential-test.js
@@ -1,21 +1,20 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { disableFeature, enableFeature } from '../../helpers/features-service';
 
 module('Unit | Abilities | credential', function (hooks) {
   setupTest(hooks);
 
-  let features;
+  let service, store;
 
   hooks.beforeEach(function () {
-    // Enable json-credentials feature by default
-    features = this.owner.lookup('service:features');
-    features.enable('json-credentials');
+    service = this.owner.lookup('service:can');
+    store = this.owner.lookup('service:store');
   });
 
   test('can read credentials, including JSON credentials, when authorized and json-credentials feature is enabled', function (assert) {
     assert.expect(3);
-    const service = this.owner.lookup('service:can');
-    const store = this.owner.lookup('service:store');
+    enableFeature('json-credentials');
     const credential = store.createRecord('credential', {
       authorized_actions: ['read'],
       type: 'json',
@@ -29,8 +28,7 @@ module('Unit | Abilities | credential', function (hooks) {
 
   test('cannot read credentials, including JSON credentials, when unauthorized and json-credentials feature is enabled', function (assert) {
     assert.expect(3);
-    const service = this.owner.lookup('service:can');
-    const store = this.owner.lookup('service:store');
+    enableFeature('json-credentials');
     const credential = store.createRecord('credential', {
       authorized_actions: [],
       type: 'json',
@@ -44,10 +42,7 @@ module('Unit | Abilities | credential', function (hooks) {
 
   test('cannot read credentials, including JSON credentials, when unauthorized and json-credentials feature is disabled', function (assert) {
     assert.expect(3);
-    const service = this.owner.lookup('service:can');
-    const featuresService = this.owner.lookup('service:features');
-    featuresService.disable('json-credentials');
-    const store = this.owner.lookup('service:store');
+    disableFeature('json-credentials');
     const credential = store.createRecord('credential', {
       authorized_actions: [],
       type: 'json',
@@ -61,9 +56,7 @@ module('Unit | Abilities | credential', function (hooks) {
 
   test('can read credentials, excepting JSON credentials, when authorized and json-credentials feature is disabled', function (assert) {
     assert.expect(3);
-    features.disable('json-credentials');
-    const service = this.owner.lookup('service:can');
-    const store = this.owner.lookup('service:store');
+    disableFeature('json-credentials');
     const credential = store.createRecord('credential', {
       authorized_actions: ['read'],
       type: 'json',


### PR DESCRIPTION
## Description

With shifting to having the test ENV features controlled by each test module, I created the `enableFeature` and `disableFeature` test helpers. 

For now I only updated one module of each `acceptance`, `integration`, and `unit` tests. Happy to update more in this PR or a later one.
