### PR TITLE
feat: 🎸 Add support to display external name for dynamic hosts

### DIFF
--- a/addons/api/addon/models/host.js
+++ b/addons/api/addon/models/host.js
@@ -29,6 +29,12 @@ export default class HostModel extends GeneratedHostModel {
   })
   external_id;
 
+  @attr('string', {
+    description: 'The external facing name for the plugin based host.',
+    readOnly: true,
+  })
+  external_name;
+
   // Aws specific
   @attr({
     readOnly: true,
@@ -88,5 +94,10 @@ export default class HostModel extends GeneratedHostModel {
       this.type = 'plugin';
       this.plugin = { name: type };
     }
+  }
+
+  // Plugin hosts can support an external name
+  get displayName() {
+    return this.name || this.external_name || this.id;
   }
 }

--- a/addons/api/mirage/factories/host.js
+++ b/addons/api/mirage/factories/host.js
@@ -10,7 +10,9 @@ import generateId from '../helpers/id';
 
 export default factory.extend({
   id: () => generateId('h_'),
-
+  name() {
+    if (this.type === 'static') return faker.random.words();
+  },
   type() {
     return this.hostCatalog?.type || factory.attrs.type;
   },
@@ -34,8 +36,16 @@ export default factory.extend({
     }
     return result;
   },
+  // Return external fields only for plugins
   external_id() {
-    return faker.datatype.uuid();
+    if (this.type === 'plugin') {
+      return faker.datatype.uuid();
+    }
+  },
+  external_name(i) {
+    if (this.type === 'plugin') {
+      return `${this.plugin.name} provided name ${i}`;
+    }
   },
   // Only aws plugins have dns_names
   dns_names() {

--- a/addons/api/mirage/generated/factories/host.js
+++ b/addons/api/mirage/generated/factories/host.js
@@ -11,7 +11,6 @@ import { faker } from '@faker-js/faker';
  */
 export default Factory.extend({
   type: 'static',
-  name: () => faker.random.words(),
   description: () => faker.random.words(),
   created_time: () => faker.date.recent(),
   updated_time: () => faker.date.recent(),

--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -3,9 +3,15 @@
 
 id:
   label: ID
+external_id:
+  label: External ID
+  help: A read-only ID given by the plugin host catalog provider
 name:
   label: Name
   help: Name for identification purposes
+external_name:
+  label: External Name
+  help: A read-only name given by the plugin host catalog provider
 description:
   label: Description
   help: Description for identification purposes
@@ -153,10 +159,12 @@ disable_credential_rotation:
   help: Azure host catalogs do not yet support credential rotation.
 dns_names:
   label: Latest DNS Names
+  help: Read-only DNS names given by the plugin host catalog provider
 host:
   label: Host
 ip_addresses:
   label: Latest IP Addresses
+  help: Read-only public and private IP addresses given by the plugin host catalog provider
 sync-interval:
   label: Sync Interval
   help: Optional. Number of seconds between the time Boundary syncs hosts in this set.

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -149,6 +149,7 @@ host-set:
 host:
   title: Host
   title_plural: Hosts
+  no_name_title: Unnamed Host
   description: A host is a resource that may be accessed by a Boundary target.
   messages:
     welcome:

--- a/ui/admin/app/components/form/host/aws/index.hbs
+++ b/ui/admin/app/components/form/host/aws/index.hbs
@@ -11,51 +11,70 @@
   as |form|
 >
 
-  <form.input
+  <Hds::Form::TextInput::Field
     @value={{@model.type}}
-    @label={{t 'form.type.label'}}
-    readonly={{true}}
-    @disabled={{true}}
-  />
-
-  <form.input
-    @name='name'
-    @type='name'
-    @value={{@model.name}}
-    @label={{t 'form.name.label'}}
-    @error={{@model.errors.name}}
-    @helperText={{t 'form.name.help'}}
-    readonly={{false}}
-    as |field|
+    name='type'
+    disabled={{true}}
+    as |F|
   >
-    {{#if @model.errors.name}}
-      <field.errors as |errors|>
-        {{#each @model.errors.name as |error|}}
-          <errors.message>{{error.message}}</errors.message>
-        {{/each}}
-      </field.errors>
-    {{/if}}
-  </form.input>
+    <F.Label>{{t 'form.type.label'}}</F.Label>
+  </Hds::Form::TextInput::Field>
 
-  <form.textarea
-    @name='description'
-    @type='description'
+  {{#if @model.external_name}}
+    <Hds::Form::TextInput::Field
+      @value={{@model.external_name}}
+      @isInvalid={{@model.errors.external_name}}
+      name='external_name'
+      disabled={{true}}
+      as |F|
+    >
+      <F.Label>{{t 'form.external_name.label'}}</F.Label>
+      <F.HelperText>{{t 'form.external_name.help'}}</F.HelperText>
+      {{#if @model.errors.external_name}}
+        <F.Error as |E|>
+          {{#each @model.errors.external_name as |error|}}
+            <E.Message>{{error.message}}</E.Message>
+          {{/each}}
+        </F.Error>
+      {{/if}}
+    </Hds::Form::TextInput::Field>
+  {{/if}}
+
+  <Hds::Form::TextInput::Field
+    @value={{@model.external_id}}
+    @isInvalid={{@model.errors.external_id}}
+    name='external_id'
+    disabled={{true}}
+    as |F|
+  >
+    <F.Label>{{t 'form.external_id.label'}}</F.Label>
+    <F.HelperText>{{t 'form.external_id.help'}}</F.HelperText>
+    {{#if @model.errors.external_id}}
+      <F.Error as |E|>
+        {{#each @model.errors.external_id as |error|}}
+          <E.Message>{{error.message}}</E.Message>
+        {{/each}}
+      </F.Error>
+    {{/if}}
+  </Hds::Form::TextInput::Field>
+
+  <Hds::Form::Textarea::Field
     @value={{@model.description}}
-    @label={{t 'form.description.label'}}
-    @error={{@model.errors.description}}
-    @helperText={{t 'form.description.help'}}
-    disabled={{@model.isSaving}}
-    readonly={{false}}
-    as |field|
+    @isInvalid={{@model.errors.description}}
+    name='description'
+    disabled={{true}}
+    as |F|
   >
+    <F.Label>{{t 'form.description.label'}}</F.Label>
+    <F.HelperText>{{t 'form.description.help'}}</F.HelperText>
     {{#if @model.errors.description}}
-      <field.errors as |errors|>
+      <F.Error as |E|>
         {{#each @model.errors.description as |error|}}
-          <errors.message>{{error.message}}</errors.message>
+          <E.Message>{{error.message}}</E.Message>
         {{/each}}
-      </field.errors>
+      </F.Error>
     {{/if}}
-  </form.textarea>
+  </Hds::Form::Textarea::Field>
 
   <InfoField
     @value={{t 'descriptions.provider'}}
@@ -69,27 +88,33 @@
     </F.HelperText>
   </InfoField>
 
-  <form.fieldset>
-    <:title>{{t 'form.ip_addresses.label'}}</:title>
-    <:body>
-      {{#each @model.ip_addresses as |ip_address|}}
-        <form.input
+  <Hds::Form::Fieldset as |F|>
+    <F.Legend>{{t 'form.ip_addresses.label'}}</F.Legend>
+    <F.HelperText>{{t 'form.ip_addresses.help'}} </F.HelperText>
+    {{#each @model.ip_addresses as |ip_address|}}
+      <F.Control>
+        <Hds::Form::TextInput::Base
           @value={{ip_address}}
-          readonly={{true}}
-          @disabled={{true}}
+          disabled={{true}}
+          @width='unset'
         />
-      {{/each}}
-    </:body>
-  </form.fieldset>
+      </F.Control>
+    {{/each}}
+  </Hds::Form::Fieldset>
 
-  <form.fieldset>
-    <:title>{{t 'form.dns_names.label'}}</:title>
-    <:body>
-      {{#each @model.dns_names as |dns_name|}}
-        <form.input @value={{dns_name}} readonly={{true}} @disabled={{true}} />
-      {{/each}}
-    </:body>
-  </form.fieldset>
+  <Hds::Form::Fieldset as |F|>
+    <F.Legend>{{t 'form.dns_names.label'}}</F.Legend>
+    <F.HelperText>{{t 'form.dns_names.help'}} </F.HelperText>
+    {{#each @model.dns_names as |dns_name|}}
+      <F.Control>
+        <Hds::Form::TextInput::Base
+          @value={{dns_name}}
+          disabled={{true}}
+          @width='unset'
+        />
+      </F.Control>
+    {{/each}}
+  </Hds::Form::Fieldset>
 
   {{#if (can 'save model' @model)}}
     <form.actions

--- a/ui/admin/app/components/form/host/azure/index.hbs
+++ b/ui/admin/app/components/form/host/azure/index.hbs
@@ -11,51 +11,70 @@
   as |form|
 >
 
-  <form.input
+  <Hds::Form::TextInput::Field
     @value={{@model.type}}
-    @label={{t 'form.type.label'}}
-    readonly={{true}}
-    @disabled={{true}}
-  />
-
-  <form.input
-    @name='name'
-    @type='name'
-    @value={{@model.name}}
-    @label={{t 'form.name.label'}}
-    @error={{@model.errors.name}}
-    @helperText={{t 'form.name.help'}}
-    readonly={{false}}
-    as |field|
+    name='type'
+    disabled={{true}}
+    as |F|
   >
-    {{#if @model.errors.name}}
-      <field.errors as |errors|>
-        {{#each @model.errors.name as |error|}}
-          <errors.message>{{error.message}}</errors.message>
-        {{/each}}
-      </field.errors>
-    {{/if}}
-  </form.input>
+    <F.Label>{{t 'form.type.label'}}</F.Label>
+  </Hds::Form::TextInput::Field>
 
-  <form.textarea
-    @name='description'
-    @type='description'
+  {{#if @model.external_name}}
+    <Hds::Form::TextInput::Field
+      @value={{@model.external_name}}
+      @isInvalid={{@model.errors.external_name}}
+      name='external_name'
+      disabled={{true}}
+      as |F|
+    >
+      <F.Label>{{t 'form.external_name.label'}}</F.Label>
+      <F.HelperText>{{t 'form.external_name.help'}}</F.HelperText>
+      {{#if @model.errors.external_name}}
+        <F.Error as |E|>
+          {{#each @model.errors.external_name as |error|}}
+            <E.Message>{{error.message}}</E.Message>
+          {{/each}}
+        </F.Error>
+      {{/if}}
+    </Hds::Form::TextInput::Field>
+  {{/if}}
+
+  <Hds::Form::TextInput::Field
+    @value={{@model.external_id}}
+    @isInvalid={{@model.errors.external_id}}
+    name='external_id'
+    disabled={{true}}
+    as |F|
+  >
+    <F.Label>{{t 'form.external_id.label'}}</F.Label>
+    <F.HelperText>{{t 'form.external_id.help'}}</F.HelperText>
+    {{#if @model.errors.external_id}}
+      <F.Error as |E|>
+        {{#each @model.errors.external_id as |error|}}
+          <E.Message>{{error.message}}</E.Message>
+        {{/each}}
+      </F.Error>
+    {{/if}}
+  </Hds::Form::TextInput::Field>
+
+  <Hds::Form::Textarea::Field
     @value={{@model.description}}
-    @label={{t 'form.description.label'}}
-    @error={{@model.errors.description}}
-    @helperText={{t 'form.description.help'}}
-    disabled={{@model.isSaving}}
-    readonly={{false}}
-    as |field|
+    @isInvalid={{@model.errors.description}}
+    name='description'
+    disabled={{true}}
+    as |F|
   >
+    <F.Label>{{t 'form.description.label'}}</F.Label>
+    <F.HelperText>{{t 'form.description.help'}}</F.HelperText>
     {{#if @model.errors.description}}
-      <field.errors as |errors|>
+      <F.Error as |E|>
         {{#each @model.errors.description as |error|}}
-          <errors.message>{{error.message}}</errors.message>
+          <E.Message>{{error.message}}</E.Message>
         {{/each}}
-      </field.errors>
+      </F.Error>
     {{/if}}
-  </form.textarea>
+  </Hds::Form::Textarea::Field>
 
   <InfoField
     @value={{t 'descriptions.provider'}}
@@ -68,19 +87,20 @@
       {{t 'resources.host-catalog.types.azure'}}
     </F.HelperText>
   </InfoField>
-  <form.fieldset>
-    <:title>{{t 'form.ip_addresses.label'}}</:title>
-    <:body>
-      {{#each @model.ip_addresses as |ip_address|}}
 
-        <form.input
+  <Hds::Form::Fieldset as |F|>
+    <F.Legend>{{t 'form.ip_addresses.label'}}</F.Legend>
+    <F.HelperText>{{t 'form.ip_addresses.help'}} </F.HelperText>
+    {{#each @model.ip_addresses as |ip_address|}}
+      <F.Control>
+        <Hds::Form::TextInput::Base
           @value={{ip_address}}
-          readonly={{true}}
-          @disabled={{true}}
+          disabled={{true}}
+          @width='unset'
         />
-      {{/each}}
-    </:body>
-  </form.fieldset>
+      </F.Control>
+    {{/each}}
+  </Hds::Form::Fieldset>
 
   {{#if (can 'save model' @model)}}
     <form.actions

--- a/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/index.hbs
@@ -31,10 +31,14 @@
       <Rose::Table as |table|>
         <table.header as |header|>
           <header.row as |row|>
-            <row.headerCell>{{t 'form.name.label'}}</row.headerCell>
+            {{#if @model.hostSet.isStatic}}
+              <row.headerCell>{{t 'form.name.label'}}</row.headerCell>
+            {{else}}
+              <row.headerCell>{{t 'form.external_name.label'}}</row.headerCell>
+            {{/if}}
             <row.headerCell>{{t 'form.type.label'}}</row.headerCell>
             <row.headerCell>{{t 'form.id.label'}}</row.headerCell>
-            {{#if @model.isStatic}}
+            {{#if @model.hostSet.isStatic}}
               <row.headerCell>{{t 'titles.actions'}}</row.headerCell>
             {{/if}}
           </header.row>


### PR DESCRIPTION
✅ Closes: ICU-8795

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-8795)

## Description
Added support for dynamic host catalogs to display the external name for hosts. Take a look at the mockup [here](https://hashicorp.atlassian.net/browse/ICU-7472), and the [PRD](https://docs.google.com/document/d/181RpEqvKAg-BWNEOEgPCRuu64_GWHBYZmT5Cjbf1uTA/edit#).

I kept the same behavior as we currently have but instead display the external name if there's no boundary name (~~I think there can only be a boundary name if a user manually updates the host's name from the CLI? Not sure since it looks like name isn't populated by default with dynamic hosts~~ Dynamic hosts won't have a name).

The name column for dynamic hosts will now be `External Name`

### Screenshots (if appropriate):
<img width="1639" alt="image" src="https://user-images.githubusercontent.com/5783847/230172723-b5dc40b7-e177-4cc0-ae9a-ce050e965269.png">

<img width="1562" alt="image" src="https://user-images.githubusercontent.com/5783847/230137902-c39ae779-08ce-4b53-9061-fe460676a6cb.png">

<img width="1541" alt="image" src="https://user-images.githubusercontent.com/5783847/230137981-1b9c74e4-5671-475c-b150-8732a1548ab2.png">


Desktop:
<img width="1459" alt="image" src="https://user-images.githubusercontent.com/5783847/230175395-fc3c975e-4d3a-4599-b1dc-a76b3a95fca9.png">
