### PR TITLE
test(admin/e2e): Add login tests

### DIFF
--- a/ui/admin/tests/e2e/tests/login.spec.js
+++ b/ui/admin/tests/e2e/tests/login.spec.js
@@ -1,0 +1,74 @@
+/* eslint-disable no-undef */
+const { test, expect } = require('@playwright/test');
+
+test('Log in, log out, and then log back in', async ({ page }) => {
+  await page.goto('/');
+
+  await page
+    .getByLabel('Login Name')
+    .fill(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
+  await page
+    .getByLabel('Password')
+    .fill(process.env.E2E_PASSWORD_ADMIN_PASSWORD);
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await expect(page.getByRole('navigation', { name: 'General' })).toBeVisible();
+  await expect(
+    page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME)
+  ).toBeEnabled();
+
+  await page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME).click();
+  await page.getByRole('button', { name: 'Sign Out' }).click();
+  await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+
+  await page.reload();
+
+  await page
+    .getByLabel('Login Name')
+    .fill(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
+  await page
+    .getByLabel('Password')
+    .fill(process.env.E2E_PASSWORD_ADMIN_PASSWORD);
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await expect(page.getByRole('navigation', { name: 'General' })).toBeVisible();
+});
+
+test.describe('Failure Cases', async () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('Log in with invalid password', async ({ page }) => {
+    await page
+      .getByLabel('Login Name')
+      .fill(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
+    await page.getByLabel('Password').fill('badpassword');
+    await page.getByRole('button', { name: 'Sign In' }).click();
+    await expect(page.getByRole('alert').getByText('Error')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+    await expect(
+      page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME)
+    ).toBeHidden();
+  });
+
+  test('Log in with only username', async ({ page }) => {
+    await page.getByLabel('Login Name').fill('testuser');
+    await page.getByRole('button', { name: 'Sign In' }).click();
+    await expect(page.getByRole('alert').getByText('Error')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+    await expect(
+      page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME)
+    ).toBeHidden();
+  });
+
+  test('Log in with only password', async ({ page }) => {
+    await page
+      .getByLabel('Password')
+      .fill(process.env.E2E_PASSWORD_ADMIN_PASSWORD);
+    await page.getByRole('button', { name: 'Sign In' }).click();
+    await expect(page.getByRole('alert').getByText('Error')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+    await expect(
+      page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME)
+    ).toBeHidden();
+  });
+});


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-7564)

## Description

This PR adds more tests to the Admin UI e2e test suite (https://github.com/hashicorp/boundary-ui/pull/1637). These tests revolve around logging in.

The tests include the following...
- Log in, log out, and then log back in
- Attempt to log in with an invalid password
- Attempt to log in with only a username
- Attempt to log in with only a password