### PR TITLE
Chore icu 9071 audit resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "npm-user-validate": "^1.0.1",
     "caniuse-lite": "^1.0.30001157",
     "immer": "^9.0.6",
     "node-notifier": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "cryptiles": "~4.1.2",
     "prismjs": "^1.27.0",
     "npm-user-validate": "^1.0.1",
     "caniuse-lite": "^1.0.30001157",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "prismjs": "^1.27.0",
     "npm-user-validate": "^1.0.1",
     "caniuse-lite": "^1.0.30001157",
     "immer": "^9.0.6",
@@ -100,7 +99,8 @@
     "loader-utils": "^2.0.4",
     "**/@storybook/**/minimatch": "^3.0.5",
     "**/ember-electron/**/minimatch": "^3.0.5",
-    "**/babel-core/json5": "^2.2.2"
+    "**/babel-core/json5": "^2.2.2",
+    "**/react-syntax-highlighter/refractor/prismjs": "^1.27.0"
   },
   "config": {
     "commitizen": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20254,11 +20254,6 @@ npm-run-path@^5.1.0:
   dependencies:
     path-key "^4.0.0"
 
-npm-user-validate@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-user-validate/-/npm-user-validate-1.0.1.tgz#31428fc5475fe8416023f178c0ab47935ad8c561"
-  integrity sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==
-
 npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9336,13 +9336,6 @@ boolean@^3.1.4:
   resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.2.0.tgz#9e5294af4e98314494cbb17979fa54ca159f116b"
   integrity sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==
 
-boom@7.x.x:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-7.3.0.tgz#733a6d956d33b0b1999da3fe6c12996950d017b9"
-  integrity sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==
-  dependencies:
-    hoek "6.x.x"
-
 bower-config@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/bower-config/-/bower-config-1.4.3.tgz#3454fecdc5f08e7aa9cc6d556e492be0669689ae"
@@ -11391,13 +11384,6 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-cryptiles@~4.1.2:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-4.1.3.tgz#2461d3390ea0b82c643a6ba79f0ed491b0934c25"
-  integrity sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==
-  dependencies:
-    boom "7.x.x"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -16412,7 +16398,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoek@6.x.x, hoek@~4.2.0:
+hoek@~4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
   integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/9071)

## Description

### Cryptiles:
- After running `yarn why cryptiles` we find out cryptiles isn't used anymore. 
- After deleting `cryptiles` from resolutions and reinstall dependencies we validate NO other deps reference `cryptiles`.

### Prismjs
`rose > react-syntax-highlighter > refractor` uses 1.24.1, which it has a security vulnerability.
We delete the global resolution and add a specific resolution for rose.

### npm-user-validate
- After running `yarn why npm-user-validate` we find out npm-user-validate isn't used anymore.
- After deleting `npm-user-validate` from resolutions and reinstall dependencies we validate NO other deps reference `npm-user-validate`.

### Test procedure:
After deleting these 3 dependencies:
- Build UI's and addons succesfully.
- Run boundary-ui-release CI to validate these changes will not affect desktop client.
