### PR TITLE
fix: 🐛 Stop sending ssh command when session initiated in CLI

### DIFF
--- a/ui/desktop/app/components/session/tabs/index.js
+++ b/ui/desktop/app/components/session/tabs/index.js
@@ -69,10 +69,14 @@ export default class SessionTerminalTabsComponent extends Component {
     const { isWindows } = await this.ipc.invoke('checkOS');
     const { model } = this.args;
 
-    // Don't send the command on windows as most users won't have an openSSH client installed
-    if (model.target?.isSSH && !isWindows) {
-      const { proxy_address, proxy_port } = model;
+    const { proxy_address, proxy_port, started_desktop_client, target } = model;
 
+    // Only send the command on certain scenarios:
+    // 1. Only for SSH targets
+    // 2. Don't connect for windows as most users won't have an openSSH client installed
+    // 3. Don't connect if the session wasn't initiated in the desktop client
+    //    which means we won't have proxy information
+    if (target?.isSSH && started_desktop_client && !isWindows) {
       // Send an SSH command immediately
       window.terminal.send(
         `ssh ${proxy_address} -p ${proxy_port} -o NoHostAuthenticationForLocalhost=yes\r`,

--- a/ui/desktop/electron-app/src/cli/path.js
+++ b/ui/desktop/electron-app/src/cli/path.js
@@ -5,11 +5,16 @@
 
 const path = require('path');
 const { isWindows } = require('../helpers/platform.js');
+const isDev = require('electron-is-dev');
 
 module.exports = {
   // Returns boundary cli path
   path: () => {
     const name = isWindows() ? 'boundary.exe' : 'boundary';
-    return path.resolve(process.resourcesPath, 'cli', name);
+
+    // The CLI will be located in a different location once packaged up in an ASAR
+    return isDev
+      ? path.resolve(__dirname, '..', '..', 'cli', name)
+      : path.resolve(process.resourcesPath, 'cli', name);
   },
 };


### PR DESCRIPTION
✅ Closes: ICU-11209

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-11209)

## Description
When a user initiates a session from the CLI, we won't be aware of the proxy details so can't automatically initiate an SSH connection. We need to prevent trying to automatically connect in these scenarios.


## How to Test
Initiate a connection from the CLI and then open the shell for that session in the desktop client.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] ~I have added before and after screenshots for UI changes~
- [ ] ~I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
