### PR TITLE
fix: 🐛 accounts update refactor

### DIFF
--- a/addons/api/addon/generated/models/account.js
+++ b/addons/api/addon/generated/models/account.js
@@ -13,11 +13,13 @@ export default class GeneratedAccountModel extends BaseModel {
   // =attributes
 
   @attr('string', {
+    readOnly: true,
     description: 'The type of the resource, to help differentiate schemas',
   })
   type;
 
   @attr('string', {
+    readOnly: true,
     description: 'The owning auth method ID.',
   })
   auth_method_id;

--- a/addons/api/tests/unit/serializers/account-test.js
+++ b/addons/api/tests/unit/serializers/account-test.js
@@ -32,9 +32,7 @@ module('Unit | Serializer | account', function (hooks) {
     const snapshot = record._createSnapshot();
     const serializedRecord = serializer.serialize(snapshot);
     assert.deepEqual(serializedRecord, {
-      type: TYPE_AUTH_METHOD_OIDC,
       name: 'Name',
-      auth_method_id: '1',
       description: 'Description',
       version: 1,
       attributes: {
@@ -70,9 +68,7 @@ module('Unit | Serializer | account', function (hooks) {
     const serializedRecord = serializer.serialize(snapshot);
     assert.notOk(serializedRecord.attributes);
     assert.deepEqual(serializedRecord, {
-      type: TYPE_AUTH_METHOD_OIDC,
       name: 'Name',
-      auth_method_id: '1',
       description: 'Description',
       version: 1,
     });
@@ -93,9 +89,7 @@ module('Unit | Serializer | account', function (hooks) {
     const snapshot = record._createSnapshot();
     const serializedRecord = serializer.serialize(snapshot);
     assert.deepEqual(serializedRecord, {
-      type: TYPE_AUTH_METHOD_PASSWORD,
       name: 'Name',
-      auth_method_id: '1',
       description: 'Description',
       attributes: {
         login_name: 'Login Name',
@@ -122,9 +116,7 @@ module('Unit | Serializer | account', function (hooks) {
     };
     const serializedRecord = serializer.serialize(snapshot);
     assert.deepEqual(serializedRecord, {
-      type: TYPE_AUTH_METHOD_PASSWORD,
       name: 'Name',
-      auth_method_id: '1',
       description: 'Description',
       attributes: {
         login_name: 'Login Name',
@@ -244,9 +236,7 @@ module('Unit | Serializer | account', function (hooks) {
     const snapshot = record._createSnapshot();
     const serializedRecord = serializer.serialize(snapshot);
     assert.deepEqual(serializedRecord, {
-      type: TYPE_AUTH_METHOD_LDAP,
       name: 'Name',
-      auth_method_id: '1',
       description: 'Description',
       version: 1,
     });

--- a/addons/api/tests/unit/serializers/account-test.js
+++ b/addons/api/tests/unit/serializers/account-test.js
@@ -199,9 +199,7 @@ module('Unit | Serializer | account', function (hooks) {
     const snapshot = record._createSnapshot();
     const serializedRecord = serializer.serialize(snapshot);
     assert.deepEqual(serializedRecord, {
-      type: TYPE_AUTH_METHOD_LDAP,
       name: 'Name',
-      auth_method_id: '1',
       description: 'Description',
       version: 1,
       attributes: {
@@ -237,6 +235,7 @@ module('Unit | Serializer | account', function (hooks) {
     const serializedRecord = serializer.serialize(snapshot);
     assert.deepEqual(serializedRecord, {
       name: 'Name',
+
       description: 'Description',
       version: 1,
     });

--- a/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/accounts/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/accounts/index.hbs
@@ -46,10 +46,10 @@
                     @route='scopes.scope.auth-methods.auth-method.accounts.account'
                     @model={{B.data.id}}
                   >
-                    {{B.data.accountName}}
+                    {{B.data.displayName}}
                   </LinkTo>
                 {{else}}
-                  {{B.data.accountName}}
+                  {{B.data.displayName}}
                 {{/if}}
                 <p>{{B.data.description}}</p>
               </B.Td>


### PR DESCRIPTION
✅ Closes: ICU-10503

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10503)

## Description
Changed `type` and `auth_method_id` on the `accounts` model to `readOnly` so they are not sent in API payload.

### Screenshots (if appropriate):

### Error when trying to send `type` and `auth_method_id` as part of payload
<img width="1491" alt="Screenshot 2023-08-03 at 11 08 12" src="https://github.com/hashicorp/boundary-ui/assets/24277002/e7c25985-4b70-4abb-a80d-03c2e7066b76">

### After making attributes read-only
![image](https://github.com/hashicorp/boundary-ui/assets/24277002/50fd5e0d-d8b3-480a-974c-e96b913d9bf1)
