### PR TITLE
feat: 🎸 redirect to targets list when canceling

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects/sessions.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions.js
@@ -93,6 +93,12 @@ export default class ScopesScopeProjectsSessionsRoute extends Route {
   async cancelSession(session) {
     await session.cancelSession();
     await this.ipc.invoke('stop', { session_id: session.id });
+    if (
+      this.router.currentRoute.name ===
+      'scopes.scope.projects.sessions.session.index'
+    ) {
+      await this.router.replaceWith('scopes.scope.projects.targets');
+    }
   }
 
   /**

--- a/ui/desktop/tests/acceptance/projects/sessions/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/index-test.js
@@ -269,7 +269,7 @@ module('Acceptance | projects | sessions', function (hooks) {
       .isVisible();
   });
 
-  test('cancelling a session', async function (assert) {
+  test('cancelling a session shows success alert', async function (assert) {
     assert.expect(1);
     stubs.ipcService.withArgs('stop');
 
@@ -277,6 +277,16 @@ module('Acceptance | projects | sessions', function (hooks) {
     await click('tbody tr:first-child td:last-child button');
 
     assert.dom('[role="alert"].is-success').isVisible();
+  });
+
+  test('cancelling a session keeps you on the sessions list screen', async function (assert) {
+    assert.expect(1);
+    stubs.ipcService.withArgs('stop');
+
+    await visit(urls.sessions);
+    await click('tbody tr:first-child td:last-child button');
+
+    assert.strictEqual(currentURL(), urls.sessions);
   });
 
   test('cancelling a session with error shows notification', async function (assert) {

--- a/ui/desktop/tests/acceptance/projects/sessions/session-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/session-test.js
@@ -53,6 +53,7 @@ module('Acceptance | projects | sessions | session', function (hooks) {
       },
     },
     projects: null,
+    targets: null,
     target: null,
     sessions: null,
     session: null,
@@ -109,7 +110,8 @@ module('Acceptance | projects | sessions | session', function (hooks) {
     urls.authenticate.global = `${urls.scopes.global}/authenticate`;
     urls.authenticate.methods.global = `${urls.authenticate.global}/${instances.authMethods.global.id}`;
     urls.projects = `${urls.scopes.org}/projects`;
-    urls.target = `${urls.projects}/targets/${instances.target.id}`;
+    urls.targets = `${urls.projects}/targets`;
+    urls.target = `${urls.targets}/${instances.target.id}`;
     urls.sessions = `${urls.projects}/sessions`;
     urls.session = `${urls.projects}/sessions/${instances.session.id}`;
 
@@ -181,7 +183,7 @@ module('Acceptance | projects | sessions | session', function (hooks) {
       .hasText(`Connected You can now access ${instances.target.name}`);
   });
 
-  test('cancelling a session', async function (assert) {
+  test('cancelling a session shows success alert', async function (assert) {
     assert.expect(1);
     stubs.ipcService.withArgs('stop');
 
@@ -189,6 +191,16 @@ module('Acceptance | projects | sessions | session', function (hooks) {
     await click('[data-test-session-detail-cancel-button]');
 
     assert.dom('[role="alert"].is-success').isVisible();
+  });
+
+  test('cancelling a session takes you to the targets list screen', async function (assert) {
+    assert.expect(1);
+    stubs.ipcService.withArgs('stop');
+
+    await visit(urls.session);
+    await click('[data-test-session-detail-cancel-button]');
+
+    assert.strictEqual(currentURL(), urls.targets);
   });
 
   test('cancelling a session with error shows notification', async function (assert) {


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10760)

## Description

redirect to targets list when canceling from the sessions detail screen

✅ Closes: ICU-10760

:desktop_computer: [Desktop preview](https://boundary-ui-desktop-git-icu-10760-route-user-t-ed6945-hashicorp.vercel.app/scopes/global/projects/targets)

When you establish a connection, click "End Session" from the sessions detail screen and user will be redirected to the targets list screen. If you click "Cancel" on a session from the sessions list screen, you should stay in the same location.

