### PR TITLE
fix: 🐛 toarray deprecation warning

### DIFF
--- a/addons/core/addon/initializers/deprecations.js
+++ b/addons/core/addon/initializers/deprecations.js
@@ -5,12 +5,17 @@
 
 import { registerDeprecationHandler } from '@ember/debug';
 
+const deprecationList = [
+  'ember-data:deprecate-early-static',
+  'ember-data:deprecate-array-like',
+];
+
 export function initialize() {
   registerDeprecationHandler((message, options, next) => {
-    // TODO: fix `deprecate-early-static` warning before ember 5 upgrade
+    // TODO: fix `deprecate-early-static` and `deprecate-array-prototype-extension` warning before ember 5 upgrade
     //silence deprecate-early-static warnings till we find a way to
     //fix ember-cli-mirage discoverEmberDataModels
-    if (options?.id === 'ember-data:deprecate-early-static') {
+    if (options?.id && deprecationList.includes(options.id)) {
       return;
     }
     if (options?.url) {

--- a/ui/admin/app/routes/scopes/scope/roles/role/add-principals.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/add-principals.js
@@ -46,7 +46,7 @@ export default class ScopesScopeRolesRoleAddPrincipalsRoute extends Route {
    */
   async model() {
     const role = this.modelFor('scopes.scope.roles.role');
-    const scopes = this.store.peekAll('scope').toArray();
+    const scopes = this.store.peekAll('scope');
     const scopeIDs = this.scope?.map((scope) => scope.id);
     const users = scopeIDs?.length
       ? this.resourceFilterStore.queryBy(

--- a/ui/admin/app/routes/scopes/scope/targets/target/enable-session-recording/index.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/enable-session-recording/index.js
@@ -41,8 +41,8 @@ export default class ScopesScopeTargetsTargetEnableSessionRecordingIndexRoute ex
     });
 
     const storageBucketList = [
-      ...globalScopeStorageBuckets.toArray(),
-      ...orgScopeStorageBuckets.toArray(),
+      ...globalScopeStorageBuckets,
+      ...orgScopeStorageBuckets,
     ];
     this.storageBucketList = storageBucketList;
   }

--- a/ui/admin/app/routes/scopes/scope/users.js
+++ b/ui/admin/app/routes/scopes/scope/users.js
@@ -14,7 +14,6 @@ export default class ScopesScopeUsersRoute extends Route {
   // =services
 
   @service store;
-  @service intl;
   @service session;
   @service can;
   @service router;
@@ -32,7 +31,7 @@ export default class ScopesScopeUsersRoute extends Route {
    * Load all users under current scope.
    * @return {Promise{[UserModel]}}
    */
-  async model() {
+  model() {
     const scope = this.modelFor('scopes.scope');
     const { id: scope_id } = scope;
     if (this.can.can('list model', scope, { collection: 'users' })) {

--- a/ui/admin/app/routes/scopes/scope/users/user.js
+++ b/ui/admin/app/routes/scopes/scope/users/user.js
@@ -19,7 +19,7 @@ export default class ScopesScopeUsersUserRoute extends Route {
    * @param {string} params.user_id
    * @return {UserModel}
    */
-  async model({ user_id }) {
+  model({ user_id }) {
     return this.store.findRecord('user', user_id);
   }
 }


### PR DESCRIPTION
[jira](https://hashicorp.atlassian.net/browse/ICU-10578)

[deprecation](https://rfcs.emberjs.com/id/0848-deprecate-array-prototype-extensions/)

this pr fixes `toArray` deprecation warning, I had to silence the warnings due to HDS table's [usage](https://github.com/hashicorp/design-system/blob/dcd881a217a7d9eaee50f9830db28f9f80db0b9d/packages/components/addon/components/hds/table/index.hbs#L50) of sort-by ember-composable-helpers which [internally](https://github.com/DockYard/ember-composable-helpers/blob/62fb18314e563d70c6588d733df4d26fd4b14aa1/addon/helpers/sort-by.js#L112) used `toArray` method. I raised it with the HDS team, but for now we will silence the warning as it happening in quite a few places.  