### PR TITLE
chore: 🤖 Update worker binary name to just boundary

### DIFF
--- a/ui/admin/app/components/form/worker/create-worker-led/index.js
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.js
@@ -120,10 +120,10 @@ sudo apt-get update && sudo apt-get install boundary ;\\
 boundary server -config="${configPath}/pki-worker.hcl"`;
 
     const hcpContent = `sudo apt-get update && sudo apt-get install jq unzip ;\\
-wget -q "$(curl -fsSL "https://api.releases.hashicorp.com/v1/releases/boundary-worker/latest?license_class=hcp" \
+wget -q "$(curl -fsSL "https://api.releases.hashicorp.com/v1/releases/boundary/latest?license_class=enterprise" \
 | jq -r '.builds[] | select(.arch == "amd64" and .os == "linux") | .url')" ;\\
 unzip *.zip ;\\
-./boundary-worker server -config="${configPath}/pki-worker.hcl"`;
+./boundary server -config="${configPath}/pki-worker.hcl"`;
 
     return this.features.isEnabled('byow-pki-hcp-cluster-id')
       ? hcpContent

--- a/ui/admin/tests/acceptance/workers/create-test.js
+++ b/ui/admin/tests/acceptance/workers/create-test.js
@@ -77,7 +77,7 @@ module('Acceptance | workers | create', function (hooks) {
     assert
       .dom(createSection[1])
       .doesNotIncludeText(
-        'wget -q "$(curl -fsSL "https://api.releases.hashicorp.com/v1/releases/boundary-worker/latest?license_class=hcp"'
+        'wget -q "$(curl -fsSL "https://api.releases.hashicorp.com/v1/releases/boundary/latest?license_class=enterprise"'
       );
   });
 
@@ -90,7 +90,7 @@ module('Acceptance | workers | create', function (hooks) {
     assert
       .dom(createSection[1])
       .includesText(
-        'wget -q "$(curl -fsSL "https://api.releases.hashicorp.com/v1/releases/boundary-worker/latest?license_class=hcp"'
+        'wget -q "$(curl -fsSL "https://api.releases.hashicorp.com/v1/releases/boundary/latest?license_class=enterprise"'
       );
     assert
       .dom(createSection[1])


### PR DESCRIPTION
✅ Closes: ICU-9570

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9570)

## Description
The binary name we use to create a worker needs to be updated to `boundary` as `boundary-worker` won't be a thing anymore in 0.13.
I also updated where we pull the latest binary from in HCP, we'll be grabbing the enterprise binary now as HCP won't exist anymore.

See this [thread](https://hashicorp.slack.com/archives/C033EGCF0RL/p1685718648284049) for more details.

:technologist: [Admin preview](PATH_TO_FEATURE)


### Screenshots (if appropriate):
<img width="1499" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/5783847/b64c92b7-2144-4865-b2d2-49ae47ee3544">

