### PR TITLE
Chore icu 9080 audit resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "ember-cli-babel": "^7.26.8",
     "jsonpointer": "5.0.0",
     "json-schema": "^0.4.0",
     "follow-redirects": "^1.14.8",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "ansi-regex": "^5.0.1",
     "ember-cli-babel": "^7.26.8",
     "jsonpointer": "5.0.0",
     "json-schema": "^0.4.0",
@@ -92,7 +91,8 @@
     "**/ember-intl/broccoli-merge-files/fast-glob/glob-parent": "^5.1.2",
     "**/watchpack/watchpack-chokidar2/chokidar/glob-parent": "^5.1.2",
     "**/core/ember-inline-svg/**/nth-check": "^2.0.1",
-    "**/snapdragon/base/cache-base/**/set-value": "^4.0.1"
+    "**/snapdragon/base/cache-base/**/set-value": "^4.0.1",
+    "**/@storybook/**/ansi-regex": "^5.0.1"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "set-value": "^4.0.1",
     "ansi-regex": "^5.0.1",
     "ember-cli-babel": "^7.26.8",
     "jsonpointer": "5.0.0",
@@ -92,7 +91,8 @@
     "**/@storybook/addon-docs/@storybook/core/@storybook/core-server/cpy/globby/fast-glob/glob-parent": "^5.1.2",
     "**/ember-intl/broccoli-merge-files/fast-glob/glob-parent": "^5.1.2",
     "**/watchpack/watchpack-chokidar2/chokidar/glob-parent": "^5.1.2",
-    "**/core/ember-inline-svg/**/nth-check": "^2.0.1"
+    "**/core/ember-inline-svg/**/nth-check": "^2.0.1",
+    "**/snapdragon/base/cache-base/**/set-value": "^4.0.1"
   },
   "config": {
     "commitizen": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8407,10 +8407,25 @@ ansi-html@0.0.7, ansi-html@^0.0.7, ansi-html@^0.0.8:
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.8.tgz#e969db193b12bcdfa6727b29ffd8882dc13cc501"
   integrity sha512-QROYz1I1Kj+8bTYgx0IlMBpRSCIU+7GjbE0oH+KF7QKc+qSF8YAlIutN59Db17tXN70Ono9upT9Ht0iG93W7ug==
 
-ansi-regex@^2.0.0, ansi-regex@^3.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1, ansi-regex@^6.0.1:
+ansi-regex@^2.0.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
+  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
+
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
+ansi-regex@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 ansi-styles@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9080)

## Description

### set-value:
- After running `yarn why set-value` some deps use it.
- After deleting `set-value` from resolutions, all deps start resolving older version `2.0.1` which has security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/set-value). We add an specific resolution to fix this and avoid collisions in the future.

### ansi-regex
- After running `yarn why ansi-regex` lots of deps use it.
- After deleting `ansi-regex` from resolutions, we start resolving older version than `5.0.1` but almost of them has no security vulnerabilitiesas per [snyk information](https://security.snyk.io/package/npm/ansi-regex). We will add an specific resolution to avoid resolve any version with security vulnerabilities.

### ember-cli-babel
- After running `yarn why ember-cli-babel` lots of deps use it.
- After deleting `ember-cli-babel` from resolutions we resolve `ember-cli-babel@7.26.11` which has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/ember-cli-babel).
