### PR TITLE
test: 💍 Add create group and roles e2e UI test

### DIFF
--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -287,3 +287,117 @@ exports.addBrokeredCredentialsToTarget = async (
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(page.getByRole('link', { name: credentialName })).toBeVisible();
 };
+
+/**
+ * Uses the UI to create a new group. Assumes you have selected the desired scope.
+ * @param {Page} page Playwright page object
+ * @param {string} groupName Name of the new group
+ */
+exports.createNewGroup = async (page, groupName) => {
+  await page
+    .getByRole('navigation', { name: 'IAM' })
+    .getByRole('link', { name: 'Groups' })
+    .click();
+  await page
+    .getByRole('article')
+    .getByRole('link', { name: 'New', exact: true })
+    .click();
+  await page.getByLabel('Name').fill(groupName);
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').getByText('Success', { exact: true })
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Dismiss' }).click();
+  await expect(
+    page
+      .getByRole('navigation', { name: 'breadcrumbs' })
+      .getByRole('link', { name: groupName })
+  ).toBeVisible();
+};
+
+/**
+ * Uses the UI to add a user to the group. Assumes you have selected the desired group.
+ * @param {Page} page Playwright page object
+ * @param {string} userName Name of the user that will be added to the group
+ */
+exports.addMemberToGroup = async (page, userName) => {
+  await page.getByRole('link', { name: 'Members', exact: true }).click();
+  await page
+    .getByRole('article')
+    .getByRole('link', { name: 'Add Members', exact: true })
+    .click();
+  await page.getByRole('checkbox', { name: userName }).click();
+  await page.getByRole('button', { name: 'Add Members', exact: true }).click();
+  await expect(
+    page.getByRole('alert').getByText('Success', { exact: true })
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Dismiss' }).click();
+  await expect(page.getByRole('table').getByText(userName)).toBeVisible();
+};
+
+/**
+ * Uses the UI to create a new role. Assumes you have selected the desired scope.
+ * @param {Page} page Playwright page object
+ * @param {string} roleName Name of the new role
+ */
+exports.createNewRole = async (page, roleName) => {
+  await page
+    .getByRole('navigation', { name: 'IAM' })
+    .getByRole('link', { name: 'Roles' })
+    .click();
+  await page.getByRole('link', { name: 'New Role' }).click();
+  await page.getByLabel('Name').fill(roleName);
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').getByText('Success', { exact: true })
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Dismiss' }).click();
+  await expect(
+    page
+      .getByRole('navigation', { name: 'breadcrumbs' })
+      .getByRole('link', { name: roleName })
+  ).toBeVisible();
+};
+
+/**
+ * Uses the UI to add a principal to the role. Assumes you have selected the desired role.
+ * @param {Page} page Playwright page object
+ * @param {string} principalName Name of the principal that will be added to the role
+ */
+exports.addPrincipalToRole = async (page, principalName) => {
+  await page.getByRole('link', { name: 'Principals', exact: true }).click();
+  await page
+    .getByRole('article')
+    .getByRole('link', { name: 'Add Principals', exact: true })
+    .click();
+  await page.getByRole('checkbox', { name: principalName }).click();
+  await page
+    .getByRole('button', { name: 'Add Principals', exact: true })
+    .click();
+  await expect(
+    page.getByRole('alert').getByText('Success', { exact: true })
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Dismiss' }).click();
+  await expect(
+    page.getByRole('table').getByRole('link', { name: principalName })
+  ).toBeVisible();
+};
+
+/**
+ * Uses the UI to add a grants to the role. Assumes you have selected the desired role.
+ * @param {Page} page Playwright page object
+ * @param {string} grants grants that will be given to the role
+ */
+exports.addGrantsToGroup = async (page, grants) => {
+  await page.getByRole('link', { name: 'Grants', exact: true }).click();
+  await page.getByRole('textbox', { name: 'New Grant' }).fill(grants);
+  await page.getByRole('button', { name: 'Add', exact: true }).click();
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(
+    page.getByRole('alert').getByText('Success', { exact: true })
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Dismiss' }).click();
+  await expect(
+    page.getByRole('textbox', { name: 'Grant', exact: true })
+  ).toHaveValue(grants);
+};

--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -521,7 +521,7 @@ exports.addPrincipalToRole = async (page, principalName) => {
 };
 
 /**
- * Uses the UI to add a grants to the role. Assumes you have selected the desired role.
+ * Uses the UI to add a grant to the role. Assumes you have selected the desired role.
  * @param {Page} page Playwright page object
  * @param {string} grants grants that will be given to the role
  */

--- a/ui/admin/tests/e2e/tests/group-role.spec.js
+++ b/ui/admin/tests/e2e/tests/group-role.spec.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/* eslint-disable no-undef */
+const { test } = require('@playwright/test');
+const { execSync } = require('child_process');
+const { authenticatedState } = require('../helpers/general');
+const {
+  authenticateBoundaryCli,
+  checkBoundaryCli,
+  deleteOrg,
+} = require('../helpers/boundary-cli');
+const {
+  createNewOrg,
+  createNewGroup,
+  addMemberToGroup,
+  createNewRole,
+  addPrincipalToRole,
+  addGrantsToGroup,
+} = require('../helpers/boundary-ui');
+
+test.use({ storageState: authenticatedState });
+
+test.beforeAll(async () => {
+  await checkBoundaryCli();
+});
+
+test('Verify a new role can be created and associated with a group', async ({
+  page,
+}) => {
+  await page.goto('/');
+  let org;
+  try {
+    const orgName = await createNewOrg(page);
+    await authenticateBoundaryCli();
+    const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+    org = orgs.items.filter((obj) => obj.name == orgName)[0];
+    const groupName = 'test-group';
+    await createNewGroup(page, groupName);
+    await addMemberToGroup(page, 'admin');
+    await createNewRole(page, 'test-role');
+    await addPrincipalToRole(page, groupName);
+    await addGrantsToGroup(page, 'id=*;type=*;actions=read,list');
+  } finally {
+    await deleteOrg(org.id);
+  }
+});

--- a/ui/admin/tests/e2e/tests/group-role.spec.js
+++ b/ui/admin/tests/e2e/tests/group-role.spec.js
@@ -42,7 +42,7 @@ test('Verify a new role can be created and associated with a group', async ({
     await addMemberToGroup(page, 'admin');
     await createNewRole(page, 'test-role');
     await addPrincipalToRole(page, groupName);
-    await addGrantsToGroup(page, 'id=*;type=*;actions=read,list');
+    await addGrantsToGroup(page, 'ids=*;type=*;actions=read,list');
   } finally {
     await deleteOrg(org.id);
   }


### PR DESCRIPTION
✅ Closes: ICU-10557

:tickets: [ICU-10557](https://hashicorp.atlassian.net/browse/ICU-10557)

## Description
This PR adds a new UI e2e test that does the following:

1. Create a new group
2. Adds user to the group
3. Creates a new role
4. Adds principle (i.e. the group) to the role
5. Assigns grants to the role
6. Verifies the grants are assigned


[ICU-10557]: https://hashicorp.atlassian.net/browse/ICU-10557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ