### PR TITLE
feat: 🎸 Add handler to make search requests to client daemon

### DIFF
--- a/addons/api/addon/handlers/client-daemon-handler.js
+++ b/addons/api/addon/handlers/client-daemon-handler.js
@@ -1,0 +1,64 @@
+import { pluralize } from 'ember-inflector';
+
+/**
+ * Not all types are yet supported by the client daemon so we'll
+ * just whitelist the ones we need to start with.
+ * @type {string[]}
+ */
+const supportedTypes = ['target', 'session'];
+
+/**
+ * Handler to sit in front of the API request layer
+ * so we can request from the daemon first
+ */
+const ClientDaemonHandler = {
+  async request(context, next) {
+    switch (context.request.op) {
+      case 'query': {
+        const { store, data } = context.request;
+        const { type, query } = data;
+
+        if (!supportedTypes.includes(type)) {
+          return next(context.request);
+        }
+
+        // TODO: Remove usages of recursive from callers and scope_id since
+        //  all calls to daemon are recursive, scope_id can be part of search query instead
+        // eslint-disable-next-line no-unused-vars
+        let { recursive, scope_id, ...modifiedQuery } = query;
+        const auth_token_id = this.session.data?.authenticated?.id;
+        modifiedQuery = {
+          ...modifiedQuery,
+          auth_token_id,
+          resource: pluralize(type),
+        };
+
+        // Currently returns with a singular top level field with resource name
+        // e.g. { targets: [...] } or { sessions: [..] }
+        // So this just unwraps to the array, or undefined
+        const [results] = Object.values(
+          await this.ipc.invoke('searchClientDaemon', modifiedQuery)
+        );
+        const payload = { items: results ?? [] };
+
+        const schema = store.modelFor(type);
+        const serializer = store.serializerFor(type);
+        const normalizedPayload = serializer.normalizeResponse(
+          store,
+          schema,
+          payload,
+          null,
+          'query'
+        );
+
+        // TODO: Add some pagination
+
+        return store.push(normalizedPayload);
+      }
+      default:
+        return next(context.request);
+    }
+  },
+};
+
+export default ClientDaemonHandler;

--- a/addons/api/addon/handlers/client-daemon-handler.js
+++ b/addons/api/addon/handlers/client-daemon-handler.js
@@ -17,8 +17,11 @@ const ClientDaemonHandler = {
       case 'query': {
         const { store, data } = context.request;
         const { type, query } = data;
+        const isClientDaemonRunning = await this.ipc.invoke(
+          'isClientDaemonRunning'
+        );
 
-        if (!supportedTypes.includes(type)) {
+        if (!supportedTypes.includes(type) || !isClientDaemonRunning) {
           return next(context.request);
         }
 

--- a/addons/api/app/handlers/client-daemon-handler.js
+++ b/addons/api/app/handlers/client-daemon-handler.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export { default } from 'api/handlers/client-daemon-handler';

--- a/addons/api/mirage/scenarios/ipc.js
+++ b/addons/api/mirage/scenarios/ipc.js
@@ -182,6 +182,10 @@ export default function initializeMockIPC(server, config) {
       return faker.system.filePath();
     }
     addTokenToClientDaemon() {}
+    searchClientDaemon() {}
+    isClientDaemonRunning() {
+      return false;
+    }
   }
 
   /**

--- a/ui/desktop/app/services/store.js
+++ b/ui/desktop/app/services/store.js
@@ -1,0 +1,82 @@
+import Store, { CacheHandler } from '@ember-data/store';
+import RequestManager from '@ember-data/request';
+import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+
+/**
+ * Not all types are yet supported by the client daemon so we'll
+ * just whitelist the ones we need to start with.
+ * @type {string[]}
+ */
+const supportedTypes = ['target', 'session'];
+
+export default class extends Store {
+  @service ipc;
+  @service session;
+
+  requestManager = new RequestManager();
+
+  constructor(args) {
+    super(args);
+
+    ClientDaemonHandler.request = ClientDaemonHandler.request.bind(this);
+
+    this.requestManager.use([ClientDaemonHandler, LegacyNetworkHandler]);
+    this.requestManager.useCache(CacheHandler);
+  }
+}
+
+/**
+ * Handler to sit in front of the API request layer
+ * so we can request from the daemon first
+ */
+const ClientDaemonHandler = {
+  async request(context, next) {
+    switch (context.request.op) {
+      case 'query': {
+        const { store, data } = context.request;
+        const { type, query } = data;
+
+        if (!supportedTypes.includes(type)) {
+          return next(context.request);
+        }
+
+        // TODO: Remove usages of recursive from callers and scope_id since
+        //  all calls to daemon are recursive, scope_id can be part of search query instead
+        // eslint-disable-next-line no-unused-vars
+        let { recursive, scope_id, ...modifiedQuery } = query;
+        const auth_token_id = this.session.data?.authenticated?.id;
+        modifiedQuery = {
+          ...modifiedQuery,
+          auth_token_id,
+          resource: pluralize(type),
+        };
+
+        // Currently returns with a singular top level field with resource name
+        // e.g. { targets: [...] } or { sessions: [..] }
+        // So this just unwraps to the array, or undefined
+        const [results] = Object.values(
+          await this.ipc.invoke('searchClientDaemon', modifiedQuery)
+        );
+        const payload = { items: results ?? [] };
+
+        const schema = store.modelFor(type);
+        const serializer = store.serializerFor(type);
+        const normalizedPayload = serializer.normalizeResponse(
+          store,
+          schema,
+          payload,
+          null,
+          'query'
+        );
+
+        // TODO: Add some pagination
+
+        return store.push(normalizedPayload);
+      }
+      default:
+        return next(context.request);
+    }
+  },
+};

--- a/ui/desktop/app/services/store.js
+++ b/ui/desktop/app/services/store.js
@@ -2,14 +2,7 @@ import Store, { CacheHandler } from '@ember-data/store';
 import RequestManager from '@ember-data/request';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
 import { inject as service } from '@ember/service';
-import { pluralize } from 'ember-inflector';
-
-/**
- * Not all types are yet supported by the client daemon so we'll
- * just whitelist the ones we need to start with.
- * @type {string[]}
- */
-const supportedTypes = ['target', 'session'];
+import ClientDaemonHandler from 'api/handlers/client-daemon-handler';
 
 export default class extends Store {
   @service ipc;
@@ -26,57 +19,3 @@ export default class extends Store {
     this.requestManager.useCache(CacheHandler);
   }
 }
-
-/**
- * Handler to sit in front of the API request layer
- * so we can request from the daemon first
- */
-const ClientDaemonHandler = {
-  async request(context, next) {
-    switch (context.request.op) {
-      case 'query': {
-        const { store, data } = context.request;
-        const { type, query } = data;
-
-        if (!supportedTypes.includes(type)) {
-          return next(context.request);
-        }
-
-        // TODO: Remove usages of recursive from callers and scope_id since
-        //  all calls to daemon are recursive, scope_id can be part of search query instead
-        // eslint-disable-next-line no-unused-vars
-        let { recursive, scope_id, ...modifiedQuery } = query;
-        const auth_token_id = this.session.data?.authenticated?.id;
-        modifiedQuery = {
-          ...modifiedQuery,
-          auth_token_id,
-          resource: pluralize(type),
-        };
-
-        // Currently returns with a singular top level field with resource name
-        // e.g. { targets: [...] } or { sessions: [..] }
-        // So this just unwraps to the array, or undefined
-        const [results] = Object.values(
-          await this.ipc.invoke('searchClientDaemon', modifiedQuery)
-        );
-        const payload = { items: results ?? [] };
-
-        const schema = store.modelFor(type);
-        const serializer = store.serializerFor(type);
-        const normalizedPayload = serializer.normalizeResponse(
-          store,
-          schema,
-          payload,
-          null,
-          'query'
-        );
-
-        // TODO: Add some pagination
-
-        return store.push(normalizedPayload);
-      }
-      default:
-        return next(context.request);
-    }
-  },
-};

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -119,12 +119,26 @@ handle('closeWindow', () => app.quit());
  */
 handle('checkCommand', async (command) => which(command, { nothrow: true }));
 
+/**
+ * Adds the user's token to the client daemon.
+ */
 handle('addTokenToClientDaemon', async (data) =>
   clientDaemonManager.addToken(data)
 );
 
+/**
+ * Call the client daemon's search endpoint to retrieve cached results.
+ */
 handle('searchClientDaemon', async (request) =>
   clientDaemonManager.search(request)
+);
+
+/**
+ * Check to see if the client daemon is running. We use the presence of a
+ * socket path as a proxy for whether the daemon is running.
+ */
+handle('isClientDaemonRunning', async (request) =>
+  Boolean(clientDaemonManager.socketPath)
 );
 
 /**

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -123,6 +123,10 @@ handle('addTokenToClientDaemon', async (data) =>
   clientDaemonManager.addToken(data)
 );
 
+handle('searchClientDaemon', async (request) =>
+  clientDaemonManager.search(request)
+);
+
 /**
  * Handler to help create terminal windows. We don't use the helper `handle` method
  * as we need access to the event and don't need to be using `ipcMain.handle`.

--- a/ui/desktop/electron-app/src/services/client-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/client-daemon-manager.js
@@ -24,7 +24,7 @@ class ClientDaemonManager {
     const data = spawnSync(daemonStatusCommand);
 
     const status = jsonify(data);
-    this.#socketPath = status.socket_address;
+    this.#socketPath = status?.socket_address;
     return status;
   }
 

--- a/ui/desktop/electron-app/src/services/client-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/client-daemon-manager.js
@@ -33,7 +33,13 @@ class ClientDaemonManager {
    * @returns {Promise<void>}
    */
   async start() {
-    const startDaemonCommand = ['daemon', 'start'];
+    // TODO: Finalize how often the daemon should be refreshing
+    const startDaemonCommand = [
+      'daemon',
+      'start',
+      '-refresh-interval-seconds',
+      '10',
+    ];
     await spawn(startDaemonCommand);
     this.status();
   }
@@ -66,6 +72,17 @@ class ClientDaemonManager {
       socketPath: this.#socketPath,
     };
     return unixSocketRequest(request, postBody);
+  }
+
+  search(requestData) {
+    const queryString = new URLSearchParams(requestData);
+
+    const request = {
+      method: 'GET',
+      path: `http://internal.boundary.local/v1/search?${queryString.toString()}`,
+      socketPath: this.#socketPath,
+    };
+    return unixSocketRequest(request);
   }
 }
 

--- a/ui/desktop/tests/acceptance/authentication-test.js
+++ b/ui/desktop/tests/acceptance/authentication-test.js
@@ -22,6 +22,7 @@ import {
   invalidateSession,
 } from 'ember-simple-auth/test-support';
 import WindowMockIPC from '../helpers/window-mock-ipc';
+import Store from 'api/services/store';
 
 module('Acceptance | authentication', function (hooks) {
   setupApplicationTest(hooks);
@@ -128,6 +129,9 @@ module('Acceptance | authentication', function (hooks) {
     // Mock the postMessage interface used by IPC.
     this.owner.register('service:browser/window', WindowMockIPC);
     setDefaultClusterUrl(this);
+
+    // Use the original store so we don't try and hit the client daemon
+    this.owner.register('service:store', Store);
   });
 
   test('visiting index while unauthenticated redirects to global authenticate method', async function (assert) {

--- a/ui/desktop/tests/acceptance/cluster-url-test.js
+++ b/ui/desktop/tests/acceptance/cluster-url-test.js
@@ -13,6 +13,7 @@ import { invalidateSession } from 'ember-simple-auth/test-support';
 import { setupBrowserFakes } from 'ember-browser-services/test-support';
 import WindowMockIPC from '../helpers/window-mock-ipc';
 import config from '../../config/environment';
+import Store from 'api/services/store';
 
 module('Acceptance | clusterUrl', function (hooks) {
   setupApplicationTest(hooks);
@@ -100,6 +101,9 @@ module('Acceptance | clusterUrl', function (hooks) {
     urls.authenticate.methods.global = `${urls.authenticate.global}/${instances.authMethods.global.id}`;
     urls.projects = `${urls.scopes.global}/projects`;
     urls.targets = `${urls.projects}/targets`;
+
+    // Use the original store so we don't try and hit the client daemon
+    this.owner.register('service:store', Store);
   });
 
   hooks.afterEach(function () {

--- a/ui/desktop/tests/acceptance/projects/sessions/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/index-test.js
@@ -22,6 +22,7 @@ import {
   STATUS_SESSION_CANCELING,
   STATUS_SESSION_TERMINATED,
 } from 'api/models/session';
+import Store from 'api/services/store';
 
 module('Acceptance | projects | sessions', function (hooks) {
   setupApplicationTest(hooks);
@@ -122,6 +123,13 @@ module('Acceptance | projects | sessions', function (hooks) {
 
     const ipcService = this.owner.lookup('service:ipc');
     stubs.ipcService = sinon.stub(ipcService, 'invoke');
+
+    // Use the original store so we don't try and hit the client daemon
+    this.owner.register('service:store', Store);
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
   });
 
   test('visiting index while unauthenticated redirects to global authenticate method', async function (assert) {

--- a/ui/desktop/tests/acceptance/projects/sessions/session-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/session-test.js
@@ -15,6 +15,7 @@ import { authenticateSession } from 'ember-simple-auth/test-support';
 import sinon from 'sinon';
 import WindowMockIPC from '../../../helpers/window-mock-ipc';
 import { STATUS_SESSION_ACTIVE } from 'api/models/session';
+import Store from 'api/services/store';
 
 module('Acceptance | projects | sessions | session', function (hooks) {
   setupApplicationTest(hooks);
@@ -121,9 +122,13 @@ module('Acceptance | projects | sessions | session', function (hooks) {
 
     const ipcService = this.owner.lookup('service:ipc');
     stubs.ipcService = sinon.stub(ipcService, 'invoke');
+
+    // Use the original store so we don't try and hit the client daemon
+    this.owner.register('service:store', Store);
   });
 
   hooks.afterEach(function () {
+    sinon.restore();
     // reset onUncaughtException to original state
     QUnit.onUncaughtException = originalUncaughtException;
   });

--- a/ui/desktop/tests/acceptance/projects/targets/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/index-test.js
@@ -21,6 +21,7 @@ import {
   invalidateSession,
   currentSession,
 } from 'ember-simple-auth/test-support';
+import Store from 'api/services/store';
 
 module('Acceptance | projects | targets', function (hooks) {
   setupApplicationTest(hooks);
@@ -138,6 +139,13 @@ module('Acceptance | projects | targets', function (hooks) {
 
     const ipcService = this.owner.lookup('service:ipc');
     stubs.ipcService = sinon.stub(ipcService, 'invoke');
+
+    // Use the original store so we don't try and hit the client daemon
+    this.owner.register('service:store', Store);
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
   });
 
   test('visiting index while unauthenticated redirects to global authenticate method', async function (assert) {

--- a/ui/desktop/tests/acceptance/projects/targets/target-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/target-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import sinon from 'sinon';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import WindowMockIPC from '../../../helpers/window-mock-ipc';
+import Store from 'api/services/store';
 
 module('Acceptance | projects | targets | target', function (hooks) {
   setupApplicationTest(hooks);
@@ -129,6 +130,13 @@ module('Acceptance | projects | targets | target', function (hooks) {
 
     const ipcService = this.owner.lookup('service:ipc');
     stubs.ipcService = sinon.stub(ipcService, 'invoke');
+
+    // Use the original store so we don't try and hit the client daemon
+    this.owner.register('service:store', Store);
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
   });
 
   test('user can connect to a target with an address', async function (assert) {

--- a/ui/desktop/tests/helpers/window-mock-ipc.js
+++ b/ui/desktop/tests/helpers/window-mock-ipc.js
@@ -25,6 +25,10 @@ class MockIPC {
   hasMacOSChrome() {}
   showWindowActions() {}
   addTokenToClientDaemon() {}
+  searchClientDaemon() {}
+  isClientDaemonRunning() {
+    return false;
+  }
 }
 
 /**

--- a/ui/desktop/tests/unit/services/store-test.js
+++ b/ui/desktop/tests/unit/services/store-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'desktop/tests/helpers';
+
+module('Unit | Service | store', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:store');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-11691

## Description
Added a handler just to the desktop client to integrate with the client daemon.

## How to Test
Build a binary from the `llb-client-daemon` branch and use that binary in your local dev environment. You can confirm in the DC that we're now not making any requests to the controller in the network tab and see the request logs in the main thread in electron.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- ~[ ] My changes generate no new warnings~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
