### PR TITLE
fix: 🐛 worker form navigation

### DIFF
--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -193,6 +193,6 @@
   <Hds::Button
     @color='secondary'
     @text={{if @model.isNew (t 'actions.cancel') (t 'actions.done')}}
-    {{on 'click' (fn @cancel @model)}}
+    {{on 'click' @cancel}}
   />
 </Rose::Form>

--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -191,11 +191,16 @@
     {{/unless}}
   </div>
 
-  <Rose::LinkButton
-    @route='scopes.scope.workers'
-    @style='secondary'
-    {{on 'click' @refresh}}
-  >
-    {{t 'actions.done'}}
-  </Rose::LinkButton>
+  {{#unless @model.isNew}}
+    {{#if this.generatedWorkerAuthToken}}
+      <Rose::LinkButton
+        @route='scopes.scope.workers'
+        @style='secondary'
+        {{on 'click' @refresh}}
+      >
+        {{t 'actions.done'}}
+      </Rose::LinkButton>
+    {{/if}}
+  {{/unless}}
+
 </Rose::Form>

--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -190,17 +190,9 @@
       </div>
     {{/unless}}
   </div>
-
-  {{#unless @model.isNew}}
-    {{#if this.generatedWorkerAuthToken}}
-      <Rose::LinkButton
-        @route='scopes.scope.workers'
-        @style='secondary'
-        {{on 'click' @refresh}}
-      >
-        {{t 'actions.done'}}
-      </Rose::LinkButton>
-    {{/if}}
-  {{/unless}}
-
+  <Hds::Button
+    @color='secondary'
+    @text={{if @model.isNew (t 'actions.cancel') (t 'actions.done')}}
+    {{on 'click' (fn @cancel @model)}}
+  />
 </Rose::Form>

--- a/ui/admin/app/routes/scopes/scope/workers.js
+++ b/ui/admin/app/routes/scopes/scope/workers.js
@@ -47,6 +47,13 @@ export default class ScopesScopeWorkersRoute extends Route {
     return super.refresh(...arguments);
   }
 
+  @action
+  cancel(worker) {
+    const { isNew } = worker;
+    if (isNew) worker.rollbackAttributes();
+    this.router.replaceWith('scopes.scope.workers');
+    this.refresh();
+  }
   /**
    * Save a worker in current scope.
    * @param {WorkerModel} worker

--- a/ui/admin/app/routes/scopes/scope/workers/worker/index.js
+++ b/ui/admin/app/routes/scopes/scope/workers/worker/index.js
@@ -4,5 +4,12 @@
  */
 
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
-export default class ScopesScopeWorkersWorkerIndexRoute extends Route {}
+export default class ScopesScopeWorkersWorkerIndexRoute extends Route {
+  @action
+  cancel(worker) {
+    worker.rollbackAttributes();
+    this.refresh();
+  }
+}

--- a/ui/admin/app/templates/scopes/scope/workers/new.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/new.hbs
@@ -22,7 +22,6 @@
       @model={{@model}}
       @cancel={{route-action 'cancel' @model}}
       @submit={{route-action 'createWorkerLed' @model}}
-      @refresh={{route-action 'refresh'}}
     />
   </page.body>
 

--- a/ui/admin/app/templates/scopes/scope/workers/new.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/new.hbs
@@ -20,6 +20,7 @@
   <page.body>
     <Form::Worker::CreateWorkerLed
       @model={{@model}}
+      @cancel={{route-action 'cancel' @model}}
       @submit={{route-action 'createWorkerLed' @model}}
       @refresh={{route-action 'refresh'}}
     />

--- a/ui/admin/tests/integration/components/form/worker/create-worker-led-test.js
+++ b/ui/admin/tests/integration/components/form/worker/create-worker-led-test.js
@@ -28,12 +28,12 @@ module(
       const guid = v1();
       this.model = {};
       this.submit = () => {};
-      this.refresh = () => {};
+      this.cancel = () => {};
 
       windowService.location.hostname = `${guid}.boundary.hcp.dev`;
 
       await render(
-        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @refresh={{this.refresh}} />`
+        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @cancel={{this.cancel}} />`
       );
 
       assert.dom('[name="cluster_id"]').hasValue(guid);
@@ -44,12 +44,12 @@ module(
       const guid = v1();
       this.model = {};
       this.submit = () => {};
-      this.refresh = () => {};
+      this.cancel = () => {};
 
       windowService.location.hostname = `${guid}.boundary.hcp.to`;
 
       await render(
-        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @refresh={{this.refresh}} />`
+        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @cancel={{this.cancel}} />`
       );
 
       assert.dom('[name="cluster_id"]').hasValue(guid);
@@ -60,12 +60,12 @@ module(
       const guid = v1();
       this.model = {};
       this.submit = () => {};
-      this.refresh = () => {};
+      this.cancel = () => {};
 
       windowService.location.hostname = `${guid}.boundary.hashicorp.cloud`;
 
       await render(
-        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @refresh={{this.refresh}} />`
+        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @cancel={{this.cancel}} />`
       );
 
       assert.dom('[name="cluster_id"]').hasValue(guid);
@@ -75,12 +75,12 @@ module(
       const windowService = this.owner.lookup('service:browser/window');
       this.model = {};
       this.submit = () => {};
-      this.refresh = () => {};
+      this.cancel = () => {};
 
       windowService.location.hostname = `personal.website.com`;
 
       await render(
-        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @refresh={{this.refresh}} />`
+        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @cancel={{this.cancel}} />`
       );
 
       assert.dom('[name="cluster_id"]').hasNoValue();


### PR DESCRIPTION
[Jira](https://hashicorp.atlassian.net/browse/ICU-9709)

Show `done` only when a worker is registered successfully, otherwise show cancel and navigate to workers list 

<img width="1069" alt="Screenshot 2023-06-09 at 6 44 31 PM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/c63d33ac-80ae-4a63-8e34-128b7a275b36">

<img width="1067" alt="Screenshot 2023-06-09 at 6 44 41 PM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/d0cb224f-b0c5-450a-9d5a-a97351f4dc30">

<img width="995" alt="Screenshot 2023-06-09 at 6 44 44 PM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/be8e2bd7-4f74-43e5-b2c2-7ad8f56f6187">


