### PR TITLE
Chore update embroider test setup

### DIFF
--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -35,7 +35,7 @@
     "@babel/plugin-proposal-decorators": "^7.18.6",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",
-    "@embroider/test-setup": "^1.6.0",
+    "@embroider/test-setup": "^2.1.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "broccoli-asset-rev": "^3.0.0",

--- a/addons/auth/package.json
+++ b/addons/auth/package.json
@@ -31,7 +31,7 @@
     "@babel/plugin-proposal-decorators": "^7.18.6",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",
-    "@embroider/test-setup": "^1.6.0",
+    "@embroider/test-setup": "^2.1.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "broccoli-asset-rev": "^3.0.0",

--- a/addons/core/package.json
+++ b/addons/core/package.json
@@ -47,7 +47,7 @@
     "@babel/plugin-proposal-decorators": "^7.18.6",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",
-    "@embroider/test-setup": "^1.6.0",
+    "@embroider/test-setup": "^2.1.1",
     "@faker-js/faker": "^7.3.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -33,7 +33,7 @@
     "doc:toc": "doctoc README.md"
   },
   "dependencies": {
-    "@embroider/test-setup": "^0.48.1",
+    "@embroider/test-setup": "^2.1.1",
     "@hashicorp/design-system-components": "^2.1.0",
     "codemirror": "5.65.7",
     "ember-auto-import": "^2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4219,14 +4219,6 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
-"@embroider/test-setup@^1.6.0":
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-1.8.3.tgz#445b9fe5a363ce50367ac2114750597f98d7806d"
-  integrity sha512-BCCbBG7UWkCw+cQ401Ip6LnqTRaQDeKImxR+e7Q4oP6H4EBj7p4iGR1z6fhMy4NNyXKPB6jk3bGa9bTiiNoEAw==
-  dependencies:
-    lodash "^4.17.21"
-    resolve "^1.20.0"
-
 "@embroider/test-setup@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-2.1.1.tgz#1cf613f479ed120fdc5d71cb834c8fb71514cce1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4219,18 +4219,18 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
-"@embroider/test-setup@^0.48.1":
-  version "0.48.1"
-  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.48.1.tgz#f64da84f8241433d0ba92154fa1eb3137ecd4df8"
-  integrity sha512-MmYTgQMDVDrZPvxeT27LTUD/BOum21ip1tEYv5H/StSeTZyZQ861Q+8HXQUFTVF/HFjGAB1c/BAgnw+8hO1ueA==
-  dependencies:
-    lodash "^4.17.21"
-    resolve "^1.20.0"
-
 "@embroider/test-setup@^1.6.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-1.8.3.tgz#445b9fe5a363ce50367ac2114750597f98d7806d"
   integrity sha512-BCCbBG7UWkCw+cQ401Ip6LnqTRaQDeKImxR+e7Q4oP6H4EBj7p4iGR1z6fhMy4NNyXKPB6jk3bGa9bTiiNoEAw==
+  dependencies:
+    lodash "^4.17.21"
+    resolve "^1.20.0"
+
+"@embroider/test-setup@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-2.1.1.tgz#1cf613f479ed120fdc5d71cb834c8fb71514cce1"
+  integrity sha512-t81a2z2OEFAOZVbV7wkgiDuCyZ3ajD7J7J+keaTfNSRiXoQgeFFASEECYq1TCsH8m/R+xHMRiY59apF2FIeFhw==
   dependencies:
     lodash "^4.17.21"
     resolve "^1.20.0"


### PR DESCRIPTION
## Description

Update `@embroider/test-setup` from `0.48.1` and `1.6.0` to `2.1.1`. As [per Changelog](https://github.com/embroider-build/embroider/blob/main/CHANGELOG.md) there are no breaking changes. 
_When review the Changelog, be aware they deliver different `@embroider/*` packages, so check the changes just for `@embroider/test-setup`_

**Testing procedure:**
- Run the tests within the root project.
- Run build procedures for the addons that suffered changes succesfully.
