### PR TITLE
refactor: 💡 migrate two rose buttons to hds in desktop client

### DIFF
--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
@@ -178,12 +178,11 @@
               </row.cell>
               <row.cell>
                 {{#if model.isCancelable}}
-                  <Rose::Button
-                    @style='secondary'
+                  <Hds::Button
+                    @text={{t 'actions.cancel'}}
+                    @color='secondary'
                     {{on 'click' (route-action 'cancelSession' model)}}
-                  >
-                    {{t 'actions.cancel'}}
-                  </Rose::Button>
+                  />
                 {{/if}}
               </row.cell>
             </body.row>

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
@@ -155,12 +155,11 @@
               </row.cell>
               <row.cell>
                 {{#if (can 'connect target' model)}}
-                  <Rose::Button
-                    @style='secondary'
+                  <Hds::Button
+                    @text={{t 'resources.session.actions.connect'}}
+                    @color='secondary'
                     {{on 'click' (route-action 'connect' model)}}
-                  >
-                    {{t 'resources.session.actions.connect'}}
-                  </Rose::Button>
+                  />
                 {{/if}}
               </row.cell>
             </body.row>


### PR DESCRIPTION

✅ Closes: ICU-10149

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10149)

## Description

Updates to the Targets list "Connect" button and the Sessions list "Cancel" button to use `<Hds::Button />` instead of `<Rose::Button />`

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:desktop_computer: [Desktop preview](https://boundary-ui-desktop-git-icu-10149-adoption-hds-0f45a7-hashicorp.vercel.app/scopes/global/projects/targets)

<!-- Add a brief description of changes here. Include any other necessary relevant links -->

### Screenshots (if appropriate):
Before:
<img width="1000" alt="Screen Shot 2023-07-14 at 12 11 27 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/d3745152-6598-4daf-b7d7-e7927dcc3bfc">
<img width="1000" alt="Screen Shot 2023-07-14 at 12 11 31 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/e7adf8bd-795b-49b4-8665-caf02ad9078c">
After:
<img width="1000" alt="Screen Shot 2023-07-14 at 12 10 51 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/c6596259-3555-4f4d-810d-3c9bb7e1d337">
<img width="1000" alt="Screen Shot 2023-07-14 at 12 11 00 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/23fdd9fe-a4eb-431e-8710-dd4ec7eabe53">
