### PR TITLE
chore: 🤖 fix deprecation warning for firstobject usage

### DIFF
--- a/addons/api/tests/unit/models/scope-test.js
+++ b/addons/api/tests/unit/models/scope-test.js
@@ -26,10 +26,7 @@ module('Unit | Model | scope', function (hooks) {
     }));
     const scopes = await store.findAll('scope');
     // check integrity of scope relationships
-    assert.notOk(
-      await scopes.firstObject.get('scope'),
-      'Global scope has no parent'
-    );
+    assert.notOk(await scopes[0].get('scope'), 'Global scope has no parent');
     assert.strictEqual(
       await scopes.objectAt(1).get('scope.scope_id'),
       'global',

--- a/ui/admin/app/routes/application.js
+++ b/ui/admin/app/routes/application.js
@@ -83,7 +83,7 @@ export default class ApplicationRoute extends Route {
    */
   @action
   error(e) {
-    const isUnauthenticated = A(e?.errors)?.firstObject?.isUnauthenticated;
+    const isUnauthenticated = A(e?.errors)?.[0]?.isUnauthenticated;
     if (isUnauthenticated) {
       this.session.invalidate();
       return false;

--- a/ui/admin/app/routes/scopes/index.js
+++ b/ui/admin/app/routes/scopes/index.js
@@ -19,7 +19,7 @@ export default class ScopesIndexRoute extends Route {
    * If authenticated, redirects to the scope route of the authenticted scope.
    * If unauthenticated, redirects to the first scope that was loaded (if any).
    * @param {[ScopeModel]} model
-   * @param {?ScopeModel} model.firstObject
+   * @param {?ScopeModel} model[0]
    */
   redirect() {
     const authenticatedScopeID = get(

--- a/ui/admin/app/routes/scopes/scope/authenticate/index.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate/index.js
@@ -20,7 +20,7 @@ export default class ScopesScopeAuthenticateIndexRoute extends Route {
    * @param {[AuthMethodModel]} model.authMethods
    */
   redirect({ authMethods }) {
-    const firstAuthMethod = authMethods.firstObject;
+    const firstAuthMethod = authMethods[0];
     if (firstAuthMethod) {
       this.router.transitionTo(
         'scopes.scope.authenticate.method',

--- a/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/accounts/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/accounts/index.hbs
@@ -24,7 +24,7 @@
   <page.body>
     {{#if @model.accounts}}
       {{! OIDC accounts display more fields }}
-      {{#if @model.accounts.firstObject.isOIDC}}
+      {{#if (get @model.accounts '0.isOIDC')}}
         <Hds::Table
           @model={{@model.accounts}}
           @columns={{array
@@ -80,7 +80,7 @@
             </B.Tr>
           </:body>
         </Hds::Table>
-      {{else if @model.accounts.firstObject.isLDAP}}
+      {{else if (get @model.accounts '0.isLDAP')}}
         <Hds::Table
           @model={{@model.accounts}}
           @columns={{array

--- a/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/managed-groups/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/managed-groups/index.hbs
@@ -23,7 +23,7 @@
 
   <page.body>
     {{#if @model.managedGroups}}
-      {{#if @model.managedGroups.firstObject.isOIDC}}
+      {{#if (get @model.managedGroups '0.isOIDC')}}
         <Hds::Table
           @model={{@model.managedGroups}}
           @columns={{array

--- a/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/managed-groups/managed-group/members.hbs
+++ b/ui/admin/app/templates/scopes/scope/auth-methods/auth-method/managed-groups/managed-group/members.hbs
@@ -31,7 +31,7 @@
 
   <page.body>
     {{#if @model.members}}
-      {{#if @model.members.firstObject.isOIDC}}
+      {{#if (get @model.members '0.isOIDC')}}
         <Hds::Table
           @model={{@model.members}}
           @columns={{array

--- a/ui/desktop/app/routes/application.js
+++ b/ui/desktop/app/routes/application.js
@@ -89,7 +89,7 @@ export default class ApplicationRoute extends Route {
    */
   @action
   error(e) {
-    const isUnauthenticated = A(e?.errors)?.firstObject?.isUnauthenticated;
+    const isUnauthenticated = A(e?.errors)?.[0]?.isUnauthenticated;
     if (isUnauthenticated) {
       this.session.invalidate();
       return false;

--- a/ui/desktop/app/routes/scopes/index.js
+++ b/ui/desktop/app/routes/scopes/index.js
@@ -19,7 +19,7 @@ export default class ScopesIndexRoute extends Route {
    * If authenticated, redirects to the scope route of the authenticted scope.
    * If unauthenticated, redirects to the first scope that was loaded (if any).
    * @param {[ScopeModel]} model
-   * @param {?ScopeModel} model.firstObject
+   * @param {?ScopeModel} model[0]
    */
   redirect() {
     const authenticatedScopeID = get(

--- a/ui/desktop/app/routes/scopes/scope/authenticate/index.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate/index.js
@@ -20,7 +20,7 @@ export default class ScopesScopeAuthenticateIndexRoute extends Route {
    * @param {[AuthMethodModel]} model.authMethods
    */
   redirect({ authMethods }) {
-    const firstAuthMethod = authMethods.firstObject;
+    const firstAuthMethod = authMethods[0];
     if (firstAuthMethod) {
       this.router.replaceWith(
         'scopes.scope.authenticate.method',


### PR DESCRIPTION
[jira](https://hashicorp.atlassian.net/browse/ICU-10576)

This pr removes the usage of `firstObject` to eliminate the [deprecation warning](https://rfcs.emberjs.com/id/0848-deprecate-array-prototype-extensions/). 

<img width="1777" alt="Screenshot 2023-08-15 at 9 47 22 AM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/ca2d4ab4-b4bf-445d-b386-afb31b6e3676">

For the templates, this is the recommended [helper](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-array-prototype-extensions.md) to fix this 

