### PR TITLE
feat: 🎸 Download latest HCP binary for worker config commands

### DIFF
--- a/ui/admin/app/components/form/worker/create-worker-led/index.js
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.js
@@ -118,8 +118,10 @@ ${listenerText}
 sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" ;\\
 sudo apt-get update && sudo apt-get install boundary ;\\
 boundary server -config="${configPath}/pki-worker.hcl"`;
-    const hcpContent = `wget -q https://releases.hashicorp.com/boundary-worker/0.12.0+hcp/boundary-worker_0.12.0+hcp_linux_amd64.zip ;\\
-sudo apt-get update && sudo apt-get install unzip ;\\
+
+    const hcpContent = `sudo apt-get update && sudo apt-get install jq unzip ;\\
+wget -q "$(curl -fsSL "https://api.releases.hashicorp.com/v1/releases/boundary-worker/latest?license_class=hcp" \
+| jq -r '.builds[] | select(.arch == "amd64" and .os == "linux") | .url')" ;\\
 unzip *.zip ;\\
 ./boundary-worker server -config="${configPath}/pki-worker.hcl"`;
 

--- a/ui/admin/tests/acceptance/workers/create-test.js
+++ b/ui/admin/tests/acceptance/workers/create-test.js
@@ -69,8 +69,16 @@ module('Acceptance | workers | create', function (hooks) {
     await visit(newWorkerURL);
     const createSection = findAll('.worker-create-section');
     assert.false(featuresService.isEnabled('byow-pki-hcp-cluster-id'));
-    assert.dom(createSection[1]).includesText('curl -fsSL');
-    assert.dom(createSection[1]).doesNotIncludeText('wget -q');
+    assert
+      .dom(createSection[1])
+      .includesText(
+        'curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add - ;'
+      );
+    assert
+      .dom(createSection[1])
+      .doesNotIncludeText(
+        'wget -q "$(curl -fsSL "https://api.releases.hashicorp.com/v1/releases/boundary-worker/latest?license_class=hcp"'
+      );
   });
 
   test('download and install step shows correct hcp instructions', async function (assert) {
@@ -79,8 +87,16 @@ module('Acceptance | workers | create', function (hooks) {
     featuresService.enable('byow-pki-hcp-cluster-id');
     await visit(newWorkerURL);
     const createSection = findAll('.worker-create-section');
-    assert.dom(createSection[1]).includesText('wget -q');
-    assert.dom(createSection[1]).doesNotIncludeText('curl -fsSL');
+    assert
+      .dom(createSection[1])
+      .includesText(
+        'wget -q "$(curl -fsSL "https://api.releases.hashicorp.com/v1/releases/boundary-worker/latest?license_class=hcp"'
+      );
+    assert
+      .dom(createSection[1])
+      .doesNotIncludeText(
+        'curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add - ;'
+      );
   });
 
   test('Users can navigate to new workers route with proper authorization', async function (assert) {


### PR DESCRIPTION
✅ Closes: ICU-7265

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-7265)

## Description
Changed the worker config commands to just download the latest HCP boundary binary. 
Used the `/latest` endpoint from the hashicorp releases and grabbed the URL to be used in a command substitution.

Note that our edition feature switching doesn't properly update the worker page since ember isn't aware of any changes as we use the feature check in getters. You can update it just by filling out a field on the page. 

### Screenshots (if appropriate):
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/5783847/236050419-719f0f15-b0d9-4879-8005-e1879b7dd0c6.png">

