### PR TITLE
chore: 🤖 remove storybook related files

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -13,7 +13,6 @@ project {
     "**/node_modules/**",
     "**/dist/**",
     "**/coverage/**",
-    "addons/rose/.storybook/preview-head.html",
     "ui/desktop/electron-app/out/**",
     "ui/desktop/electron-app/ember-dist/**",
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,4 @@ libpeerconnection.log
 npm-debug.log*
 testem.log
 yarn-error.log
-storybook-static
-**/.storybook/*.html
 .watchman-cookie*


### PR DESCRIPTION
noticed we still have some storybook-related files in the repo, since storybook is removed from our apps, these should be deleted as well.  