### PR TITLE
fix: 🐛 proxy promise deprecation

### DIFF
--- a/ui/admin/app/routes/scopes/scope/roles/role/index.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/index.js
@@ -22,7 +22,9 @@ export default class ScopesScopeRolesRoleIndexRoute extends Route {
       : (await this.store.query('scope', { scope_id: currentScope.id })).map(
           (scope) => ({
             model: scope,
-            subScopes: this.store.query('scope', { scope_id: scope.id }),
+            subScopes: this.store
+              .query('scope', { scope_id: scope.id })
+              .then((models) => models.map((model) => model)),
           })
         );
     const grantScopes = [

--- a/ui/admin/app/routes/scopes/scope/roles/role/index.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/index.js
@@ -5,7 +5,6 @@
 
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { all } from 'rsvp';
 
 export default class ScopesScopeRolesRoleIndexRoute extends Route {
   // =services
@@ -24,7 +23,7 @@ export default class ScopesScopeRolesRoleIndexRoute extends Route {
     let subScopes = [];
     //await the store query to fix ember's proxy promise deprecation warning
     if (!currentScope.isProject) {
-      subScopes = await all(
+      subScopes = await Promise.all(
         scopes.map(async (scope) => ({
           model: scope,
           subScopes: await this.store.query('scope', { scope_id: scope.id }),

--- a/ui/admin/app/routes/scopes/scope/roles/role/index.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/index.js
@@ -5,6 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { all } from 'rsvp';
 
 export default class ScopesScopeRolesRoleIndexRoute extends Route {
   // =services
@@ -17,16 +18,20 @@ export default class ScopesScopeRolesRoleIndexRoute extends Route {
    */
   async afterModel() {
     const currentScope = this.modelFor('scopes.scope');
-    const subScopes = currentScope.isProject
-      ? []
-      : (await this.store.query('scope', { scope_id: currentScope.id })).map(
-          (scope) => ({
-            model: scope,
-            subScopes: this.store
-              .query('scope', { scope_id: scope.id })
-              .then((models) => models.map((model) => model)),
-          })
-        );
+    const scopes = await this.store.query('scope', {
+      scope_id: currentScope.id,
+    });
+    let subScopes = [];
+    //await the store query to fix ember's proxy promise deprecation warning
+    if (!currentScope.isProject) {
+      subScopes = await all(
+        scopes.map(async (scope) => ({
+          model: scope,
+          subScopes: await this.store.query('scope', { scope_id: scope.id }),
+        }))
+      );
+    }
+
     const grantScopes = [
       {
         model: currentScope,

--- a/yarn.lock
+++ b/yarn.lock
@@ -18913,7 +18913,7 @@ react-dom@^16:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10635)

 
This pr gets rid of the [promiseArray deprecation warning](https://api.emberjs.com/ember-data/4.12/classes/CurrentDeprecations/properties?anchor=DEPRECATE_PROMISE_PROXIES)

Since the listed methods in the link above return a promise now, we need to resolve this object before we access them in the templates.

[preview](https://boundary-ui-git-icu-10635-fix-proxy-promises-warning-hashicorp.vercel.app/scopes/global/roles/r_22a3qt99e6)

 
<img width="1017" alt="Screenshot 2023-08-18 at 2 13 25 PM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/fe3ca8db-99bb-41ff-ba16-e31dfe50a1e1">

