### PR TITLE
fix: 🐛 increase auth form width, which was too narrow

### DIFF
--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -249,7 +249,7 @@
   padding: (sizing.rems(l) * 4) (sizing.rems(l) * 3) (sizing.rems(l) * 2)
     (sizing.rems(l) * 3);
   position: relative;
-  width: sizing.rems(l) * 16;
+  width: sizing.rems(l) * 26;
 
   &::before {
     background-color: var(--black);


### PR DESCRIPTION
The Desktop cluster URL and auth card widths were too narrow.  This PR increases it.

After:
<img width="1537" alt="Screenshot 2023-06-01 at 14 23 39" src="https://github.com/hashicorp/boundary-ui/assets/8390120/44e80057-64fe-4ab2-831e-a998c1411c64">

Before:
<img width="1491" alt="Screenshot 2023-06-01 at 14 23 02" src="https://github.com/hashicorp/boundary-ui/assets/8390120/ee40d499-85bf-4f55-a8dc-bbf9a7e66a7c">
