### PR TITLE
refactor: 💡 Explicit declare disabled for form fields

### DIFF
--- a/addons/core/addon/components/form/authenticate/password/index.hbs
+++ b/addons/core/addon/components/form/authenticate/password/index.hbs
@@ -15,6 +15,7 @@
     @type='text'
     @value={{this.identification}}
     @label={{t 'form.login_name.label'}}
+    disabled={{@disabled}}
   />
 
   <form.input
@@ -22,6 +23,7 @@
     @type='password'
     @value={{this.password}}
     @label={{t 'form.password.label'}}
+    disabled={{@disabled}}
   />
 
   <form.actions

--- a/ui/admin/app/components/auth-methods/auth-method/actions/index.hbs
+++ b/ui/admin/app/components/auth-methods/auth-method/actions/index.hbs
@@ -42,14 +42,14 @@
 >
   {{#if @model.isPrimary}}
     <dropdown.button
-      @disabled={{@model.canSave}}
+      @disabled={{@disabled}}
       {{on 'click' (route-action 'removeAsPrimary' @model)}}
     >
       {{t 'resources.auth-method.actions.remove-as-primary'}}
     </dropdown.button>
   {{else}}
     <dropdown.button
-      @disabled={{@model.canSave}}
+      @disabled={{@disabled}}
       {{on 'click' (route-action 'makePrimary' @model)}}
     >
       {{t 'resources.auth-method.actions.make-primary'}}
@@ -80,7 +80,7 @@
     <dropdown.separator />
     <dropdown.button
       @style='danger'
-      @disabled={{@model.canSave}}
+      @disabled={{@disabled}}
       {{on 'click' (route-action 'delete' @model)}}
     >
       {{t 'resources.auth-method.actions.delete'}}

--- a/ui/admin/app/components/auth-methods/auth-method/managed-groups/managed-group/actions/index.hbs
+++ b/ui/admin/app/components/auth-methods/auth-method/managed-groups/managed-group/actions/index.hbs
@@ -6,7 +6,7 @@
   >
     <dropdown.button
       @style='danger'
-      @disabled={{@model.canSave}}
+      @disabled={{@disabled}}
       {{on 'click' (route-action 'deleteManagedGroup' @model)}}
     >
       {{t 'resources.managed-group.actions.delete'}}

--- a/ui/admin/app/components/form/account/oidc/index.hbs
+++ b/ui/admin/app/components/form/account/oidc/index.hbs
@@ -9,7 +9,7 @@
     @value={{@model.type}}
     @label={{t 'form.type.label'}}
     readonly={{true}}
-    @disabled={{true}}
+    disabled={{@disabled}}
   />
 
   {{#unless @model.isNew}}
@@ -17,25 +17,25 @@
       @value={{@model.issuer}}
       @label={{t 'form.issuer.label'}}
       readonly={{true}}
-      @disabled={{true}}
+      disabled={{@disabled}}
     />
     <form.input
       @value={{@model.subject}}
       @label={{t 'form.subject.label'}}
       readonly={{true}}
-      @disabled={{true}}
+      disabled={{@disabled}}
     />
     <form.input
       @value={{@model.email}}
       @label={{t 'form.email.label'}}
       readonly={{true}}
-      @disabled={{true}}
+      disabled={{@disabled}}
     />
     <form.input
       @value={{@model.full_name}}
       @label={{t 'form.full_name.label'}}
       readonly={{true}}
-      @disabled={{true}}
+      disabled={{@disabled}}
     />
   {{/unless}}
 
@@ -65,7 +65,7 @@
     @label={{t 'form.description.label'}}
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -85,6 +85,7 @@
       @value={{@model.issuer}}
       @label={{t 'form.issuer.label'}}
       @error={{@model.errors.issuer}}
+      disabled={{@disabled}}
       readonly={{false}}
       as |field|
     >
@@ -103,6 +104,7 @@
       @value={{@model.subject}}
       @label={{t 'form.subject.label'}}
       @error={{@model.errors.subject}}
+      disabled={{@disabled}}
       readonly={{false}}
       as |field|
     >

--- a/ui/admin/app/components/form/account/password/index.hbs
+++ b/ui/admin/app/components/form/account/password/index.hbs
@@ -9,7 +9,7 @@
     @value={{@model.type}}
     @label={{t 'form.type.label'}}
     readonly={{true}}
-    @disabled={{true}}
+    disabled={{@disabled}}
   />
 
   <form.input
@@ -19,6 +19,7 @@
     @label={{t 'form.name.label'}}
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -38,7 +39,7 @@
     @label={{t 'form.description.label'}}
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -57,6 +58,7 @@
     @value={{@model.login_name}}
     @label={{t 'form.login_name.label'}}
     @error={{@model.errors.login_name}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -77,6 +79,7 @@
       @label={{t 'form.password.label'}}
       @error={{@model.errors.password}}
       readonly={{false}}
+      disabled={{@disabled}}
       autocomplete='new-password'
       as |field|
     >

--- a/ui/admin/app/components/form/auth-method/oidc/index.hbs
+++ b/ui/admin/app/components/form/auth-method/oidc/index.hbs
@@ -16,7 +16,7 @@
     @value={{@model.type}}
     @label={{t 'form.type.label'}}
     readonly={{true}}
-    @disabled={{true}}
+    disabled={{@disabled}}
   />
 
   <form.input
@@ -27,6 +27,7 @@
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -46,6 +47,7 @@
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.description}}
@@ -65,6 +67,7 @@
     @helperText={{t 'form.issuer.help'}}
     @error={{@model.errors.issuer}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.issuer}}
@@ -94,6 +97,7 @@
     @helperText={{t 'form.client_id.help'}}
     @error={{@model.errors.client_id}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.client_id}}
@@ -113,6 +117,7 @@
     @helperText={{t 'form.client_secret.help'}}
     @error={{@model.errors.client_secret}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.client_secret}}
@@ -129,7 +134,7 @@
       @value={{@model.client_secret_hmac}}
       @label={{t 'form.client_secret_hmac.label'}}
       readonly={{true}}
-      @disabled={{true}}
+      disabled={{@disabled}}
     />
   {{/unless}}
 
@@ -273,6 +278,7 @@
                   @value={{audience.value}}
                   @error={{@model.errors.allowed_audiences}}
                   @contextual={{true}}
+                  disabled={{@disabled}}
                   as |field|
                 >
                   <field.label>{{t 'form.claim.label'}}</field.label>
@@ -304,6 +310,7 @@
                 @name='allowed_audiences'
                 @value={{this.newAllowedAudience}}
                 @label={{t 'resources.auth-method.titles.new-allowed-audience'}}
+                disabled={{@disabled}}
               />
             </row.cell>
             <row.cell @shrink={{true}}>
@@ -360,6 +367,7 @@
                   @value={{claimsScope.value}}
                   @error={{@model.errors.claims_scopes}}
                   @contextual={{true}}
+                  disabled={{@disabled}}
                   as |field|
                 >
                   <field.label>{{t 'form.claims_scope.label'}}</field.label>
@@ -391,6 +399,7 @@
                 @name='claims_scopes'
                 @value={{this.newClaimsScope}}
                 @label={{t 'resources.auth-method.titles.new-claims-scope'}}
+                disabled={{@disabled}}
               />
             </row.cell>
             <row.cell @shrink={{true}}>
@@ -446,6 +455,7 @@
                   @value={{claimMap.from}}
                   @error={{@model.errors.account_claim_maps}}
                   @contextual={{true}}
+                  disabled={{@disabled}}
                   as |field|
                 >
                   <field.label>{{t 'form.from_claim.label'}}</field.label>
@@ -498,6 +508,7 @@
                 @name='from_claim'
                 @value={{this.newFromClaim}}
                 @label={{t 'resources.auth-method.titles.new-from-claim'}}
+                disabled={{@disabled}}
               />
             </row.cell>
             <row.cell>
@@ -572,6 +583,7 @@
                   @value={{cert.value}}
                   @error={{@model.errors.idp_ca_certs}}
                   @contextual={{true}}
+                  disabled={{@disabled}}
                   as |field|
                 >
                   <field.label>{{t 'form.certificate.label'}}</field.label>
@@ -634,6 +646,7 @@
     @helperText={{t 'form.max_age.help'}}
     @error={{@model.errors.max_age}}
     readonly={{false}}
+    disabled={{@disabled}}
     step='1'
     min='0'
     as |field|
@@ -655,6 +668,7 @@
     @helperText={{t 'form.api_url_prefix.help'}}
     @error={{@model.errors.api_url_prefix}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.api_url_prefix}}
@@ -672,7 +686,7 @@
       @label={{t 'form.callback_url.label'}}
       @helperText={{t 'form.callback_url.help'}}
       readonly={{true}}
-      @disabled={{true}}
+      disabled={{@disabled}}
     />
   {{/unless}}
   {{#if (can 'save model' @model)}}

--- a/ui/admin/app/components/form/auth-method/password/index.hbs
+++ b/ui/admin/app/components/form/auth-method/password/index.hbs
@@ -9,7 +9,7 @@
     @value={{@model.type}}
     @label={{t 'form.type.label'}}
     readonly={{true}}
-    @disabled={{true}}
+    disabled={{@disabled}}
   />
 
   <form.input
@@ -20,6 +20,7 @@
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -38,7 +39,7 @@
     @label={{t 'form.description.label'}}
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >

--- a/ui/admin/app/components/form/credential-store/static/index.hbs
+++ b/ui/admin/app/components/form/credential-store/static/index.hbs
@@ -13,6 +13,7 @@
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}

--- a/ui/admin/app/components/form/credential-store/vault/index.hbs
+++ b/ui/admin/app/components/form/credential-store/vault/index.hbs
@@ -14,6 +14,7 @@
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -88,7 +89,7 @@
     @label={{t 'resources.credential-store.form.address.label'}}
     @error={{@model.errors.address}}
     @helperText={{t 'resources.credential-store.form.address.help'}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -110,7 +111,7 @@
       @helperText={{t 'form.worker_filter.help'}}
       @linkText={{t 'actions.learn-more'}}
       @link={{doc-url 'worker-filters'}}
-      disabled={{@model.isSaving}}
+      disabled={{@disabled}}
       readonly={{false}}
       as |field|
     >
@@ -132,7 +133,7 @@
       @label={{t 'resources.credential-store.form.token.label'}}
       @error={{@model.errors.token}}
       @helperText={{t 'resources.credential-store.form.token.help'}}
-      disabled={{@model.isSaving}}
+      disabled={{@disabled}}
       readonly={{false}}
       as |field|
     >
@@ -151,7 +152,7 @@
       @value={{@model.token_hmac}}
       @label={{t 'resources.credential-store.form.token_hmac.label'}}
       readonly={{true}}
-      @disabled={{true}}
+      disabled={{@disabled}}
     />
   {{/unless}}
 
@@ -162,7 +163,7 @@
     @label={{t 'resources.credential-store.form.namespace.label'}}
     @error={{@model.errors.namespace}}
     @helperText={{t 'resources.credential-store.form.namespace.help'}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -182,7 +183,7 @@
     @label={{t 'resources.credential-store.form.tls_server_name.label'}}
     @error={{@model.errors.tls_server_name}}
     @helperText={{t 'resources.credential-store.form.tls_server_name.help'}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -222,7 +223,7 @@
     @label={{t 'resources.credential-store.form.client_certificate.label'}}
     @error={{@model.errors.client_certificate}}
     @helperText={{t 'resources.credential-store.form.client_certificate.help'}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -244,7 +245,7 @@
     @helperText={{t
       'resources.credential-store.form.client_certificate_key.help'
     }}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -264,7 +265,7 @@
         'resources.credential-store.form.client_certificate_key_hmac.label'
       }}
       readonly={{true}}
-      @disabled={{true}}
+      disabled={{@disabled}}
     />
   {{/unless}}
 
@@ -275,7 +276,7 @@
     @label={{t 'resources.credential-store.form.ca_cert.label'}}
     @error={{@model.errors.ca_cert}}
     @helperText={{t 'resources.credential-store.form.ca_cert.help'}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >

--- a/ui/admin/app/components/form/credential/json/index.hbs
+++ b/ui/admin/app/components/form/credential/json/index.hbs
@@ -12,6 +12,7 @@
     @label={{t 'form.name.label'}}
     @error={{@model.errors.name}}
     @helperText={{t 'form.name.help'}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}

--- a/ui/admin/app/components/form/credential/ssh_private_key/index.hbs
+++ b/ui/admin/app/components/form/credential/ssh_private_key/index.hbs
@@ -12,6 +12,7 @@
     @label={{t 'form.name.label'}}
     @error={{@model.errors.name}}
     @helperText={{t 'form.name.help'}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -78,6 +79,7 @@
     @label={{t 'resources.credential.form.username.label'}}
     @helperText={{t 'resources.credential.form.username.help'}}
     @error={{@model.errors.username}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.username}}
@@ -114,6 +116,7 @@
       @helperText={{t 'resources.credential.form.private_key_passphrase.help'}}
       @error={{@model.errors.private_key_passphrase}}
       autocomplete='new-password'
+      disabled={{@disabled}}
       as |field|
     >
       {{#if @model.errors.private_key_passphrase}}

--- a/ui/admin/app/components/form/credential/username_password/index.hbs
+++ b/ui/admin/app/components/form/credential/username_password/index.hbs
@@ -12,6 +12,7 @@
     @label={{t 'form.name.label'}}
     @error={{@model.errors.name}}
     @helperText={{t 'form.name.help'}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -78,6 +79,7 @@
     @label={{t 'resources.credential.form.username.label'}}
     @helperText={{t 'resources.credential.form.username.help'}}
     @error={{@model.errors.username}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.username}}
@@ -98,6 +100,7 @@
       @helperText={{t 'resources.credential.form.password.help'}}
       @error={{@model.errors.password}}
       autocomplete='new-password'
+      disabled={{@disabled}}
       as |field|
     >
       {{#if @model.errors.password}}

--- a/ui/admin/app/components/form/group/index.hbs
+++ b/ui/admin/app/components/form/group/index.hbs
@@ -14,6 +14,7 @@
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -32,7 +33,7 @@
     @label={{t 'form.description.label'}}
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >

--- a/ui/admin/app/components/form/host-catalog/aws/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/aws/index.hbs
@@ -13,6 +13,7 @@
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -32,6 +33,7 @@
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.description}}
@@ -107,6 +109,7 @@
     @linkText={{t 'actions.learn-more'}}
     @link={{doc-url 'host-catalog.aws.region'}}
     readonly={{false}}
+    disabled={{@disabled}}
   />
 
   <form.input
@@ -118,6 +121,7 @@
     @linkText={{t 'actions.learn-more'}}
     @link={{doc-url 'host-catalog.aws'}}
     readonly={{false}}
+    disabled={{@disabled}}
   />
 
   <form.input
@@ -129,6 +133,7 @@
     @linkText={{t 'actions.learn-more'}}
     @link={{doc-url 'host-catalog.aws'}}
     readonly={{false}}
+    disabled={{@disabled}}
   />
 
   <form.checkbox

--- a/ui/admin/app/components/form/host-catalog/azure/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/azure/index.hbs
@@ -13,6 +13,7 @@
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -32,6 +33,7 @@
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.description}}
@@ -107,6 +109,7 @@
     @linkText={{t 'actions.learn-more'}}
     @link={{doc-url 'host-catalog.azure'}}
     readonly={{false}}
+    disabled={{@disabled}}
   />
 
   <form.input
@@ -118,6 +121,7 @@
     @linkText={{t 'actions.learn-more'}}
     @link={{doc-url 'host-catalog.azure'}}
     readonly={{false}}
+    disabled={{@disabled}}
   />
 
   <form.input
@@ -129,6 +133,7 @@
     @linkText={{t 'actions.learn-more'}}
     @link={{doc-url 'host-catalog.azure'}}
     readonly={{false}}
+    disabled={{@disabled}}
   />
 
   <form.input
@@ -140,6 +145,7 @@
     @linkText={{t 'actions.learn-more'}}
     @link={{doc-url 'host-catalog.azure'}}
     readonly={{false}}
+    disabled={{@disabled}}
   />
 
   <form.checkbox
@@ -147,7 +153,7 @@
     @checked={{@model.disable_credential_rotation}}
     @helperText={{t 'form.disable_credential_rotation.help'}}
     @label={{t 'form.disable_credential_rotation.label'}}
-    @disabled={{true}}
+    disabled={{@disabled}}
   />
 
   {{#if (can 'save model' @model)}}

--- a/ui/admin/app/components/form/host-catalog/static/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/static/index.hbs
@@ -12,7 +12,7 @@
     @label={{t 'form.name.label'}}
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -32,7 +32,7 @@
     @label={{t 'form.description.label'}}
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >

--- a/ui/admin/app/components/form/host-set/aws/index.hbs
+++ b/ui/admin/app/components/form/host-set/aws/index.hbs
@@ -15,6 +15,7 @@
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -33,7 +34,7 @@
     @label={{t 'form.description.label'}}
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -50,7 +51,7 @@
     @value={{@model.type}}
     @label={{t 'form.type.label'}}
     readonly={{true}}
-    @disabled={{true}}
+    disabled={{@disabled}}
   />
 
   <InfoField
@@ -184,6 +185,7 @@
                   @value={{filter.value}}
                   @error={{@model.errors.filters}}
                   @contextual={{true}}
+                  disabled={{@disabled}}
                   as |field|
                 >
                   <field.field />
@@ -213,6 +215,7 @@
                 @type='text'
                 @name='filters'
                 @value={{@model.filter_string}}
+                disabled={{@disabled}}
               />
             </row.cell>
             <row.cell @shrink={{true}}>
@@ -247,6 +250,7 @@
     @helperText={{t 'form.sync-interval.help'}}
     @link={{doc-url 'host-set.sync-interval-seconds'}}
     @linkText={{t 'actions.learn-more'}}
+    disabled={{@disabled}}
     min='0'
     step='1'
     as |field|

--- a/ui/admin/app/components/form/host-set/azure/index.hbs
+++ b/ui/admin/app/components/form/host-set/azure/index.hbs
@@ -15,6 +15,7 @@
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -33,7 +34,7 @@
     @label={{t 'form.description.label'}}
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -50,7 +51,7 @@
     @value={{@model.type}}
     @label={{t 'form.type.label'}}
     readonly={{true}}
-    @disabled={{true}}
+    disabled={{@disabled}}
   />
 
   <InfoField
@@ -96,6 +97,7 @@
                   @value={{endpoint.value}}
                   @error={{@model.errors.preferred_endpoints}}
                   @contextual={{true}}
+                  disabled={{@disabled}}
                   placeholder='cidr:2001:4860:4860::8888/32'
                   as |field|
                 >
@@ -126,6 +128,7 @@
                 @type='text'
                 @name='preferred_endpoints'
                 @value={{@model.preferred_endpoint}}
+                disabled={{@disabled}}
                 placeholder='cidr:2001:4860:4860::8888/32'
               />
             </row.cell>
@@ -164,7 +167,7 @@
     @helperText={{t 'resources.host-set.form.filter.azure.help'}}
     @linkText={{t 'actions.learn-more'}}
     @error={{@model.errors.filter_string}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -185,6 +188,7 @@
     @helperText={{t 'form.sync-interval.help'}}
     @link={{doc-url 'host-set.sync-interval-seconds'}}
     @linkText={{t 'actions.learn-more'}}
+    disabled={{@disabled}}
     min='0'
     step='1'
     as |field|

--- a/ui/admin/app/components/form/host-set/static/index.hbs
+++ b/ui/admin/app/components/form/host-set/static/index.hbs
@@ -13,6 +13,7 @@
     @label={{t 'form.name.label'}}
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >

--- a/ui/admin/app/components/form/host/aws/index.hbs
+++ b/ui/admin/app/components/form/host/aws/index.hbs
@@ -10,7 +10,7 @@
     @value={{@model.type}}
     @label={{t 'form.type.label'}}
     readonly={{true}}
-    @disabled={{true}}
+    disabled={{@disabled}}
   />
 
   <form.input
@@ -21,6 +21,7 @@
     @error={{@model.errors.name}}
     @helperText={{t 'form.name.help'}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -39,7 +40,7 @@
     @label={{t 'form.description.label'}}
     @error={{@model.errors.description}}
     @helperText={{t 'form.description.help'}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >

--- a/ui/admin/app/components/form/host/azure/index.hbs
+++ b/ui/admin/app/components/form/host/azure/index.hbs
@@ -10,7 +10,7 @@
     @value={{@model.type}}
     @label={{t 'form.type.label'}}
     readonly={{true}}
-    @disabled={{true}}
+    disabled={{@disabled}}
   />
 
   <form.input
@@ -21,6 +21,7 @@
     @error={{@model.errors.name}}
     @helperText={{t 'form.name.help'}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -39,7 +40,7 @@
     @label={{t 'form.description.label'}}
     @error={{@model.errors.description}}
     @helperText={{t 'form.description.help'}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >

--- a/ui/admin/app/components/form/host/static/index.hbs
+++ b/ui/admin/app/components/form/host/static/index.hbs
@@ -10,7 +10,7 @@
     @value={{@model.type}}
     @label={{t 'form.type.label'}}
     readonly={{true}}
-    @disabled={{true}}
+    disabled={{@disabled}}
   />
 
   <form.input
@@ -21,6 +21,7 @@
     @error={{@model.errors.name}}
     @helperText={{t 'form.name.help'}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -39,7 +40,7 @@
     @label={{t 'form.description.label'}}
     @error={{@model.errors.description}}
     @helperText={{t 'form.description.help'}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -60,6 +61,7 @@
     @error={{@model.errors.address}}
     @helperText={{t 'form.address.help'}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.address}}

--- a/ui/admin/app/components/form/managed-group/index.hbs
+++ b/ui/admin/app/components/form/managed-group/index.hbs
@@ -9,7 +9,7 @@
     @value={{@model.type}}
     @label={{t 'form.type.label'}}
     readonly={{true}}
-    @disabled={{true}}
+    disabled={{@disabled}}
   />
 
   <form.input
@@ -20,6 +20,7 @@
     @helperText={{t 'form.name.help'}}
     @error={{@model.error.name}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -38,7 +39,7 @@
     @label={{t 'form.description.label'}}
     @error={{@model.errors.description}}
     @helperText={{t 'form.description.help'}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -58,6 +59,7 @@
     @label={{t 'form.filter.label'}}
     @error={{@model.errors.filter_string}}
     @helperText={{t 'form.filter.help'}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.filter_string}}

--- a/ui/admin/app/components/form/role/grants/index.hbs
+++ b/ui/admin/app/components/form/role/grants/index.hbs
@@ -45,17 +45,6 @@
   @disabled={{@model.isSaving}}
   as |form|
 >
-
-  {{!--
-  {{#if @model.errors.grants}}
-    <input.errors as |errors|>
-      {{#each @model.errors.grants as |error|}}
-        <errors.message>{{error.message}}</errors.message>
-      {{/each}}
-    </input.errors>
-  {{/if}}
-  --}}
-
   <Rose::List::KeyValue as |list|>
     {{#each this.grants as |grant|}}
       <list.item as |item|>

--- a/ui/admin/app/components/form/user/index.hbs
+++ b/ui/admin/app/components/form/user/index.hbs
@@ -14,6 +14,7 @@
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -32,7 +33,7 @@
     @label={{t 'form.description.label'}}
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >

--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -14,6 +14,7 @@
         @helperText={{t 'resources.worker.form.cluster_id.help'}}
         @linkText={{t 'actions.learn-more'}}
         @link={{doc-url 'worker.manage-workers'}}
+        disabled={{@disabled}}
         placeholder='69b6ddb3-ffec-42ab-a994-f43a6519470a'
       />
     {{/if}}
@@ -25,6 +26,7 @@
       @helperText={{t 'resources.worker.form.ip_address.help'}}
       @linkText={{t 'actions.learn-more'}}
       @link={{doc-url 'worker'}}
+      disabled={{@disabled}}
       placeholder='worker1.example.com'
     />
 
@@ -33,6 +35,7 @@
       @value={{this.configFilePath}}
       @label={{t 'resources.worker.form.config_file_path.label'}}
       @helperText={{t 'resources.worker.form.config_file_path.help'}}
+      disabled={{@disabled}}
       placeholder='/home/ubuntu/boundary'
     />
 
@@ -42,6 +45,7 @@
         @value={{this.initialUpstreams}}
         @label={{t 'resources.worker.form.initial_upstreams.label'}}
         @helperText={{t 'resources.worker.form.initial_upstreams.help'}}
+        disabled={{@disabled}}
         placeholder='10.0.0.1, 10.0.0.2, 10.0.0.3'
       />
     {{/if}}
@@ -80,6 +84,7 @@
                 <form.input
                   @type='text'
                   @value={{this.newWorkerKey}}
+                  disabled={{@disabled}}
                   placeholder='Key'
                 />
               </row.cell>
@@ -87,6 +92,7 @@
                 <form.input
                   @type='text'
                   @value={{this.newWorkerValue}}
+                  disabled={{@disabled}}
                   placeholder='Value'
                 />
               </row.cell>
@@ -149,7 +155,7 @@
       <form.input
         @name='worker_auth_registration_request'
         @value={{this.generatedWorkerAuthToken}}
-        @disabled={{@model.cannotSave}}
+        disabled={{@disabled}}
         @label={{t
           'resources.worker.form.steps.3.worker_auth_registration_request.label'
         }}
@@ -162,7 +168,7 @@
           @submit={{true}}
           @style='primary'
           class='nowrap'
-          @disabled={{@model.cannotSave}}
+          disabled={{@disabled}}
         >
           {{t 'resources.worker.actions.register'}}
         </Rose::Button>

--- a/ui/admin/app/components/form/worker/index.hbs
+++ b/ui/admin/app/components/form/worker/index.hbs
@@ -11,7 +11,7 @@
     @value={{@model.type}}
     @label={{t 'form.type.label'}}
     @helperText={{t 'form.worker_type.help'}}
-    @disabled={{true}}
+    disabled={{@disabled}}
     readonly={{true}}
   />
 
@@ -23,6 +23,7 @@
     @helperText={{t 'form.name.help'}}
     @error={{@model.errors.name}}
     readonly={{false}}
+    disabled={{@disabled}}
     as |field|
   >
     {{#if @model.errors.name}}
@@ -40,7 +41,7 @@
     @label={{t 'form.description.label'}}
     @helperText={{t 'form.description.help'}}
     @error={{@model.errors.description}}
-    disabled={{@model.isSaving}}
+    disabled={{@disabled}}
     readonly={{false}}
     as |field|
   >
@@ -64,7 +65,7 @@
                 <form.input
                   @type='text'
                   @value={{key}}
-                  @disabled={{true}}
+                  disabled={{@disabled}}
                   @readOnly={{true}}
                 />
               </row.cell>
@@ -72,7 +73,7 @@
                 <form.input
                   @type='text'
                   @value={{join ', ' value}}
-                  @disabled={{true}}
+                  disabled={{@disabled}}
                   @readOnly={{true}}
                 />
               </row.cell>
@@ -88,7 +89,7 @@
     @value={{@model.address}}
     @label={{t 'form.address.label'}}
     @helperText={{t 'form.worker_address.help'}}
-    @disabled={{true}}
+    disabled={{@disabled}}
     readonly={{true}}
   />
   {{#let
@@ -105,7 +106,7 @@
       }}
       @label={{t 'form.worker_last_seen.label'}}
       @helperText={{t 'form.worker_last_seen.help'}}
-      @disabled={{true}}
+      disabled={{@disabled}}
       readonly={{true}}
     />
   {{/let}}
@@ -115,7 +116,7 @@
     @value={{@model.release_version}}
     @label={{t 'form.worker_release_version.label'}}
     @helperText={{t 'form.worker_release_version.help'}}
-    @disabled={{true}}
+    disabled={{@disabled}}
     readonly={{true}}
   />
 

--- a/ui/desktop/app/templates/cluster-url.hbs
+++ b/ui/desktop/app/templates/cluster-url.hbs
@@ -16,6 +16,7 @@
         @value={{this.clusterUrl}}
         @label={{t 'form.cluster-url.label'}}
         @helperText={{t 'form.cluster-url.description'}}
+        disabled={{@disabled}}
         {{autofocus}}
       />
       <form.actions @submitText={{t 'actions.submit'}} @showCancel={{false}} />


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-7233)

## Description

This PR introduces:
- Explicit declaration of `disable` attribute within form fields.
- Refactor the existing `disable` declarations to follow the same pattern.
- **Why this changes?** We discuss them within FE tech time December 8th 2022. But we can back it up if the team thinks so.

_This pattern is JUST used if we want to provide default behaviour, disabling fields when the form itself gets disable state, if we want and specific behaviour for an specific field, this pattern does not apply._

Pattern to follow extracted from FE tech time notes:
_Assuming the form component used is `Rose::Form`._
- For rose components: `disabled={{@disabled}}`
- For HDS components: `disabled={{form.disabled}}`
