### PR TITLE
Chore icu 9087 audit resolutions electron app

### DIFF
--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -42,7 +42,6 @@
   },
   "resolutions": {
     "highlight.js": "^10.4.1",
-    "normalize-url": "^4.5.1",
     "jszip": "^3.7.0",
     "path-parse": "^1.0.7",
     "jsonpointer": "^5.0.0",

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -42,7 +42,6 @@
   },
   "resolutions": {
     "highlight.js": "^10.4.1",
-    "jszip": "^3.7.0",
     "path-parse": "^1.0.7",
     "jsonpointer": "^5.0.0",
     "node-fetch": "^2.6.7",

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -42,7 +42,6 @@
   },
   "resolutions": {
     "highlight.js": "^10.4.1",
-    "path-parse": "^1.0.7",
     "jsonpointer": "^5.0.0",
     "node-fetch": "^2.6.7",
     "plist": "^3.0.5",

--- a/ui/desktop/electron-app/yarn.lock
+++ b/ui/desktop/electron-app/yarn.lock
@@ -2460,10 +2460,10 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-url@^4.5.1, normalize-url@^6.0.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
-  integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
+normalize-url@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
+  integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
 npm-conf@^1.1.3:
   version "1.1.3"
@@ -3269,7 +3269,7 @@ tar-stream@^1.5.2:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
-tar@^6.0.5, tar@^6.1.11, tar@^6.1.2, tar@^6.1.9:
+tar@^6.0.5, tar@^6.1.11, tar@^6.1.2:
   version "6.1.11"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
   integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9087)

## Description

### normalize-url
- After running `yarn why normalize-url` a dep uses it.
- After deleting `normalize-url` from resolutions, we resolve `normalize-url@6.1.0` wich is newer than before and has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/normalize-url).

### jszip
- After running `yarn why jszip` a dep uses it.
- After deleting `jszip` from resolutions there are no changes within `yarn.lock` and we keep resolving `jszip@3.10.1` which has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/jszip).

### path-parse
- After running `yarn why path-parse` a couple of deps use it.
- After deleting `path-parse` from resolutions there are no changes within `yarn.lock` and we keep resolving `path-parse@1.0.7` which has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/path-parse).
