### PR TITLE
refactor: 💡 update to allow state change & update edit action

### DIFF
--- a/addons/api/addon/models/auth-method.js
+++ b/addons/api/addon/models/auth-method.js
@@ -20,6 +20,7 @@ export const TYPES_AUTH_METHOD = Object.freeze([
  * Enum options per auth method type and field.
  */
 export const options = {
+  state: ['inactive', 'active-private', 'active-public'],
   oidc: {
     signing_algorithms: [
       'RS256',
@@ -33,7 +34,6 @@ export const options = {
       'PS512',
       'EdDSA',
     ],
-    state: ['inactive', 'active-private', 'active-public'],
     account_claim_maps: {
       to: ['sub', 'name', 'email'],
     },
@@ -42,7 +42,6 @@ export const options = {
     account_attribute_maps: {
       to: ['fullName', 'email'],
     },
-    state: ['inactive', 'active-private', 'active-public'],
   },
 };
 
@@ -118,9 +117,11 @@ export default class AuthMethodModel extends GeneratedAuthMethodModel {
    */
   changeState(state, options = { adapterOptions: {} }) {
     const defaultAdapterOptions = {
-      method: 'change-state',
       state,
     };
+    if (this.isOIDC) {
+      defaultAdapterOptions.method = 'change-state';
+    }
     return this.save({
       ...options,
       adapterOptions: {

--- a/addons/api/addon/serializers/auth-method.js
+++ b/addons/api/addon/serializers/auth-method.js
@@ -4,11 +4,7 @@
  */
 
 import ApplicationSerializer from './application';
-import {
-  TYPE_AUTH_METHOD_PASSWORD,
-  TYPE_AUTH_METHOD_OIDC,
-  TYPE_AUTH_METHOD_LDAP,
-} from 'api/models/auth-method';
+import { TYPE_AUTH_METHOD_PASSWORD } from 'api/models/auth-method';
 
 export default class AuthMethodSerializer extends ApplicationSerializer {
   // =methods
@@ -23,10 +19,8 @@ export default class AuthMethodSerializer extends ApplicationSerializer {
     switch (snapshot.record.type) {
       case TYPE_AUTH_METHOD_PASSWORD:
         return this.serializePassword(...arguments);
-      case TYPE_AUTH_METHOD_OIDC:
-        return this.serializeOIDC(...arguments);
-      case TYPE_AUTH_METHOD_LDAP:
-        return this.serializeLDAP(...arguments);
+      default:
+        return this.serializeDefault(...arguments);
     }
   }
 
@@ -46,33 +40,8 @@ export default class AuthMethodSerializer extends ApplicationSerializer {
    * @param {Snapshot} snapshot
    * @return {object}
    */
-  serializeOIDC(snapshot) {
+  serializeDefault(snapshot) {
     let serialized = super.serialize(...arguments);
-    const state = snapshot?.adapterOptions?.state;
-    if (state) {
-      serialized = this.serializeWithState(snapshot, state);
-    } else {
-      delete serialized.attributes.state;
-    }
-    return serialized;
-  }
-
-  /**
-   * If `adapterOptions.state` is set, the serialization should
-   * include **only state** and version.  Normally, this is not serialized.
-   * @param {Snapshot} snapshot
-   * @return {object}
-   */
-  serializeLDAP(snapshot) {
-    let serialized = super.serialize(...arguments);
-    // Deleting these attributes is a temporary fix.
-    const { bind_dn, client_certificate } = snapshot.changedAttributes();
-    if (!bind_dn) {
-      delete serialized.attributes.bind_dn;
-    }
-    if (!client_certificate) {
-      delete serialized.attributes.client_certificate;
-    }
     const state = snapshot?.adapterOptions?.state;
     if (state) {
       serialized = this.serializeWithState(snapshot, state);

--- a/addons/api/addon/serializers/auth-method.js
+++ b/addons/api/addon/serializers/auth-method.js
@@ -60,13 +60,12 @@ export default class AuthMethodSerializer extends ApplicationSerializer {
   /**
    * If `adapterOptions.state` is set, the serialization should
    * include **only state** and version.  Normally, this is not serialized.
-   * Some attributes are removed if they are not in a 'dirty' state because
-   * the API expects a corresponding field to also be updated.
    * @param {Snapshot} snapshot
    * @return {object}
    */
   serializeLDAP(snapshot) {
     let serialized = super.serialize(...arguments);
+    // Deleting these attributes is a temporary fix.
     const { bind_dn, client_certificate } = snapshot.changedAttributes();
     if (!bind_dn) {
       delete serialized.attributes.bind_dn;

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -76,7 +76,7 @@ auth-method:
       help: Used to provide to the LDAP server for mTLS connections. Must be x509 PEM encoded.
     client_certificate_key:
       label: Client TLS Key
-      help: Used with the ClientTLSCert for mTLS connections to the LDAP server. Must be x509 PEM encoded.
+      help: Used with the ClientTLSCert for mTLS connections to the LDAP server. Must be x509 PEM encoded. We will not show this data after it is saved, but you can replace it.
     start_tls:
       label: Use StartTLS
       help: Use StartTLS to create a secure connection.
@@ -88,7 +88,7 @@ auth-method:
       help: Distinguished name of entry to bind when performing user and group search.
     bind_password:
       label: Bind Password
-      help: Password to use with BindDN when searching for user.
+      help: Password to use with BindDN when searching for user. We will not show this data after it is saved, but you can replace it.
     upn_domain:
       label: UPN Domain
       help: Add this domain to the username when authenticating.

--- a/ui/admin/app/components/auth-methods/auth-method/actions/index.hbs
+++ b/ui/admin/app/components/auth-methods/auth-method/actions/index.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{#if @model.isOIDC}}
+{{#if (or @model.isOIDC @model.isLDAP)}}
   <Rose::Dropdown
     @text={{t (concat 'states.' @model.state)}}
     @icon={{if
@@ -26,7 +26,7 @@
           @changed={{route-action 'changeState'}}
           as |radioGroup|
         >
-          {{#each @model.options.oidc.state as |state|}}
+          {{#each @model.options.state as |state|}}
             <dropdown.item>
               <radioGroup.radio
                 @label={{t (concat 'states.' state)}}

--- a/ui/admin/app/components/form/auth-method/ldap/index.hbs
+++ b/ui/admin/app/components/form/auth-method/ldap/index.hbs
@@ -66,7 +66,7 @@
     <p class='hds-typography-display-300 hds-font-weight-bold'>{{t
         'resources.auth-method.section.connection.title'
       }}</p>
-    <Hds::Form::HelperText @controlId='helper-text-for-section'>{{t
+    <Hds::Form::HelperText @controlId='for-connection'>{{t
         'resources.auth-method.section.connection.help'
       }}</Hds::Form::HelperText>
   </div>
@@ -242,7 +242,7 @@
     <p class='hds-typography-display-300 hds-font-weight-bold'>{{t
         'resources.auth-method.section.authenticated-search.title'
       }}</p>
-    <Hds::Form::HelperText @controlId='helper-text-for-section'>{{t
+    <Hds::Form::HelperText @controlId='for-authenticated-search'>{{t
         'resources.auth-method.section.authenticated-search.help'
       }}</Hds::Form::HelperText>
   </div>
@@ -320,7 +320,7 @@
     <p class='hds-typography-display-300 hds-font-weight-bold'>{{t
         'resources.auth-method.section.anonymous-search.title'
       }}</p>
-    <Hds::Form::HelperText @controlId='helper-text-for-section'>{{t
+    <Hds::Form::HelperText @controlId='for-anonymous-search'>{{t
         'resources.auth-method.section.anonymous-search.help'
       }}</Hds::Form::HelperText>
   </div>
@@ -357,7 +357,7 @@
     <p class='hds-typography-display-300 hds-font-weight-bold'>{{t
         'resources.auth-method.section.user-entries.title'
       }}</p>
-    <Hds::Form::HelperText @controlId='helper-text-for-section'>{{t
+    <Hds::Form::HelperText @controlId='for-user-entries'>{{t
         'resources.auth-method.section.user-entries.help'
       }}</Hds::Form::HelperText>
   </div>
@@ -552,7 +552,7 @@
     <p class='hds-typography-display-300 hds-font-weight-bold'>{{t
         'resources.auth-method.section.group-entries.title'
       }}</p>
-    <Hds::Form::HelperText @controlId='helper-text-for-section'>{{t
+    <Hds::Form::HelperText @controlId='for-group-entries'>{{t
         'resources.auth-method.section.group-entries.help'
       }}</Hds::Form::HelperText>
   </div>

--- a/ui/admin/app/components/form/auth-method/ldap/index.hbs
+++ b/ui/admin/app/components/form/auth-method/ldap/index.hbs
@@ -208,6 +208,32 @@
         </F.Error>
       {{/if}}
     </Hds::Form::TextInput::Field>
+  {{else}}
+    <Form::Field::SecretInput
+      @isOptional={{true}}
+      @value={{@model.client_certificate_key}}
+      @isInvalid={{@model.errors.client_certificate_key}}
+      @name='client_certificate_key'
+      @isDisabled={{form.disabled}}
+      @showEditButton={{true}}
+      @cancel={{fn this.rollbackSecretAttrs 'client_certificate_key'}}
+      {{on 'input' (set-from-event @model 'client_certificate_key')}}
+      as |F|
+    >
+      <F.Label>{{t
+          'resources.auth-method.form.client_certificate_key.label'
+        }}</F.Label>
+      <F.HelperText>{{t
+          'resources.auth-method.form.client_certificate_key.help'
+        }}</F.HelperText>
+      {{#if @model.errors.client_certificate_key}}
+        <F.Error as |E|>
+          {{#each @model.errors.client_certificate_key as |error|}}
+            <E.Message>{{error.message}}</E.Message>
+          {{/each}}
+        </F.Error>
+      {{/if}}
+    </Form::Field::SecretInput>
   {{/if}}
 
   <Hds::Form::Toggle::Field
@@ -289,6 +315,30 @@
         </F.Error>
       {{/if}}
     </Hds::Form::TextInput::Field>
+  {{else}}
+    <Form::Field::SecretInput
+      @isOptional={{true}}
+      @value={{@model.bind_password}}
+      @isInvalid={{@model.errors.bind_password}}
+      @name='bind_password'
+      @isDisabled={{form.disabled}}
+      @showEditButton={{true}}
+      @cancel={{fn this.rollbackSecretAttrs 'bind_password'}}
+      {{on 'input' (set-from-event @model 'bind_password')}}
+      as |F|
+    >
+      <F.Label>{{t 'resources.auth-method.form.bind_password.label'}}</F.Label>
+      <F.HelperText>{{t
+          'resources.auth-method.form.bind_password.help'
+        }}</F.HelperText>
+      {{#if @model.errors.bind_password}}
+        <F.Error as |E|>
+          {{#each @model.errors.bind_password as |error|}}
+            <E.Message>{{error.message}}</E.Message>
+          {{/each}}
+        </F.Error>
+      {{/if}}
+    </Form::Field::SecretInput>
   {{/if}}
 
   <Hds::Form::TextInput::Field

--- a/ui/admin/app/components/form/auth-method/ldap/index.js
+++ b/ui/admin/app/components/form/auth-method/ldap/index.js
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { options } from 'api/models/auth-method';
+import { set } from '@ember/object';
 
 export default class FormAuthMethodLdapComponent extends Component {
   // =attributes
@@ -82,5 +83,17 @@ export default class FormAuthMethodLdapComponent extends Component {
    */
   parseUrlsArray() {
     return (this.args.model.urls || []).map((item) => item.value).toString();
+  }
+
+  /**
+   * @param {string} currentAttr
+   */
+  @action
+  rollbackSecretAttrs(currentAttr) {
+    const changedAttrs = this.args.model.changedAttributes();
+    if (currentAttr in changedAttrs) {
+      const [oldVal] = changedAttrs[currentAttr];
+      set(this.args.model, currentAttr, oldVal);
+    }
   }
 }

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method.js
@@ -59,10 +59,18 @@ export default class ScopesScopeAuthMethodsAuthMethodRoute extends Route {
         authMethod.account_claim_maps
       );
     }
+    if (authMethod.certificates) {
+      authMethod.certificates = structuredClone(authMethod.certificates);
+    }
+    if (authMethod.account_attribute_maps) {
+      authMethod.account_attribute_maps = structuredClone(
+        authMethod.account_attribute_maps
+      );
+    }
   }
 
   /**
-   * Update state of OIDC auth method
+   * Update state of OIDC or LDAP auth method
    * @param {string} state
    */
   @action

--- a/ui/admin/tests/acceptance/auth-methods/delete-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/delete-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { visit, click, find } from '@ember/test-helpers';
+import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -15,10 +15,20 @@ import {
   //   //currentSession,
   //   //invalidateSession,
 } from 'ember-simple-auth/test-support';
+import { TYPE_AUTH_METHOD_LDAP } from 'api/models/auth-method';
 
 module('Acceptance | auth methods | delete', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+
+  let featuresService;
+  let getAuthMethodCount;
+
+  const DELETE_DROPDOWN_SELECTOR =
+    '.rose-layout-page-actions .rose-dropdown-button-danger';
+  const DIALOG_DELETE_BTN_SELECTOR = '.rose-dialog .rose-button-primary';
+  const DIALOG_CANCEL_BTN_SELECTOR = '.rose-dialog .rose-button-secondary';
+  const ERROR_MSG_SELECTOR = '.rose-notification-body';
 
   const instances = {
     scopes: {
@@ -26,12 +36,13 @@ module('Acceptance | auth methods | delete', function (hooks) {
       org: null,
     },
     authMethod: null,
+    ldapAuthMethod: null,
   };
   const urls = {
     orgScope: null,
     authMethods: null,
-    newAuthMethod: null,
     authMethod: null,
+    ldapAuthMethod: null,
   };
 
   hooks.beforeEach(function () {
@@ -45,20 +56,42 @@ module('Acceptance | auth methods | delete', function (hooks) {
     instances.authMethod = this.server.create('auth-method', {
       scope: instances.scopes.org,
     });
+    instances.ldapAuthMethod = this.server.create('auth-method', {
+      scope: instances.scopes.org,
+      type: TYPE_AUTH_METHOD_LDAP,
+    });
 
     // Generate route URLs for resources
     urls.orgScope = `/scopes/${instances.scopes.org.id}`;
     urls.authMethods = `${urls.orgScope}/auth-methods`;
-    urls.newAuthMethod = `${urls.authMethods}/new?type=password`;
     urls.authMethod = `${urls.authMethods}/${instances.authMethod.id}`;
+    urls.ldapAuthMethod = `${urls.authMethods}/${instances.ldapAuthMethod.id}`;
+    featuresService = this.owner.lookup('service:features');
+    getAuthMethodCount = () =>
+      this.server.schema.authMethods.all().models.length;
   });
 
   test('can delete an auth method', async function (assert) {
     assert.expect(1);
-    const authMethodsCount = this.server.db.authMethods.length;
-    await visit(urls.authMethod);
-    await click('.rose-layout-page-actions .rose-dropdown-button-danger');
-    assert.strictEqual(this.server.db.authMethods.length, authMethodsCount - 1);
+    const authMethodsCount = getAuthMethodCount();
+    await visit(urls.authMethods);
+
+    await click(`[href="${urls.authMethod}"]`);
+    await click(DELETE_DROPDOWN_SELECTOR);
+
+    assert.strictEqual(getAuthMethodCount(), authMethodsCount - 1);
+  });
+
+  test('can delete an ldap auth method', async function (assert) {
+    assert.expect(1);
+    featuresService.enable('ldap-auth-methods');
+    const authMethodsCount = getAuthMethodCount();
+    await visit(urls.authMethods);
+
+    await click(`[href="${urls.ldapAuthMethod}"]`);
+    await click(DELETE_DROPDOWN_SELECTOR);
+
+    assert.strictEqual(getAuthMethodCount(), authMethodsCount - 1);
   });
 
   test('errors are displayed when delete on an auth method fails', async function (assert) {
@@ -74,14 +107,36 @@ module('Acceptance | auth methods | delete', function (hooks) {
         }
       );
     });
-    await visit(urls.authMethod);
-    await click('.rose-layout-page-actions .rose-dropdown-button-danger');
+    await visit(urls.authMethods);
+
+    await click(`[href="${urls.authMethod}"]`);
+    await click(DELETE_DROPDOWN_SELECTOR);
     await a11yAudit();
-    assert.strictEqual(
-      find('.rose-notification-body').textContent.trim(),
-      'Oops.',
-      'Displays primary error message.'
-    );
+
+    assert.dom(ERROR_MSG_SELECTOR).hasText('Oops.');
+  });
+
+  test('errors are displayed when delete on an ldap auth method fails', async function (assert) {
+    assert.expect(1);
+    featuresService.enable('ldap-auth-methods');
+    this.server.del('/auth-methods/:id', () => {
+      return new Response(
+        490,
+        {},
+        {
+          status: 490,
+          code: 'error',
+          message: 'Oops.',
+        }
+      );
+    });
+    await visit(urls.authMethods);
+
+    await click(`[href="${urls.ldapAuthMethod}"]`);
+    await click(DELETE_DROPDOWN_SELECTOR);
+    await a11yAudit();
+
+    assert.dom(ERROR_MSG_SELECTOR).hasText('Oops.');
   });
 
   test('cannot delete an auth method without proper authorization', async function (assert) {
@@ -90,9 +145,86 @@ module('Acceptance | auth methods | delete', function (hooks) {
       instances.authMethod.authorized_actions.filter(
         (item) => item !== 'delete'
       );
-    await visit(urls.authMethod);
-    assert.notOk(
-      find('.rose-layout-page-actions .rose-dropdown-button-danger')
-    );
+    await visit(urls.authMethods);
+
+    await click(`[href="${urls.authMethod}"]`);
+
+    assert.dom(DELETE_DROPDOWN_SELECTOR).doesNotExist();
+  });
+
+  test('cannot delete an ldap auth method without proper authorization', async function (assert) {
+    assert.expect(1);
+    featuresService.enable('ldap-auth-methods');
+    instances.ldapAuthMethod.authorized_actions =
+      instances.ldapAuthMethod.authorized_actions.filter(
+        (item) => item !== 'delete'
+      );
+    await visit(urls.authMethods);
+
+    await click(`[href="${urls.ldapAuthMethod}"]`);
+
+    assert.dom(DELETE_DROPDOWN_SELECTOR).doesNotExist();
+  });
+
+  test('user can accept delete auth method via dialog', async function (assert) {
+    assert.expect(2);
+    const confirmService = this.owner.lookup('service:confirm');
+    confirmService.enabled = true;
+    const authMethodCount = getAuthMethodCount();
+    await visit(urls.authMethods);
+
+    await click(`[href="${urls.authMethod}"]`);
+    await click(DELETE_DROPDOWN_SELECTOR);
+    await click(DIALOG_DELETE_BTN_SELECTOR);
+
+    assert.strictEqual(currentURL(), urls.authMethods);
+    assert.strictEqual(getAuthMethodCount(), authMethodCount - 1);
+  });
+
+  test('user can accept delete ldap auth method via dialog', async function (assert) {
+    assert.expect(2);
+    const confirmService = this.owner.lookup('service:confirm');
+    confirmService.enabled = true;
+    featuresService.enable('ldap-auth-methods');
+    const authMethodCount = getAuthMethodCount();
+    await visit(urls.authMethods);
+
+    await click(`[href="${urls.ldapAuthMethod}"]`);
+    await click(DELETE_DROPDOWN_SELECTOR);
+    await click(DIALOG_DELETE_BTN_SELECTOR);
+
+    assert.strictEqual(currentURL(), urls.authMethods);
+    assert.strictEqual(getAuthMethodCount(), authMethodCount - 1);
+  });
+
+  test('user can cancel delete auth method via dialog', async function (assert) {
+    assert.expect(2);
+    const confirmService = this.owner.lookup('service:confirm');
+    confirmService.enabled = true;
+    const authMethodCount = getAuthMethodCount();
+    await visit(urls.authMethods);
+
+    await click(`[href="${urls.authMethod}"]`);
+    await click(DELETE_DROPDOWN_SELECTOR);
+    await click(DIALOG_CANCEL_BTN_SELECTOR);
+
+    assert.strictEqual(currentURL(), urls.authMethod);
+    assert.strictEqual(getAuthMethodCount(), authMethodCount);
+  });
+
+  test('user can cancel delete ldap auth method via dialog', async function (assert) {
+    assert.expect(2);
+    const confirmService = this.owner.lookup('service:confirm');
+    confirmService.enabled = true;
+    featuresService.enable('ldap-auth-methods');
+    const authMethodCount = getAuthMethodCount();
+    await visit(urls.authMethods);
+
+    await click(`[href="${urls.ldapAuthMethod}"]`);
+    await click(DELETE_DROPDOWN_SELECTOR);
+    await click(DIALOG_CANCEL_BTN_SELECTOR);
+
+    assert.strictEqual(currentURL(), urls.ldapAuthMethod);
+    assert.strictEqual(getAuthMethodCount(), authMethodCount);
   });
 });


### PR DESCRIPTION
✅ Closes: ICU-10078 & 10079

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10078)
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10079)

## Description
Allows state change for ldap auth-method.
Verifies that cancelling changes rolls back attributes.
Verifies that deleting ldap auth method is successful.
Verifies that editing an ldap auth method is successful.
Acceptance tests for delete and update.
<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](https://boundary-ui-git-icu-10078-enable-edit-mode-hashicorp.vercel.app/scopes/global/auth-methods/am_ec8st2tp51)
