### PR TITLE
fix: 🐛 Fix not calling delete properly in OIDC

### DIFF
--- a/addons/core/addon/authenticators/oidc.js
+++ b/addons/core/addon/authenticators/oidc.js
@@ -34,6 +34,18 @@ export default class OIDCAuthenticator extends BaseOIDCAuthenticator {
   }
 
   /**
+   * Generates a scope URL with which to deauthenticate.
+   * @override
+   * @param {object} options
+   * @param {string} scopeID
+   * @return {string}
+   */
+  buildDeauthEndpointURL({ id }) {
+    const adapter = this.store.adapterFor('application');
+    return adapter.buildURL('auth-token', id, {}, 'findRecord');
+  }
+
+  /**
    * Generates an auth token validation URL used to check tokens on restoration.
    * @override
    * @param {string} tokenID


### PR DESCRIPTION
## Description
It seems like we weren't properly calling the DELETE route for the tokens in OIDC authentications.


## Screenshots (if appropriate):
Before:
<img width="1840" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/5783847/00114059-5671-4662-b1be-4cc1f5050733">

After:
<img width="2527" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/5783847/1b2272a2-025b-4b74-bd1f-7e71712157b9">

## How to Test

Use boundary dev and test that that the tokens in boundary are deleted (by listing the tokens) after signing out. 

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
