### PR TITLE
fix: 🐛 Fix issue with brokered credentials that overflow

### DIFF
--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -608,6 +608,7 @@ $chevron-down: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%231
     .secret-container {
       margin: 0.75rem 0.5rem;
       border-bottom: 1px solid var(--token-color-border-primary);
+      word-break: break-word;
 
       &:last-child {
         border-bottom: 0;


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-11368

## Description
We have a bug where brokered credentials overflow currently. Copying still works correctly and doesn't introduce new line breaks.

## Screenshots (if appropriate):
Before:
<img width="1549" alt="Screenshot 2023-11-02 at 2 40 02 PM" src="https://github.com/hashicorp/boundary-ui/assets/5783847/61f73acc-620e-4529-b069-ba6ba8fa9641">

After:
<img width="1549" alt="Screenshot 2023-11-02 at 2 40 44 PM" src="https://github.com/hashicorp/boundary-ui/assets/5783847/0e7fd144-5e2f-472d-aa48-cfd224c711ad">


## How to Test
Create a target with some brokered credentials that have long secrets and make sure when showing them that they do not overflow.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~