### PR TITLE
fix: 🐛 filterby deprecation warning

### DIFF
--- a/ui/admin/app/routes/scopes/scope/authenticate.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate.js
@@ -52,7 +52,8 @@ export default class ScopesScopeAuthenticateRoute extends Route {
     // and filter out any that have no auth methods
     const scopes = this.modelFor('scopes').filter(
       ({ id: scope_id, isOrg }) =>
-        isOrg && authMethodsForAllScopes.filterBy('scopeID', scope_id).length
+        isOrg &&
+        authMethodsForAllScopes.filter((i) => i.scopeID === scope_id).length
     );
     return hash({
       scope: this.modelFor('scopes.scope'),

--- a/ui/admin/app/routes/scopes/scope/index.js
+++ b/ui/admin/app/routes/scopes/scope/index.js
@@ -23,8 +23,9 @@ export default class ScopesScopeIndexRoute extends Route {
    * If authenticated but no orgs exist, redirect into onboarding.
    */
   redirect(model) {
-    const hasOrgs = this.store.peekAll('scope').filterBy('type', 'org').length;
-
+    const hasOrgs = this.store
+      .peekAll('scope')
+      .filter((scope) => scope.type === 'org').length;
     // Must authenticate before proceeding anywhere else
     if (!this.session.isAuthenticated) {
       return this.router.transitionTo('scopes.scope.authenticate');


### PR DESCRIPTION
[jira](https://hashicorp.atlassian.net/browse/ICU-10657)

This PR fixes the `filterby` [deprecation](https://rfcs.emberjs.com/id/0848-deprecate-array-prototype-extensions/) warning.

<img width="1608" alt="Screenshot 2023-08-22 at 4 37 43 PM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/b3faea3f-b636-4584-96ed-6a253ad1186e">

[preview](https://boundary-ui-git-icu-10657-fix-filterby-deprecation-hashicorp.vercel.app/) [check console logs for the warning]