### PR TITLE
chore: 🤖 remove devtron

### DIFF
--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -37,7 +37,6 @@
     "@electron-forge/maker-squirrel": "^6.1.1",
     "@electron-forge/maker-zip": "^6.1.1",
     "decompress": "^4.2.1",
-    "devtron": "^1.4.0",
     "electron": "25.3.2"
   },
   "resolutions": {

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -195,19 +195,6 @@ app.on('ready', async () => {
     });
   });
 
-  if (isDev) {
-    try {
-      require('devtron').install();
-    } catch (err) {
-      console.log('Failed to install Devtron: ', err);
-    }
-    try {
-      await installExtension(EMBER_INSPECTOR);
-    } catch (err) {
-      console.log('Failed to install Ember Inspector: ', err);
-    }
-  }
-
   // Configure dev tools menu
   const menuTemplate = Menu.buildFromTemplate(menu.generateMenuTemplate());
   if (isDev) {

--- a/ui/desktop/electron-app/tests/index.js
+++ b/ui/desktop/electron-app/tests/index.js
@@ -3,20 +3,21 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-const { default: installExtension, EMBER_INSPECTOR } = require('electron-devtools-installer');
+const {
+  default: installExtension,
+  EMBER_INSPECTOR,
+} = require('electron-devtools-installer');
 const path = require('path');
 const { app } = require('electron');
 const handleFileUrls = require('../src/handle-file-urls');
-const { setupTestem, openTestWindow } = require('ember-electron/lib/test-support');
+const {
+  setupTestem,
+  openTestWindow,
+} = require('ember-electron/lib/test-support');
 
 const emberAppDir = path.resolve(__dirname, '..', 'ember-test');
 
 app.on('ready', async function onReady() {
-  try {
-    require('devtron').install();
-  } catch (err) {
-    console.log('Failed to install Devtron: ', err);
-  }
   try {
     await installExtension(EMBER_INSPECTOR);
   } catch (err) {

--- a/ui/desktop/electron-app/yarn.lock
+++ b/ui/desktop/electron-app/yarn.lock
@@ -409,11 +409,6 @@ abbrev@^1.0.0:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-accessibility-developer-tools@^2.11.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz#3da0cce9d6ec6373964b84f35db7cfc3df7ab514"
-  integrity sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=
-
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -1029,15 +1024,6 @@ detect-node@^2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.5.tgz#9d270aa7eaa5af0b72c4c9d9b814e7f4ce738b79"
   integrity sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw==
-
-devtron@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/devtron/-/devtron-1.4.0.tgz#b5e748bd6e95bbe70bfcc68aae6fe696119441e1"
-  integrity sha1-tedIvW6Vu+cL/MaKrm/mlhGUQeE=
-  dependencies:
-    accessibility-developer-tools "^2.11.0"
-    highlight.js "^9.3.0"
-    humanize-plus "^1.8.1"
 
 dir-compare@^3.0.0:
   version "3.3.0"
@@ -1696,7 +1682,7 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highlight.js@^10.4.1, highlight.js@^9.3.0:
+highlight.js@^10.4.1:
   version "10.7.2"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.2.tgz#89319b861edc66c48854ed1e6da21ea89f847360"
   integrity sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==
@@ -1749,11 +1735,6 @@ humanize-ms@^1.2.1:
   integrity sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==
   dependencies:
     ms "^2.0.0"
-
-humanize-plus@^1.8.1:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/humanize-plus/-/humanize-plus-1.8.2.tgz#a65b34459ad6367adbb3707a82a3c9f916167030"
-  integrity sha1-pls0RZrWNnrbs3B6gqPJ+RYWcDA=
 
 iconv-lite@^0.6.2:
   version "0.6.3"


### PR DESCRIPTION
[Jira](https://hashicorp.atlassian.net/browse/ICU-10886)

This PR gets rid of [devtron](https://github.com/electron-userland/devtron) package, as it is not being maintained and looks outdated. This also fixes the log failures on desktop app start-up

`failed to install devtron: typeerror: electron.browserwindow.adddevtoolsextension is not a function `
