### PR TITLE
chore: 🤖 Update prepare-commit-msg to not execute when rebasing

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -4,9 +4,11 @@
 COMMIT_MSG_FILE=$1
 COMMIT_SOURCE=$2
 SHA1=$3
+# Gets the current branch name but if we're in a detached head state, return "HEAD"
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
-# Don't run commitizen for merge or squash commits
-if [ "${COMMIT_SOURCE}" = merge ] || [ "${COMMIT_SOURCE}" = squash ];then
+# Don't run commitizen for merge or squash commits, as well as when rebasing
+if [ "${COMMIT_SOURCE}" = merge ] || [ "${COMMIT_SOURCE}" = squash ] || [ "${COMMIT_SOURCE}" = "message" -a "${BRANCH_NAME}" = "HEAD" ];then
     exit 0
 fi
 


### PR DESCRIPTION
## Description
There's an annoying (at least to me) behavior from the commit hooks where when rebasing, commitizen will execute on _every_ commit that is getting rebased ontop of the branch. If you've been working on a branch for a while or on a long living branch, this can be very annoying as you might have quite a few commits to go through. If I am changing the commit messages, I normally would be doing that during the interactive rebase rather than having commitizen running on every individual commit. 

In the same way merge commits don't cause commitizen to run, I don't think rebases should cause commitizen to run.
 
Let me know if you think we shouldn't change this or it affects your workflow.


