### PR TITLE
fix: 🐛 add flex-shrink to flight-icon to avoid icon shrinking

### DIFF
--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -529,6 +529,10 @@ $chevron-down: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%231
   .copyable-button {
     background-color: var(--token-color-palette-neutral-50);
   }
+
+  .flight-icon {
+    flex-shrink: 0;
+  }
 }
 
 .details-screen-body {


### PR DESCRIPTION
## Description

add flex-shrink to flight-icon to avoid icon shrinking

### Screenshots (if appropriate):
before:
<img width="306" alt="Screen Shot 2023-08-22 at 11 51 08 AM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/24d8f870-3d5d-4371-98ef-16cc3568ff18">

after:
<img width="306" alt="Screen Shot 2023-08-22 at 11 50 52 AM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/52e75b0f-9dde-40e7-85b4-8f34dfd0a667">
