### PR TITLE
test(admin/e2e): Add test for AWS Dynamic Host Catalogs

### DIFF
--- a/ui/admin/tests/e2e/tests/dynamic-host-catalog.spec.js
+++ b/ui/admin/tests/e2e/tests/dynamic-host-catalog.spec.js
@@ -1,0 +1,192 @@
+/* eslint-disable no-undef */
+const { test, expect } = require('@playwright/test');
+const { nanoid } = require('nanoid');
+const { checkEnv, authenticatedState } = require('../helpers/general');
+const { createNewOrg, createNewProject } = require('../helpers/boundary-ui');
+
+test.use({ storageState: authenticatedState });
+
+test.beforeAll(async () => {
+  await checkEnv([
+    'E2E_AWS_ACCESS_KEY_ID',
+    'E2E_AWS_SECRET_ACCESS_KEY',
+    'E2E_AWS_HOST_SET_FILTER',
+    'E2E_AWS_HOST_SET_IPS',
+    'E2E_AWS_HOST_SET_FILTER2',
+    'E2E_AWS_HOST_SET_IPS2',
+  ]);
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test.describe('AWS', async () => {
+  test('Create a Dynamic Host Catalog and set up Host Sets', async ({
+    page,
+  }) => {
+    await createNewOrg(page);
+    await createNewProject(page);
+
+    const hostCatalogName = 'Host Catalog ' + nanoid();
+    await page
+      .getByRole('navigation', { name: 'Resources' })
+      .getByRole('link', { name: 'Host Catalogs' })
+      .click();
+    await page.getByRole('link', { name: 'New' }).click();
+    await page.getByLabel('Name').fill(hostCatalogName);
+    await page.getByLabel('Description').fill('This is an automated test');
+    await page
+      .getByRole('group', { name: 'Type' })
+      .getByLabel('Dynamic')
+      .click();
+    await page
+      .getByRole('group', { name: 'Provider' })
+      .getByLabel('AWS')
+      .click();
+    await page.getByLabel('AWS Region').fill('us-east-1');
+    await page
+      .getByLabel('Access Key ID')
+      .fill(process.env.E2E_AWS_ACCESS_KEY_ID);
+    await page
+      .getByLabel('Secret Access Key')
+      .fill(process.env.E2E_AWS_SECRET_ACCESS_KEY);
+    await page.getByLabel('Disable credential rotation').click({ force: true });
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(
+      page.getByRole('alert').getByText('Success', { exact: true })
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+    await expect(
+      page
+        .getByRole('navigation', { name: 'breadcrumbs' })
+        .getByRole('link', { name: hostCatalogName })
+    ).toBeVisible();
+
+    const hostSetName1 = 'Host Set ' + nanoid();
+    await page.getByRole('link', { name: 'Host Sets' }).click();
+    await page.getByRole('link', { name: 'New', exact: true }).click();
+    await page.getByLabel('Name').fill(hostSetName1);
+    await page.getByLabel('Description').fill('This is an automated test');
+    await page
+      .getByRole('group', { name: 'Filter' })
+      .getByRole('textbox')
+      .fill(process.env.E2E_AWS_HOST_SET_FILTER);
+    await page
+      .getByRole('group', { name: 'Filter' })
+      .getByRole('button', { name: 'Add' })
+      .click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(
+      page.getByRole('alert').getByText('Success', { exact: true })
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+    await expect(
+      page
+        .getByRole('navigation', { name: 'breadcrumbs' })
+        .getByRole('link', { name: hostSetName1 })
+    ).toBeVisible();
+
+    await page.getByRole('link', { name: 'Hosts' }).click();
+    await expect(
+      page
+        .getByRole('navigation', { name: 'breadcrumbs' })
+        .getByRole('link', { name: 'Hosts' })
+    ).toBeVisible();
+
+    let i = 0;
+    let rowCount = 0;
+    let hostsAreVisible = false;
+    let expectedHosts = JSON.parse(process.env.E2E_AWS_HOST_SET_IPS);
+    do {
+      i = i + 1;
+      // Getting the number of rows in the second rowgroup (the first rowgroup is the header row)
+      rowCount = await page
+        .getByRole('table')
+        .getByRole('rowgroup')
+        .nth(1)
+        .getByRole('row')
+        .count();
+      if (rowCount == expectedHosts.length) {
+        hostsAreVisible = true;
+        break;
+      }
+      await page.reload();
+      await page
+        .getByRole('navigation', { name: 'breadcrumbs' })
+        .getByRole('link', { name: hostSetName1 })
+        .waitFor();
+    } while (i < 5);
+
+    if (!hostsAreVisible) {
+      throw new Error(
+        'Hosts are not visible. EXPECTED: ' +
+          expectedHosts.length +
+          ', ACTUAL: ' +
+          rowCount
+      );
+    }
+
+    const hostSetName2 = 'Host Set ' + nanoid();
+    await page
+      .getByRole('navigation', { name: 'breadcrumbs' })
+      .getByRole('link', { name: hostCatalogName })
+      .click();
+    await page.getByText('Manage').click();
+    await page.getByRole('link', { name: 'New Host Set' }).click();
+    await page.getByLabel('Name').fill(hostSetName2);
+    await page.getByLabel('Description').fill('This is an automated test');
+    await page
+      .getByRole('group', { name: 'Filter' })
+      .getByRole('textbox')
+      .fill(process.env.E2E_AWS_HOST_SET_FILTER2);
+    await page
+      .getByRole('group', { name: 'Filter' })
+      .getByRole('button', { name: 'Add' })
+      .click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(
+      page.getByRole('alert').getByText('Success', { exact: true })
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+    await expect(
+      page
+        .getByRole('navigation', { name: 'breadcrumbs' })
+        .getByRole('link', { name: hostSetName2 })
+    ).toBeVisible();
+
+    await page.getByRole('link', { name: 'Hosts' }).click();
+    i = 0;
+    rowCount = 0;
+    hostsAreVisible = false;
+    expectedHosts = JSON.parse(process.env.E2E_AWS_HOST_SET_IPS2);
+    do {
+      i = i + 1;
+      // Getting the number of rows in the second rowgroup (the first rowgroup is the header row)
+      rowCount = await page
+        .getByRole('table')
+        .getByRole('rowgroup')
+        .nth(1)
+        .getByRole('row')
+        .count();
+      if (rowCount == expectedHosts.length) {
+        hostsAreVisible = true;
+        break;
+      }
+      await page.reload();
+      await page
+        .getByRole('navigation', { name: 'breadcrumbs' })
+        .getByRole('link', { name: hostSetName2 })
+        .waitFor();
+    } while (i < 5);
+
+    if (!hostsAreVisible) {
+      throw new Error(
+        'Hosts are not visible. EXPECTED: ' +
+          expectedHosts.length +
+          ', ACTUAL: ' +
+          rowCount
+      );
+    }
+  });
+});

--- a/ui/admin/tests/e2e/tests/target.spec.js
+++ b/ui/admin/tests/e2e/tests/target.spec.js
@@ -56,18 +56,18 @@ test('Verify session created then cancel the session', async ({ page }) => {
 
     connect = exec(
       'boundary connect' +
-        ' -target-id=' +
-        target.id +
-        ' -exec /usr/bin/ssh --' +
-        ' -l ' +
-        process.env.E2E_SSH_USER +
-        ' -i ' +
-        process.env.E2E_SSH_KEY_PATH +
-        ' -o UserKnownHostsFile=/dev/null' +
-        ' -o StrictHostKeyChecking=no' +
-        ' -o IdentitiesOnly=yes' + // forces the use of the provided key
-        ' -p {{boundary.port}}' +
-        ' {{boundary.ip}}'
+      ' -target-id=' +
+      target.id +
+      ' -exec /usr/bin/ssh --' +
+      ' -l ' +
+      process.env.E2E_SSH_USER +
+      ' -i ' +
+      process.env.E2E_SSH_KEY_PATH +
+      ' -o UserKnownHostsFile=/dev/null' +
+      ' -o StrictHostKeyChecking=no' +
+      ' -o IdentitiesOnly=yes' + // forces the use of the provided key
+      ' -p {{boundary.port}}' +
+      ' {{boundary.ip}}'
     );
 
     await page


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-7564)

## Description

This PR adds another test to the Admin UI e2e test suite (https://github.com/hashicorp/boundary-ui/pull/1637). 

This test does the following...
- Creates an AWS Dynamic Host Catalog
- Creates a Host Set in that Dynamic Host Catalog and confirms that it sees the appropriate number of hosts
- Creates another Host Set in that Dynamic Host Catalog and confirms that it sees the appropriate number of hosts

Note: This video cuts out when it's adding AWS Credentials just to be extra safe

https://user-images.githubusercontent.com/2474253/220957841-15f4fd0b-e1c8-435e-a4ce-de31402b735f.mp4


