### PR TITLE
feat: 🎸 Add flag to ssh command to not prompt for known hosts

### DIFF
--- a/ui/desktop/app/components/session/tabs/index.js
+++ b/ui/desktop/app/components/session/tabs/index.js
@@ -44,7 +44,10 @@ export default class SessionTerminalTabsComponent extends Component {
       const { proxy_address, proxy_port } = model;
 
       // Send an SSH command immediately
-      window.terminal.send(`ssh ${proxy_address} -p ${proxy_port}\r`, this.id);
+      window.terminal.send(
+        `ssh ${proxy_address} -p ${proxy_port} -o NoHostAuthenticationForLocalhost=yes\r`,
+        this.id
+      );
     }
   }
 


### PR DESCRIPTION
## Description
We had a suggestion to add the `-o` flag when sending the SSH command and auto connecting which is a great UX improvement.

## Screenshots (if appropriate):

https://github.com/hashicorp/boundary-ui/assets/5783847/c9a0b6cd-fd3a-4a80-bead-b95ceea133ad

## How to Test
Automatically connect to an SSH target and it should not prompt for trusting the known hosts.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
