### PR TITLE
chore: 🤖 Update stylelint config dependency

### DIFF
--- a/addons/rose/app/styles/rose/components/_message.scss
+++ b/addons/rose/app/styles/rose/components/_message.scss
@@ -16,7 +16,7 @@
   width: sizing.rems(l) * 15; // 16 rems/320 px
   margin-bottom: sizing.rems(l);
 
-  @media (max-width: media.width(small)) {
+  @media (width <= (media.width(small))) {
     width: auto;
   }
 

--- a/addons/rose/app/styles/rose/components/dialog/_dialog.scss
+++ b/addons/rose/app/styles/rose/components/dialog/_dialog.scss
@@ -22,7 +22,8 @@ $xxxxs: sizing.rems(xxxxs); // 1
 
   border-radius: $xxxs;
   background-color: var(--subtle);
-  box-shadow: 0 $xs $s rgba(var(--stark-components), var(--opacity-2)),
+  box-shadow:
+    0 $xs $s rgba(var(--stark-components), var(--opacity-2)),
     0 $xxs $xxs rgba(var(--stark-components), var(--opacity-3));
 
   &.rose-dialog-success {
@@ -130,7 +131,7 @@ $xxxxs: sizing.rems(xxxxs); // 1
     max-width: 80vw;
     width: 650px;
 
-    @media (max-width: media.width(small)) {
+    @media (width <= (media.width(small))) {
       left: 5%;
     }
 

--- a/addons/rose/app/styles/rose/components/header/_index.scss
+++ b/addons/rose/app/styles/rose/components/header/_index.scss
@@ -36,7 +36,7 @@
   box-shadow: var(--box-shadow);
 }
 
-@media (max-width: media.width(small)) {
+@media (width <= (media.width(small))) {
   .rose-header {
     grid-template-columns: 1fr 3fr;
     grid-template-areas:

--- a/addons/rose/app/styles/rose/components/header/_nav.scss
+++ b/addons/rose/app/styles/rose/components/header/_nav.scss
@@ -13,7 +13,7 @@
   align-items: center;
   margin-right: sizing.rems(s);
 
-  @media (max-width: media.width(small)) {
+  @media (width <= (media.width(small))) {
     padding: 0 20px;
     background: var(--ui-header-subtler);
   }

--- a/addons/rose/app/styles/rose/components/layout/_body-content.scss
+++ b/addons/rose/app/styles/rose/components/layout/_body-content.scss
@@ -21,7 +21,7 @@
   }
 }
 
-@media (max-width: media.width(xlarge)) {
+@media (width <= (media.width(xlarge))) {
   .rose-layout-body-content {
     grid-template-areas:
       'body'

--- a/addons/rose/app/styles/rose/components/layout/_page.scss
+++ b/addons/rose/app/styles/rose/components/layout/_page.scss
@@ -41,7 +41,7 @@
   }
 }
 
-@media (max-width: media.width(small)) {
+@media (width <= (media.width(small))) {
   .rose-layout-page {
     grid-template-columns: 1fr;
     grid-template-areas:

--- a/addons/rose/app/styles/rose/components/layout/_sidebar.scss
+++ b/addons/rose/app/styles/rose/components/layout/_sidebar.scss
@@ -35,7 +35,7 @@
   }
 }
 
-@media (max-width: media.width(medium)) {
+@media (width <= (media.width(medium))) {
   .rose-layout-sidebar {
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr auto;

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -96,7 +96,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "stylelint": "^15.10.1",
     "stylelint-config-prettier-scss": "^0.0.1",
-    "stylelint-config-standard-scss": "^6.0.0",
+    "stylelint-config-standard-scss": "^11.0.0",
     "webpack": "^5.78.0"
   },
   "peerDependencies": {

--- a/ui/admin/app/styles/_notify.scss
+++ b/ui/admin/app/styles/_notify.scss
@@ -86,7 +86,7 @@
   }
 }
 
-@media only screen and (max-width: 680px) {
+@media only screen and (width <= 680px) {
   .ember-notify-cn {
     box-sizing: border-box;
     padding-left: 20px;

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -22,7 +22,7 @@
     width: sizing.rems(l) * 18;
   }
 
-  @media (max-width: media.width(small)) {
+  @media (width <= (media.width(small))) {
     display: block;
 
     > .rose-layout-page {

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -102,7 +102,7 @@
     "sinon": "^14.0.0",
     "stylelint": "^15.10.1",
     "stylelint-config-prettier-scss": "^0.0.1",
-    "stylelint-config-standard-scss": "^6.0.0",
+    "stylelint-config-standard-scss": "^11.0.0",
     "tracked-built-ins": "^3.1.1",
     "webpack": "^5.78.0"
   },

--- a/ui/desktop/app/styles/_notify.scss
+++ b/ui/desktop/app/styles/_notify.scss
@@ -90,7 +90,6 @@
 
 @media only screen and (width <= 680px) {
   .ember-notify-cn {
-    background-color: #fff;
     box-sizing: border-box;
     padding-left: 20px;
     width: 100%;

--- a/ui/desktop/app/styles/_notify.scss
+++ b/ui/desktop/app/styles/_notify.scss
@@ -88,8 +88,9 @@
   }
 }
 
-@media only screen and (max-width: 680px) {
+@media only screen and (width <= 680px) {
   .ember-notify-cn {
+    background-color: #fff;
     box-sizing: border-box;
     padding-left: 20px;
     width: 100%;

--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -284,7 +284,7 @@
   }
 }
 
-@media (max-width: media.width(medium)) {
+@media (width <= (media.width(medium))) {
   .branded-card {
     max-width: 100%;
     width: auto;

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -116,7 +116,7 @@
     "stylelint": "^15.10.1",
     "stylelint-config-prettier-scss": "^0.0.1",
     "stylelint-config-standard": "^32.0.0",
-    "stylelint-config-standard-scss": "^6.0.0",
+    "stylelint-config-standard-scss": "^11.0.0",
     "tracked-built-ins": "^3.1.1",
     "webpack": "^5.78.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14428,6 +14428,11 @@ known-css-properties@^0.27.0:
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.27.0.tgz#82a9358dda5fe7f7bd12b5e7142c0a205393c0c5"
   integrity sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==
 
+known-css-properties@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.29.0.tgz#e8ba024fb03886f23cb882e806929f32d814158f"
+  integrity sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ==
+
 language-subtag-registry@^0.3.20:
   version "0.3.22"
   resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz#2e1500861b2e457eba7e7ae86877cbd08fa1fd1d"
@@ -16974,12 +16979,12 @@ postcss-safe-parser@^6.0.0:
   resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
   integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
 
-postcss-scss@^4.0.2:
+postcss-scss@^4.0.9:
   version "4.0.9"
   resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.9.tgz#a03c773cd4c9623cb04ce142a52afcec74806685"
   integrity sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==
 
-postcss-selector-parser@^6.0.11, postcss-selector-parser@^6.0.13:
+postcss-selector-parser@^6.0.13:
   version "6.0.13"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz#d05d8d76b1e8e173257ef9d60b706a8e5e99bf1b"
   integrity sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==
@@ -19238,39 +19243,32 @@ stylelint-config-prettier@>=9.0.3:
   resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz#0dccebeff359dcc393c9229184408b08964d561c"
   integrity sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==
 
-stylelint-config-recommended-scss@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-8.0.0.tgz#1c1e93e619fe2275d4c1067928d92e0614f7d64f"
-  integrity sha512-BxjxEzRaZoQb7Iinc3p92GS6zRdRAkIuEu2ZFLTxJK2e1AIcCb5B5MXY9KOXdGTnYFZ+KKx6R4Fv9zU6CtMYPQ==
+stylelint-config-recommended-scss@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-13.1.0.tgz#04e529ae0e9c1abb1e04de79258461c07811876f"
+  integrity sha512-8L5nDfd+YH6AOoBGKmhH8pLWF1dpfY816JtGMePcBqqSsLU+Ysawx44fQSlMOJ2xTfI9yTGpup5JU77c17w1Ww==
   dependencies:
-    postcss-scss "^4.0.2"
-    stylelint-config-recommended "^9.0.0"
-    stylelint-scss "^4.0.0"
+    postcss-scss "^4.0.9"
+    stylelint-config-recommended "^13.0.0"
+    stylelint-scss "^5.3.0"
 
 stylelint-config-recommended@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-11.0.0.tgz#b1cb7d71bd92f9b8593f93c2ca6df16ed7d61522"
   integrity sha512-SoGIHNI748OCZn6BxFYT83ytWoYETCINVHV3LKScVAWQQauWdvmdDqJC5YXWjpBbxg2E761Tg5aUGKLFOVhEkA==
 
-stylelint-config-recommended@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz#1c9e07536a8cd875405f8ecef7314916d94e7e40"
-  integrity sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==
+stylelint-config-recommended@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz#c48a358cc46b629ea01f22db60b351f703e00597"
+  integrity sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==
 
-stylelint-config-standard-scss@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-standard-scss/-/stylelint-config-standard-scss-6.1.0.tgz#a6cddd2a9430578b92fc89726a59474d5548a444"
-  integrity sha512-iZ2B5kQT2G3rUzx+437cEpdcnFOQkwnwqXuY8Z0QUwIHQVE8mnYChGAquyKFUKZRZ0pRnrciARlPaR1RBtPb0Q==
+stylelint-config-standard-scss@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard-scss/-/stylelint-config-standard-scss-11.1.0.tgz#53c2fb9423ed89c0921aa83479892a912cc1ca15"
+  integrity sha512-5gnBgeNTgRVdchMwiFQPuBOtj9QefYtfXiddrOMJA2pI22zxt6ddI2s+e5Oh7/6QYl7QLJujGnaUR5YyGq72ow==
   dependencies:
-    stylelint-config-recommended-scss "^8.0.0"
-    stylelint-config-standard "^29.0.0"
-
-stylelint-config-standard@^29.0.0:
-  version "29.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-29.0.0.tgz#4cc0e0f05512a39bb8b8e97853247d3a95d66fa2"
-  integrity sha512-uy8tZLbfq6ZrXy4JKu3W+7lYLgRQBxYTUUB88vPgQ+ZzAxdrvcaSUW9hOMNLYBnwH+9Kkj19M2DHdZ4gKwI7tg==
-  dependencies:
-    stylelint-config-recommended "^9.0.0"
+    stylelint-config-recommended-scss "^13.1.0"
+    stylelint-config-standard "^34.0.0"
 
 stylelint-config-standard@^32.0.0:
   version "32.0.0"
@@ -19279,14 +19277,22 @@ stylelint-config-standard@^32.0.0:
   dependencies:
     stylelint-config-recommended "^11.0.0"
 
-stylelint-scss@^4.0.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-4.7.0.tgz#f986bf8c5a4b93eae2b67d3a3562eef822657908"
-  integrity sha512-TSUgIeS0H3jqDZnby1UO1Qv3poi1N8wUYIJY6D1tuUq2MN3lwp/rITVo0wD+1SWTmRm0tNmGO0b7nKInnqF6Hg==
+stylelint-config-standard@^34.0.0:
+  version "34.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-34.0.0.tgz#309f3c48118a02aae262230c174282e40e766cf4"
+  integrity sha512-u0VSZnVyW9VSryBG2LSO+OQTjN7zF9XJaAJRX/4EwkmU0R2jYwmBSN10acqZisDitS0CLiEiGjX7+Hrq8TAhfQ==
   dependencies:
+    stylelint-config-recommended "^13.0.0"
+
+stylelint-scss@^5.3.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-5.3.1.tgz#7f0f5f06d0a2a3c515aa71d3a8de3548045e03e1"
+  integrity sha512-5I9ZDIm77BZrjOccma5WyW2nJEKjXDd4Ca8Kk+oBapSO4pewSlno3n+OyimcyVJJujQZkBN2D+xuMkIamSc6hA==
+  dependencies:
+    known-css-properties "^0.29.0"
     postcss-media-query-parser "^0.2.3"
     postcss-resolve-nested-selector "^0.1.1"
-    postcss-selector-parser "^6.0.11"
+    postcss-selector-parser "^6.0.13"
     postcss-value-parser "^4.2.0"
 
 stylelint@^15.10.1:


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-11818

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-11818)

## Description
- Updated `styelint-config-standard-scss` to fix incorrect peer dependency warning for `styelint`
- Upgrading to `11.0.0`  introduced a new rule for writing media ranges for media queries.  Instead of using `prefix` style  notation(`max-width: 668px`), the new configuration wants us to use `context` style notation(`width <= 668px`)
- Tested the new style of notation by adding a white background to the `.ember-notify-cn` attribute and it works as expected.

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
#### Warning
<img width="1244" alt="Screenshot 2023-11-20 at 11 28 53" src="https://github.com/hashicorp/boundary-ui/assets/24277002/680643f1-929f-43ad-8593-1bd7f468d7a4">

#### Test for sizes under `668px`
https://github.com/hashicorp/boundary-ui/assets/24277002/cf035cd6-cbc4-4759-a9cb-6cd3f2d8454c

#### Test for sizes above `668px`
https://github.com/hashicorp/boundary-ui/assets/24277002/df11308e-e256-4889-8413-b3f45ca4736a

## How to Test
- [ ] Start up desktop  
- [ ] Click on sessions
- [ ] Click the "Cancel" action on any active session and make sure that the notification looks correctly for the action and the styles applied in the media range
<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
~~- [ ] I have added JSON response output for API changes~~
- [x] I have added steps to reproduce and test for bug fixes in the description
~~- [ ] I have commented on my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
