### PR TITLE
fix: 🐛 fix descriptions for targets list for desktop

### DIFF
--- a/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
@@ -121,10 +121,10 @@
                 {{else}}
                   {{model.displayName}}
                 {{/if}}
-                {{#if model.target.description}}
-                  <p>{{model.target.description}}</p>
+                {{#if model.description}}
+                  <p>{{model.description}}</p>
                 {{/if}}
-                {{#if model.target.isActive}}
+                {{#if model.isActive}}
                   <Hds::Badge
                     @text={{t 'states.active'}}
                     @color='success'


### PR DESCRIPTION
✅ Closes: ICU-9375

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9375)

## Description
Target descriptions were not displaying due to some previous refactoring.  Corrected `description` and `isActive` references.

### Screenshots (if appropriate):
## Before
![image](https://github.com/hashicorp/boundary-ui/assets/24277002/fa208628-8047-42d9-87da-e36c39cff69b) 

## After
<img width="1282" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/24277002/010bcbe3-66a4-468e-808d-4011adb9c549">

