### PR TITLE
fix: 🐛 Fix generic-vault getting extra null fields when saving

### DIFF
--- a/addons/api/addon/generated/models/credential-library.js
+++ b/addons/api/addon/generated/models/credential-library.js
@@ -48,6 +48,7 @@ export default class GeneratedCredentialLibraryModel extends BaseModel {
   //= attributes (vault)
 
   @attr('string', {
+    for: 'vault-generic',
     isNestedAttribute: true,
     description:
       'The HTTP method the library uses when requesting credentials from Vault.',
@@ -56,6 +57,7 @@ export default class GeneratedCredentialLibraryModel extends BaseModel {
   http_method;
 
   @attr('string', {
+    for: 'vault-generic',
     isNestedAttribute: true,
     description:
       'The body of the HTTP request the library sends to Vault when requesting credentials. Only valid if `http_method` is set to `POST`.',
@@ -69,18 +71,21 @@ export default class GeneratedCredentialLibraryModel extends BaseModel {
   path;
 
   @attr('string', {
+    for: 'vault-ssh-certificate',
     isNestedAttribute: true,
     description: 'The username to use when making an SSH connection.',
   })
   username;
 
   @attr('string', {
+    for: 'vault-ssh-certificate',
     isNestedAttribute: true,
     description: 'The desired key type to use when generating a private key.',
   })
   key_type;
 
   @attr('number', {
+    for: 'vault-ssh-certificate',
     isNestedAttribute: true,
     description:
       'Specifies the number of bits used when generating the private key. Not used if key type is ed25519',
@@ -88,12 +93,14 @@ export default class GeneratedCredentialLibraryModel extends BaseModel {
   key_bits;
 
   @attr('string', {
+    for: 'vault-ssh-certificate',
     isNestedAttribute: true,
     description: 'Specifies the requested time to live for the certificate.',
   })
   ttl;
 
   @attr('string', {
+    for: 'vault-ssh-certificate',
     isNestedAttribute: true,
     description:
       'Specifies the key id that the created certificate should have.',
@@ -101,6 +108,7 @@ export default class GeneratedCredentialLibraryModel extends BaseModel {
   key_id;
 
   @attr('object-as-array', {
+    for: 'vault-ssh-certificate',
     isNestedAttribute: true,
     description:
       'Specifies a map of the critical options that the certificate should be signed for.',
@@ -108,6 +116,7 @@ export default class GeneratedCredentialLibraryModel extends BaseModel {
   critical_options;
 
   @attr('object-as-array', {
+    for: 'vault-ssh-certificate',
     isNestedAttribute: true,
     description:
       'Specifies a map of the extensions that the certificate should be signed for.',

--- a/addons/api/addon/serializers/credential-library.js
+++ b/addons/api/addon/serializers/credential-library.js
@@ -28,7 +28,7 @@ export default class CredentialLibrarySerializer extends ApplicationSerializer {
   }
 
   serializeAttribute(snapshot, json, key, attribute) {
-    let value = super.serializeAttribute(...arguments);
+    const value = super.serializeAttribute(...arguments);
     const { options } = attribute;
     const { type } = snapshot.record;
 

--- a/addons/api/addon/serializers/credential-library.js
+++ b/addons/api/addon/serializers/credential-library.js
@@ -32,8 +32,9 @@ export default class CredentialLibrarySerializer extends ApplicationSerializer {
     const { options } = attribute;
     const { type } = snapshot.record;
 
-    // For any attribute that doesn't match its `for`
-    // or isn't undefined, we delete it from the json
+    // If an attribute has a `for` option, it must match the
+    // record's `type`, else the attribute is excluded
+    // from serialization.
     if (options?.for && options.for !== type) {
       if (options.isNestedAttribute) {
         delete json.attributes[key];

--- a/addons/api/addon/serializers/credential-library.js
+++ b/addons/api/addon/serializers/credential-library.js
@@ -28,7 +28,7 @@ export default class CredentialLibrarySerializer extends ApplicationSerializer {
   }
 
   serializeAttribute(snapshot, json, key, attribute) {
-    const value = super.serializeAttribute(...arguments);
+    super.serializeAttribute(...arguments);
     const { options } = attribute;
     const { type } = snapshot.record;
 
@@ -41,8 +41,6 @@ export default class CredentialLibrarySerializer extends ApplicationSerializer {
     ) {
       delete json.attributes[key];
     }
-
-    return value;
   }
 
   serializeVaultGeneric() {

--- a/addons/api/addon/serializers/credential-library.js
+++ b/addons/api/addon/serializers/credential-library.js
@@ -34,19 +34,20 @@ export default class CredentialLibrarySerializer extends ApplicationSerializer {
 
     // For any attribute that doesn't match its `for`
     // or isn't undefined, we delete it from the json
-    if (
-      options.isNestedAttribute &&
-      options.for !== type &&
-      options.for !== undefined
-    ) {
-      delete json.attributes[key];
+    if (options?.for && options.for !== type) {
+      if (options.isNestedAttribute) {
+        delete json.attributes[key];
+      } else {
+        delete json[key];
+      }
     }
   }
 
   serializeVaultGeneric() {
     const serialized = super.serialize(...arguments);
     if (serialized.attributes) {
-      // Serialize `http_request_body` only if `http_method` is POST
+      // Set `http_request_body` only if `http_method` is POST
+      // otherwise set to null to have the field removed
       if (!serialized.attributes?.http_method?.match(/post/i)) {
         serialized.attributes.http_request_body = null;
       }

--- a/addons/api/tests/unit/serializers/credential-library-test.js
+++ b/addons/api/tests/unit/serializers/credential-library-test.js
@@ -31,13 +31,7 @@ module('Unit | Serializer | credential library', function (hooks) {
       attributes: {
         path: '/vault/path',
         http_method: 'GET',
-        critical_options: null,
-        extensions: null,
-        key_bits: null,
-        key_id: null,
-        key_type: null,
-        ttl: null,
-        username: null,
+        http_request_body: null,
       },
     });
   });
@@ -71,41 +65,54 @@ module('Unit | Serializer | credential library', function (hooks) {
       attributes: {
         path: '/vault/path',
         http_method: 'GET',
-        critical_options: null,
-        extensions: null,
-        key_bits: null,
-        key_id: null,
-        key_type: null,
-        ttl: null,
-        username: null,
+        http_request_body: null,
       },
       version: 1,
     });
   });
 
   test('it serializes empty strings to null', function (assert) {
-    assert.expect(1);
+    assert.expect(2);
     const store = this.owner.lookup('service:store');
-    const record = store.createRecord('credential-library', {
+    const vaultGenericRecord = store.createRecord('credential-library', {
+      type: TYPE_CREDENTIAL_LIBRARY_VAULT_GENERIC,
       http_method: '',
       path: null,
     });
-    let serializedRecord = record.serialize();
-    assert.deepEqual(serializedRecord, {
+    const vaultSSHCertificateRecord = store.createRecord('credential-library', {
+      type: TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE,
+      http_method: '',
+      path: null,
+    });
+    let serializedVaultGenericRecord = vaultGenericRecord.serialize();
+    let serializedVaultSSHCertificateRecord =
+      vaultSSHCertificateRecord.serialize();
+    assert.deepEqual(serializedVaultGenericRecord, {
       attributes: {
         path: null,
+        http_method: null,
+        http_request_body: null,
+      },
+      credential_store_id: null,
+      description: null,
+      name: null,
+      type: TYPE_CREDENTIAL_LIBRARY_VAULT_GENERIC,
+    });
+    assert.deepEqual(serializedVaultSSHCertificateRecord, {
+      attributes: {
         critical_options: null,
         extensions: null,
         key_bits: null,
         key_id: null,
         key_type: null,
+        path: null,
         ttl: null,
         username: null,
       },
       credential_store_id: null,
       description: null,
       name: null,
-      type: null,
+      type: TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE,
     });
   });
 
@@ -123,14 +130,8 @@ module('Unit | Serializer | credential library', function (hooks) {
       {
         attributes: {
           http_method: 'GET',
+          http_request_body: null,
           path: null,
-          critical_options: null,
-          extensions: null,
-          key_bits: null,
-          key_id: null,
-          key_type: null,
-          ttl: null,
-          username: null,
         },
         credential_store_id: null,
         description: null,
@@ -149,13 +150,6 @@ module('Unit | Serializer | credential library', function (hooks) {
           http_method: 'POST',
           http_request_body: 'body',
           path: null,
-          critical_options: null,
-          extensions: null,
-          key_bits: null,
-          key_id: null,
-          key_type: null,
-          ttl: null,
-          username: null,
         },
         credential_store_id: null,
         description: null,


### PR DESCRIPTION
✅ Closes: ICU-8141

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-8141)

## Description
There was a regression introduced in 0.12.0 where we can't save the generic-vault type for credential libraries. The issue is we were sending extra `null` fields from the `vault-ssh-certificate` type and it's erroring out.

