### PR TITLE
Fix electron clipboard action

### DIFF
--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -268,7 +268,6 @@ app.on('before-quit', (event) => {
 // resources (e.g. file descriptors, handles, etc) before shutting down the process. It is
 // not safe to resume normal operation after 'uncaughtException'.
 process.on('uncaughtException', (err) => {
-  console.log(err, 'what the err');
   console.log('An exception in the main thread was not handled.');
   console.log(
     'This is a serious issue that needs to be handled and/or debugged.'

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -185,7 +185,6 @@ app.on('ready', async () => {
   // Disallow all permissions requests,
   // per Electronegativity PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK
   ses.setPermissionRequestHandler((webContents, permission, callback) => {
-    /* eng-disable PERMISSION_REQUEST_HANDLER_JS_CHECK */
     // We need to allow this for native clipboard usage
     if (permission === 'clipboard-sanitized-write') {
       // Approves the permissions request

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -186,6 +186,11 @@ app.on('ready', async () => {
   // per Electronegativity PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK
   ses.setPermissionRequestHandler((webContents, permission, callback) => {
     /* eng-disable PERMISSION_REQUEST_HANDLER_JS_CHECK */
+    //we need to allow this for the hds clipboard action to not fail
+    if (permission === 'clipboard-sanitized-write') {
+      // Approves the permissions request
+      return callback(true);
+    }
     return callback(false);
   });
 
@@ -263,6 +268,7 @@ app.on('before-quit', (event) => {
 // resources (e.g. file descriptors, handles, etc) before shutting down the process. It is
 // not safe to resume normal operation after 'uncaughtException'.
 process.on('uncaughtException', (err) => {
+  console.log(err, 'what the err');
   console.log('An exception in the main thread was not handled.');
   console.log(
     'This is a serious issue that needs to be handled and/or debugged.'

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -186,7 +186,7 @@ app.on('ready', async () => {
   // per Electronegativity PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK
   ses.setPermissionRequestHandler((webContents, permission, callback) => {
     /* eng-disable PERMISSION_REQUEST_HANDLER_JS_CHECK */
-    //we need to allow this for the hds clipboard action to not fail
+    // We need to allow this for native clipboard usage
     if (permission === 'clipboard-sanitized-write') {
       // Approves the permissions request
       return callback(true);


### PR DESCRIPTION
## Description

By default electron's security policy blocks all write requests and we need to allow `clipboard-sanitized-write` for the `HDS copy::snippet` copy action to not fail in desktop app

 some relevant links [here](https://www.electronjs.org/docs/latest/tutorial/security#5-handle-session-permission-requests-from-remote-content) and [here](https://www.electronjs.org/docs/latest/api/session#sessetpermissionrequesthandlerhandler)

## Screenshots (if appropriate):
before:
![image (6)](https://github.com/hashicorp/boundary-ui/assets/15043878/bc5117e3-ba27-41d4-8456-3200955d87d1)

after:
<img width="799" alt="Screenshot 2023-10-31 at 5 26 19 PM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/e61fd711-ece4-4c71-a5e9-cda827764101">

## How to Test

- click the port address copy button. You should not see the red icon and no errors in the logs. 
- the screen should look like the `after` image above to indicate that the copy action is successful. 

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
