### PR TITLE
chore: 🤖 silence `deprecate_early_static` warnings

### DIFF
--- a/addons/core/addon/initializers/deprecations.js
+++ b/addons/core/addon/initializers/deprecations.js
@@ -7,6 +7,11 @@ import { registerDeprecationHandler } from '@ember/debug';
 
 export function initialize() {
   registerDeprecationHandler((message, options, next) => {
+    //silence deprecate-early-static warnings till we find a way to
+    //fix ember-cli-mirage discoverEmberDataModels
+    if (options?.id === 'ember-data:deprecate-early-static') {
+      return;
+    }
     if (options?.url) {
       message += options.url;
     }

--- a/addons/core/addon/initializers/deprecations.js
+++ b/addons/core/addon/initializers/deprecations.js
@@ -7,6 +7,7 @@ import { registerDeprecationHandler } from '@ember/debug';
 
 export function initialize() {
   registerDeprecationHandler((message, options, next) => {
+    // TODO: fix `deprecate-early-static` warning before ember 5 upgrade
     //silence deprecate-early-static warnings till we find a way to
     //fix ember-cli-mirage discoverEmberDataModels
     if (options?.id === 'ember-data:deprecate-early-static') {


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10577)


this pr will silence the `deprecate_early_static` [warning](https://rfcs.emberjs.com/id/0741-ember-data-deprecate-model-static-field-access-without-lookup/), which affects only when mocks are used. This is due to the discoverEmberDataModels method that accesses the static fields of the model directly. 

<img width="1411" alt="Screenshot 2023-08-15 at 11 02 49 AM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/4a81ff18-4ef1-40d5-ab81-c085c19daceb">
