### PR TITLE
Chore icu 9083 audit resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "mout": "^1.2.4",
     "nanoid": "^3.1.31",
     "plist": "^3.0.5",
     "lzma-native": "^8.0.6",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "ember-template-recast": "^6.0.0",
     "markdown-it": "^12.3.2",
     "mout": "^1.2.4",
     "nanoid": "^3.1.31",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "markdown-it": "^12.3.2",
     "mout": "^1.2.4",
     "nanoid": "^3.1.31",
     "plist": "^3.0.5",
@@ -83,7 +82,9 @@
     "**/core/ember-inline-svg/**/nth-check": "^2.0.1",
     "**/snapdragon/base/cache-base/**/set-value": "^4.0.1",
     "**/@storybook/**/ansi-regex": "^5.0.1",
-    "**/jsprim/json-schema": "^0.4.0"
+    "**/jsprim/json-schema": "^0.4.0",
+    "**/@storybook/**/yuidocjs/markdown-it": "^12.3.2",
+    "**/ember-cli/markdown-it-terminal/markdown-it": "^12.3.2"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "nanoid": "^3.1.31",
     "plist": "^3.0.5",
     "lzma-native": "^8.0.6",
     "ansi-html": "^0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12861,7 +12861,7 @@ ember-template-lint@^4.14.0:
     v8-compile-cache "^2.3.0"
     yargs "^17.5.1"
 
-ember-template-recast@^6.0.0, ember-template-recast@^6.1.3:
+ember-template-recast@^6.1.3:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/ember-template-recast/-/ember-template-recast-6.1.4.tgz#e964c184adfd876878009f8aa0b84c95633fce20"
   integrity sha512-fCh+rOK6z+/tsdkTbOE+e7f84P6ObnIRQrCCrnu21E4X05hPeradikIkRMhJdxn4NWrxitfZskQDd37TR/lsNQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -18997,7 +18997,7 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
-nanoid@^3.1.23, nanoid@^3.1.31, nanoid@^3.3.4, nanoid@^3.3.6:
+nanoid@^3.1.23, nanoid@^3.3.4, nanoid@^3.3.6:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -13042,7 +13042,7 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
-entities@^3.0.1:
+entities@^3.0.1, entities@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
@@ -17538,6 +17538,13 @@ linkify-it@^3.0.1:
   dependencies:
     uc.micro "^1.0.1"
 
+linkify-it@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-4.0.1.tgz#01f1d5e508190d06669982ba31a7d9f56a5751ec"
+  integrity sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==
+  dependencies:
+    uc.micro "^1.0.1"
+
 lint-staged@^13.0.2:
   version "13.0.2"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.0.2.tgz#35a1c57130e9ad5b1dea784972a40777ba433dd5"
@@ -18187,7 +18194,7 @@ markdown-it-terminal@0.2.1:
     lodash.merge "^4.6.2"
     markdown-it "^8.3.1"
 
-markdown-it@^12.2.0, markdown-it@^12.3.2, markdown-it@^13.0.1, markdown-it@^4.3.0, markdown-it@^8.3.1:
+markdown-it@^12.2.0, markdown-it@^12.3.2, markdown-it@^4.3.0, markdown-it@^8.3.1:
   version "12.3.2"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
   integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
@@ -18195,6 +18202,17 @@ markdown-it@^12.2.0, markdown-it@^12.3.2, markdown-it@^13.0.1, markdown-it@^4.3.
     argparse "^2.0.1"
     entities "~2.1.0"
     linkify-it "^3.0.1"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
+markdown-it@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-13.0.1.tgz#c6ecc431cacf1a5da531423fc6a42807814af430"
+  integrity sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==
+  dependencies:
+    argparse "^2.0.1"
+    entities "~3.0.1"
+    linkify-it "^4.0.1"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18940,7 +18940,7 @@ morgan@^1.10.0:
     on-finished "~2.3.0"
     on-headers "~1.0.2"
 
-mout@^1.0.0, mout@^1.2.4:
+mout@^1.0.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/mout/-/mout-1.2.4.tgz#9ffd261c4d6509e7ebcbf6b641a89b36ecdf8155"
   integrity sha512-mZb9uOruMWgn/fw28DG4/yE3Kehfk1zKCLhuDU2O3vlKdnBBr4XaOCqVTflJ5aODavGUPqFHZgrFX3NJVuxGhQ==


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9083)

## Description

### Ember-template-recast
- After running `yarn why ember-template-recast` one dep uses it.
- After deleting `ember-template-recast` from resolutions, we resolve `ember-template-recast@6.1.4` which has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/ember-template-recast).

### markdown-it
- After running `yarn why markdown-it` several deps use it.
- After deleting `markdown-it` from resolutions, different versions are resolved. We will add specific resolutions to resolve  `markdown-it@^12.3.2` which has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/markdown-it).

### mout
- After running `yarn why mout` one dep uses it.
- After deleting `mout` from resolutions, we still resolving `mout@1.2.4` which has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/mout).

### nanoid
- After running `yarn why nanoid` several deps uses it.
- After deleting `nanoid` from resolutions, we still resolving `nanoid@3.3.6` which has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/nanoid).
