### PR TITLE
feat: 🎸 Resize terminal container dynamically

### DIFF
--- a/ui/desktop/app/components/session/tabs/index.js
+++ b/ui/desktop/app/components/session/tabs/index.js
@@ -10,6 +10,20 @@ const terminalOptions = {
   cursorBlink: true,
 };
 
+// This dynamically sets the terminal container's height inline so we have an accurate
+// height for the terminal container. This is necessary because we don't have an
+// intrinsic height from our parent containers and we don't have any content yet from
+// the terminal to have a usable height for the container. This means that calling `.fit()`
+// doesn't get an accurate representation of what the container size can actually be
+const calculateTerminalContainerHeight = (termContainer) => {
+  const viewportHeight = window.innerHeight;
+  // Calculate the height by getting the viewport height, subtracting what
+  // the top offset from the container is, and leaving a small padding to
+  // also prevent any overflow scrolling on the container
+  const height = viewportHeight - termContainer.offsetTop - 24;
+  termContainer.style.height = `${height}px`;
+};
+
 export default class SessionTerminalTabsComponent extends Component {
   // =services
 
@@ -34,6 +48,7 @@ export default class SessionTerminalTabsComponent extends Component {
     this.terminal = xterm;
     const fitAddon = new FitAddon();
     const termContainer = document.getElementById(`terminal-container`);
+    calculateTerminalContainerHeight(termContainer);
 
     xterm.loadAddon(fitAddon);
     xterm.open(termContainer);
@@ -42,7 +57,7 @@ export default class SessionTerminalTabsComponent extends Component {
 
     // Generate a UUID to have the terminal handlers be unique
     this.id = uuidv4();
-    this.#setupTerminal(fitAddon, xterm);
+    this.#setupTerminal(fitAddon, xterm, termContainer);
 
     const { isWindows } = await this.ipc.invoke('checkOS');
     const { model } = this.args;
@@ -73,7 +88,7 @@ export default class SessionTerminalTabsComponent extends Component {
     }
   }
 
-  #setupTerminal(fitAddon, xterm) {
+  #setupTerminal(fitAddon, xterm, termContainer) {
     // Terminal is exposed by contextBridge within the preload script
     window.terminal.create({ id: this.id, cols: xterm.cols, rows: xterm.rows });
     xterm.onData((data) => window.terminal.send(data, this.id));
@@ -86,6 +101,7 @@ export default class SessionTerminalTabsComponent extends Component {
     // Handle resizing terminal windows. We debounce the resizing as we don't want
     // to resize xterm and the pty process before the previous one has finished
     const debouncedFit = debounce(() => {
+      calculateTerminalContainerHeight(termContainer);
       fitAddon.fit();
     }, 150);
     window.onresize = () => {


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-11108)

## Description
I decided to dynamically set the height of the container for the terminal as there is no better solution for this that I could think of. Using a standard `80vh` causes a really annoying issue with two scroll bars at smaller resolutions and bigger gaps at larger heights due to the fixed height of our other elements.

## Screenshots (if appropriate):
Before: 
![image](https://github.com/hashicorp/boundary-ui/assets/5783847/1c6c3bd9-6d4d-4a7c-ab4a-9bba42d36aed)

After: 

https://github.com/hashicorp/boundary-ui/assets/5783847/7cbd8750-c688-4e0f-8c96-76b243248bec

## How to Test
Resize the window in electron

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
