### PR TITLE
fix: 🐛 API sorted resources that were empty

### DIFF
--- a/addons/api/addon/adapters/application.js
+++ b/addons/api/addon/adapters/application.js
@@ -41,11 +41,17 @@ function payloadIsBlank(adapterPayload) {
  * @return {object}
  */
 function prenormalizeArrayResponse(response) {
-  return payloadIsBlank(response) ? { items: [] } : response;
+  if (payloadIsBlank(response)) {
+    return { items: [] };
+  } else if ('items' in response) {
+    return response;
+  } else {
+    return { ...response, items: [] };
+  }
 }
 
 export default class ApplicationAdapter extends RESTAdapter.extend(
-  AdapterBuildURLMixin
+  AdapterBuildURLMixin,
 ) {
   // =attributes
 

--- a/addons/api/addon/adapters/application.js
+++ b/addons/api/addon/adapters/application.js
@@ -37,6 +37,10 @@ function payloadIsBlank(adapterPayload) {
  * adapter and serializers together.  Before it forwards a response from the
  * adapter on to the serializer, it checks for an "empty" response.  If the
  * response is empty, fetch manager throws and error and never forwards it on.
+ * Some resources from the api are presorted and will always return sort metada.
+ * If the response is not empty we need to check if it has the "items" property
+ * before returning the reponse. If it does not have "items", we will add it
+ * to the response so it can be handled correctly by the normalizer.
  * @param {object} response
  * @return {object}
  */

--- a/addons/api/tests/unit/adapters/application-test.js
+++ b/addons/api/tests/unit/adapters/application-test.js
@@ -67,7 +67,7 @@ module('Unit | Adapter | application', function (hooks) {
       'user',
       '1',
       mockSnapshot,
-      'findRecord'
+      'findRecord',
     );
     assert.strictEqual(findRecordURL, '/v1/users/1:my-custom-method');
     const findAllURL = adapter.buildURL('user', null, mockSnapshot, 'findAll');
@@ -76,28 +76,28 @@ module('Unit | Adapter | application', function (hooks) {
       'user',
       '2',
       mockSnapshot,
-      'findBelongsTo'
+      'findBelongsTo',
     );
     assert.strictEqual(findBelongsToURL, '/v1/users/2:my-custom-method');
     const createRecordURL = adapter.buildURL(
       'user',
       null,
       mockSnapshot,
-      'createRecord'
+      'createRecord',
     );
     assert.strictEqual(createRecordURL, '/v1/users:my-custom-method');
     const updateRecordURL = adapter.buildURL(
       'user',
       '3',
       mockSnapshot,
-      'updateRecord'
+      'updateRecord',
     );
     assert.strictEqual(updateRecordURL, '/v1/users/3:my-custom-method');
     const deleteRecordURL = adapter.buildURL(
       'user',
       '4',
       mockSnapshot,
-      'deleteRecord'
+      'deleteRecord',
     );
     assert.strictEqual(deleteRecordURL, '/v1/users/4:my-custom-method');
   });
@@ -109,7 +109,7 @@ module('Unit | Adapter | application', function (hooks) {
       assert.strictEqual(
         scope_id,
         'p_456',
-        'Scoped resource URL was requested.'
+        'Scoped resource URL was requested.',
       );
       return { items: [] };
     });
@@ -154,9 +154,28 @@ module('Unit | Adapter | application', function (hooks) {
       store,
       { modelName: 'user' },
       null,
-      []
+      [],
     );
     assert.deepEqual(prenormalized, { items: [] });
+  });
+
+  test('it prenormalizes "empty" responses for API sorted resources into a form that the fetch-manager will not reject', async function (assert) {
+    assert.expect(1);
+    const payload = {
+      response_type: 'complete',
+      sort_by: 'updated_time',
+      sort_dir: 'asc',
+    };
+    const adapter = this.owner.lookup('adapter:application');
+    const store = this.owner.lookup('service:store');
+    this.server.get('/v1/targets', () => new Response(200, {}, payload));
+    const prenormalized = await adapter.findAll(
+      store,
+      { modelName: 'target' },
+      null,
+      [],
+    );
+    assert.deepEqual(prenormalized, { ...payload, items: [] });
   });
 
   test('it correctly identifies 400 responses as invalid', function (assert) {
@@ -209,7 +228,7 @@ module('Unit | Adapter | application', function (hooks) {
     assert.strictEqual(
       handledResponse.errors.length,
       2,
-      'A base error plus one field error'
+      'A base error plus one field error',
     );
   });
 });


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-11819)

## Description

API sorted resources throw error when there are no resources return from the API

If there are no targets, sessions, or credential stores the Admin UI will error out because it does not know how to normalize that response due to the lack of the `items: []` property.

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
Before:
https://github.com/hashicorp/boundary-ui/assets/29386339/22629283-1e39-480d-9afd-97ba7922c65f

Error:
<img width="639" alt="Screenshot 2023-11-17 at 11 34 00 AM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/b78f017b-625e-4571-9d77-73b3ea0e22eb">

After:
https://github.com/hashicorp/boundary-ui/assets/29386339/901e6d03-2e88-4f75-acec-a8211904368f

## How to Test

Create a new Project. It should have no targets, sessions, or credential stores. You should be able to visit those routes and see a "No Resource" message with a button to create new resource.

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] ~I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
