### PR TITLE
fix: 🐛 Fix broken hot reloading for desktop client

### DIFF
--- a/ui/desktop/electron-app/src/config/content-security-policy.js
+++ b/ui/desktop/electron-app/src/config/content-security-policy.js
@@ -26,8 +26,8 @@ const enableDevCSP = () => {
   csp['style-src'].push("'unsafe-inline'");
   csp['script-src'].push("'unsafe-eval'");
   csp['script-src'].push("'unsafe-inline'");
-  csp['script-src'].push('http://localhost:7020');
-  csp['connect-src'].push('ws://localhost:7020');
+  csp['script-src'].push('http://localhost:8000');
+  csp['connect-src'].push('ws://localhost:8000');
 };
 
 const generateCSPHeader = () => {


### PR DESCRIPTION
## Description
While Cameron and I were pairing, he noticed the ember reloading script gets blocked by CSP headers. Fixing this enables correctly hot reloading on desktop client again so you don't have to manually refresh the client.

## How to Test
Make a code change in desktop client and it should auto reload.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
