### PR TITLE
fix: 🐛 Fix an issue with HDS css causing scrollbars/whitespace

### DIFF
--- a/addons/rose/addon/styles/hds/overrides.scss
+++ b/addons/rose/addon/styles/hds/overrides.scss
@@ -30,6 +30,13 @@
   .hds-table__td p {
     color: var(--token-form-indicator-optional-color);
   }
+
+  // TODO: This is a temporary hack to fix an issue causing weird whitespace
+  //   and scrollbars from an accessible class in HDS. We have to use !important
+  //   as they already forced it with !important and we can't override it otherwise
+  .sr-only {
+    position: unset !important;
+  }
 }
 
 .hds-dropdown {


### PR DESCRIPTION
✅ Closes: ICU-11292

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-11292)

## Description
There seems to be a bug causing extra whitespace/scrollbars when an accessible class is applied in conjunction with icon only badges in HDS. I'm adding a temporary hack to remove the CSS that's causing it. 

Not sure if this is the best approach, open to other ideas or possibly using rose icons again?

## Screenshots (if appropriate):
Before:
<img width="1452" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/5783847/f512b1fb-2617-42b1-b03f-43a3d4d7535e">

After:
<img width="1452" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/5783847/5c3765a8-211f-4299-a713-fe1e42c157ea">

## How to Test
Create some sessions in desktop client and make the window small enough so the table is larger than the viewport. It should not have two scrollbars with whitespace at the bottom.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
