### PR TITLE
Chore icu 9089 audit resolutions desktop

### DIFF
--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -42,7 +42,6 @@
   "resolutions": {
     "highlight.js": "^10.4.1",
     "@electron-forge/maker-dmg/**/is-my-json-valid/jsonpointer": "^5.0.0",
-    "node-fetch": "^2.6.7",
     "plist": "^3.0.5",
     "lzma-native": "^8.0.6",
     "minimist": "^1.2.6",

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -41,7 +41,7 @@
   },
   "resolutions": {
     "highlight.js": "^10.4.1",
-    "jsonpointer": "^5.0.0",
+    "@electron-forge/maker-dmg/**/is-my-json-valid/jsonpointer": "^5.0.0",
     "node-fetch": "^2.6.7",
     "plist": "^3.0.5",
     "lzma-native": "^8.0.6",

--- a/ui/desktop/electron-app/yarn.lock
+++ b/ui/desktop/electron-app/yarn.lock
@@ -1952,9 +1952,9 @@ jsonfile@^6.0.1:
     graceful-fs "^4.1.6"
 
 jsonpointer@^4.0.0, jsonpointer@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.0.tgz#f802669a524ec4805fa7389eadbc9921d5dc8072"
-  integrity sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.1.tgz#2110e0af0900fd37467b5907ecd13a7884a1b559"
+  integrity sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==
 
 jszip@^3.1.0:
   version "3.10.1"


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9089)

## Description

### jsonpointer
- After running `yarn why jsonpointer` is used by 1 dep.
- After deleting `jsonpointer` from resolutions we start resolving a version with security vulnerabilities. We add a more specific resolution for `jsonpointer@^5`. So we resolve a version with no security vulnerabilities as per [snyk](https://security.snyk.io/package/npm/jsonpointer).

### node-fetch
- After running `yarn why node-fetch` is used by some deps, within `electron-app` and outside.
- After deleting `node-fetch` resolution, we resolve `node-fetch@2.6.7` within `electron-app` and `node-fetch@2.6.11` neither of these version have security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/node-fetch). It is safe to delete `node-fetch` from resolutions.

Testing procedure for these PR: run `boundary-ui-release` CI pipeline, build succesfully both UI's (ui and desktop) locally 
