### PR TITLE
chore: 🤖 Add patch-package to fix ember-intl for windows builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "test:ui-desktop": "yarn --cwd ui/desktop test",
     "compliance:licenses": "license-checker --onlyAllow 'Apache*;Apache License, Version 2.0;Apache-2.0;Apache 2.0;Artistic-2.0;BSD;BSD-3-Clause;CC-BY-3.0;CC-BY-4.0;CC0-1.0;ISC;MIT;MPL-2.0;Public Domain;Python-2.0;Unicode-TOU;Unlicense;WTFPL' --excludePackages 'boundary-ui;admin@0.0.0;desktop@0.0.0;base64-js@0.0.2;cycle@1.0.3;cldr-core@41.0.0;make-plural@7.2.0;@hashicorp/ember-asciinema-player@0.0.0'",
     "doc:toc": "doctoc README.md",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "postinstall": "patch-package"
   },
   "devDependencies": {
     "cz-conventional-changelog": "^3.1.0",
@@ -46,7 +47,9 @@
     "git-cz": "^4.8.0",
     "husky": "^8.0.0",
     "license-checker": "^25.0.1",
-    "lint-staged": "^13.0.2"
+    "lint-staged": "^13.0.2",
+    "patch-package": "^7.0.0",
+    "postinstall-postinstall": "^2.1.0"
   },
   "resolutions": {
     "request": "^2.88.0",

--- a/patches/ember-intl+6.0.0-beta.4.patch
+++ b/patches/ember-intl+6.0.0-beta.4.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/ember-intl/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js b/node_modules/ember-intl/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+index 3782ed5..37506d4 100644
+--- a/node_modules/ember-intl/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
++++ b/node_modules/ember-intl/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+@@ -16,12 +16,16 @@ const enums = require('../../enums');
+  * @private
+  */
+ function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
+-  let dirname = path.dirname(filepath).replace(inputPath, '');
++  const normalizedFilePath = path.normalize(filepath);
++  const normalizedInputPath = path.normalize(inputPath);
++  const normalizedAddonNames = addonNames.map(path.normalize);
++
++  let dirname = path.dirname(normalizedFilePath).replace(normalizedInputPath, '');
+ 
+   if (dirname) {
+     let prefix = path.sep;
+ 
+-    for (let addon of addonNames) {
++    for (let addon of normalizedAddonNames) {
+       let addonPrefix = `${path.sep}${enums.addonNamespace}${path.sep}${addon}`;
+ 
+       if (dirname.startsWith(addonPrefix)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10803,6 +10803,11 @@ ci-info@^3.3.2:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.2.tgz#6d2967ffa407466481c6c90b6e16b3098f080128"
   integrity sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==
 
+ci-info@^3.7.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
+  integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -18609,6 +18614,13 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -20751,7 +20763,7 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
-open@^7.0.2, open@^7.0.3:
+open@^7.0.2, open@^7.0.3, open@^7.4.2:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
   integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
@@ -21169,6 +21181,26 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+patch-package@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-7.0.0.tgz#5c646b6b4b4bf37e5184a6950777b21dea6bb66e"
+  integrity sha512-eYunHbnnB2ghjTNc5iL1Uo7TsGMuXk0vibX3RFcE/CdVdXzmdbMsG/4K4IgoSuIkLTI5oHrMQk4+NkFqSed0BQ==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^4.1.2"
+    ci-info "^3.7.0"
+    cross-spawn "^7.0.3"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^9.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.6"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    yaml "^2.2.2"
 
 path-browserify@0.0.1:
   version "0.0.1"
@@ -21625,6 +21657,11 @@ postcss@^8.4.17, postcss@^8.4.18:
     nanoid "^3.3.4"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+postinstall-postinstall@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
+  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -26507,6 +26544,11 @@ yaml@^2.1.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
   integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
+
+yaml@^2.2.2:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.1.tgz#02fe0975d23cd441242aa7204e09fc28ac2ac33b"
+  integrity sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==
 
 yargs-parser@^20.0.0, yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.9"


### PR DESCRIPTION
✅ Closes: ICU-9914

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9914)

## Description
Added `patch-package` to manually patch the `ember-intl` [issue](https://github.com/ember-intl/ember-intl/issues/1451) that causes our windows builds to not properly produce a binary with correct translations. This also resolves https://github.com/hashicorp/boundary-ui/issues/1708. 

Tested a windows build and translations works as expected. 

### Screenshots (if appropriate):
![image](https://github.com/hashicorp/boundary-ui/assets/5783847/941427f6-8714-487b-b81b-61b2776a75c1)
