### PR TITLE
refactor: 💡 removed whitespace from layout in add-members view

### DIFF
--- a/addons/rose/addon/styles/hds/overrides.scss
+++ b/addons/rose/addon/styles/hds/overrides.scss
@@ -17,9 +17,10 @@
   }
 }
 
-// removes field bottom margin (for tables with checkbox and badge in a cell)
+// removes field bottom margin (for tables with input elements in cell)
 .hds-table {
-  [class^=hds-form-field], [class^=hds-form-group] {
+  [class^='hds-form-field'],
+  [class^='hds-form-group'] {
     margin-bottom: 0;
   }
 }

--- a/addons/rose/addon/styles/hds/overrides.scss
+++ b/addons/rose/addon/styles/hds/overrides.scss
@@ -19,7 +19,7 @@
 
 // removes field bottom margin (for tables with checkbox and badge in a cell)
 .hds-table__td {
-  .hds-form-field--layout-flag {
+  [class^=hds-form-field], [class^=hds-form-group] {
     margin-bottom: 0;
   }
 }

--- a/addons/rose/addon/styles/hds/overrides.scss
+++ b/addons/rose/addon/styles/hds/overrides.scss
@@ -16,3 +16,10 @@
     }
   }
 }
+
+// removes field bottom margin (for tables with checkbox and badge in a cell)
+.hds-table__td {
+  .hds-form-field--layout-flag {
+    margin-bottom: 0;
+  }
+}

--- a/addons/rose/addon/styles/hds/overrides.scss
+++ b/addons/rose/addon/styles/hds/overrides.scss
@@ -18,7 +18,7 @@
 }
 
 // removes field bottom margin (for tables with checkbox and badge in a cell)
-.hds-table__td {
+.hds-table {
   [class^=hds-form-field], [class^=hds-form-group] {
     margin-bottom: 0;
   }

--- a/addons/rose/addon/styles/hds/overrides.scss
+++ b/addons/rose/addon/styles/hds/overrides.scss
@@ -17,10 +17,17 @@
   }
 }
 
-// removes field bottom margin (for tables with input elements in cell)
 .hds-table {
+  border-collapse: revert;
+
   [class^='hds-form-field'],
   [class^='hds-form-group'] {
     margin-bottom: 0;
+  }
+}
+
+.hds-dropdown {
+  .hds-dropdown-toggle-icon {
+    color: inherit;
   }
 }

--- a/ui/admin/app/components/form/group/add-members/index.hbs
+++ b/ui/admin/app/components/form/group/add-members/index.hbs
@@ -3,7 +3,6 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{! template-lint-disable no-whitespace-for-layout  }}
 {{#if this.availableUsers}}
   <Rose::Form
     class='full-width'
@@ -17,45 +16,38 @@
       @submitText={{t 'resources.group.actions.add-members'}}
       @cancelText={{t 'actions.cancel'}}
     />
-
-    <Rose::Table as |table|>
-      <table.header as |header|>
-        <header.row as |row|>
-          <row.headerCell>{{t 'form.name.label'}}</row.headerCell>
-          <row.headerCell>{{t 'form.id.label'}}</row.headerCell>
-          <row.headerCell>{{t 'resources.scope.title'}}</row.headerCell>
-          <row.headerCell>{{t 'form.description.label'}}</row.headerCell>
-        </header.row>
-      </table.header>
-      <table.body as |body|>
-        {{#each this.availableUsers as |user|}}
-          <body.row as |row|>
-            <row.headerCell>
-              <form.checkbox
-                @label={{user.displayName}}
-                @onChange={{fn this.toggleMember user}}
-              />
-              {{#if user.accountName}}
-                {{!
-                  The following is a formatting hack since we don't have a great
-                  way to manage micro-whitespace or alignment among separate
-                  components without resorting to heavy-handed grids
-                  or contextualization.  This is a one-off.
-                }}
-                <br />
-                &nbsp;&nbsp;&nbsp; &nbsp;&nbsp;
-                <Hds::Badge @text={{user.accountName}} />
+    <Hds::Table
+      @model={{this.availableUsers}}
+      @columns={{array
+        (hash label=(t 'form.name.label'))
+        (hash label=(t 'form.id.label'))
+        (hash label=(t 'resources.scope.title'))
+        (hash label=(t 'form.description.label'))
+      }}
+    >
+      <:body as |B|>
+        <B.Tr>
+          <B.Td>
+            <Hds::Form::Checkbox::Field
+              {{on 'change' (fn this.toggleMember B.data)}}
+              as |F|
+            >
+              <F.Label>{{B.data.displayName}}</F.Label>
+              {{#if B.data.accountName}}
+                <F.HelperText>
+                  <Hds::Badge @text={{B.data.accountName}} />
+                </F.HelperText>
               {{/if}}
-            </row.headerCell>
-            <row.cell><code>{{user.id}}</code></row.cell>
-            <row.cell>
-              <ScopeBadge @scope={{user.scopeModel}} />
-            </row.cell>
-            <row.cell>{{user.description}}</row.cell>
-          </body.row>
-        {{/each}}
-      </table.body>
-    </Rose::Table>
+            </Hds::Form::Checkbox::Field>
+
+          </B.Td>
+          <B.Td><code>{{B.data.id}}</code></B.Td>
+          <B.Td><ScopeBadge @scope={{B.data.scopeModel}} /></B.Td>
+          <B.Td>{{B.data.description}}</B.Td>
+        </B.Tr>
+
+      </:body>
+    </Hds::Table>
 
   </Rose::Form>
 {{/if}}

--- a/ui/admin/app/components/form/group/add-members/index.hbs
+++ b/ui/admin/app/components/form/group/add-members/index.hbs
@@ -29,20 +29,17 @@
       <:body as |B|>
         <B.Tr>
           <B.Td>
-            <div class='checkbox-badge-valign-middle'>
-              <Hds::Form::Checkbox::Field
-                class='hds-form-field--layout-vertical'
-                {{on 'change' (fn this.toggleMember B.data)}}
-                as |F|
-              >
-                <F.Label>{{B.data.displayName}}</F.Label>
-                {{#if B.data.accountName}}
-                  <F.HelperText>
-                    <Hds::Badge @text={{B.data.accountName}} />
-                  </F.HelperText>
-                {{/if}}
-              </Hds::Form::Checkbox::Field>
-            </div>
+            <Hds::Form::Checkbox::Field
+              {{on 'change' (fn this.toggleMember B.data)}}
+              as |F|
+            >
+              <F.Label>{{B.data.displayName}}</F.Label>
+              {{#if B.data.accountName}}
+                <F.HelperText>
+                  <Hds::Badge @text={{B.data.accountName}} />
+                </F.HelperText>
+              {{/if}}
+            </Hds::Form::Checkbox::Field>
           </B.Td>
           <B.Td><code>{{B.data.id}}</code></B.Td>
           <B.Td><ScopeBadge @scope={{B.data.scopeModel}} /></B.Td>

--- a/ui/admin/app/components/form/group/add-members/index.hbs
+++ b/ui/admin/app/components/form/group/add-members/index.hbs
@@ -24,22 +24,25 @@
         (hash label=(t 'resources.scope.title'))
         (hash label=(t 'form.description.label'))
       }}
+      @valign='middle'
     >
       <:body as |B|>
         <B.Tr>
           <B.Td>
-            <Hds::Form::Checkbox::Field
-              {{on 'change' (fn this.toggleMember B.data)}}
-              as |F|
-            >
-              <F.Label>{{B.data.displayName}}</F.Label>
-              {{#if B.data.accountName}}
-                <F.HelperText>
-                  <Hds::Badge @text={{B.data.accountName}} />
-                </F.HelperText>
-              {{/if}}
-            </Hds::Form::Checkbox::Field>
-
+            <div class='checkbox-badge-valign-middle'>
+              <Hds::Form::Checkbox::Field
+                class='hds-form-field--layout-vertical'
+                {{on 'change' (fn this.toggleMember B.data)}}
+                as |F|
+              >
+                <F.Label>{{B.data.displayName}}</F.Label>
+                {{#if B.data.accountName}}
+                  <F.HelperText>
+                    <Hds::Badge @text={{B.data.accountName}} />
+                  </F.HelperText>
+                {{/if}}
+              </Hds::Form::Checkbox::Field>
+            </div>
           </B.Td>
           <B.Td><code>{{B.data.id}}</code></B.Td>
           <B.Td><ScopeBadge @scope={{B.data.scopeModel}} /></B.Td>

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -685,3 +685,11 @@
   }
   /* stylelint-enable selector-class-pattern */
 }
+
+// removes default margin-bottom from hds-form-field to allow checkbox and badge align vertically property
+.checkbox-badge-valign-middle {
+  [class^='hds-form-field'],
+  [class^='hds-form-field-group'] {
+    margin-bottom: 0;
+  }
+}

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -675,12 +675,6 @@
         width: 1%;
         white-space: nowrap;
       }
-
-      // Reset field margins to rely instead on cell paddings
-      .hds-form-field--layout-vertical,
-      .hds-form-text-input {
-        margin: 0;
-      }
     }
   }
   /* stylelint-enable selector-class-pattern */

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -685,11 +685,3 @@
   }
   /* stylelint-enable selector-class-pattern */
 }
-
-// removes default margin-bottom from hds-form-field to allow checkbox and badge align vertically property
-.checkbox-badge-valign-middle {
-  [class^='hds-form-field'],
-  [class^='hds-form-field-group'] {
-    margin-bottom: 0;
-  }
-}


### PR DESCRIPTION
✅ Closes: ICU-5986

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-5986)

## Description
Removed whitespace from layout in `add-members` view for groups by replacing `Rose::Table` with `Hds::Table`.  We were able to achieve the same look as the previous whitespace formatting hack by using  a `Hds::Table ` and a `<HelperText>` to wrap the badge for `account_name` instead of custom `css`.  

## Note
There will be a small bit of `override` css that will globally remove margin from form-fields when uses inside of an `Hds::Table`

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

### Screenshots (if appropriate):
<img width="2483" alt="image" src="https://user-images.githubusercontent.com/24277002/234358135-6577b988-2d29-4476-933e-122e91218528.png">

