### PR TITLE
refactor: 💡 remove custom xterm styles

### DIFF
--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -689,13 +689,3 @@ $chevron-down: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%231
     color: var(--token-color-foreground-faint);
   }
 }
-
-#terminal-container {
-  .xterm .xterm-viewport {
-    border-radius: 8px;
-  }
-
-  .xterm .xterm-screen canvas {
-    margin-left: 0.5rem;
-  }
-}


### PR DESCRIPTION
## Description

<!-- Add a brief description of changes here -->
This only removes the `border-radius` and `padding` changes, not the height changes. These changes were conflicting with OS level themes and behaved different if you use a mouse or a trackpad on Mac computers. The plan is to revisit custom themes after release and allow the theme to update dependent on the user's OS theme. There is a way to hide the scrollbar entirely but that felt like a bad trade off for user experience.

## Screenshots (if appropriate):
Before:
<img width="1222" alt="Screen Shot 2023-09-15 at 10 40 52 AM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/39c4c32b-687f-4482-8f07-f5f139738bbe">
After:
<img width="1110" alt="Screenshot 2023-09-22 at 11 58 22 AM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/3a2657c0-4a37-4b20-897b-a0b1e4a36cc1">

## How to Test

Connect to target and click on shell tab

:desktop_computer: [Desktop preview](https://boundary-ui-desktop-git-remove-custom-xterm-styles-hashicorp.vercel.app/scopes/global/projects/targets)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] ~I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] ~I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
