### PR TITLE
fix: 🐛 dynamic storage bucket showing as static

### DIFF
--- a/addons/api/addon/models/storage-bucket.js
+++ b/addons/api/addon/models/storage-bucket.js
@@ -38,7 +38,13 @@ export default class StorageBucketModel extends GeneratedStorageBucketModel {
    * @type {string}
    */
   get credentialType() {
-    if (!this.#credentialType) return 'static';
+    if (!this.#credentialType) {
+      if (this.role_arn) {
+        this.#credentialType = TYPE_CREDENTIAL_DYNAMIC;
+      } else {
+        this.#credentialType = TYPE_CREDENTIAL_STATIC;
+      }
+    }
     return this.#credentialType;
   }
 

--- a/addons/api/tests/unit/models/storage-bucket-test.js
+++ b/addons/api/tests/unit/models/storage-bucket-test.js
@@ -46,7 +46,7 @@ module('Unit | Model | storage bucket', function (hooks) {
   });
 
   test('it has credentialType property and returns the expected values', async function (assert) {
-    assert.expect(2);
+    assert.expect(4);
     const store = this.owner.lookup('service:store');
     const modelA = store.createRecord('storage-bucket', {
       role_arn: 'test-role-arn',
@@ -58,8 +58,18 @@ module('Unit | Model | storage bucket', function (hooks) {
       access_key_id: 'test-access-key-id',
       credentialType: TYPE_CREDENTIAL_STATIC,
     });
+    const modelC = store.createRecord('storage-bucket', {
+      role_arn: null,
+      access_key_id: 'test-access-key-id',
+    });
+    const modelD = store.createRecord('storage-bucket', {
+      role_arn: 'test-role-arn',
+      access_key_id: null,
+    });
     assert.strictEqual(modelA.credentialType, TYPE_CREDENTIAL_DYNAMIC);
     assert.strictEqual(modelB.credentialType, TYPE_CREDENTIAL_STATIC);
+    assert.strictEqual(modelC.credentialType, TYPE_CREDENTIAL_STATIC);
+    assert.strictEqual(modelD.credentialType, TYPE_CREDENTIAL_DYNAMIC);
   });
 
   test('it has isAWS property and returns the expected values', async function (assert) {


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-11218)

## Description

Fixes the issue where storage buckets that use dynamic credentials are showing up as static after creation and reloading the screen.

## Screenshots (if appropriate):
Before:
<img width="684" alt="Screenshot 2023-09-28 at 11 07 44 AM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/e47fc35f-362e-49f4-bfee-c4a75e5aaccd">

After:
<img width="684" alt="Screenshot 2023-09-28 at 11 07 16 AM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/ee765d71-1669-4fd1-a89f-6f2fb544ec09">

## How to Test

Need to setup a worker running in aws to test this. I will be testing this against a real boundary instance but wanted to get the PR ready.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] ~I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] ~I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
