### PR TITLE
Chore icu 9074 audit resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "highlight.js": "^10.4.1",
     "hoek": "~4.2.0",
     "elliptic": "~6.5.4",
-    "merge": "^2.1.1",
     "xmlhttprequest-ssl": "^1.6.2",
     "underscore": "^1.12.1",
     "hosted-git-info": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "highlight.js": "^10.4.1",
     "hoek": "~4.2.0",
     "elliptic": "~6.5.4",
-    "xmlhttprequest-ssl": "^1.6.2",
     "underscore": "^1.12.1",
     "hosted-git-info": "^3.0.8",
     "trim": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "highlight.js": "^10.4.1",
     "hoek": "~4.2.0",
     "elliptic": "~6.5.4",
-    "yargs-parser": "~20.2.7",
     "merge": "^2.1.1",
     "xmlhttprequest-ssl": "^1.6.2",
     "underscore": "^1.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26151,10 +26151,15 @@ yaml@^2.1.1:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
   integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
 
-yargs-parser@^20.0.0, yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^21.0.0, yargs-parser@~20.2.7:
+yargs-parser@^20.0.0, yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
+yargs-parser@^21.0.0:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^16.2.0:
   version "16.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -26096,11 +26096,6 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmlhttprequest-ssl@^1.6.2:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
-  integrity sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==
-
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9074)

## Description

Delete next dependencies from `resolutions`.

### yargs-parser
- After running `yarn why yargs-parser` is used by `rose` & `desktop`.
- After deleting `yargs-parser` from resolutions, we still resolving `20.2.9` which has no security vulnerabilities, as per [synk info](https://security.snyk.io/package/npm/yargs-parser/20.2.9). We also see the newolution of `21.1.1` which means we were blocking deps from using this newer version.

### merge
- After running `yarn why merge` is used by core addon, for a couple of 3rd party deps.
- After deletin `merge` from resolutions, we see no changes within `yarn.lock`. Also, stills resolving the `2.1.1` which has no security vulnerabilities, as per [synk info](https://security.snyk.io/package/npm/merge).

### xmlhttprequest-ssl
- After running `yarn why xmlhttprequest-ssl` no matches were found, so it is not used.
- After deleting `xmlhttprequest-ssl` from `yarn.lock` shows it is not used.

CI test run with all these changes, [link here](https://github.com/hashicorp/boundary-ui-releases/actions/runs/5260289559).
