### PR TITLE
fix: 🐛 radio card group name

### DIFF
--- a/ui/admin/app/components/form/host-catalog/aws/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/aws/index.hbs
@@ -69,7 +69,7 @@
         </G.RadioCard>
       {{/each}}
     </Hds::Form::RadioCard::Group>
-    <Hds::Form::RadioCard::Group @name='type' @alignment='center' as |G|>
+    <Hds::Form::RadioCard::Group @name='plugin_type' @alignment='center' as |G|>
       <G.Legend>{{t 'titles.provider'}}</G.Legend>
       <G.Legend>{{t 'titles.choose-a-provider'}}</G.Legend>
       <G.HelperText>{{t 'descriptions.choose-a-provider'}}</G.HelperText>

--- a/ui/admin/app/components/form/host-catalog/azure/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/azure/index.hbs
@@ -68,7 +68,7 @@
         </G.RadioCard>
       {{/each}}
     </Hds::Form::RadioCard::Group>
-    <Hds::Form::RadioCard::Group @name='type' @alignment='center' as |G|>
+    <Hds::Form::RadioCard::Group @name='plugin_type' @alignment='center' as |G|>
       <G.Legend>{{t 'titles.provider'}}</G.Legend>
       <G.Legend>{{t 'titles.choose-a-provider'}}</G.Legend>
       <G.HelperText>{{concat

--- a/ui/admin/app/components/form/host-catalog/static/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/static/index.hbs
@@ -71,32 +71,6 @@
         </G.RadioCard>
       {{/each}}
     </Hds::Form::RadioCard::Group>
-
-    {{#if @model.isPlugin}}
-
-      <Hds::Form::RadioCard::Group @name='type' as |G|>
-        <G.Legend>{{t 'titles.provider'}}</G.Legend>
-        <G.Legend>{{t 'titles.choose-a-provider'}}</G.Legend>
-        <G.HelperText>{{t 'descriptions.choose-a-provider'}}</G.HelperText>
-
-        {{#each-in this.mapResourceTypeWithIcon as |pluginType|}}
-          <G.RadioCard
-            @value={{pluginType}}
-            @checked={{eq pluginType @model.type}}
-            @maxWidth='20rem'
-            {{on 'input' (fn @changeType pluginType)}}
-            as |R|
-          >
-            <R.Label>{{t
-                (concat 'resources.host-catalog.types.' pluginType)
-              }}</R.Label>
-            <R.Description>{{t
-                (concat 'resources.host-catalog.help.' pluginType)
-              }}</R.Description>
-          </G.RadioCard>
-        {{/each-in}}
-      </Hds::Form::RadioCard::Group>
-    {{/if}}
   {{/if}}
 
   {{#if (can 'save model' @model)}}


### PR DESCRIPTION
 https://hashicorp.atlassian.net/browse/ICU-9510

This issue is due to using the same name for two radio groups within the same form

 Before:
<img width="976" alt="Screenshot 2023-05-30 at 4 35 41 PM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/994a9350-e2ea-429e-9036-8f8d6a320043">

After:
<img width="1166" alt="Screenshot 2023-05-30 at 4 36 13 PM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/c030770d-e1da-404e-8e74-5c87fc2bc57a">


