### PR TITLE
refactor: 💡 allow target connection even with no read ability

### DIFF
--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { loading } from 'ember-loading';
+
+export default class ScopesScopeProjectsTargetsIndexController extends Controller {
+  // =services
+
+  @service confirm;
+  @service ipc;
+  @service router;
+  @service session;
+  @service store;
+
+  // =methods
+
+  /**
+   * Quick connect method used to call main connect method and handle
+   * connection errors unique to this route
+   * @param {TargetModel} target
+   */
+  @action
+  async quickConnect(target) {
+    try {
+      await this.connect(target);
+    } catch (error) {
+      this.confirm
+        .confirm(error.message, { isConnectError: true })
+        // Retry
+        .then(() => this.quickConnect(target));
+    }
+  }
+
+  /**
+   * Establish a session to current target.
+   * @param {TargetModel} target
+   * @param {HostModel} host
+   */
+  @action
+  @loading
+  async connect(target, host) {
+    // Check for CLI
+    const cliExists = await this.ipc.invoke('cliExists');
+    if (!cliExists) throw new Error('Cannot find Boundary CLI.');
+
+    const options = {
+      target_id: target.id,
+      token: this.session.data.authenticated.token,
+    };
+
+    if (host) options.host_id = host.id;
+
+    // Create target session
+    const connectionDetails = await this.ipc.invoke('connect', options);
+
+    // Associate the connection details with the session
+    let session;
+    const { session_id, address, port, credentials } = connectionDetails;
+    try {
+      session = await this.store.findRecord('session', session_id);
+    } catch (error) {
+      /**
+       * if the user cannot read or fetch the session we add the important
+       * information returned from the connect command to allow the user
+       * to still continue their work with the information they need
+       */
+      this.store.pushPayload('session', {
+        sessions: [
+          {
+            id: session_id,
+            proxy_address: address,
+            proxy_port: port,
+            target_id: target.id,
+          },
+        ],
+      });
+      session = this.store.peekRecord('session', session_id);
+    }
+
+    // Flag the session has been open in the desktop client
+    session.started_desktop_client = true;
+    /**
+     * Update the session record with proxy information from the CLI
+     * In the future, it may make sense to push this off to the API so that
+     * we don't have to manually persist the proxy details.
+     */
+    session.proxy_address = address;
+    session.proxy_port = port;
+    if (credentials) {
+      credentials.forEach((cred) => session.addCredential(cred));
+    }
+
+    await this.router.transitionTo(
+      'scopes.scope.projects.sessions.session',
+      session_id
+    );
+  }
+}

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -95,7 +95,7 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
       credentials.forEach((cred) => session.addCredential(cred));
     }
 
-    await this.router.transitionTo(
+    this.router.transitionTo(
       'scopes.scope.projects.sessions.session',
       session_id
     );

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
@@ -160,14 +160,23 @@
             </B.Td>
             <B.Td>
               {{#if (can 'connect target' B.data)}}
-                <Hds::Button
-                  data-test-targets-connect-button={{B.data.id}}
-                  @text={{t 'resources.session.actions.connect'}}
-                  @color='secondary'
-                  @route='scopes.scope.projects.targets.target'
-                  @model={{B.data.id}}
-                  @query={{hash isConnecting=true}}
-                />
+                {{#if (can 'read target' B.data)}}
+                  <Hds::Button
+                    data-test-targets-connect-button={{B.data.id}}
+                    @text={{t 'resources.session.actions.connect'}}
+                    @color='secondary'
+                    @route='scopes.scope.projects.targets.target'
+                    @model={{B.data.id}}
+                    @query={{hash isConnecting=true}}
+                  />
+                {{else}}
+                  <Hds::Button
+                    data-test-targets-connect-button={{B.data.id}}
+                    @text={{t 'resources.session.actions.connect'}}
+                    @color='secondary'
+                    {{on 'click' (fn this.quickConnect B.data)}}
+                  />
+                {{/if}}
               {{/if}}
             </B.Td>
           </B.Tr>

--- a/ui/desktop/tests/acceptance/projects/targets/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/index-test.js
@@ -230,7 +230,7 @@ module('Acceptance | projects | targets', function (hooks) {
       .doesNotExist();
   });
 
-  test('user is redirected to target details page when unable to connect from list view if they have read and authorize-seesion permissions', async function (assert) {
+  test('user is redirected to target details page when unable to connect from list view if they have read and authorize-session permissions', async function (assert) {
     assert.expect(3);
     stubs.ipcService.withArgs('cliExists').returns(true);
     stubs.ipcService.withArgs('connect').rejects();

--- a/ui/desktop/tests/acceptance/projects/targets/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/index-test.js
@@ -29,10 +29,15 @@ module('Acceptance | projects | targets', function (hooks) {
   let getTargetCount;
 
   const ROSE_APP_STATE_TITLE = '.rose-message-title';
+  const APP_STATE_TITLE = '.hds-application-state__title';
   const TARGET_DETAILS_ROUTE_NAME =
     'scopes.scope.projects.targets.target.index';
   const ROSE_DIALOG_MODAL = '.rose-dialog-error';
   const CHOOSE_HOST_MODAL = '[data-test-host-modal]';
+  const ROSE_DIALOG_MODAL_BUTTONS = '.rose-dialog-footer button';
+  const ROSE_DIALOG_RETRY_BUTTON = '.rose-dialog footer .rose-button-primary';
+  const ROSE_DIALOG_CANCEL_BUTTON =
+    '.rose-dialog footer .rose-button-secondary';
 
   const instances = {
     scopes: {
@@ -225,7 +230,7 @@ module('Acceptance | projects | targets', function (hooks) {
       .doesNotExist();
   });
 
-  test('user is redirected to target details page when unable to connect from list view', async function (assert) {
+  test('user is redirected to target details page when unable to connect from list view if they have read and authorize-seesion permissions', async function (assert) {
     assert.expect(3);
     stubs.ipcService.withArgs('cliExists').returns(true);
     stubs.ipcService.withArgs('connect').rejects();
@@ -239,5 +244,48 @@ module('Acceptance | projects | targets', function (hooks) {
     assert.dom(ROSE_DIALOG_MODAL).exists();
     assert.dom(CHOOSE_HOST_MODAL).doesNotExist();
     assert.strictEqual(currentRouteName(), TARGET_DETAILS_ROUTE_NAME);
+  });
+
+  test('user can connect without target read permissions', async function (assert) {
+    assert.expect(2);
+    instances.target.authorized_actions =
+      instances.target.authorized_actions.filter((item) => item !== 'read');
+    stubs.ipcService.withArgs('cliExists').returns(true);
+    stubs.ipcService.withArgs('connect').returns({
+      session_id: instances.session.id,
+      address: 'a_123',
+      port: 'p_123',
+      protocol: 'tcp',
+    });
+
+    await visit(urls.targets);
+
+    await click(`[data-test-targets-connect-button="${instances.target.id}"]`);
+
+    assert.strictEqual(
+      currentURL(),
+      `${urls.projects}/sessions/${instances.session.id}`
+    );
+    assert.dom(APP_STATE_TITLE).hasText('Connected');
+  });
+
+  test('user can retry connect without target read permissions', async function (assert) {
+    assert.expect(5);
+    instances.target.authorized_actions =
+      instances.target.authorized_actions.filter((item) => item !== 'read');
+    stubs.ipcService.withArgs('cliExists').returns(true);
+    stubs.ipcService.withArgs('connect').rejects();
+    const confirmService = this.owner.lookup('service:confirm');
+    confirmService.enabled = true;
+
+    await visit(urls.targets);
+
+    await click(`[data-test-targets-connect-button="${instances.target.id}"]`);
+
+    assert.strictEqual(currentURL(), urls.targets);
+    assert.dom(ROSE_DIALOG_MODAL).exists();
+    assert.dom(ROSE_DIALOG_MODAL_BUTTONS).exists({ count: 2 });
+    assert.dom(ROSE_DIALOG_RETRY_BUTTON).hasText('Retry');
+    assert.dom(ROSE_DIALOG_CANCEL_BUTTON).hasText('Cancel');
   });
 });


### PR DESCRIPTION
## Description

If a user can connect to a target but not read, we will allow them to connect now.
Connect logic has moved back to the `scopes.scope.projects.targets.index` route and we call the main `connect` method on that route as well from the child route. Connect no longer handles the error states, each route which has unique error handling implements that logic in it's own route. As we move away from `route-actions` all of this logic will likely move to the controllers for each route.

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

## How to Test

If you have a user (not admin) that you can remove the `read` permission from for targets, you can test this build locally.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] ~I have added before and after screenshots for UI changes~
- [ ] ~I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] ~My changes generate no new warnings~
- [x] I have added tests that prove my fix is effective or that my feature works
