### PR TITLE
fix: 🐛 support metadata access on another API host

### DIFF
--- a/ui/admin/app/instance-initializers/feature-edition.js
+++ b/ui/admin/app/instance-initializers/feature-edition.js
@@ -7,14 +7,19 @@ import fetch from 'fetch';
 
 async function autoInitializeFeatureEdition(owner) {
   const service = owner.lookup('service:feature-edition');
-  const url = '/metadata.json';
+  const adapter = owner.lookup('adapter:application');
+
   let edition;
   let features;
 
   // Attempt to load edition for the metadata JSON
   try {
+    const { host } = adapter;
+    const path = '/metadata.json';
+    const url = `${host}${path}`;
     const response = await fetch(url);
     const json = await response.json();
+
     edition = json?.license?.edition;
     features = json?.license?.features;
   } catch (e) {


### PR DESCRIPTION
This fix adds support for fetching `metadata.json` from an arbitrary API host as specified by the `API_HOST` env var.  This is expected to affect only development environments where the UI and controller are running on different hosts/ports.