### PR TITLE
fix: 🐛 host modal renders whenever there is an error during connection

### DIFF
--- a/ui/desktop/app/components/target/host-modal/index.hbs
+++ b/ui/desktop/app/components/target/host-modal/index.hbs
@@ -4,7 +4,7 @@
 }}
 
 {{#if @showModal}}
-  <Hds::Modal data-test-host-modal @onClose={{@toggle}} as |M|>
+  <Hds::Modal data-test-host-modal @onClose={{fn @toggle false}} as |M|>
     <M.Header @tagline={{@target.displayName}}>
       {{t 'resources.session.actions.host'}}
     </M.Header>

--- a/ui/desktop/app/components/target/host-modal/index.hbs
+++ b/ui/desktop/app/components/target/host-modal/index.hbs
@@ -4,7 +4,7 @@
 }}
 
 {{#if @showModal}}
-  <Hds::Modal data-test-host-modal @onClose={{fn @toggle false}} as |M|>
+  <Hds::Modal data-test-host-modal @onClose={{fn @toggleModal false}} as |M|>
     <M.Header @tagline={{@target.displayName}}>
       {{t 'resources.session.actions.host'}}
     </M.Header>

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
@@ -17,7 +17,7 @@ export default class ScopesScopeProjectsTargetsTargetController extends Controll
   // =methods
 
   @action
-  toggle() {
-    this.isConnecting = !this.isConnecting;
+  toggle(value) {
+    this.isConnecting = value;
   }
 }

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
@@ -17,7 +17,7 @@ export default class ScopesScopeProjectsTargetsTargetController extends Controll
   // =methods
 
   @action
-  toggle(value) {
+  toggleModal(value) {
     this.isConnecting = value;
   }
 }

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
@@ -7,7 +7,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
-import { tracked } from '@glimmer/tracking';
 
 export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
   // =services
@@ -20,7 +19,7 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
 
   // =attributes
 
-  @tracked connectionError = false;
+  isConnectionError = false;
 
   // =methods
 
@@ -76,12 +75,13 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
    */
   @action
   didTransition() {
-    if (this.connectionError) {
+    if (this.isConnectionError) {
       /* eslint-disable-next-line ember/no-controller-access-in-routes */
       const controller = this.controllerFor(
         'scopes.scope.projects.targets.target'
       );
       controller.set('isConnecting', false);
+      this.isConnectionError = false;
     }
     return true;
   }
@@ -148,7 +148,7 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
         session
       );
     } catch (e) {
-      this.connectionError = true;
+      this.isConnectionError = true;
       this.confirm
         .confirm(e.message, { isConnectError: true })
         // Retry

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
@@ -70,6 +70,10 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
     }
   }
 
+  /**
+   * Sets the 'isConnecting' queryParam to false if connection failed.
+   * @returns {boolean}
+   */
   @action
   didTransition() {
     if (this.connectionError) {

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
@@ -7,6 +7,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
+import { tracked } from '@glimmer/tracking';
 
 export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
   // =services
@@ -16,6 +17,10 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
   @service ipc;
   @service router;
   @service session;
+
+  // =attributes
+
+  @tracked connectionError = false;
 
   // =methods
 
@@ -63,6 +68,18 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
         await this.connect(model.target);
       }
     }
+  }
+
+  @action
+  didTransition() {
+    if (this.connectionError) {
+      /* eslint-disable-next-line ember/no-controller-access-in-routes */
+      const controller = this.controllerFor(
+        'scopes.scope.projects.targets.target'
+      );
+      controller.set('isConnecting', false);
+    }
+    return true;
   }
 
   /**
@@ -127,6 +144,7 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
         session
       );
     } catch (e) {
+      this.connectionError = true;
       this.confirm
         .confirm(e.message, { isConnectError: true })
         // Retry

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
@@ -87,6 +87,25 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
   }
 
   /**
+   * Establish a session to current target.
+   * @param {TargetModel} target
+   * @param {HostModel} host
+   * hostConnect is only called when making a connection with a host and ensures that the host modal is automatically closed in the case of a connection error.
+   */
+  @action
+  async hostConnect(target, host) {
+    await this.connect(target, host);
+    if (this.isConnectionError) {
+      /* eslint-disable-next-line ember/no-controller-access-in-routes */
+      const controller = this.controllerFor(
+        'scopes.scope.projects.targets.target'
+      );
+      controller.set('isConnecting', false);
+      this.isConnectionError = false;
+    }
+  }
+
+  /**
    * Determine if we show host modal or quick connect based on target attributes.
    * @param {TargetModel} model
    */
@@ -96,7 +115,7 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
     if (model.target.address || model.hosts.length === 1) {
       await this.connect(model.target);
     } else {
-      toggleModal();
+      toggleModal(true);
     }
   }
 
@@ -152,7 +171,7 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
       this.confirm
         .confirm(e.message, { isConnectError: true })
         // Retry
-        .then(() => this.connect(model))
+        .then(() => this.connect(model, host))
         .catch(() => null /* no op */);
     }
   }

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target.hbs
@@ -22,7 +22,7 @@
         @icon='entry-point'
         @iconPosition='trailing'
         disabled={{not (can 'initiateConnection target' @model.target)}}
-        {{on 'click' (route-action 'preConnect' @model this.toggle)}}
+        {{on 'click' (route-action 'preConnect' @model this.toggleModal)}}
       />
     {{/if}}
   </page.actions>
@@ -32,7 +32,7 @@
       {{#if (can 'initiateConnection target' @model.target)}}
         <Target::HostModal
           @showModal={{this.isConnecting}}
-          @toggle={{this.toggle}}
+          @toggleModal={{this.toggleModal}}
           @connect={{route-action 'hostConnect'}}
           @hosts={{@model.hosts}}
           @target={{@model.target}}

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target.hbs
@@ -33,7 +33,7 @@
         <Target::HostModal
           @showModal={{this.isConnecting}}
           @toggle={{this.toggle}}
-          @connect={{route-action 'connect'}}
+          @connect={{route-action 'hostConnect'}}
           @hosts={{@model.hosts}}
           @target={{@model.target}}
         />

--- a/ui/desktop/tests/acceptance/projects/targets/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/index-test.js
@@ -32,6 +32,8 @@ module('Acceptance | projects | targets', function (hooks) {
   const APP_STATE_TITLE = '.hds-application-state__title';
   const TARGET_DETAILS_ROUTE_NAME =
     'scopes.scope.projects.targets.target.index';
+  const ROSE_DIALOG_MODAL = '.rose-dialog-error';
+  const CHOOSE_HOST_MODAL = '[data-test-host-modal]';
 
   const instances = {
     scopes: {
@@ -239,5 +241,18 @@ module('Acceptance | projects | targets', function (hooks) {
 
     assert.strictEqual(currentRouteName(), TARGET_DETAILS_ROUTE_NAME);
     assert.dom(APP_STATE_TITLE).includesText('Cannot connect');
+  });
+
+  test('choose host modal does not render when there is a connect error', async function (assert) {
+    assert.expect(2);
+    const confirmService = this.owner.lookup('service:confirm');
+    confirmService.enabled = true;
+    await visit(urls.projects);
+
+    await click(`[href="${urls.targets}"]`);
+    await click(`[data-test-targets-connect-button="${instances.target.id}"]`);
+
+    assert.dom(ROSE_DIALOG_MODAL).exists();
+    assert.dom(CHOOSE_HOST_MODAL).doesNotExist();
   });
 });

--- a/ui/desktop/tests/integration/components/target/host-modal-test.js
+++ b/ui/desktop/tests/integration/components/target/host-modal-test.js
@@ -18,13 +18,13 @@ module('Integration | Component | target/host-modal', function (hooks) {
   let hostA;
   let hostB;
   let connect;
-  let toggle;
+  let toggleModal;
 
   hooks.beforeEach(function () {
     connect = () => {
       this.set('called', true);
     };
-    toggle = () => {
+    toggleModal = () => {
       this.set('called', true);
     };
     store = this.owner.lookup('service:store');
@@ -47,13 +47,13 @@ module('Integration | Component | target/host-modal', function (hooks) {
   test('it renders', async function (assert) {
     assert.expect(1);
     this.set('connect', connect);
-    this.set('toggle', toggle);
+    this.set('toggleModal', toggleModal);
     this.set('hosts', [hostA, hostB]);
     this.set('target', target);
 
     await render(hbs`<Target::HostModal
       @showModal={{true}}
-      @toggle={{this.toggle}}
+      @toggleModal={{this.toggleModal}}
       @connect={{this.connect}}
       @hosts={{this.hosts}}
       @target={{this.target}} />`);
@@ -67,14 +67,14 @@ module('Integration | Component | target/host-modal', function (hooks) {
       this.set('showModal', false);
     };
     this.set('connect', connect);
-    this.set('toggle', toggleModal);
+    this.set('toggleModal', toggleModal);
     this.set('showModal', true);
     this.set('hosts', [hostA, hostB]);
     this.set('target', target);
 
     await render(hbs`<Target::HostModal
       @showModal={{this.showModal}}
-      @toggle={{this.toggle}}
+      @toggleModal={{this.toggleModal}}
       @connect={{this.connect}}
       @hosts={{this.hosts}}
       @target={{this.target}} />`);
@@ -89,13 +89,13 @@ module('Integration | Component | target/host-modal', function (hooks) {
   test('it calls connect when Quick Connect button clicked', async function (assert) {
     assert.expect(1);
     this.set('connect', connect);
-    this.set('toggle', toggle);
+    this.set('toggleModal', toggleModal);
     this.set('hosts', [hostA, hostB]);
     this.set('target', target);
 
     await render(hbs`<Target::HostModal
       @showModal={{true}}
-      @toggle={{this.toggle}}
+      @toggleModal={{this.toggleModal}}
       @connect={{this.connect}}
       @hosts={{this.hosts}}
       @target={{this.target}} />`);
@@ -108,13 +108,13 @@ module('Integration | Component | target/host-modal', function (hooks) {
   test('it calls connect when host item is clicked', async function (assert) {
     assert.expect(1);
     this.set('connect', connect);
-    this.set('toggle', toggle);
+    this.set('toggleModal', toggleModal);
     this.set('hosts', [hostA, hostB]);
     this.set('target', target);
 
     await render(hbs`<Target::HostModal
       @showModal={{true}}
-      @toggle={{this.toggle}}
+      @toggleModal={{this.toggleModal}}
       @connect={{this.connect}}
       @hosts={{this.hosts}}
       @target={{this.target}} />`);


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-11231)

## Description
If the `connect` action were to cause an error then an error modal would render (when connecting from target list view). However, the choose hosts modal would also, incorrectly, render. 

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
Before: 
![image](https://github.com/hashicorp/boundary-ui/assets/107949262/aeb6b4ae-133c-4fc4-a03b-9a719264b478)
After:
![image](https://github.com/hashicorp/boundary-ui/assets/107949262/0b411715-cd49-457f-94a3-e44728a58f56)

## How to Test

<!-- Add steps to test this change. Include any other necessary relevant links -->
1. Start a boundary dev instance.
2. Create a ssh target with a valid address but no hosts and no injected credentials.
3. Attempt to connect to the ssh target using the "connect" button in target list view (targets table).
4. Only an error modal should render. The choose hosts modal should not render.
<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:desktop_computer: [Desktop preview](https://boundary-ui-desktop-git-icu-11231-host-modal-r-a2c005-hashicorp.vercel.app/scopes/global/projects/targets)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- [X] I have added steps to reproduce and test for bug fixes in the description
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
