### PR TITLE
chore: 🤖 use trusted SHA for atlassian/gajira-comment

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -68,7 +68,7 @@ jobs:
 
     - name: Sync comment
       if: github.event.action == 'created' && steps.search.outputs.issue
-      uses: atlassian/gajira-comment@v2.0.2 # TSCCR: no entry for repository "atlassian/gajira-comment"
+      uses: atlassian/gajira-comment@76589d6b6d0b94b1ca6b01171c01a6affb5d6701 # v3.0.0
       with:
         issue: ${{ steps.search.outputs.issue }}
         comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"


### PR DESCRIPTION
✅ Closes: ICU-9815

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9815)

## Description
The `atlassian/gajira-comment` github action was onboarded onto TSCCR via PR.

Then the entry in `jira.yml` was updated using via the cli  using this command `tsccr-helper -pin-workflow=./.github/workflows/jira.yml`

Checkout ticket for more details.
