### PR TITLE
fix: 🐛 Fix edge case with showing host modal

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
@@ -172,7 +172,11 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
         .confirm(e.message, { isConnectError: true })
         // Retry
         .then(() => this.connect(model, host))
-        .catch(() => null /* no op */);
+        .catch(() => {
+          // Reset the flag as this was user initiated and we're not
+          // in a transition or have a host modal open
+          this.isConnectionError = false;
+        });
     }
   }
 }


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-11285)

## Description
If a user clicks retry when an error occurs during connection, we never reset our error connection flag which will prevent any further host modals from appearing or 

## How to Test

Setup two targets with hosts where one will error out when connecting. Hit retry and try connecting to the other target and the host modal should still appear.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
