### PR TITLE
Chore icu 9073 audit resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "immer": "^9.0.6",
     "node-notifier": "^8.0.1",
     "highlight.js": "^10.4.1",
     "hoek": "~4.2.0",
@@ -98,7 +97,8 @@
     "**/@storybook/**/minimatch": "^3.0.5",
     "**/ember-electron/**/minimatch": "^3.0.5",
     "**/babel-core/json5": "^2.2.2",
-    "**/react-syntax-highlighter/refractor/prismjs": "^1.27.0"
+    "**/react-syntax-highlighter/refractor/prismjs": "^1.27.0",
+    "**/@storybook/**/immer": "^9.0.6"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "elliptic": "~6.5.4",
     "yargs-parser": "~20.2.7",
     "merge": "^2.1.1",
     "xmlhttprequest-ssl": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "caniuse-lite": "^1.0.30001157",
     "immer": "^9.0.6",
     "node-notifier": "^8.0.1",
     "highlight.js": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "hoek": "~4.2.0",
     "elliptic": "~6.5.4",
     "yargs-parser": "~20.2.7",
     "merge": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "highlight.js": "^10.4.1",
     "hoek": "~4.2.0",
     "elliptic": "~6.5.4",
     "yargs-parser": "~20.2.7",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "node-notifier": "^8.0.1",
     "highlight.js": "^10.4.1",
     "hoek": "~4.2.0",
     "elliptic": "~6.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20080,16 +20080,16 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@^10.0.0, node-notifier@^8.0.1:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.2.tgz#f3167a38ef0d2c8a866a83e318c1ba0efeb702c5"
-  integrity sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg==
+node-notifier@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-10.0.1.tgz#0e82014a15a8456c4cfcdb25858750399ae5f1c7"
+  integrity sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==
   dependencies:
     growly "^1.3.0"
     is-wsl "^2.2.0"
-    semver "^7.3.2"
+    semver "^7.3.5"
     shellwords "^0.1.1"
-    uuid "^8.3.0"
+    uuid "^8.3.2"
     which "^2.0.2"
 
 node-releases@^2.0.8:
@@ -25478,7 +25478,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0, uuid@^8.3.2:
+uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -12262,7 +12262,7 @@ element-resize-detector@^1.2.2:
   dependencies:
     batch-processor "1.0.0"
 
-elliptic@^6.5.3, elliptic@~6.5.4:
+elliptic@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -16398,11 +16398,6 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoek@~4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
-  integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
-
 hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10383,7 +10383,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001157, caniuse-lite@^1.0.30001449:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001449:
   version "1.0.30001466"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001466.tgz#c1e6197c540392e09709ecaa9e3e403428c53375"
   integrity sha512-ewtFBSfWjEmxUgNBSZItFSmVtvk9zkwkl1OfRZlKA8slltRN+/C/tuGVrF9styXkN36Yu3+SeJ1qkXxDEyNZ5w==


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9073)

## Description

### highlight.js
- After running `yarn why highlight.js` is used by `react-syntax`(3rd party dep).
- After deleting `highlight.js` from resolutions shows no updates within `yarn.lock`, it is safe to delete.

### hoek
- After running `yarn why hoek` no matches were found, so it is not used.
- After deleting `hoek` from resolutions, `yarn.lock` shows no one is depending on it (no changes).

### elliptic
- After running `yarn why elliptic` is used by `webpack`.
- After deleting `elliptic` from resolutions, we still resolving `6.5.4` which has no security vulnerabilities, as per [synk info](https://security.snyk.io/package/npm/elliptic).

### How to test:
- Build all the UI's + add-ons successfully.


