### PR TITLE
test(admin/e2e): Rename variables for clarity

### DIFF
--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -127,7 +127,7 @@ exports.createNewHostInHostSet = async (page) => {
   await page.getByRole('link', { name: 'Create and Add Host' }).click();
   await page.getByLabel('Name').fill(hostName);
   await page.getByLabel('Description').fill('This is an automated test');
-  await page.getByLabel('Address').fill(process.env.E2E_TARGET_IP);
+  await page.getByLabel('Address').fill(process.env.E2E_TARGET_ADDRESS);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
     page.getByRole('alert').getByText('Success', { exact: true })
@@ -152,7 +152,7 @@ exports.createNewTarget = async (page) => {
   await page.getByRole('link', { name: 'New' }).click();
   await page.getByLabel('Name').fill(targetName);
   await page.getByLabel('Description').fill('This is an automated test');
-  await page.getByLabel('Default Port').fill(process.env.E2E_SSH_PORT);
+  await page.getByLabel('Default Port').fill(process.env.E2E_TARGET_PORT);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
     page.getByRole('alert').getByText('Success', { exact: true })
@@ -181,8 +181,8 @@ exports.createNewTargetWithAddress = async (page) => {
   await page.getByRole('link', { name: 'New' }).click();
   await page.getByLabel('Name').fill(targetName);
   await page.getByLabel('Description').fill('This is an automated test');
-  await page.getByLabel('Target Address').fill(process.env.E2E_TARGET_IP);
-  await page.getByLabel('Default Port').fill(process.env.E2E_SSH_PORT);
+  await page.getByLabel('Target Address').fill(process.env.E2E_TARGET_ADDRESS);
+  await page.getByLabel('Default Port').fill(process.env.E2E_TARGET_PORT);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
     page.getByRole('alert').getByText('Success', { exact: true })
@@ -323,7 +323,7 @@ exports.makeAuthMethodPrimary = async (page) => {
     .getByRole('navigation', { name: 'IAM' })
     .getByRole('link', { name: 'Auth Methods' })
     .click();
-  await page.getByRole('button', { name: 'Manage' }).click()
+  await page.getByRole('button', { name: 'Manage' }).click();
   await page.getByText('Make Primary', { exact: true }).click();
   await page.getByText('OK', { exact: true }).click();
   await expect(

--- a/ui/admin/tests/e2e/tests/credential-store-static.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static.spec.js
@@ -28,10 +28,10 @@ test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await checkEnv([
-    'E2E_TARGET_IP',
     'E2E_SSH_USER',
     'E2E_SSH_KEY_PATH',
-    'E2E_SSH_PORT',
+    'E2E_TARGET_ADDRESS',
+    'E2E_TARGET_PORT',
   ]);
 
   await checkBoundaryCli();

--- a/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
@@ -36,7 +36,7 @@ test.beforeAll(async () => {
     'VAULT_ADDR', // Address used by Vault CLI
     'VAULT_TOKEN',
     'E2E_VAULT_ADDR', // Address used by Boundary Server (could be different from VAULT_ADDR depending on network config (i.e. docker network))
-    'E2E_TARGET_IP',
+    'E2E_TARGET_ADDRESS',
     'E2E_SSH_USER',
     'E2E_SSH_KEY_PATH',
   ]);

--- a/ui/admin/tests/e2e/tests/target.spec.js
+++ b/ui/admin/tests/e2e/tests/target.spec.js
@@ -29,10 +29,10 @@ test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await checkEnv([
-    'E2E_TARGET_IP',
     'E2E_SSH_USER',
     'E2E_SSH_KEY_PATH',
-    'E2E_SSH_PORT',
+    'E2E_TARGET_ADDRESS',
+    'E2E_TARGET_PORT',
   ]);
 
   await checkBoundaryCli();


### PR DESCRIPTION
:tickets: [ICU-8678](https://hashicorp.atlassian.net/browse/ICU-8678)

This PR renames some environment variables used in the Admin UI test suite to improve clarity. This is an outcome from some work adding a test in the BE e2e test suite: https://github.com/hashicorp/boundary/pull/3671

[ICU-8678]: https://hashicorp.atlassian.net/browse/ICU-8678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ