### PR TITLE
feat: 🎸 update connect logic for targets with static addresses

### DIFF
--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Controller from '@ember/controller';
+
+export default class ScopesScopeProjectsTargetsTargetController extends Controller {
+  // =attributes
+
+  queryParams = [{ isConnecting: { type: 'boolean' } }];
+
+  isConnecting = false;
+}

--- a/ui/desktop/app/routes/scopes/scope/projects/targets.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets.js
@@ -7,15 +7,12 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { resourceFilter } from 'core/decorators/resource-filter';
-import { loading } from 'ember-loading';
 
 export default class ScopesScopeProjectsTargetsRoute extends Route {
   // =services
 
   @service can;
   @service clusterUrl;
-  @service confirm;
-  @service ipc;
   @service resourceFilterStore;
   @service router;
   @service session;
@@ -72,58 +69,6 @@ export default class ScopesScopeProjectsTargetsRoute extends Route {
   @action
   acknowledge(session) {
     session.acknowledged = true;
-  }
-
-  /**
-   * Establish a session to current target.
-   * @param {TargetModel} model
-   * @param {HostModel} host
-   */
-  @action
-  @loading
-  async connect(model, host) {
-    // TODO: Connect: move this logic into the target model
-    try {
-      // Check for CLI
-      const cliExists = await this.ipc.invoke('cliExists');
-      if (!cliExists) throw new Error('Cannot find Boundary CLI.');
-
-      const options = {
-        target_id: model.id,
-        token: this.session.data.authenticated.token,
-      };
-
-      if (host) options.host_id = host.id;
-
-      // Create target session
-      const connectionDetails = await this.ipc.invoke('connect', options);
-
-      // Associate the connection details with the session
-      const { session_id, address, port, credentials } = connectionDetails;
-      const session = await this.store.findRecord('session', session_id);
-
-      // Flag the session has been open in the desktop client
-      session.started_desktop_client = true;
-      // Update the session record with proxy information from the CLI
-      // In the future, it may make sense to push this off to the API so that
-      // we don't have to manually persist the proxy details.
-      session.proxy_address = address;
-      session.proxy_port = port;
-      if (credentials) {
-        credentials.forEach((cred) => session.addCredential(cred));
-      }
-
-      await this.router.transitionTo(
-        'scopes.scope.projects.sessions.session',
-        session
-      );
-    } catch (e) {
-      this.confirm
-        .confirm(e.message, { isConnectError: true })
-        // Retry
-        .then(() => this.connect(model))
-        .catch(() => null /* no op */);
-    }
   }
 
   /**

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
@@ -5,11 +5,23 @@
 
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { loading } from 'ember-loading';
 
 export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
   // =services
 
   @service store;
+  @service confirm;
+  @service ipc;
+  @service router;
+  @service session;
+
+  queryParams = {
+    isConnecting: {
+      refreshModel: true,
+    },
+  };
 
   // =methods
 
@@ -17,9 +29,86 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
    * Load a target
    * @param {object} params
    * @param {string} params.target_id
+   * @param {bool} params.isConnecting
    * @return {TargetModel}
    */
-  model({ target_id }) {
-    return this.store.findRecord('target', target_id, { reload: true });
+  async model({ target_id, isConnecting }) {
+    const target = await this.store.findRecord('target', target_id, {
+      reload: true,
+    });
+
+    if (isConnecting) {
+      this.preConnect(target);
+    }
+    return target;
+  }
+
+  /**
+   * Determine if connection workflow based on target attributes.
+   * @param {TargetModel} model
+   */
+  @action
+  @loading
+  async preConnect(target) {
+    console.log('preconnect called');
+    if (target.address) {
+      this.connect(target);
+    }
+  }
+
+  /**
+   * Establish a session to current target.
+   * @param {TargetModel} model
+   * @param {HostModel} host
+   */
+  @action
+  @loading
+  async connect(model, host) {
+    // TODO: Connect: move this logic into the target model
+    try {
+      console.log(model);
+      // Check for CLI
+      const cliExists = await this.ipc.invoke('cliExists');
+      console.log(cliExists);
+      if (!cliExists) throw new Error('Cannot find Boundary CLI.');
+
+      const options = {
+        target_id: model.id,
+        token: this.session.data.authenticated.token,
+      };
+
+      if (host) options.host_id = host.id;
+
+      // Create target session
+      const connectionDetails = await this.ipc.invoke('connect', options);
+      console.log(connectionDetails);
+
+      // Associate the connection details with the session
+      const { session_id, address, port, credentials } = connectionDetails;
+      const session = await this.store.findRecord('session', session_id);
+      console.log(session);
+
+      // Flag the session has been open in the desktop client
+      session.started_desktop_client = true;
+      // Update the session record with proxy information from the CLI
+      // In the future, it may make sense to push this off to the API so that
+      // we don't have to manually persist the proxy details.
+      session.proxy_address = address;
+      session.proxy_port = port;
+      if (credentials) {
+        credentials.forEach((cred) => session.addCredential(cred));
+      }
+
+      await this.router.transitionTo(
+        'scopes.scope.projects.sessions.session',
+        session
+      );
+    } catch (e) {
+      this.confirm
+        .confirm(e.message, { isConnectError: true })
+        // Retry
+        .then(() => this.connect(model))
+        .catch(() => null /* no op */);
+    }
   }
 }

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
@@ -17,12 +17,6 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
   @service router;
   @service session;
 
-  queryParams = {
-    isConnecting: {
-      refreshModel: true,
-    },
-  };
-
   // =methods
 
   /**
@@ -38,20 +32,21 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
     });
 
     if (isConnecting) {
-      this.preConnect(target);
+      await this.preConnect(target);
     }
+
     return target;
   }
 
   /**
-   * Determine if connection workflow based on target attributes.
+   * Determine if we show host modal or quick connect based on target attributes.
    * @param {TargetModel} model
    */
   @action
   @loading
   async preConnect(target) {
     if (target.address) {
-      this.connect(target);
+      await this.connect(target);
     }
   }
 

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
@@ -50,7 +50,6 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
   @action
   @loading
   async preConnect(target) {
-    console.log('preconnect called');
     if (target.address) {
       this.connect(target);
     }
@@ -66,10 +65,8 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
   async connect(model, host) {
     // TODO: Connect: move this logic into the target model
     try {
-      console.log(model);
       // Check for CLI
       const cliExists = await this.ipc.invoke('cliExists');
-      console.log(cliExists);
       if (!cliExists) throw new Error('Cannot find Boundary CLI.');
 
       const options = {
@@ -81,12 +78,10 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
 
       // Create target session
       const connectionDetails = await this.ipc.invoke('connect', options);
-      console.log(connectionDetails);
 
       // Associate the connection details with the session
       const { session_id, address, port, credentials } = connectionDetails;
       const session = await this.store.findRecord('session', session_id);
-      console.log(session);
 
       // Flag the session has been open in the desktop client
       session.started_desktop_client = true;

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
@@ -115,8 +115,10 @@
               <span class='hds-font-weight-semibold'>
                 {{#if (can 'read model' B.data)}}
                   <LinkTo
+                    data-test-visit-target
                     @route='scopes.scope.projects.targets.target'
                     @model={{B.data.id}}
+                    @query={{hash isConnecting=false}}
                   >
                     {{B.data.displayName}}
                   </LinkTo>
@@ -159,9 +161,12 @@
             <B.Td>
               {{#if (can 'connect target' B.data)}}
                 <Hds::Button
+                  data-test-targets-connect-button
                   @text={{t 'resources.session.actions.connect'}}
                   @color='secondary'
-                  {{on 'click' (route-action 'connect' B.data)}}
+                  @route='scopes.scope.projects.targets.target'
+                  @model={{B.data.id}}
+                  @query={{hash isConnecting=true}}
                 />
               {{/if}}
             </B.Td>

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target.hbs
@@ -20,7 +20,7 @@
       @text={{t 'resources.session.actions.connect'}}
       @icon='entry-point'
       @iconPosition='trailing'
-      {{on 'click' (route-action 'connect' @model)}}
+      {{on 'click' (route-action 'preConnect' @model)}}
     />
   </page.actions>
 

--- a/ui/desktop/tests/acceptance/scopes-test.js
+++ b/ui/desktop/tests/acceptance/scopes-test.js
@@ -103,7 +103,7 @@ module('Acceptance | scopes', function (hooks) {
     );
     instances.target = this.server.create(
       'target',
-      { scope: instances.scopes.project },
+      { scope: instances.scopes.project, address: 'localhost' },
       'withAssociations'
     );
 
@@ -172,14 +172,17 @@ module('Acceptance | scopes', function (hooks) {
     const targetsCount = this.server.schema.targets.all().models.length;
 
     await visit(urls.targets);
+
     assert.strictEqual(currentURL(), urls.targets);
     assert.strictEqual(findAll('tbody tr').length, targetsCount);
   });
 
   test('visiting global scope', async function (assert) {
     assert.expect(1);
+
     await visit(urls.scopes.global);
     await a11yAudit();
+
     assert.strictEqual(currentURL(), urls.globalTargets);
   });
 
@@ -194,15 +197,19 @@ module('Acceptance | scopes', function (hooks) {
       const response = id === 'global' ? new Response(404) : scope;
       return response;
     });
+
     await visit(urls.scopes.global);
     await a11yAudit();
+
     assert.strictEqual(currentURL(), urls.globalTargets);
   });
 
   test('visiting org scope', async function (assert) {
     assert.expect(1);
+
     await visit(urls.scopes.org);
     await a11yAudit();
+
     assert.strictEqual(currentURL(), urls.targets);
   });
 
@@ -212,8 +219,10 @@ module('Acceptance | scopes', function (hooks) {
 
     await click('.rose-header-nav .rose-dropdown a:nth-of-type(2)');
     assert.strictEqual(currentURL(), urls.targets);
+
     await click('.rose-header-nav .rose-dropdown a:nth-of-type(3)');
     assert.strictEqual(currentURL(), urls.org2Targets);
+
     await click('.rose-header-nav .rose-dropdown a:nth-of-type(1)');
     assert.strictEqual(currentURL(), urls.globalTargets);
   });
@@ -221,23 +230,29 @@ module('Acceptance | scopes', function (hooks) {
   test('visiting index while unauthenticated redirects to global authenticate method', async function (assert) {
     invalidateSession();
     assert.expect(2);
+
     await visit(urls.targets);
     await a11yAudit();
+
     assert.notOk(currentSession().isAuthenticated);
     assert.strictEqual(currentURL(), urls.authenticate.methods.global);
   });
 
   test('visiting a target', async function (assert) {
     assert.expect(1);
+
     await visit(urls.targets);
-    await click('tbody tr td span a');
+    await click('[data-test-visit-target]');
+
     assert.strictEqual(currentURL(), urls.target);
   });
 
   test('visiting empty targets', async function (assert) {
     assert.expect(1);
     this.server.get('/targets', () => new Response(200));
+
     await visit(urls.targets);
+
     assert.ok(
       find('.rose-message-title').textContent.trim(),
       'No Targets Available'
@@ -257,10 +272,8 @@ module('Acceptance | scopes', function (hooks) {
     confirmService.enabled = true;
 
     await visit(urls.targets);
-    await click(
-      'tbody tr:first-child td:last-child button',
-      'Activate connect mode'
-    );
+    await click('[data-test-targets-connect-button]');
+
     assert.ok(find('.dialog-detail'), 'Success dialog');
     assert.strictEqual(findAll('.rose-dialog-footer button').length, 1);
     assert.strictEqual(
@@ -277,10 +290,8 @@ module('Acceptance | scopes', function (hooks) {
     confirmService.enabled = true;
 
     await visit(urls.scopes.global);
-    await click(
-      'tbody tr:first-child td:last-child button',
-      'Activate connect mode'
-    );
+    await click('[data-test-targets-connect-button]');
+
     assert.ok(find('.rose-dialog-error'), 'Error dialog');
     const dialogButtons = findAll('.rose-dialog-footer button');
     assert.strictEqual(dialogButtons.length, 2);
@@ -304,10 +315,8 @@ module('Acceptance | scopes', function (hooks) {
     confirmService.enabled = true;
 
     await visit(urls.targets);
-    await click(
-      'tbody tr:first-child td:last-child button',
-      'Activate connect mode'
-    );
+    await click('[data-test-targets-connect-button]');
+
     assert.ok(find('.rose-dialog-error'), 'Error dialog');
     const dialogButtons = findAll('.rose-dialog-footer button');
     assert.strictEqual(dialogButtons.length, 2);

--- a/ui/desktop/tests/unit/controllers/scopes/scope/projects/targets/target-test.js
+++ b/ui/desktop/tests/unit/controllers/scopes/scope/projects/targets/target-test.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupTest } from 'desktop/tests/helpers';
+
+module(
+  'Unit | Controller | scopes/scope/projects/targets/target',
+  function (hooks) {
+    setupTest(hooks);
+
+    test('it exists', function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/projects/targets/target'
+      );
+      assert.ok(controller);
+    });
+  }
+);


### PR DESCRIPTION
## Description

✅ Closes: ICU-10430

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10430)

Update connect logic for targets with static addresses. This does technically break the connect workflow for targets with hosts but that is the next 2 stories I will be working on.
[Route Logic: Target with Static Hosts](https://hashicorp.atlassian.net/browse/ICU-10431)
[Route Logic: Target with Dynamic Hosts](https://hashicorp.atlassian.net/browse/ICU-10432)

Steps to test:

The **_third Target in the list_** will have a static address that you can establish a connection with.

1. Visit a Target
    - Click on the target name and you should see the target details screen with the "Connect" button in the top right.
2. Connect to a Target
    - Option 1: Click on the "Connect" button at the end of the row for a target that has a static address. This should end with you at the sessions detail screen and a pending session.
    - Option 2: Click on the target name that has a static address and you should see the target details screen with the "Connect" button in the top right. Click on "Connect" and you should see the sessions detail screen and have a pending session.

:desktop_computer: [Desktop preview](https://boundary-ui-desktop-btrhz00gu-hashicorp.vercel.app/scopes/global/projects/targets)

