### PR TITLE
feat: 🎸 add ldap type to dropdown in list view

### DIFF
--- a/ui/admin/app/templates/scopes/scope/auth-methods/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/auth-methods/index.hbs
@@ -18,24 +18,26 @@
 
   <page.actions>
     {{#if (can 'create model' this.scopeModel collection='auth-methods')}}
-      <Rose::Dropdown
-        @text={{t 'titles.new'}}
-        @dropdownRight={{true}}
-        as |dropdown|
-      >
-        <dropdown.link
+      <Hds::Dropdown as |dd|>
+        <dd.ToggleButton @text={{t 'titles.new'}} @color='secondary' />
+        <dd.Interactive
+          @text={{t 'resources.auth-method.types.password'}}
           @route='scopes.scope.auth-methods.new'
           @query={{hash type='password'}}
-        >
-          {{t 'resources.auth-method.types.password'}}
-        </dropdown.link>
-        <dropdown.link
+        />
+        <dd.Interactive
+          @text={{t 'resources.auth-method.types.oidc'}}
           @route='scopes.scope.auth-methods.new'
           @query={{hash type='oidc'}}
-        >
-          {{t 'resources.auth-method.types.oidc'}}
-        </dropdown.link>
-      </Rose::Dropdown>
+        />
+        {{#if (feature-flag 'ldap-auth-methods')}}
+          <dd.Interactive
+            @text={{t 'resources.auth-method.types.ldap'}}
+            @route='scopes.scope.auth-methods.new'
+            @query={{hash type='ldap'}}
+          />
+        {{/if}}
+      </Hds::Dropdown>
     {{/if}}
   </page.actions>
 


### PR DESCRIPTION
✅ Closes: ICU-10071

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10071)

## Description
Adds ldap option to New dropdown in list view. 
Note: Clicking the ldap option won't work until the form is added.
<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](https://boundary-ui-git-icu-10071-ldap-auth-methods-list-view-hashicorp.vercel.app/scopes/global/auth-methods)


<!-- Add a brief description of changes here. Include any other necessary relevant links -->

### Screenshots (if appropriate):
when feature flag is enabled:
<img width="290" alt="Screenshot 2023-07-11 at 10 02 37 AM" src="https://github.com/hashicorp/boundary-ui/assets/107949262/bfda9d67-0e93-4c7e-838a-8245952c7af2">
when feature flag is disabled:
<img width="255" alt="Screenshot 2023-07-11 at 10 03 28 AM" src="https://github.com/hashicorp/boundary-ui/assets/107949262/6e4ad444-ed65-4572-9716-6aa910726d84">
