### PR TITLE
fix: 🐛 Fix electron not inheriting path variable in production

### DIFF
--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -28,6 +28,7 @@
     "node-html-parser": "^5.3.3",
     "node-pty": "^1.0.0",
     "semver": "^7.5.3",
+    "shell-env": "^3.0.1",
     "shell-quote": "^1.7.3",
     "tree-kill": "^1.2.2"
   },

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -29,6 +29,7 @@ const sessionManager = require('./services/session-manager.js');
 const menu = require('./config/menu.js');
 const appUpdater = require('./helpers/app-updater.js');
 const { isMac, isLinux } = require('./helpers/platform.js');
+const fixPath = require('./utils/fixPath');
 const isDev = require('electron-is-dev');
 
 // Register the custom file protocol
@@ -47,6 +48,10 @@ protocol.registerSchemesAsPrivileged([
     },
   },
 ]);
+
+// This is to correctly set the process.env.PATH as electron does not
+// correctly inherit the path variable in production
+fixPath();
 
 const createWindow = (partition, closeWindowCB) => {
   /**

--- a/ui/desktop/electron-app/src/utils/fixPath.js
+++ b/ui/desktop/electron-app/src/utils/fixPath.js
@@ -1,0 +1,22 @@
+const { isWindows } = require('../helpers/platform.js');
+const shellEnv = require('shell-env');
+
+// Utility function to help correctly set the PATH variable on unix systems
+// Inspired by https://github.com/sindresorhus/fix-path
+const fixPath = () => {
+  if (isWindows()) {
+    return;
+  }
+
+  const { PATH } = shellEnv.sync();
+  process.env.PATH =
+    PATH ||
+    [
+      './node_modules/.bin',
+      '/.nodebrew/current/bin',
+      '/usr/local/bin',
+      process.env.PATH,
+    ].join(':');
+};
+
+module.exports = fixPath;

--- a/ui/desktop/electron-app/yarn.lock
+++ b/ui/desktop/electron-app/yarn.lock
@@ -438,6 +438,11 @@ ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
 ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -987,6 +992,11 @@ decompress@^4.2.1:
     make-dir "^1.0.0"
     pify "^2.3.0"
     strip-dirs "^2.0.0"
+
+default-shell@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/default-shell/-/default-shell-1.0.1.tgz#752304bddc6174f49eb29cb988feea0b8813c8bc"
+  integrity sha512-/Os8tTMPSriNHCsVj3VLjMZblIl1sIg8EXz3qg7C5K+y9calfTA/qzlfPvCQ+LEgLWmtZ9wCnzE1w+S6TPPFyQ==
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -3027,6 +3037,15 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shell-env@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shell-env/-/shell-env-3.0.1.tgz#515a62f6cbd5e139365be2535745e8e53438ce77"
+  integrity sha512-b09fpMipAQ9ObwvIeKoQFLDXcEcCpYUUZanlad4OYQscw2I49C/u97OPQg9jWYo36bRDn62fbe07oWYqovIvKA==
+  dependencies:
+    default-shell "^1.0.1"
+    execa "^1.0.0"
+    strip-ansi "^5.2.0"
+
 shell-quote@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
@@ -3190,6 +3209,13 @@ string_decoder@~1.1.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-ansi@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
## Description
It turns out electron does not properly inherit the path variable from process.env.PATH in production. This presents a problem as users won't have access to many of their binaries that they normally would have on their path.

If you're wondering why I didn't use the `fix-path` package directly, it's because they switched over to ESM and we can't directly use it. Their previous version doesn't fix linux so I had to manually use it.

## Screenshots (if appropriate):
Before:
<img width="1392" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/5783847/0b402c7f-1097-49fd-988b-c9e4f9e2ef43">

After:
<img width="1392" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/5783847/8eda379a-1a06-4912-8b7f-bafe0561ae59">

## How to Test
Create a production build locally and confirm your path gets loaded correctly when opening a shell in boundary.
