### PR TITLE
Icu 10521 add route logic from sessions list to session detail screen

### DIFF
--- a/addons/api/addon/abilities/session.js
+++ b/addons/api/addon/abilities/session.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import ModelAbility from './model';
+
+/**
+ * Provides abilities for sessions.
+ */
+export default class SessionAbility extends ModelAbility {
+  // =services
+
+  // =permissions
+
+  /**
+   * Only "active" or "pending" sessions may be read.
+   * @type {boolean}
+   */
+  get canRead() {
+    return (this.model.isActive || this.model.isPending) && super.canRead;
+  }
+}

--- a/addons/api/addon/models/session.js
+++ b/addons/api/addon/models/session.js
@@ -10,7 +10,16 @@ import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
 import { inject as service } from '@ember/service';
 
-export const statusTypes = ['active', 'pending', 'canceling', 'terminated'];
+export const STATUS_SESSION_ACTIVE = 'active';
+export const STATUS_SESSION_PENDING = 'pending';
+export const STATUS_SESSION_CANCELING = 'canceling';
+export const STATUS_SESSION_TERMINATED = 'terminated';
+export const statusTypes = [
+  STATUS_SESSION_ACTIVE,
+  STATUS_SESSION_PENDING,
+  STATUS_SESSION_CANCELING,
+  STATUS_SESSION_TERMINATED,
+];
 
 /**
  *
@@ -103,8 +112,8 @@ export default class SessionModel extends GeneratedSessionModel {
   @tracked proxy_port;
   credentials = A();
 
-  @equal('status', 'active') isActive;
-  @equal('status', 'pending') isPending;
+  @equal('status', STATUS_SESSION_ACTIVE) isActive;
+  @equal('status', STATUS_SESSION_PENDING) isPending;
 
   /**
    * True if status is an unknown string.

--- a/addons/api/app/abilities/session.js
+++ b/addons/api/app/abilities/session.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export { default } from 'api/abilities/session';

--- a/addons/api/tests/unit/abilities/session-test.js
+++ b/addons/api/tests/unit/abilities/session-test.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Ability | session', function (hooks) {
+  setupTest(hooks);
+
+  let canService;
+  let store;
+
+  hooks.beforeEach(function () {
+    canService = this.owner.lookup('service:can');
+    store = this.owner.lookup('service:store');
+  });
+
+  test('it exists', function (assert) {
+    const ability = this.owner.lookup('ability:session');
+    assert.ok(ability);
+  });
+
+  test('can read a session that is active', function (assert) {
+    assert.expect(1);
+
+    const session = store.createRecord('session', {
+      authorized_actions: ['read'],
+      status: 'active',
+    });
+
+    assert.true(canService.can('read session', session));
+  });
+
+  test('can read a session that is pending', function (assert) {
+    assert.expect(1);
+
+    const session = store.createRecord('session', {
+      authorized_actions: ['read'],
+      status: 'pending',
+    });
+
+    assert.true(canService.can('read session', session));
+  });
+
+  test('cannot read a session that is not authorized', function (assert) {
+    assert.expect(4);
+
+    const activeSession = store.createRecord('session', {
+      authorized_actions: [],
+      status: 'active',
+    });
+    const pendingSession = store.createRecord('session', {
+      authorized_actions: [],
+      status: 'pending',
+    });
+    const cancelingSession = store.createRecord('session', {
+      authorized_actions: [],
+      status: 'canceling',
+    });
+    const terminatedSession = store.createRecord('session', {
+      authorized_actions: [],
+      status: 'terminated',
+    });
+
+    assert.false(canService.can('read session', activeSession));
+    assert.false(canService.can('read session', pendingSession));
+    assert.false(canService.can('read session', cancelingSession));
+    assert.false(canService.can('read session', terminatedSession));
+  });
+
+  test('cannot read a session that is canceling', function (assert) {
+    assert.expect(1);
+
+    const session = store.createRecord('session', {
+      authorized_actions: ['read'],
+      status: 'canceling',
+    });
+
+    assert.false(canService.can('read session', session));
+  });
+
+  test('cannot read a session that is terminated', function (assert) {
+    assert.expect(1);
+
+    const session = store.createRecord('session', {
+      authorized_actions: ['read'],
+      status: 'terminated',
+    });
+
+    assert.false(canService.can('read session', session));
+  });
+});

--- a/addons/api/tests/unit/abilities/session-test.js
+++ b/addons/api/tests/unit/abilities/session-test.js
@@ -5,6 +5,12 @@
 
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import {
+  STATUS_SESSION_ACTIVE,
+  STATUS_SESSION_PENDING,
+  STATUS_SESSION_CANCELING,
+  STATUS_SESSION_TERMINATED,
+} from 'api/models/session';
 
 module('Unit | Ability | session', function (hooks) {
   setupTest(hooks);
@@ -27,7 +33,7 @@ module('Unit | Ability | session', function (hooks) {
 
     const session = store.createRecord('session', {
       authorized_actions: ['read'],
-      status: 'active',
+      status: STATUS_SESSION_ACTIVE,
     });
 
     assert.true(canService.can('read session', session));
@@ -38,7 +44,7 @@ module('Unit | Ability | session', function (hooks) {
 
     const session = store.createRecord('session', {
       authorized_actions: ['read'],
-      status: 'pending',
+      status: STATUS_SESSION_PENDING,
     });
 
     assert.true(canService.can('read session', session));
@@ -49,19 +55,19 @@ module('Unit | Ability | session', function (hooks) {
 
     const activeSession = store.createRecord('session', {
       authorized_actions: [],
-      status: 'active',
+      status: STATUS_SESSION_ACTIVE,
     });
     const pendingSession = store.createRecord('session', {
       authorized_actions: [],
-      status: 'pending',
+      status: STATUS_SESSION_PENDING,
     });
     const cancelingSession = store.createRecord('session', {
       authorized_actions: [],
-      status: 'canceling',
+      status: STATUS_SESSION_CANCELING,
     });
     const terminatedSession = store.createRecord('session', {
       authorized_actions: [],
-      status: 'terminated',
+      status: STATUS_SESSION_TERMINATED,
     });
 
     assert.false(canService.can('read session', activeSession));
@@ -75,7 +81,7 @@ module('Unit | Ability | session', function (hooks) {
 
     const session = store.createRecord('session', {
       authorized_actions: ['read'],
-      status: 'canceling',
+      status: STATUS_SESSION_CANCELING,
     });
 
     assert.false(canService.can('read session', session));
@@ -86,7 +92,7 @@ module('Unit | Ability | session', function (hooks) {
 
     const session = store.createRecord('session', {
       authorized_actions: ['read'],
-      status: 'terminated',
+      status: STATUS_SESSION_TERMINATED,
     });
 
     assert.false(canService.can('read session', session));

--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -233,10 +233,6 @@
   color: var(--ui-gray-subtler-2);
 }
 
-.session-status-active {
-  color: var(--success);
-}
-
 .nowrap {
   white-space: nowrap;
 }

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
@@ -130,31 +130,38 @@
         <:body as |B|>
           <B.Tr>
             <B.Td>
-              {{#if (can 'read model' B.data)}}
-                {{#if B.data.isActive}}
-                  <Hds::Badge
-                    @text={{t 'resources.session.title'}}
-                    @icon='entry-point'
-                    @isIconOnly={{true}}
-                    @color='success'
-                    {{! there are plans to remove this class. It is here to make the test 
-                    pass. This is going to change later so Cameron suggested it's ok to
-                    have it for now.}}
-                    class='session-status-active'
-                  />
-                {{else}}
-                  <Hds::Badge
-                    @text={{t 'resources.session.title'}}
-                    @icon='entry-point'
-                    @isIconOnly={{true}}
-                  />
-                {{/if}}
+              {{#if (can 'read session' B.data)}}
+                <Hds::Badge
+                  @text={{t 'resources.session.title'}}
+                  @icon='entry-point'
+                  @isIconOnly={{true}}
+                  @color='success'
+                />
                 <Copyable
                   @text={{B.data.id}}
                   @buttonText={{t 'actions.copy-to-clipboard'}}
                   @acknowledgeText={{t 'states.copied'}}
                 >
-                  <code>{{B.data.id}}</code>
+                  <LinkTo
+                    @route='scopes.scope.projects.sessions.session'
+                    @model={{B.data.id}}
+                    data-test-session-detail-link
+                  >
+                    <code>{{B.data.id}}</code>
+                  </LinkTo>
+                </Copyable>
+              {{else}}
+                <Hds::Badge
+                  @text={{t 'resources.session.title'}}
+                  @icon='entry-point'
+                  @isIconOnly={{true}}
+                />
+                <Copyable
+                  @text={{B.data.id}}
+                  @buttonText={{t 'actions.copy-to-clipboard'}}
+                  @acknowledgeText={{t 'states.copied'}}
+                >
+                  <code data-test-session-id-copy>{{B.data.id}}</code>
                 </Copyable>
               {{/if}}
             </B.Td>


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10521)

## Description

add route logic from sessions list to session detail screen
only `active` and `pending` sessions can be visited and will have a link

:desktop_computer: [Desktop preview](https://boundary-ui-desktop-git-icu-10521-add-route-lo-7b9fa0-hashicorp.vercel.app/scopes/global/projects/sessions)

<!-- Add a brief description of changes here. Include any other necessary relevant links -->

### Screenshots (if appropriate):
<img width="1038" alt="Screen Shot 2023-08-09 at 3 01 49 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/9df89d14-0ad5-466b-bbe2-aefda98c1bef">