### PR TITLE
Chore icu 9079 audit resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "path-parse": "^1.0.7",
     "nth-check": "^2.0.1",
     "tmpl": "^1.0.5",
     "set-value": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "tmpl": "^1.0.5",
     "set-value": "^4.0.1",
     "ansi-regex": "^5.0.1",
     "ember-cli-babel": "^7.26.8",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "nth-check": "^2.0.1",
     "tmpl": "^1.0.5",
     "set-value": "^4.0.1",
     "ansi-regex": "^5.0.1",
@@ -90,7 +89,8 @@
     "**/@storybook/builder-webpack4/@storybook/core-common/glob-base/glob-parent": "^5.1.2",
     "**/@storybook/addon-docs/@storybook/core/@storybook/core-server/cpy/globby/fast-glob/glob-parent": "^5.1.2",
     "**/ember-intl/broccoli-merge-files/fast-glob/glob-parent": "^5.1.2",
-    "**/watchpack/watchpack-chokidar2/chokidar/glob-parent": "^5.1.2"
+    "**/watchpack/watchpack-chokidar2/chokidar/glob-parent": "^5.1.2",
+    "**/core/ember-inline-svg/**/nth-check": "^2.0.1"
   },
   "config": {
     "commitizen": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -25051,7 +25051,7 @@ tmp@^0.2.1:
   dependencies:
     rimraf "^3.0.0"
 
-tmpl@1.0.x, tmpl@^1.0.5:
+tmpl@1.0.x:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
   integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9079)

## Description

### path-parse
- After running `yarn why path-parse` different deps use it.
- After deleting `path-parse` from resolutions the `yarn.lock` shows no changes, and we still resolving `1.0.7` which  has no security vulnerabilities, as per [snyk information](https://security.snyk.io/package/npm/path-parse). It is safe to delete `path-parse` from resolutions.

### nth-check
- After running `yarn why nth-check` different deps use it.
- After deleting `nth-check` from resolutions, a dep starts resolving `nth-check@1.0.2` which has security vulnerabilities, as per [snyk information](https://security.snyk.io/package/npm/nth-check). We will add an specific resolution.

### tmpl
- After running `yarn why tmpl` is used by one dep.
- After deleting `tmpl` from resolutions the `yarn.lock` shows we still resolving `1.0.5` which has no security vulnerabilities, as per [snyk information](https://security.snyk.io/package/npm/tmpl). It is safe to delete `tmpl` from resolutions.
