### PR TITLE
refactor: 💡 remove explicit byow-pki-upstream, as it is default

### DIFF
--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -41,7 +41,7 @@
       placeholder='/home/ubuntu/boundary'
     />
 
-    {{#if (feature-flag 'byow-pki-upstream')}}
+    {{#if (not (feature-flag 'byow-pki-hcp-cluster-id'))}}
       <form.input
         @name='initial_upstreams'
         @value={{this.initialUpstreams}}

--- a/ui/admin/app/components/form/worker/create-worker-led/index.js
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.js
@@ -90,9 +90,9 @@ worker {
   public_addr = "${this.ipAddress || '<public_ip_address>'}"
   auth_storage_path = "${this.configFilePath || '<path>'}/worker1"
   ${
-    this.features.isEnabled('byow-pki-upstream')
-      ? `${tagsText}${upstreamText}`
-      : `${tagsText}`
+    this.features.isEnabled('byow-pki-hcp-cluster-id')
+      ? `${tagsText}`
+      : `${tagsText}${upstreamText}`
   }
 }`;
 

--- a/ui/admin/config/environment.js
+++ b/ui/admin/config/environment.js
@@ -13,7 +13,6 @@ const EDITION = process.env.EDITION || 'oss'; // Default edition is OSS
 const baseEdition = {
   byow: false,
   'byow-pki-hcp-cluster-id': false,
-  'byow-pki-upstream': false,
   'json-credentials': false,
   'ssh-target': false,
   'static-credentials': false,
@@ -28,7 +27,6 @@ const featureEditions = {};
 featureEditions.oss = {
   ...baseEdition,
   byow: true,
-  'byow-pki-upstream': true,
   'json-credentials': true,
   'static-credentials': true,
   'target-worker-filters-v2': true,
@@ -43,7 +41,6 @@ featureEditions.enterprise = {
 featureEditions.hcp = {
   ...featureEditions.enterprise,
   'byow-pki-hcp-cluster-id': true,
-  'byow-pki-upstream': false,
   'target-worker-filters-v2-hcp': true,
 };
 

--- a/ui/admin/tests/acceptance/workers/create-test.js
+++ b/ui/admin/tests/acceptance/workers/create-test.js
@@ -47,7 +47,6 @@ module('Acceptance | workers | create', function (hooks) {
     assert.expect(2);
     const featuresService = this.owner.lookup('service:features');
     featuresService.enable('byow-pki-hcp-cluster-id');
-    featuresService.disable('byow-pki-upstream');
     await visit(newWorkerURL);
     const labels = findAll('label.rose-form-label');
     assert.dom(labels[0]).hasText('Boundary Cluster ID');
@@ -58,7 +57,6 @@ module('Acceptance | workers | create', function (hooks) {
     assert.expect(2);
     const featuresService = this.owner.lookup('service:features');
     featuresService.disable('byow-pki-hcp-cluster-id');
-    featuresService.enable('byow-pki-upstream');
     await visit(newWorkerURL);
     const labels = findAll('label.rose-form-label');
     assert.dom(labels[0]).doesNotIncludeText('Boundary Cluster ID');

--- a/ui/admin/tests/integration/components/form/worker/create-worker-led-test.js
+++ b/ui/admin/tests/integration/components/form/worker/create-worker-led-test.js
@@ -21,7 +21,6 @@ module(
     hooks.beforeEach(function () {
       const featuresService = this.owner.lookup('service:features');
       featuresService.enable('byow-pki-hcp-cluster-id');
-      featuresService.disable('byow-pki-upstream');
     });
 
     test('it correctly populates the cluster id for an hcp dev cluster', async function (assert) {


### PR DESCRIPTION
:tickets: [✅ Closes: ICU-8551](https://hashicorp.atlassian.net/browse/ICU-8551)

## Description

This PR removes the feature flag`byow-pki-upstream` for being mutually exclusive with `byow-pki-hcp-cluster-id`.  The removed flag becomes the default if `byow-pki-hcp-cluster-id` is disabled.