### PR TITLE
Chore icu 9082 audit resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "node-fetch": "^2.6.7",
     "shelljs": "^0.8.5",
     "ember-template-recast": "^6.0.0",
     "markdown-it": "^12.3.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "shelljs": "^0.8.5",
     "ember-template-recast": "^6.0.0",
     "markdown-it": "^12.3.2",
     "mout": "^1.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20305,7 +20305,7 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
   integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9082)

## Description

### node-fetch:
- After running `yarn why node-fetch` different deps use it.
- After deleting `node-fetch` from resolutions, we resolve `node-fetch@2.6.11` which has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/node-fetch).

### shelljs:
- After running `yarn why shelljs` one dep uses it.
- After deleting `shelljs` from resolutions, we keep resolving `shelljs@0.8.5` which has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/shelljs).

### ember-template-recast (not modified):
- After running `yarn why ember-template-recast` onde dep uses it.
- After deleting `ember-template-recast` from resolutions, we are reproducing a weir third party dependencies side effects. Even tho we have specific resolutions for `ansi-regex`, we start resolving older version of it with security vulnerabilities. We didn't dig a lot, but we suspect the side effects could be cause by the `ansi-regex` resolution we have specified within `ui/desktop/electron-app/package.json`. We already have a [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9088) that accounts for that work.
We will leave `ember-template-recast` within resolutions until the mentioned Jira ticket is complete.
