### PR TITLE
test: 💍 Add TCP target update test

### DIFF
--- a/ui/admin/tests/e2e/tests/target.spec.js
+++ b/ui/admin/tests/e2e/tests/target.spec.js
@@ -4,7 +4,7 @@
  */
 
 /* eslint-disable no-undef */
-const { test } = require('@playwright/test');
+const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');
 const { checkEnv, authenticatedState } = require('../helpers/general');
 const {
@@ -117,5 +117,37 @@ test('Verify session created to target with address, then cancel the session', a
     if (connect) {
       connect.kill('SIGTERM');
     }
+  }
+});
+
+test('Verify TCP target is updated', async ({ page }) => {
+  await page.goto('/');
+  let orgName;
+  try {
+    orgName = await createNewOrg(page);
+    await createNewProject(page);
+    await createNewTargetWithAddress(page);
+
+    // Update target
+    await page.getByRole('button', { name: 'Edit Form' }).click();
+    await page.getByLabel('Name').fill('New target name');
+    await page.getByLabel('Description').fill('New description');
+    await page.getByLabel('Target Address').fill('127.0.0.1');
+    await page.getByLabel('Default Port').fill('10');
+    await page.getByLabel('Default Client Port').fill('10');
+    await page.getByLabel('Maximum Duration').fill('1000');
+    await page.getByLabel('Maximum Connections').fill('10');
+    await page.getByLabel('Egress worker filter').click();
+    await page.getByRole('textbox', { name: 'Filter', exact: true }).fill('"dev" in "/tags/type"');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(
+      page.getByRole('alert').getByText('Success', { exact: true })
+    ).toBeVisible();
+  } finally {
+    await authenticateBoundaryCli();
+    const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+    const org = orgs.items.filter((obj) => obj.name === orgName)[0];
+    await deleteOrg(org.id);
   }
 });


### PR DESCRIPTION
✅ Closes: ICU-9772

:tickets: [ICU-9772](https://hashicorp.atlassian.net/browse/ICU-9772)

## Description
This PR adds a UI test that verifies that TCP target can be updated.
The test does the following:

- creates an organisation
- creates a project
- creates a target
- updates target's fields
- saves the changes
- verifies 'Success' alert is displayed
- deletes the organization

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:rose: [Rose preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

<!-- Add a brief description of changes here. Include any other necessary relevant links -->

### Screenshots (if appropriate):


[ICU-9772]: https://hashicorp.atlassian.net/browse/ICU-9772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ