### PR TITLE
chore: 🤖 Add support for pagination in query method

### DIFF
--- a/addons/api/addon/adapters/application.js
+++ b/addons/api/addon/adapters/application.js
@@ -128,8 +128,8 @@ export default class ApplicationAdapter extends RESTAdapter.extend(
     let result;
     let data = [];
 
-    //run this loop as long as the response_type is delta,
-    //which indicates that there are more items in the list
+    // Run this loop as long as the response_type is delta,
+    // which indicates that there are more items in the list
     do {
       try {
         result = await super.query(store, schema, query);

--- a/addons/api/addon/adapters/application.js
+++ b/addons/api/addon/adapters/application.js
@@ -131,28 +131,21 @@ export default class ApplicationAdapter extends RESTAdapter.extend(
     // Run this loop as long as the response_type is delta,
     // which indicates that there are more items in the list
     do {
-      try {
-        result = await super.query(store, schema, query);
-
-        //add the result items to a data array
-        if (result.items) {
-          data.push(...result.items);
-        }
-
-        //pass in the refresh token for subsequent calls to fetch the remaining list iems
+      result = await super.query(store, schema, query);
+      //add the result items to a data array
+      if (result && result.items) {
+        data.push(...result.items);
+        //pass in the refresh token for subsequent calls to fetch the remaining list items
         query.refresh_token = result.refresh_token;
-
         //break the loop as soon the response_type becomes complete
         if (result.response_type === 'complete') {
           break;
         }
-      } catch (err) {
-        throw new Error(err);
       }
-    } while (result.response_type === 'delta');
+    } while (result && result.response_type === 'delta');
 
     result.items = data;
-    return result;
+    return prenormalizeArrayResponse(result);
   }
 
   /**

--- a/addons/api/addon/adapters/application.js
+++ b/addons/api/addon/adapters/application.js
@@ -45,7 +45,7 @@ function prenormalizeArrayResponse(response) {
 }
 
 export default class ApplicationAdapter extends RESTAdapter.extend(
-  AdapterBuildURLMixin
+  AdapterBuildURLMixin,
 ) {
   // =attributes
 
@@ -147,7 +147,7 @@ export default class ApplicationAdapter extends RESTAdapter.extend(
           break;
         }
       } catch (err) {
-        console.error(err);
+        throw new Error(err);
       }
     } while (result.response_type === 'delta');
 

--- a/addons/api/addon/serializers/application.js
+++ b/addons/api/addon/serializers/application.js
@@ -145,18 +145,18 @@ export default class ApplicationSerializer extends RESTSerializer {
     const transformedPayload = {};
     // Find the Ember-data-expected root key name.
     const payloadKey = this.payloadKeyFromModelName(
-      primaryModelClass.modelName
+      primaryModelClass.modelName,
     );
     // Copy the data rooted under `items` in the existing payload into the new
     // payload under the expected root key name.
-    transformedPayload[payloadKey] = structuredClone(payload.items);
+    transformedPayload[payloadKey] = structuredClone(payload?.items);
     // Return the result of normalizing the transformed payload.
     return super.normalizeArrayResponse(
       store,
       primaryModelClass,
       transformedPayload,
       id,
-      requestType
+      requestType,
     );
   }
 
@@ -183,7 +183,7 @@ export default class ApplicationSerializer extends RESTSerializer {
     const transformedPayload = {};
     // Find the Ember-data-expected root key name.
     const payloadKey = this.payloadKeyFromModelName(
-      primaryModelClass.modelName
+      primaryModelClass.modelName,
     );
     // Copy the unrooted payload under the expected root key name.
     transformedPayload[payloadKey] = payload;
@@ -193,7 +193,7 @@ export default class ApplicationSerializer extends RESTSerializer {
       primaryModelClass,
       transformedPayload,
       id,
-      requestType
+      requestType,
     );
   }
 
@@ -318,7 +318,7 @@ export default class ApplicationSerializer extends RESTSerializer {
     primaryModelClass,
     payload,
     id,
-    requestType
+    requestType,
   ) {
     const newPayload = structuredClone(payload);
 
@@ -338,7 +338,7 @@ export default class ApplicationSerializer extends RESTSerializer {
       primaryModelClass,
       newPayload,
       id,
-      requestType
+      requestType,
     );
   }
 }

--- a/ui/admin/app/routes/scopes/scope/targets.js
+++ b/ui/admin/app/routes/scopes/scope/targets.js
@@ -62,7 +62,7 @@ export default class ScopesScopeTargetsRoute extends Route {
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(target) {
     await target.save();
@@ -121,11 +121,11 @@ export default class ScopesScopeTargetsRoute extends Route {
 
     if (hostSourceCount) {
       const hostSourceIDs = target.host_sources.map(
-        ({ host_source_id }) => host_source_id
+        ({ host_source_id }) => host_source_id,
       );
       const confirmMessage = this.intl.t(
         'resources.target.questions.delete-host-sources.message',
-        { hostSourceCount }
+        { hostSourceCount },
       );
 
       // Ask for confirmation

--- a/ui/admin/app/routes/scopes/scope/users.js
+++ b/ui/admin/app/routes/scopes/scope/users.js
@@ -60,7 +60,7 @@ export default class ScopesScopeUsersRoute extends Route {
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(user) {
     await user.save();

--- a/ui/admin/tests/acceptance/authentication-test.js
+++ b/ui/admin/tests/acceptance/authentication-test.js
@@ -74,7 +74,7 @@ module('Acceptance | authentication', function (hooks) {
         type: 'org',
         scope: { id: globalScope.id, type: globalScope.type },
       },
-      'withChildren'
+      'withChildren',
     );
     scope = { id: orgScope.id, type: orgScope.type };
     globalAuthMethod = this.server.create('auth-method', {
@@ -309,7 +309,7 @@ module('Acceptance | authentication', function (hooks) {
     await click('.rose-header-utilities .rose-dropdown summary');
     // Find and click on last element in dropdown - should be deauthenticate button
     const menu = findAll(
-      '.rose-header-utilities .rose-dropdown .rose-dropdown-content button'
+      '.rose-header-utilities .rose-dropdown .rose-dropdown-content button',
     );
     await click(menu[menu.length - 1]);
     assert.notOk(currentSession().isAuthenticated);
@@ -324,13 +324,13 @@ module('Acceptance | authentication', function (hooks) {
     await visit(orgsURL);
     assert.ok(
       currentSession().isAuthenticated,
-      'Session begins authenticated, before encountering 401'
+      'Session begins authenticated, before encountering 401',
     );
     this.server.get('/users', () => new Response(401));
     await visit(usersURL);
     assert.notOk(
       currentSession().isAuthenticated,
-      'Session is unauthenticated, after encountering 401'
+      'Session is unauthenticated, after encountering 401',
     );
   });
 
@@ -358,7 +358,7 @@ module('Acceptance | authentication', function (hooks) {
     await click('[name="theme"][value="system-default-theme"]');
     assert.strictEqual(
       currentSession().get('data.theme'),
-      'system-default-theme'
+      'system-default-theme',
     );
     assert.notOk(getRootElement().classList.contains('rose-theme-light'));
     assert.notOk(getRootElement().classList.contains('rose-theme-dark'));
@@ -380,7 +380,7 @@ module('Acceptance | authentication', function (hooks) {
             },
           };
         }
-      }
+      },
     );
     await visit(authMethodOIDCAuthenticateURL);
     await click('form [type="submit"]');


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-11688)

Backend introduced pagination for all resources, and they have a default page_size of 1000, which means if there are more than 1k resources, the UI will not get the full list unless we pass in the `refresh_token` of the current result list. 

The goal of this PR is to simply return the full result set from the API


<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

<img width="884" alt="Screenshot 2023-11-10 at 9 37 45 AM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/a8868cb7-c7f7-4446-8181-a8f14bbdd39b">

## How to Test
[Note: you need to run the `llb/pagination` to test this]
- Add 4 targets, and in the routes/target set a page_size of 1(this is to mock the API default page_size limit). You should still see all 4 on the UI 
<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[] I have added before and after screenshots for UI changes~
- [x] I have added JSON response output for API changes
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
