### PR TITLE
refactor: 💡 allow target connect without read ability

### DIFF
--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+
+export default class ScopesScopeProjectsTargetsIndexController extends Controller {
+  // =methods
+
+  /**
+   * Checks if a user can read AND connect to a target
+   * @param {TargetModel} target
+   */
+  @action
+  async quickConnect(target) {
+    await target.connect();
+  }
+}

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
@@ -97,7 +97,6 @@
     {{/if}}
 
     {{#if @model}}
-
       <Hds::Table
         @model={{@model}}
         @columns={{array
@@ -160,22 +159,29 @@
             </B.Td>
             <B.Td>
               {{#if (can 'connect target' B.data)}}
-                <Hds::Button
-                  data-test-targets-connect-button={{B.data.id}}
-                  @text={{t 'resources.session.actions.connect'}}
-                  @color='secondary'
-                  @route='scopes.scope.projects.targets.target'
-                  @model={{B.data.id}}
-                  @query={{hash isConnecting=true}}
-                />
+                {{#if (can 'read target' B.data)}}
+                  <Hds::Button
+                    data-test-targets-connect-button={{B.data.id}}
+                    @text={{t 'resources.session.actions.connect'}}
+                    @color='secondary'
+                    @route='scopes.scope.projects.targets.target'
+                    @model={{B.data.id}}
+                    @query={{hash isConnecting=true}}
+                  />
+                {{else}}
+                  <Hds::Button
+                    data-test-targets-connect-button={{B.data.id}}
+                    @text={{t 'resources.session.actions.connect'}}
+                    @color='secondary'
+                    {{on 'click' (fn this.quickConnect B.data)}}
+                  />
+                {{/if}}
               {{/if}}
             </B.Td>
           </B.Tr>
         </:body>
       </Hds::Table>
-
     {{else}}
-
       <Rose::Layout::Centered>
         <Rose::Message
           @title={{t 'resources.target.messages.none.title'}}
@@ -186,7 +192,6 @@
           </message.description>
         </Rose::Message>
       </Rose::Layout::Centered>
-
     {{/if}}
   </page.body>
 


### PR DESCRIPTION
## Description

This work allows for a user to still connect to a target even if they do not have permissions to read the target. 

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

## How to Test

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] ~I have added before and after screenshots for UI changes~
- [ ] ~I have added JSON response output for API changes~
- [ ] ~I have added steps to reproduce and test for bug fixes in the description~
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] ~My changes generate no new warnings~
- [ ] I have added tests that prove my fix is effective or that my feature works
