### PR TITLE
refactor: 💡 add support for named block content in form actions

### DIFF
--- a/addons/core/addon/components/form/authenticate/details/index.hbs
+++ b/addons/core/addon/components/form/authenticate/details/index.hbs
@@ -34,11 +34,11 @@
   </Hds::Form::TextInput::Field>
 
   <form.actions>
-    <:actions as |A|>
+    <:actions>
       <Hds::Button
         @text={{t 'actions.authenticate'}}
         @isFullWidth={{true}}
-        disabled={{A.submitDisabled}}
+        disabled={{form.disabled}}
         type='submit'
       />
     </:actions>

--- a/addons/core/addon/components/form/authenticate/details/index.hbs
+++ b/addons/core/addon/components/form/authenticate/details/index.hbs
@@ -33,9 +33,14 @@
     <F.Label>{{t 'form.password.label'}}</F.Label>
   </Hds::Form::TextInput::Field>
 
-  <form.actions
-    @submitText={{t 'actions.authenticate'}}
-    @showCancel={{false}}
-  />
-
+  <form.actions>
+    <:actions as |A|>
+      <Hds::Button
+        @text={{t 'actions.authenticate'}}
+        @isFullWidth={{true}}
+        disabled={{A.submitDisabled}}
+        type='submit'
+      />
+    </:actions>
+  </form.actions>
 </Rose::Form>

--- a/addons/core/addon/components/form/authenticate/oidc/index.hbs
+++ b/addons/core/addon/components/form/authenticate/oidc/index.hbs
@@ -10,11 +10,11 @@
   as |form|
 >
   <form.actions>
-    <:actions as |A|>
+    <:actions>
       <Hds::Button
         @text={{t 'actions.authenticate'}}
         @isFullWidth={{true}}
-        disabled={{A.submitDisabled}}
+        disabled={{form.disabled}}
         type='submit'
       />
     </:actions>

--- a/addons/core/addon/components/form/authenticate/oidc/index.hbs
+++ b/addons/core/addon/components/form/authenticate/oidc/index.hbs
@@ -9,10 +9,14 @@
   @disabled={{@disabled}}
   as |form|
 >
-
-  <form.actions
-    @submitText={{t 'actions.authenticate'}}
-    @showCancel={{false}}
-  />
-
+  <form.actions>
+    <:actions as |A|>
+      <Hds::Button
+        @text={{t 'actions.authenticate'}}
+        @isFullWidth={{true}}
+        disabled={{A.submitDisabled}}
+        type='submit'
+      />
+    </:actions>
+  </form.actions>
 </Rose::Form>

--- a/addons/rose/addon/components/rose/form/actions/edit-toggle/index.hbs
+++ b/addons/rose/addon/components/rose/form/actions/edit-toggle/index.hbs
@@ -5,7 +5,7 @@
 
 <Hds::ButtonSet class='rose-form-actions' ...attributes>
   {{#if (has-block 'edit')}}
-    {{yield (hash enableEdit=@enableEdit) to='edit'}}
+    {{yield to='edit'}}
   {{else}}
     <Hds::Button
       @text={{@enableEditText}}

--- a/addons/rose/addon/components/rose/form/actions/edit-toggle/index.hbs
+++ b/addons/rose/addon/components/rose/form/actions/edit-toggle/index.hbs
@@ -4,9 +4,13 @@
 }}
 
 <Hds::ButtonSet class='rose-form-actions' ...attributes>
-  <Hds::Button
-    @text={{@enableEditText}}
-    @color='secondary'
-    {{on 'click' @enableEdit}}
-  />
+  {{#if (has-block 'edit')}}
+    {{yield (hash enableEdit=@enableEdit) to='edit'}}
+  {{else}}
+    <Hds::Button
+      @text={{@enableEditText}}
+      @color='secondary'
+      {{on 'click' @enableEdit}}
+    />
+  {{/if}}
 </Hds::ButtonSet>

--- a/addons/rose/addon/components/rose/form/actions/index.hbs
+++ b/addons/rose/addon/components/rose/form/actions/index.hbs
@@ -4,17 +4,28 @@
 }}
 
 <Hds::ButtonSet class='rose-form-actions' ...attributes>
-  <Hds::Button
-    @text={{@submitText}}
-    disabled={{@submitDisabled}}
-    type='submit'
-  />
-  {{#if this.showCancel}}
+  {{#if (has-block 'actions')}}
+    {{yield
+      (hash
+        submitDisabled=@submitDisabled
+        cancelDisabled=@cancelDisabled
+        cancel=@cancel
+      )
+      to='actions'
+    }}
+  {{else}}
     <Hds::Button
-      @text={{@cancelText}}
-      @color='secondary'
-      disabled={{@cancelDisabled}}
-      {{on 'click' @cancel}}
+      @text={{@submitText}}
+      disabled={{@submitDisabled}}
+      type='submit'
     />
+    {{#if this.showCancel}}
+      <Hds::Button
+        @text={{@cancelText}}
+        @color='secondary'
+        disabled={{@cancelDisabled}}
+        {{on 'click' @cancel}}
+      />
+    {{/if}}
   {{/if}}
 </Hds::ButtonSet>

--- a/addons/rose/addon/components/rose/form/actions/index.hbs
+++ b/addons/rose/addon/components/rose/form/actions/index.hbs
@@ -5,14 +5,7 @@
 
 <Hds::ButtonSet class='rose-form-actions' ...attributes>
   {{#if (has-block 'actions')}}
-    {{yield
-      (hash
-        submitDisabled=@submitDisabled
-        cancelDisabled=@cancelDisabled
-        cancel=@cancel
-      )
-      to='actions'
-    }}
+    {{yield to='actions'}}
   {{else}}
     <Hds::Button
       @text={{@submitText}}

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -168,14 +168,6 @@
   }
 }
 
-.rose-frame {
-  .rose-form-actions {
-    .hds-button {
-      width: 100%;
-    }
-  }
-}
-
 .rose-dialog-cover {
   svg {
     max-width: 20rem;

--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -286,12 +286,6 @@
   .branded-card-description {
     margin-bottom: sizing.rems(l);
   }
-
-  .rose-form-actions {
-    .hds-button {
-      width: 100%;
-    }
-  }
 }
 
 @media (max-width: media.width(medium)) {

--- a/ui/desktop/app/templates/cluster-url.hbs
+++ b/ui/desktop/app/templates/cluster-url.hbs
@@ -25,11 +25,11 @@
       />
 
       <form.actions>
-        <:actions as |A|>
+        <:actions>
           <Hds::Button
             @text={{t 'actions.submit'}}
             @isFullWidth={{true}}
-            disabled={{A.submitDisabled}}
+            disabled={{form.disabled}}
             type='submit'
           />
         </:actions>

--- a/ui/desktop/app/templates/cluster-url.hbs
+++ b/ui/desktop/app/templates/cluster-url.hbs
@@ -23,7 +23,17 @@
         @helperText={{t 'form.cluster-url.description'}}
         {{autofocus}}
       />
-      <form.actions @submitText={{t 'actions.submit'}} @showCancel={{false}} />
+
+      <form.actions>
+        <:actions as |A|>
+          <Hds::Button
+            @text={{t 'actions.submit'}}
+            @isFullWidth={{true}}
+            disabled={{A.submitDisabled}}
+            type='submit'
+          />
+        </:actions>
+      </form.actions>
     </Rose::Form>
   </BrandedCard>
 </main>


### PR DESCRIPTION
✅ Closes: ICU-9507

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9507)

## Description
Add support for named block content in rose form actions.
Checkout ticket for details.

:technologist: [Admin preview](https://boundary-ui-git-icu-9507-add-support-for-block-cef1e7-hashicorp.vercel.app/scopes/global/authenticate/am_3enprm7y2t)

:desktop_computer: [Desktop preview](https://boundary-ui-desktop-git-icu-9507-add-support-f-74fad1-hashicorp.vercel.app/cluster-url)
