### PR TITLE
refactor: 💡 rename div around ordered-series-diagram

### DIFF
--- a/ui/admin/app/components/ordered-series-diagram/index.hbs
+++ b/ui/admin/app/components/ordered-series-diagram/index.hbs
@@ -1,10 +1,8 @@
-<div class='ordered-series-spacer'>
-  <ol ...attributes class='ordered-series-diagram'>
-    {{yield
-      (hash
-        Item=(component 'ordered-series-diagram/item')
-        Group=(component 'ordered-series-diagram/group')
-      )
-    }}
-  </ol>
-</div>
+<ol class='ordered-series-diagram' ...attributes>
+  {{yield
+    (hash
+      Item=(component 'ordered-series-diagram/item')
+      Group=(component 'ordered-series-diagram/group')
+    )
+  }}
+</ol>

--- a/ui/admin/app/components/ordered-series-diagram/index.hbs
+++ b/ui/admin/app/components/ordered-series-diagram/index.hbs
@@ -1,4 +1,4 @@
-<div class='worker-wrapper'>
+<div class='ordered-series-spacer'>
   <ol ...attributes class='ordered-series-diagram'>
     {{yield
       (hash

--- a/ui/admin/app/components/worker-diagram/dual-filter/hcp/index.hbs
+++ b/ui/admin/app/components/worker-diagram/dual-filter/hcp/index.hbs
@@ -18,13 +18,11 @@
       </D.Item>
     </D.Group>
   </OrderedSeriesDiagram>
-  <div class='worker-diagram-explainer'>
-    <Hds::Form::HelperText>
-      {{t
-        'resources.target.workers.filter-explainer.dual-egress-on-ingress-on'
-      }}
-    </Hds::Form::HelperText>
-  </div>
+  <p
+    class='hds-foreground-faint hds-typography-body-100 hds-font-weight-regular'
+  >
+    {{t 'resources.target.workers.filter-explainer.dual-egress-on-ingress-on'}}
+  </p>
 {{else if @ingressWorkerFilterEnabled}}
   <OrderedSeriesDiagram data-test-dual-filter-hcp-egress-off-ingress-on as |D|>
     <D.Item @icon='user'>
@@ -37,11 +35,11 @@
       {{t 'resources.target.workers.diagram.host'}}
     </D.Item>
   </OrderedSeriesDiagram>
-  <div class='worker-diagram-explainer'>
-    <Hds::Form::HelperText>
-      {{t 'resources.target.workers.filter-explainer.ingress-worker'}}
-    </Hds::Form::HelperText>
-  </div>
+  <p
+    class='hds-foreground-faint hds-typography-body-100 hds-font-weight-regular'
+  >
+    {{t 'resources.target.workers.filter-explainer.ingress-worker'}}
+  </p>
 {{else if @egressWorkerFilterEnabled}}
   <OrderedSeriesDiagram data-test-dual-filter-hcp-egress-on-ingress-off as |D|>
     <D.Item @icon='user'>
@@ -66,11 +64,11 @@
       </D.Item>
     </D.Group>
   </OrderedSeriesDiagram>
-  <div class='worker-diagram-explainer'>
-    <Hds::Form::HelperText>
-      {{t 'resources.target.workers.filter-explainer.hcp-dual-egress-on'}}
-    </Hds::Form::HelperText>
-  </div>
+  <p
+    class='hds-foreground-faint hds-typography-body-100 hds-font-weight-regular'
+  >
+    {{t 'resources.target.workers.filter-explainer.hcp-dual-egress-on'}}
+  </p>
 {{else}}
   <OrderedSeriesDiagram data-test-dual-filter-hcp-egress-off-ingress-off as |D|>
     <D.Item @icon='user'>
@@ -83,9 +81,9 @@
       {{t 'resources.target.workers.diagram.host'}}
     </D.Item>
   </OrderedSeriesDiagram>
-  <div class='worker-diagram-explainer'>
-    <Hds::Form::HelperText>
-      {{t 'resources.target.workers.filter-explainer.hcp-worker'}}
-    </Hds::Form::HelperText>
-  </div>
+  <p
+    class='hds-foreground-faint hds-typography-body-100 hds-font-weight-regular'
+  >
+    {{t 'resources.target.workers.filter-explainer.hcp-worker'}}
+  </p>
 {{/if}}

--- a/ui/admin/app/components/worker-diagram/dual-filter/index.hbs
+++ b/ui/admin/app/components/worker-diagram/dual-filter/index.hbs
@@ -18,13 +18,11 @@
       </D.Item>
     </D.Group>
   </OrderedSeriesDiagram>
-  <div class='worker-diagram-explainer'>
-    <Hds::Form::HelperText>
-      {{t
-        'resources.target.workers.filter-explainer.dual-egress-on-ingress-on'
-      }}
-    </Hds::Form::HelperText>
-  </div>
+  <p
+    class='hds-foreground-faint hds-typography-body-100 hds-font-weight-regular'
+  >
+    {{t 'resources.target.workers.filter-explainer.dual-egress-on-ingress-on'}}
+  </p>
 {{else if @ingressWorkerFilterEnabled}}
   <OrderedSeriesDiagram data-test-dual-filter-egress-off-ingress-on as |D|>
     <D.Item @icon='user'>
@@ -37,11 +35,11 @@
       {{t 'resources.target.workers.diagram.host'}}
     </D.Item>
   </OrderedSeriesDiagram>
-  <div class='worker-diagram-explainer'>
-    <Hds::Form::HelperText>
-      {{t 'resources.target.workers.filter-explainer.ingress-worker'}}
-    </Hds::Form::HelperText>
-  </div>
+  <p
+    class='hds-foreground-faint hds-typography-body-100 hds-font-weight-regular'
+  >
+    {{t 'resources.target.workers.filter-explainer.ingress-worker'}}
+  </p>
 {{else if @egressWorkerFilterEnabled}}
   <OrderedSeriesDiagram data-test-dual-filter-egress-on-ingress-off as |D|>
     <D.Item @icon='user'>
@@ -62,11 +60,11 @@
       </D.Item>
     </D.Group>
   </OrderedSeriesDiagram>
-  <div class='worker-diagram-explainer'>
-    <Hds::Form::HelperText>
-      {{t 'resources.target.workers.filter-explainer.dual-egress-on'}}
-    </Hds::Form::HelperText>
-  </div>
+  <p
+    class='hds-foreground-faint hds-typography-body-100 hds-font-weight-regular'
+  >
+    {{t 'resources.target.workers.filter-explainer.dual-egress-on'}}
+  </p>
 {{else}}
   <OrderedSeriesDiagram data-test-dual-filter-egress-off-ingress-off as |D|>
     <D.Item @icon='user'>
@@ -79,9 +77,9 @@
       {{t 'resources.target.workers.diagram.host'}}
     </D.Item>
   </OrderedSeriesDiagram>
-  <div class='worker-diagram-explainer'>
-    <Hds::Form::HelperText>
-      {{t 'resources.target.workers.filter-explainer.any-worker'}}
-    </Hds::Form::HelperText>
-  </div>
+  <p
+    class='hds-foreground-faint hds-typography-body-100 hds-font-weight-regular'
+  >
+    {{t 'resources.target.workers.filter-explainer.any-worker'}}
+  </p>
 {{/if}}

--- a/ui/admin/app/components/worker-diagram/index.hbs
+++ b/ui/admin/app/components/worker-diagram/index.hbs
@@ -1,17 +1,19 @@
-{{#if (feature-flag 'target-worker-filters-v2-ingress')}}
-  {{#if (feature-flag 'target-worker-filters-v2-hcp')}}
-    <WorkerDiagram::DualFilter::Hcp
-      @egressWorkerFilterEnabled={{@egressWorkerFilterEnabled}}
-      @ingressWorkerFilterEnabled={{@ingressWorkerFilterEnabled}}
-    />
+<div class='worker-diagram'>
+  {{#if (feature-flag 'target-worker-filters-v2-ingress')}}
+    {{#if (feature-flag 'target-worker-filters-v2-hcp')}}
+      <WorkerDiagram::DualFilter::Hcp
+        @egressWorkerFilterEnabled={{@egressWorkerFilterEnabled}}
+        @ingressWorkerFilterEnabled={{@ingressWorkerFilterEnabled}}
+      />
+    {{else}}
+      <WorkerDiagram::DualFilter
+        @egressWorkerFilterEnabled={{@egressWorkerFilterEnabled}}
+        @ingressWorkerFilterEnabled={{@ingressWorkerFilterEnabled}}
+      />
+    {{/if}}
   {{else}}
-    <WorkerDiagram::DualFilter
+    <WorkerDiagram::SingleFilter
       @egressWorkerFilterEnabled={{@egressWorkerFilterEnabled}}
-      @ingressWorkerFilterEnabled={{@ingressWorkerFilterEnabled}}
     />
   {{/if}}
-{{else}}
-  <WorkerDiagram::SingleFilter
-    @egressWorkerFilterEnabled={{@egressWorkerFilterEnabled}}
-  />
-{{/if}}
+</div>

--- a/ui/admin/app/components/worker-diagram/single-filter/index.hbs
+++ b/ui/admin/app/components/worker-diagram/single-filter/index.hbs
@@ -15,11 +15,11 @@
       </D.Item>
     </D.Group>
   </OrderedSeriesDiagram>
-  <div class='worker-diagram-explainer'>
-    <Hds::Form::HelperText>
-      {{t 'resources.target.workers.filter-explainer.egress-worker'}}
-    </Hds::Form::HelperText>
-  </div>
+  <p
+    class='hds-foreground-faint hds-typography-body-100 hds-font-weight-regular'
+  >
+    {{t 'resources.target.workers.filter-explainer.egress-worker'}}
+  </p>
 {{else}}
   <OrderedSeriesDiagram data-test-single-filter-egress-off as |D|>
     <D.Item @icon='user'>
@@ -32,9 +32,9 @@
       {{t 'resources.target.workers.diagram.host'}}
     </D.Item>
   </OrderedSeriesDiagram>
-  <div class='worker-diagram-explainer'>
-    <Hds::Form::HelperText>
-      {{t 'resources.target.workers.filter-explainer.any-worker'}}
-    </Hds::Form::HelperText>
-  </div>
+  <p
+    class='hds-foreground-faint hds-typography-body-100 hds-font-weight-regular'
+  >
+    {{t 'resources.target.workers.filter-explainer.any-worker'}}
+  </p>
 {{/if}}

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -530,8 +530,7 @@
 .ordered-series-spacer {
   display: flex;
   align-items: center;
-  min-height: 11rem;
-  margin-top: 0.4375rem;
+  min-height: 11.5rem;
   width: 100%;
 }
 

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -527,6 +527,14 @@
   }
 }
 
+.ordered-series-spacer {
+  display: flex;
+  align-items: center;
+  min-height: 11rem;
+  margin-top: 0.4375rem;
+  width: 100%;
+}
+
 .ordered-series-diagram {
   --group-title-line-height: 2.25rem;
 
@@ -628,14 +636,6 @@
 
   .worker-diagram-explainer {
     min-height: 4rem; // 1
-  }
-
-  .worker-wrapper {
-    display: flex;
-    align-items: center;
-    min-height: 11rem;
-    margin-top: sizing.rems(xs) - sizing.rems(xxxxs); // 10
-    width: 100%;
   }
 }
 

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -527,13 +527,6 @@
   }
 }
 
-.ordered-series-spacer {
-  display: flex;
-  align-items: center;
-  min-height: 11.5rem;
-  width: 100%;
-}
-
 .ordered-series-diagram {
   --group-title-line-height: 2.25rem;
 
@@ -566,8 +559,6 @@
   }
 
   &-group {
-    display: flex;
-
     &-content {
       border-radius: 0.5rem;
       padding: 0 0.75rem 0.75rem;
@@ -607,6 +598,10 @@
 
   .hds-form-legend {
     font-size: sizing.rems(l) - sizing.rems(xxs); // 20
+
+    + .hds-form-helper-text {
+      margin-bottom: 1rem;
+    }
   }
 
   .hds-alert {
@@ -633,8 +628,12 @@
     }
   }
 
-  .worker-diagram-explainer {
-    min-height: 4rem; // 1
+  .worker-diagram {
+    min-height: 15rem;
+
+    .ordered-series-diagram {
+      min-height: 10rem;
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Remove `div` wrapping the ordered series diagram component. Wrap the worker diagram component in a `div` to give it a min-height that will account for the height of grouped items that will have a highlighted background.

:technologist: [Admin preview](https://boundary-ctgujg4wd-hashicorp.vercel.app/scopes/s_1sheljmjgm/targets/t_h4m3u5vfzm)

No highlighted group:
<img width="513" alt="Screen Shot 2023-02-14 at 1 39 30 PM" src="https://user-images.githubusercontent.com/29386339/218840044-b35bc60f-00c3-4095-977d-01489d5d4f91.png">
Highlighted group:
<img width="513" alt="Screen Shot 2023-02-14 at 1 39 24 PM" src="https://user-images.githubusercontent.com/29386339/218840068-a0d095e9-91d1-485c-bd81-891df27cc3e5.png">
