### PR TITLE
fix: 🐛 ICU-11208 fix view of role scopes

### DIFF
--- a/ui/admin/app/routes/scopes/scope/roles/role/index.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/index.js
@@ -18,7 +18,7 @@ export default class ScopesScopeRolesRoleIndexRoute extends Route {
   async afterModel() {
     const currentScope = this.modelFor('scopes.scope');
     const scopes = await this.store.query('scope', {
-      scope_id: currentScope.id,
+      scope_id: 'global',
     });
     let subScopes = [];
     //await the store query to fix ember's proxy promise deprecation warning


### PR DESCRIPTION
✅ Closes: ICU-11208

:tickets: [ICU-11208](https://hashicorp.atlassian.net/browse/ICU-11208)

## Description
- Fixed view of role under `org`, and `project` scope.

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

https://github.com/hashicorp/boundary-ui/assets/24277002/ecd7a758-d52b-4e1b-9a1c-179dfc3cf0f3

## How to Test
- Select the global scope, click on roles in the sidebar nav, choose any role from the list, and click. Details for the role should be visible.
-  Select the generated org scope, click on roles in the sidebar nav, choose any role from the list, and click. Details for the role should be visible.
- Select the project scope under the generated org scope, click on roles in the sidebar nav, choose any role from the list, and click. Details for the role should be visible.
<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
~~-[ ] I have added JSON response output for API changes~~
- [x] I have added steps to reproduce and test for bug fixes in the description
~~- [ ] I have commented on my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
