### PR TITLE
chore: 🤖 Update commitizen hook to add jira link automatically

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -6,11 +6,22 @@ COMMIT_SOURCE=$2
 SHA1=$3
 # Gets the current branch name but if we're in a detached head state, return "HEAD"
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+# Regex to match the ICU-#### branch name pattern we use
+ISSUE_REGEX="^(ICU-[0-9]+)"
 
 # Don't run commitizen for merge or squash commits, as well as when rebasing
 if [ "${COMMIT_SOURCE}" = merge ] || [ "${COMMIT_SOURCE}" = squash ] || [ "${COMMIT_SOURCE}" = "message" -a "${BRANCH_NAME}" = "HEAD" ];then
     exit 0
 fi
 
-# This is to allow interaction with the terminal for commitizen
-exec < /dev/tty && npx git-cz --hook || true
+# If the branch name matches, set the JIRA link automatically
+if [[ $BRANCH_NAME =~ $ISSUE_REGEX ]]
+then
+  issue="${BASH_REMATCH[1]}"
+  url="https://hashicorp.atlassian.net/browse/${issue}"
+  exec < /dev/tty && npx git-cz --issues="$url" --hook || true
+else
+  # This is to allow interaction with the terminal for commitizen
+  exec < /dev/tty && npx git-cz --hook || true
+fi
+

--- a/changelog.config.js
+++ b/changelog.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  questions: ["type", "subject", "body", "issues"],
+};


### PR DESCRIPTION
## Description
Updated commitizen hook to automatically pull the issue and construct a jira URL from it. Also added a config file to remove the breaking changes question in commitizen.

## Screenshots (if appropriate):
![image](https://github.com/hashicorp/boundary-ui/assets/5783847/612621af-4b15-46b3-bf1f-da4fc054c044)

## How to Test
Create a branch that starts with ICU-### to test 

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- ~[ ] My changes generate no new warnings~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
