### PR TITLE
chore(admin/e2e): Add missing compliance headers

### DIFF
--- a/ui/admin/tests/e2e/helpers/vault-cli.js
+++ b/ui/admin/tests/e2e/helpers/vault-cli.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 /* eslint-disable no-undef */
 const { execSync } = require('child_process');
 

--- a/ui/admin/tests/e2e/tests/credential-store-static.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static.spec.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 /* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');

--- a/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 /* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');

--- a/ui/admin/tests/e2e/tests/fixtures/boundary-controller-policy.hcl
+++ b/ui/admin/tests/e2e/tests/fixtures/boundary-controller-policy.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 path "auth/token/lookup-self" {
   capabilities = ["read"]
 }

--- a/ui/admin/tests/e2e/tests/fixtures/kv-policy.hcl
+++ b/ui/admin/tests/e2e/tests/fixtures/kv-policy.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 path "e2e_secrets/data/cred" {
   capabilities = ["read"]
 }

--- a/ui/admin/tests/e2e/tests/login.spec.js
+++ b/ui/admin/tests/e2e/tests/login.spec.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 /* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 


### PR DESCRIPTION
## Description

This PR is a follow-up to https://github.com/hashicorp/boundary-ui/pull/1617 (Add Compliance and License Headers).

There were some additional files that didn't make it in the original PR. This PR adds the appropriate compliance and license headers to the new files. 