### PR TITLE
fix: 🐛 replace deprecated substr with substring

### DIFF
--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -168,7 +168,7 @@ app.on('ready', async () => {
   ses.protocol.handle(emberAppProtocol, (request) => {
     /* eng-disable PROTOCOL_HANDLER_JS_CHECK */
     const isDir = request.url.endsWith('/');
-    const absolutePath = request.url.substr(emberAppURL.length);
+    const absolutePath = request.url.substring(emberAppURL.length);
     const normalizedPath = isDir
       ? path.normalize(`${emberAppDir}/index.html`)
       : path.normalize(`${emberAppDir}${absolutePath}`);


### PR DESCRIPTION
[jira](https://hashicorp.atlassian.net/browse/ICU-10505)


replace deprecated `substr` with `substring`. 

To learn more see [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr)


**Test**: 

- the desktop app works as expected

[workflow](https://github.com/hashicorp/boundary-ui-releases/actions/runs/5744870337) 


<img width="1517" alt="Screenshot 2023-08-03 at 9 15 46 AM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/56ec8c4c-f0b0-4c93-85c3-cf372c1962aa">
