### PR TITLE
Icu 10491 create route for session/session-id

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -280,6 +280,7 @@ session:
       description: No active sessions available to display yet.
   actions:
     connect: Connect
+    end: End session
   credential:
     title: Credential
     title_plural: Credentials

--- a/ui/desktop/app/router.js
+++ b/ui/desktop/app/router.js
@@ -23,7 +23,9 @@ Router.map(function () {
         this.route('targets', function () {
           this.route('target', { path: ':target_id' }, function () {});
         });
-        this.route('sessions', function () {});
+        this.route('sessions', function () {
+          this.route('session', { path: ':session_id' }, function () {});
+        });
       });
     });
   });

--- a/ui/desktop/app/routes/scopes/scope/projects/sessions/session.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions/session.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class ScopesScopeProjectsSessionsSessionRoute extends Route {
+  // =services
+
+  @service store;
+
+  // =methods
+
+  /**
+   * Load a session
+   * @param {object} params
+   * @param {string} params.session_id
+   * @return {TargetModel}
+   */
+  model({ session_id }) {
+    return this.store.findRecord('session', session_id, { reload: true });
+  }
+}

--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -506,6 +506,7 @@ $chevron-down: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%231
   }
 }
 
+.session-details-header,
 .target-details-header {
   display: flex;
   align-items: center;

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/session.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/session.hbs
@@ -1,0 +1,35 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: MPL-2.0
+}}
+{{page-title @model.displayName}}
+
+<Rose::Layout::Page as |page|>
+
+  <page.header>
+    <h1 class='session-details-header'>
+      <Hds::IconTile @color='boundary' @icon='terminal' />
+      {{@model.displayName}}
+    </h1>
+  </page.header>
+
+  <page.actions>
+    <Hds::Button
+      @text={{t 'resources.session.actions.end'}}
+      @icon='x'
+      @color='secondary'
+      {{on 'click' (route-action 'cancelSession' @model)}}
+    />
+  </page.actions>
+
+  <page.body>
+    <div class='copy-url-container'>{{t 'actions.copy-to-clipboard'}}</div>
+    <Rose::Layout::BodyContent as |bc|>
+      <bc.Body class='session-details-body'>
+        {{t 'resources.session.description'}}
+      </bc.Body>
+      <bc.Sidebar class='session-details-sidebar'>{{@model.id}}</bc.Sidebar>
+    </Rose::Layout::BodyContent>
+  </page.body>
+
+</Rose::Layout::Page>

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{page-title @model.target.displayName}}
+{{page-title @model.displayName}}
 
 <Rose::Layout::Page as |page|>
 

--- a/ui/desktop/tests/unit/routes/scopes/scope/projects/sessions/session-test.js
+++ b/ui/desktop/tests/unit/routes/scopes/scope/projects/sessions/session-test.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupTest } from 'desktop/tests/helpers';
+
+module(
+  'Unit | Route | scopes/scope/projects/sessions/session',
+  function (hooks) {
+    setupTest(hooks);
+
+    test('it exists', function (assert) {
+      let route = this.owner.lookup(
+        'route:scopes/scope/projects/sessions/session'
+      );
+      assert.ok(route);
+    });
+  }
+);


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10491) Route creation
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10492) Header
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10493) Layout

## Description

Create route for session/session-id
Add base header and layout for screen

**_No logic routing logic for ending the session or redirecting away from detail screen_**
_**Also no direct route for user, requires direct url manipulation, add `/session-id` to end of sessions route**_

:desktop_computer: [Desktop preview](https://boundary-ui-desktop-git-icu-10491-create-route-4609f4-hashicorp.vercel.app/scopes/global/projects/sessions/ss_69vzrnh490)

<!-- Add a brief description of changes here. Include any other necessary relevant links -->

### Screenshots (if appropriate):
<img width="1382" alt="Screen Shot 2023-08-04 at 7 34 47 AM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/83ce8b89-4d88-4f65-8069-4800237cc39c">