### PR TITLE
fix: 🐛 fix cancel session failing after shell has started

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects/sessions.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions.js
@@ -93,7 +93,12 @@ export default class ScopesScopeProjectsSessionsRoute extends Route {
   @notifyError(({ message }) => message, { catch: true })
   @notifySuccess('notifications.canceled-success')
   async cancelSession(session) {
-    await session.cancelSession();
+    // fetch session from API to verify we have most up to date record
+    const updatedSession = await this.store.findRecord('session', session.id, {
+      reload: true,
+    });
+    await updatedSession.cancelSession();
+
     await this.ipc.invoke('stop', { session_id: session.id });
     if (
       this.router.currentRoute.name ===


### PR DESCRIPTION
## Description

fix cancel session failing after shell has started

✅ Closes: ICU-11035

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-11035)

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

https://github.com/hashicorp/boundary-ui/assets/29386339/f1983454-10d4-42c9-a1a5-1c8985cc4405


## How to Test

Cancel session will always work with mirage data. To really test this, you need to setup a dev instance, create all the needed resources (target, credentials, etc). Connect to that target, start the shell in the desktop client, then try to end the session. This should now work.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] ~I have added before and after screenshots for UI changes~
- [ ] ~I have added JSON response output for API changes~
- [ ] ~I have added steps to reproduce and test for bug fixes in the description~
- [ ] ~I have commented on my code, particularly in hard-to-understand areas~
- [ ] ~My changes generate no new warnings~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
