### PR TITLE
Delete hosted-git-info from resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "**/react-syntax-highlighter/refractor/prismjs": "^1.27.0",
     "**/@storybook/**/immer": "^9.0.6",
     "**/nomnom/underscore": "^1.12.1",
-    "**/normalize-package-data/hosted-git-info": "^3.0.8",
     "**/remark-parse/trim": "^1.0.1",
     "**/react-dev-utils/browserslist": "^4.16.5",
     "**/@storybook/cli/puppeteer-core/ws": "^7.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16648,12 +16648,10 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
-hosted-git-info@^2.1.4, hosted-git-info@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.8.tgz#6e35d4cc87af2c5f816e4cb9ce350ba87a3f370d"
-  integrity sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==
-  dependencies:
-    lru-cache "^6.0.0"
+hosted-git-info@^2.1.4:
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 hosted-git-info@^4.0.1:
   version "4.1.0"


### PR DESCRIPTION
## Description

This solved a recently introduced issue where hosted-git-info resolves intermittent different versions, causing constant changes in `yarn.lock`.

Delete `hosted-git-info` from resolutions. After deletion we are resolving `2.8.9` which has NO security vulnerabilities as [per synk information](https://security.snyk.io/package/npm/hosted-git-info).
