### PR TITLE
Chore icu 9090 audit resolutions desktop

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "plist": "^3.0.5",
     "lzma-native": "^8.0.6",
     "ansi-html": "^0.0.8",
     "shell-quote": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "async": "^2.6.4",
     "terser": "^5.14.2",
     "jpeg-js": "^0.4.4",
-    "got": "^11.8.5",
     "loader-utils": "^2.0.4",
     "**/ember-electron/**/minimatch": "^3.0.5",
     "**/babel-core/json5": "^2.2.2",
@@ -74,7 +73,8 @@
     "**/snapdragon/base/cache-base/**/set-value": "^4.0.1",
     "**/jsprim/json-schema": "^0.4.0",
     "**/ember-cli/markdown-it-terminal/markdown-it": "^12.3.2",
-    "**/ember-cli-mirage/@embroider/macros": "^1.0.0"
+    "**/ember-cli-mirage/@embroider/macros": "^1.0.0",
+    "**/ember-electron/**/got": "^11.8.6"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "resolutions": {
     "request": "^2.88.0",
-    "lzma-native": "^8.0.6",
     "ansi-html": "^0.0.8",
     "shell-quote": "^1.7.3",
     "hawk": "^9.0.1",

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -41,7 +41,6 @@
   },
   "resolutions": {
     "highlight.js": "^10.4.1",
-    "@electron-forge/maker-dmg/**/is-my-json-valid/jsonpointer": "^5.0.0",
-    "got": "^11.8.5"
+    "@electron-forge/maker-dmg/**/is-my-json-valid/jsonpointer": "^5.0.0"
   }
 }

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -42,7 +42,6 @@
   "resolutions": {
     "highlight.js": "^10.4.1",
     "@electron-forge/maker-dmg/**/is-my-json-valid/jsonpointer": "^5.0.0",
-    "lzma-native": "^8.0.6",
     "minimist": "^1.2.6",
     "got": "^11.8.5"
   }

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -42,7 +42,6 @@
   "resolutions": {
     "highlight.js": "^10.4.1",
     "@electron-forge/maker-dmg/**/is-my-json-valid/jsonpointer": "^5.0.0",
-    "plist": "^3.0.5",
     "lzma-native": "^8.0.6",
     "minimist": "^1.2.6",
     "got": "^11.8.5"

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -42,7 +42,6 @@
   "resolutions": {
     "highlight.js": "^10.4.1",
     "@electron-forge/maker-dmg/**/is-my-json-valid/jsonpointer": "^5.0.0",
-    "minimist": "^1.2.6",
     "got": "^11.8.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16183,7 +16183,7 @@ lru-cache@^7.5.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.0.tgz#b9e2a6a72a129d81ab317202d93c7691df727e61"
   integrity sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==
 
-lzma-native@^8.0.5, lzma-native@^8.0.6:
+lzma-native@^8.0.5:
   version "8.0.6"
   resolved "https://registry.yarnpkg.com/lzma-native/-/lzma-native-8.0.6.tgz#3ea456209d643bafd9b5d911781bdf0b396b2665"
   integrity sha512-09xfg67mkL2Lz20PrrDeNYZxzeW7ADtpYFbwSQh9U8+76RIzx5QsJBMy8qikv3hbUPfpy6hqwxt6FcGK81g9AA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -18195,7 +18195,7 @@ playwright@^1.15.0:
     ws "^7.4.6"
     yazl "^2.5.1"
 
-plist@^3.0.0, plist@^3.0.1, plist@^3.0.4, plist@^3.0.5:
+plist@^3.0.0, plist@^3.0.1, plist@^3.0.4:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/plist/-/plist-3.1.0.tgz#797a516a93e62f5bde55e0b9cc9c967f860893c9"
   integrity sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -13593,7 +13593,7 @@ good-listener@^1.2.2:
   dependencies:
     delegate "^3.1.2"
 
-got@^11.7.0, got@^11.8.2, got@^11.8.5, got@^9.6.0:
+got@^11.7.0, got@^11.8.2, got@^11.8.6, got@^9.6.0:
   version "11.8.6"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.6.tgz#276e827ead8772eddbcfc97170590b841823233a"
   integrity sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9090)

## Description

### plist
- After running `yarn why plist` is used by some deps.
- After deleting `plist` from resolutions, we still resolving `plist@3.1.0` which has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/plist).

### lzma-native
- After running `yarn why lzma-native` is used by some deps, within electron-app and at the root of boundary-ui.
- After deleting `lzma-native` from both resolutions, we still resolving `lzma-native@8.0.6` which has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/lzma-native).

### minimist
- After running `yarn why minimist` is used by some deps.
- After deleting `minimist` from resolutions, we still resolving `minimist@1.2.8` which has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/minimist).

### got
- After running `yarn why got` is used by some deps.
- After deleting `got` from resolutions, we still resolving `got@11.8.5` which has no security vulnerabilities as per [snyk information](https://security.snyk.io/package/npm/got). We will add a more specific got resolution within root package.json since `boundary-ui/ui/desktop` was resolving `got@9.6.0` which has security vulnerabilities.

Testing procedure:
- Build successfully boths UI's (Admin and Desktop).
- Run `boundary-ui-release` CI successfully.
