### PR TITLE
refactor: 💡 Turn on sandboxing for renderer process

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects/sessions/session.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions/session.js
@@ -6,6 +6,8 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
 
 export default class ScopesScopeProjectsSessionsSessionRoute extends Route {
   // =services
@@ -30,10 +32,26 @@ export default class ScopesScopeProjectsSessionsSessionRoute extends Route {
 
   @action
   async openTerminal(model) {
-    const { proxy_address, proxy_port } = model;
-    // Window is exposed by contextBridge within preload script.
-    window.terminal.open('terminal-container');
-    // Send command
-    window.terminal.openSsh(proxy_address, proxy_port);
+    const xterm = new Terminal();
+    const fitAddon = new FitAddon();
+    const termContainer = document.getElementById('terminal-container');
+
+    // TODO: Do we need the fit addon?
+    xterm.loadAddon(fitAddon);
+    xterm.open(termContainer);
+    fitAddon.fit();
+
+    // Terminal is exposed by contextBridge within the preload script.
+    xterm.onData((data) => window.terminal.send(data));
+    window.terminal.receive((event, value) => {
+      xterm.write(value);
+    });
+
+    if (model.target?.isSSH) {
+      const { proxy_address, proxy_port } = model;
+
+      // Send an SSH command immediately
+      window.terminal.send(`ssh ${proxy_address} -p ${proxy_port}\r`);
+    }
   }
 }

--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -9,7 +9,6 @@
 
 @import 'rose';
 @import 'notify';
-@import 'electron-app/node_modules/xterm/css/xterm';
 
 .rose-layout-centered {
   > .rose-layout-page {

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -29,9 +29,7 @@
     "node-pty": "^1.0.0",
     "semver": "^7.5.3",
     "shell-quote": "^1.7.3",
-    "tree-kill": "^1.2.2",
-    "xterm": "^5.2.1",
-    "xterm-addon-fit": "^0.7.0"
+    "tree-kill": "^1.2.2"
   },
   "devDependencies": {
     "@electron-forge/cli": "^6.1.1",

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -95,10 +95,7 @@ const createWindow = (partition, closeWindowCB) => {
   // TODO: Figure out how to spawn more than one terminal process in a browser window
   //       while keeping track of handlers
   // Terminal
-  const shell2 =
-    os.platform() === 'win32'
-      ? 'powershell.exe'
-      : process.env.SHELL || '/bin/bash';
+  const shell2 = os.platform() === 'win32' ? 'powershell.exe' : '/bin/bash';
   const ptyProcess = pty.spawn(shell2, [], {
     name: 'xterm-color',
     cols: 80,

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -67,10 +67,10 @@ const createWindow = (partition, closeWindowCB) => {
     titleBarStyle: showWindowChrome ? 'hiddenInset' : 'none',
     webPreferences: {
       partition,
-      // sandbox: true, // TODO check why xterm does not work when sandbox, perhaps when move to preload?
+      sandbox: true,
       webSecurity: true,
       contextIsolation: true,
-      nodeIntegration: true, // TODO: check if we can make it work without nodeIntegration.
+      nodeIntegration: false,
       allowRunningInsecureContent: false,
       // The preload script establishes the message-based IPC pathway without
       // exposing new modules to the renderer.
@@ -92,8 +92,13 @@ const createWindow = (partition, closeWindowCB) => {
 
   const browserWindow = new BrowserWindow(browserWindowOptions);
 
+  // TODO: Figure out how to spawn more than one terminal process in a browser window
+  //       while keeping track of handlers
   // Terminal
-  const shell2 = os.platform() === 'win32' ? 'powershell.exe' : 'bash';
+  const shell2 =
+    os.platform() === 'win32'
+      ? 'powershell.exe'
+      : process.env.SHELL || '/bin/bash';
   const ptyProcess = pty.spawn(shell2, [], {
     name: 'xterm-color',
     cols: 80,
@@ -102,16 +107,15 @@ const createWindow = (partition, closeWindowCB) => {
     env: process.env,
   });
 
-  // This sends to the main window (the listener is on preload.js) and xterm
-  // whatever the ptyProcess (host terminal) outputs.
+  // This sends to the renderer and xterm whatever the ptyProcess (host terminal) outputs.
   ptyProcess.on('data', function (data) {
-    mainWindow.webContents.send('terminal.incomingData', data);
+    mainWindow.webContents.send('terminalIncomingData', data);
     console.log('Data sent');
   });
 
   // This writes into ptyProcess (host terminal) whatever we write through xterm.
-  ipcMain.on('terminal.keystroke', (event, key) => {
-    ptyProcess.write(key);
+  ipcMain.on('terminalKeystroke', (event, value) => {
+    ptyProcess.write(value);
   });
 
   // If the user-specified cluster URL changes, reload the page so that

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -11,8 +11,6 @@ const sessionManager = require('../services/session-manager.js');
 const runtimeSettings = require('../services/runtime-settings.js');
 const sanitizer = require('../utils/sanitizer.js');
 const { isMac } = require('../helpers/platform.js');
-// const { Terminal } = require('xterm');
-// const { FitAddon } = require('xterm-addon-fit');
 
 /**
  * Returns the current runtime clusterUrl, which is used by the main thread to

--- a/ui/desktop/electron-app/yarn.lock
+++ b/ui/desktop/electron-app/yarn.lock
@@ -3495,16 +3495,6 @@ xtend@^4.0.0:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-xterm-addon-fit@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.7.0.tgz#b8ade6d96e63b47443862088f6670b49fb752c6a"
-  integrity sha512-tQgHGoHqRTgeROPnvmtEJywLKoC/V9eNs4bLLz7iyJr1aW/QFzRwfd3MGiJ6odJd9xEfxcW36/xRU47JkD5NKQ==
-
-xterm@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.2.1.tgz#b3fea7bdb55b9be1d4b31f4cd1091f26ac42afb8"
-  integrity sha512-cs5Y1fFevgcdoh2hJROMVIWwoBHD80P1fIP79gopLHJIE4kTzzblanoivxTiQ4+92YM9IxS36H1q0MxIJXQBcA==
-
 y18n@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"

--- a/ui/desktop/ember-cli-build.js
+++ b/ui/desktop/ember-cli-build.js
@@ -41,5 +41,7 @@ module.exports = function (defaults) {
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
 
+  app.import('node_modules/xterm/css/xterm.css');
+
   return app.toTree();
 };

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -44,7 +44,9 @@
     "posttest": "ember coverage-merge && yarn clean:coverage"
   },
   "dependencies": {
-    "ember-named-blocks-polyfill": "^0.2.5"
+    "ember-named-blocks-polyfill": "^0.2.5",
+    "xterm": "^5.2.1",
+    "xterm-addon-fit": "^0.7.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.18.2",
@@ -98,6 +100,7 @@
     "eslint-plugin-qunit": "^7.3.0",
     "js-bexpr": "hashicorp/js-bexpr#9b4a4b54d85eba67fdfc0990133d1518d890b1e1",
     "loader.js": "^4.7.0",
+    "lodash": "4.17.21",
     "npm-run-all": "^4.1.5",
     "playwright": "^1.15.0",
     "prettier": "^2.7.1",
@@ -110,8 +113,7 @@
     "stylelint": "^15.10.1",
     "stylelint-config-prettier-scss": "^0.0.1",
     "stylelint-config-standard-scss": "^7.0.1",
-    "webpack": "^5.76.0",
-     "lodash": "4.17.21"
+    "webpack": "^5.76.0"
   },
   "engines": {
     "node": "16.* || 18.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15639,9 +15639,9 @@ lines-and-columns@^1.1.6:
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 linkify-it@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.2.tgz#f55eeb8bc1d3ae754049e124ab3bb56d97797fb8"
-  integrity sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
+  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
   dependencies:
     uc.micro "^1.0.1"
 
@@ -18731,7 +18731,7 @@ react-dom@^16:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-is@^16.13.1, react-is@^16.8.1:
+react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -21048,9 +21048,9 @@ terser-webpack-plugin@^5.3.7:
     terser "^5.16.8"
 
 terser@^4.1.2, terser@^5.14.2, terser@^5.16.8, terser@^5.3.0, terser@^5.7.2:
-  version "5.19.2"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.19.2.tgz#bdb8017a9a4a8de4663a7983f45c506534f9234e"
-  integrity sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==
+  version "5.19.3"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.19.3.tgz#359baeba615aef13db4b8c4d77a2aa0d8814aa9e"
+  integrity sha512-pQzJ9UJzM0IgmT4FAtYI6+VqFf0lj/to58AV0Xfgg0Up37RyPG7Al+1cepC6/BVuAxR9oNb41/DL4DEoHJvTdg==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"
@@ -22459,6 +22459,16 @@ xtend@~2.1.1:
   integrity sha1-bv7MKk2tjmlixJAbM3znuoe10os=
   dependencies:
     object-keys "~0.4.0"
+
+xterm-addon-fit@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.7.0.tgz#b8ade6d96e63b47443862088f6670b49fb752c6a"
+  integrity sha512-tQgHGoHqRTgeROPnvmtEJywLKoC/V9eNs4bLLz7iyJr1aW/QFzRwfd3MGiJ6odJd9xEfxcW36/xRU47JkD5NKQ==
+
+xterm@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.2.1.tgz#b3fea7bdb55b9be1d4b31f4cd1091f26ac42afb8"
+  integrity sha512-cs5Y1fFevgcdoh2hJROMVIWwoBHD80P1fIP79gopLHJIE4kTzzblanoivxTiQ4+92YM9IxS36H1q0MxIJXQBcA==
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
## Description
This lets us keep sandboxing on and `nodeIntegration` off in the renderer process.

We still only have one pty process which is shared across the entire browser window and need to do proper cleanup. 