### PR TITLE
feat: 🎸 add ldap-auth-methods feature flag

### DIFF
--- a/ui/admin/config/features.js
+++ b/ui/admin/config/features.js
@@ -27,6 +27,7 @@ const baseEdition = {
   'target-worker-filters-v2-hcp': false,
   'target-network-address': false,
   'vault-worker-filter': false,
+  'ldap-auth-methods': false,
 };
 // Editions maps edition keys to their associated featuresets.
 const featureEditions = {};
@@ -37,6 +38,7 @@ featureEditions.oss = {
   'static-credentials': true,
   'target-worker-filters-v2': true,
   'target-network-address': true,
+  'ldap-auth-methods': false,
 };
 featureEditions.enterprise = {
   ...featureEditions.oss,


### PR DESCRIPTION
## Description
The work in this [PR](https://github.com/hashicorp/boundary-ui/pull/1688) is being separated in order to increase readability. This is the first part which just includes adding the feature flag for ldap auth-methods. It will stay disabled for Phase 1 of implementation. It will be used in the abilities for auth-methods and accounts in order to disallow for any actions involving ldap auth methods and accounts.