### PR TITLE
Chore icu 9073 audit resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "elliptic": "~6.5.4",
     "yargs-parser": "~20.2.7",
     "merge": "^2.1.1",
     "xmlhttprequest-ssl": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "hoek": "~4.2.0",
     "elliptic": "~6.5.4",
     "yargs-parser": "~20.2.7",
     "merge": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "highlight.js": "^10.4.1",
     "hoek": "~4.2.0",
     "elliptic": "~6.5.4",
     "yargs-parser": "~20.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12262,7 +12262,7 @@ element-resize-detector@^1.2.2:
   dependencies:
     batch-processor "1.0.0"
 
-elliptic@^6.5.3, elliptic@~6.5.4:
+elliptic@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -16398,11 +16398,6 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoek@~4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
-  integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
-
 hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9073)

## Description:

Delete next dependencies from `resolutions`.

### highlight.js
- After running `yarn why highlight.js` is used by `react-syntax`(3rd party dep).
- After deleting `highlight.js` from resolutions shows no updates within `yarn.lock`, it is safe to delete.

### hoek
- After running `yarn why hoek` no matches were found, so it is not used.
- After deleting `hoek` from resolutions, `yarn.lock` shows no one is depending on it (no changes).

### elliptic
- After running `yarn why elliptic` is used by `webpack`.
- After deleting `elliptic` from resolutions, we still resolving `6.5.4` which has no security vulnerabilities, as per [synk info](https://security.snyk.io/package/npm/elliptic).

CI test run with all these changes, [link here](https://github.com/hashicorp/boundary-ui-releases/actions/runs/5260174776)
