### PR TITLE
Chore icu 9081 audit resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "ember-cli-babel": "^7.26.8",
     "jsonpointer": "5.0.0",
     "json-schema": "^0.4.0",
     "follow-redirects": "^1.14.8",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "ansi-regex": "^5.0.1",
     "ember-cli-babel": "^7.26.8",
     "jsonpointer": "5.0.0",
     "json-schema": "^0.4.0",
@@ -92,7 +91,8 @@
     "**/ember-intl/broccoli-merge-files/fast-glob/glob-parent": "^5.1.2",
     "**/watchpack/watchpack-chokidar2/chokidar/glob-parent": "^5.1.2",
     "**/core/ember-inline-svg/**/nth-check": "^2.0.1",
-    "**/snapdragon/base/cache-base/**/set-value": "^4.0.1"
+    "**/snapdragon/base/cache-base/**/set-value": "^4.0.1",
+    "**/@storybook/**/ansi-regex": "^5.0.1"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "jsonpointer": "5.0.0",
     "json-schema": "^0.4.0",
     "follow-redirects": "^1.14.8",
     "node-fetch": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "set-value": "^4.0.1",
     "ansi-regex": "^5.0.1",
     "ember-cli-babel": "^7.26.8",
     "jsonpointer": "5.0.0",
@@ -92,7 +91,8 @@
     "**/@storybook/addon-docs/@storybook/core/@storybook/core-server/cpy/globby/fast-glob/glob-parent": "^5.1.2",
     "**/ember-intl/broccoli-merge-files/fast-glob/glob-parent": "^5.1.2",
     "**/watchpack/watchpack-chokidar2/chokidar/glob-parent": "^5.1.2",
-    "**/core/ember-inline-svg/**/nth-check": "^2.0.1"
+    "**/core/ember-inline-svg/**/nth-check": "^2.0.1",
+    "**/snapdragon/base/cache-base/**/set-value": "^4.0.1"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "follow-redirects": "^1.14.8",
     "node-fetch": "^2.6.7",
     "shelljs": "^0.8.5",
     "ember-template-recast": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "json-schema": "^0.4.0",
     "follow-redirects": "^1.14.8",
     "node-fetch": "^2.6.7",
     "shelljs": "^0.8.5",
@@ -90,7 +89,8 @@
     "**/watchpack/watchpack-chokidar2/chokidar/glob-parent": "^5.1.2",
     "**/core/ember-inline-svg/**/nth-check": "^2.0.1",
     "**/snapdragon/base/cache-base/**/set-value": "^4.0.1",
-    "**/@storybook/**/ansi-regex": "^5.0.1"
+    "**/@storybook/**/ansi-regex": "^5.0.1",
+    "**/jsprim/json-schema": "^0.4.0"
   },
   "config": {
     "commitizen": {

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -48,7 +48,6 @@
     "tar": "^6.1.9",
     "ansi-regex": "^5.0.1",
     "nth-check": "^2.0.1",
-    "json-schema": "^0.4.0",
     "jsonpointer": "^5.0.0",
     "node-fetch": "^2.6.7",
     "plist": "^3.0.5",

--- a/ui/desktop/electron-app/yarn.lock
+++ b/ui/desktop/electron-app/yarn.lock
@@ -1988,11 +1988,6 @@ json-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
-json-schema@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
-  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
-
 json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18573,11 +18573,6 @@ jsonlint@^1.6.3:
     JSV "^4.0.x"
     nomnom "^1.5.x"
 
-jsonpointer@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.0.tgz#f802669a524ec4805fa7389eadbc9921d5dc8072"
-  integrity sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==
-
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8407,10 +8407,25 @@ ansi-html@0.0.7, ansi-html@^0.0.7, ansi-html@^0.0.8:
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.8.tgz#e969db193b12bcdfa6727b29ffd8882dc13cc501"
   integrity sha512-QROYz1I1Kj+8bTYgx0IlMBpRSCIU+7GjbE0oH+KF7QKc+qSF8YAlIutN59Db17tXN70Ono9upT9Ht0iG93W7ug==
 
-ansi-regex@^2.0.0, ansi-regex@^3.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1, ansi-regex@^6.0.1:
+ansi-regex@^2.0.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
+  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
+
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
+ansi-regex@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 ansi-styles@^2.2.1:
   version "2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15538,7 +15538,7 @@ focus-trap@^6.7.1:
   dependencies:
     tabbable "^5.3.3"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.8:
+follow-redirects@^1.0.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9081)

## Description

### jsonpointer
- After running `yarn why jsonpointer` no dependencies use it.
- After deleting `jsonpointer` from resolutions, yarn.lock does not resolve it anymore, so it is safe to delete from resolutions.

### json-schema
- After running `yarn why json-schema` ui/desktop uses it.
- After deleting `json-schema` from resolutions, we resolve an older version with security vulnerabilities, as per [snyk information](https://security.snyk.io/package/npm/json-schema). We will clean up `json-schema` resolution for `electron-app/package.json` project, and modify to a more specific resolutions within root `package.json`.

### follow-redirects
- After running `yarn why follow-redirects` one dep uses it.
- After deleting `follow-redirects` from resolutions, we keep resolving `1.15.2` which has no security vulnerabilities as per [synk information](https://security.snyk.io/package/npm/follow-redirects).
