### PR TITLE
test(admin/e2e): Fixes for Admin UI test suite

### DIFF
--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -46,7 +46,7 @@ exports.createNewProject = async (page) => {
     .getByRole('navigation', { name: 'General' })
     .getByRole('link', { name: 'Projects' })
     .click();
-  await page.getByRole('link', { name: 'New' }).click();
+  await page.getByRole('link', { name: 'New', exact: true }).click();
   await page.getByLabel('Name').fill(projectName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('button', { name: 'Save' }).click();
@@ -74,7 +74,7 @@ exports.createNewHostCatalog = async (page) => {
     .getByRole('navigation', { name: 'Resources' })
     .getByRole('link', { name: 'Host Catalogs' })
     .click();
-  await page.getByRole('link', { name: 'New' }).click();
+  await page.getByRole('link', { name: 'New', exact: true }).click();
   await page.getByLabel('Name').fill(hostCatalogName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('button', { name: 'Save' }).click();
@@ -149,7 +149,7 @@ exports.createNewTarget = async (page) => {
     .getByRole('navigation', { name: 'Resources' })
     .getByRole('link', { name: 'Targets' })
     .click();
-  await page.getByRole('link', { name: 'New' }).click();
+  await page.getByRole('link', { name: 'New', exact: true }).click();
   await page.getByLabel('Name').fill(targetName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByLabel('Default Port').fill(process.env.E2E_TARGET_PORT);
@@ -178,7 +178,7 @@ exports.createNewTargetWithAddress = async (page) => {
     .getByRole('navigation', { name: 'Resources' })
     .getByRole('link', { name: 'Targets' })
     .click();
-  await page.getByRole('link', { name: 'New' }).click();
+  await page.getByRole('link', { name: 'New', exact: true }).click();
   await page.getByLabel('Name').fill(targetName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByLabel('Target Address').fill(process.env.E2E_TARGET_ADDRESS);

--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -298,7 +298,7 @@ exports.createNewPasswordAuthMethod = async (page, authMethodName) => {
     .getByRole('navigation', { name: 'IAM' })
     .getByRole('link', { name: 'Auth Methods' })
     .click();
-  await page.getByTitle('New', { exact: true }).click();
+  await page.getByRole('button', { name: 'New' }).click();
   await page.getByText('Password', { exact: true }).click();
   await page.getByLabel('Name').fill(authMethodName);
   await page.getByRole('button', { name: 'Save' }).click();

--- a/ui/admin/tests/e2e/tests/credential-store-static.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static.spec.js
@@ -57,7 +57,7 @@ test.beforeEach(async ({ page }) => {
     .getByRole('navigation', { name: 'Resources' })
     .getByRole('link', { name: 'Credential Stores' })
     .click();
-  await page.getByRole('link', { name: 'New' }).click();
+  await page.getByRole('link', { name: 'New', exact: true }).click();
   await page.getByLabel('Name', { exact: true }).fill(credentialStoreName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('group', { name: 'Type' }).getByLabel('Static').click();

--- a/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
@@ -93,7 +93,7 @@ test('Vault Credential Store (User & Key Pair)', async ({ page }) => {
     .getByRole('navigation', { name: 'Resources' })
     .getByRole('link', { name: 'Credential Stores' })
     .click();
-  await page.getByRole('link', { name: 'New' }).click();
+  await page.getByRole('link', { name: 'New', exact: true }).click();
   await page.getByLabel('Name', { exact: true }).fill(credentialStoreName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('group', { name: 'Type' }).getByLabel('Vault').click();

--- a/ui/admin/tests/e2e/tests/dynamic-host-catalog.spec.js
+++ b/ui/admin/tests/e2e/tests/dynamic-host-catalog.spec.js
@@ -36,7 +36,7 @@ test.describe('AWS', async () => {
       .getByRole('navigation', { name: 'Resources' })
       .getByRole('link', { name: 'Host Catalogs' })
       .click();
-    await page.getByRole('link', { name: 'New' }).click();
+    await page.getByRole('link', { name: 'New', exact: true }).click();
     await page.getByLabel('Name').fill(hostCatalogName);
     await page.getByLabel('Description').fill('This is an automated test');
     await page

--- a/ui/admin/tests/e2e/tests/target.spec.js
+++ b/ui/admin/tests/e2e/tests/target.spec.js
@@ -139,7 +139,7 @@ test('Verify TCP target is updated', async ({ page }) => {
     await page.getByLabel('Maximum Connections').fill('10');
     await page.getByLabel('Egress worker filter').click();
     await page
-      .getByRole('textbox', { name: 'Filter', exact: true })
+      .getByRole('textbox', { name: 'Filter\n    (Optional)', exact: true })
       .fill('"dev" in "/tags/type"');
     await page.getByRole('button', { name: 'Save' }).click();
 

--- a/ui/admin/tests/e2e/tests/target.spec.js
+++ b/ui/admin/tests/e2e/tests/target.spec.js
@@ -139,7 +139,7 @@ test('Verify TCP target is updated', async ({ page }) => {
     await page.getByLabel('Maximum Connections').fill('10');
     await page.getByLabel('Egress worker filter').click();
     await page
-      .getByRole('textbox', { name: 'Filter\n    (Optional)', exact: true })
+      .getByRole('textbox', { name: /^Filter/, exact: true })
       .fill('"dev" in "/tags/type"');
     await page.getByRole('button', { name: 'Save' }).click();
 


### PR DESCRIPTION
## Description

This PR updates some locators in the Admin UI e2e test suite to get it to pass again. There were 3 areas to update.

1. The "New" link was not getting detected. We needed to update the locator from...
```
await page.getByRole('link', { name: 'New' }).click();
-> 
await page.getByRole('link', { name: 'New', exact: true }).click();
```
![Screenshot 2023-09-28 at 11 03 59 AM](https://github.com/hashicorp/boundary-ui/assets/2474253/64dacb4d-76f0-41af-9efa-07d84137faea)

2. The "New" button in the top-right was not getting detected. 
```
await page.getByTitle('New', { exact: true }).click();
-> 
await page.getByRole('button', { name: 'New' }).click();
```
![Screenshot 2023-09-28 at 11 04 03 AM](https://github.com/hashicorp/boundary-ui/assets/2474253/de6a782c-8a1c-44d8-9e58-7f2b320da17f)

3. The Worker Filter textbox was not getting detected (Note: Not sure how I feel about this one...)
```
.getByRole('textbox', { name: 'Filter', exact: true })
-> 
getByRole('textbox', { name: 'Filter\n (Optional)', exact: true })
```
![Screenshot 2023-09-28 at 11 04 19 AM](https://github.com/hashicorp/boundary-ui/assets/2474253/6239b8a4-d3ea-4df0-96c4-070c8488d689)

