### PR TITLE
fix: 🐛 Add header for dynamic host catalog hosts page

### DIFF
--- a/ui/admin/app/components/host-catalogs/host-catalog/host-sets/host-set/hosts/host/header/index.hbs
+++ b/ui/admin/app/components/host-catalogs/host-catalog/host-sets/host-set/hosts/host/header/index.hbs
@@ -1,0 +1,17 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<h2>
+  {{t 'resources.host.title'}}
+  <DocLink @doc='host' @iconSize='large' />
+</h2>
+<p>{{t 'resources.host.description'}}</p>
+<Copyable
+  @text={{@model.id}}
+  @buttonText={{t 'actions.copy-to-clipboard'}}
+  @acknowledgeText={{t 'states.copied'}}
+>
+  <code>{{@model.id}}</code>
+</Copyable>

--- a/ui/admin/app/components/host-catalogs/host-catalog/host-sets/host-set/hosts/host/navigation/index.hbs
+++ b/ui/admin/app/components/host-catalogs/host-catalog/host-sets/host-set/hosts/host/navigation/index.hbs
@@ -1,0 +1,12 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+
+<Rose::Nav::Tabs as |nav|>
+  <nav.link
+    @route='scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts.host.index'
+  >
+    {{t 'titles.details'}}
+  </nav.link>
+</Rose::Nav::Tabs>

--- a/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host/index.hbs
@@ -3,12 +3,22 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-<Form::Host @model={{@model}} />
+<Rose::Layout::Page as |page|>
+  <page.breadcrumbs>
+    <BreadCrumbs />
+  </page.breadcrumbs>
 
-{{!--
-<Form::Host
-  @model={{@model}}
-  @submit={{route-action 'save' @model}}
-  @cancel={{route-action 'cancel' @model}}
-/>
---}}
+  <page.header>
+    <HostCatalogs::HostCatalog::HostSets::HostSet::Hosts::Host::Header
+      @model={{@model}}
+    />
+  </page.header>
+
+  <page.navigation>
+    <HostCatalogs::HostCatalog::HostSets::HostSet::Hosts::Host::Navigation />
+  </page.navigation>
+
+  <page.body>
+    <Form::Host @model={{@model}} />
+  </page.body>
+</Rose::Layout::Page>


### PR DESCRIPTION
✅ Closes: ICU-9629

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER)

## Description
Added a header for the hosts page in dynamic host catalogs.

:technologist: [Admin preview](https://boundary-ui-git-icu-9629-fe-dhc-host-set-missi-0cc208-hashicorp.vercel.app/scopes/s_1sheljmjgm/host-catalogs/hc_tf6wuazt5y/host-sets/hs_siob9t77b1/hosts/h_n0k6xy7x84)

### Screenshots (if appropriate):


<img width="1535" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/5783847/b0005eff-5dbb-48b4-b30c-8a219f417871">

<img width="1551" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/5783847/ee951b84-dacf-4e13-9072-05709fac96b9">
