### PR TITLE
Chore icu 9078 audit resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "normalize-url": "^4.5.1",
     "glob-parent": "^5.1.2",
     "tar": "^6.1.9",
     "path-parse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "glob-parent": "^5.1.2",
     "tar": "^6.1.9",
     "path-parse": "^1.0.7",
     "nth-check": "^2.0.1",
@@ -89,7 +88,11 @@
     "**/pretty-bytes/meow/trim-newlines": "^3.0.1",
     "**/ember-cli/**/clean-css-promise/clean-css": "^4.1.11",
     "**/bower-config/minimist": "^1.2.6",
-    "**/commitizen/minimist": "^1.2.6"
+    "**/commitizen/minimist": "^1.2.6",
+    "**/@storybook/builder-webpack4/@storybook/core-common/glob-base/glob-parent": "^5.1.2",
+    "**/@storybook/addon-docs/@storybook/core/@storybook/core-server/cpy/globby/fast-glob/glob-parent": "^5.1.2",
+    "**/ember-intl/broccoli-merge-files/fast-glob/glob-parent": "^5.1.2",
+    "**/watchpack/watchpack-chokidar2/chokidar/glob-parent": "^5.1.2"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "tar": "^6.1.9",
     "path-parse": "^1.0.7",
     "nth-check": "^2.0.1",
     "tmpl": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20417,10 +20417,10 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
-normalize-url@^4.5.1, normalize-url@^6.0.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
-  integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
+normalize-url@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
+  integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
 npm-conf@^1.1.3:
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24693,7 +24693,7 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tar@^6.0.2, tar@^6.0.5, tar@^6.1.0, tar@^6.1.2, tar@^6.1.9:
+tar@^6.0.2, tar@^6.0.5, tar@^6.1.0, tar@^6.1.2:
   version "6.1.15"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.15.tgz#c9738b0b98845a3b344d334b8fa3041aaba53a69"
   integrity sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -16001,12 +16001,19 @@ glob-base@^0.3.0:
     glob-parent "^2.0.0"
     is-glob "^2.0.0"
 
-glob-parent@^2.0.0, glob-parent@^3.1.0, glob-parent@^5.1.2, glob-parent@^6.0.1, glob-parent@~5.1.2:
+glob-parent@^2.0.0, glob-parent@^3.1.0, glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
+
+glob-parent@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
 
 glob-promise@^3.4.0:
   version "3.4.0"


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9078)

## Description

### normalize-url
- After running `yarn why normalize-url` one dep is using it.
- After deleting `normalize-url` from resolutions, we resolve now a much newer version `6.1.0` which as per [synk information](https://security.snyk.io/package/npm/normalize-url) has no security vulnerabilities.

### glob-parent

- After running `yarn why glob-parent` a lot of deps use it.
- After deleting `glob-parent` from resolutions, 2 deps still resolving `glob-parent@3.1.0` which has security vulnerabilities, as per [synk information](https://security.snyk.io/package/npm/glob-parent). We will add more specific resolutions.

### Tar
- After running `yarn why tar` a lot of deps use it.
- After deleting `tar` from resolutions, we do resolve newer version without security vulnerabilities, as per [synk information](https://security.snyk.io/package/npm/tar). It is safe to remove `tar` from resolutions.
