### PR TITLE
chore: 🤖 Add custom key handler for windows

### DIFF
--- a/ui/desktop/app/components/session/tabs/index.js
+++ b/ui/desktop/app/components/session/tabs/index.js
@@ -61,11 +61,11 @@ export default class SessionTerminalTabsComponent extends Component {
      * Custom key event handler for windows to achieve Ctrl+C as on the other OS's
      */
     if (isWindows) {
-      xterm.attachCustomKeyEventHandler((arg) => {
+      xterm.attachCustomKeyEventHandler(async (arg) => {
         if (arg.ctrlKey && arg.code === 'KeyC' && arg.type === 'keydown') {
           const selection = xterm.getSelection();
           if (selection) {
-            navigator.clipboard.writeText(selection);
+            await navigator.clipboard.writeText(selection);
             return false;
           }
         }

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -54,7 +54,7 @@ handle('openExternal', async (href) => {
   } else {
     throw new Error(
       `URLs may only be opened over HTTPS in an external browser.
-       The URL '${href}' could not be opened.`
+       The URL '${href}' could not be opened.`,
     );
   }
 });
@@ -68,7 +68,7 @@ handle('cliExists', () => boundaryCli.exists());
  * Establishes a boundary session and returns session details.
  */
 handle('connect', ({ target_id, token, host_id }) =>
-  sessionManager.start(runtimeSettings.clusterUrl, target_id, token, host_id)
+  sessionManager.start(runtimeSettings.clusterUrl, target_id, token, host_id),
 );
 
 /**
@@ -82,7 +82,7 @@ handle('stop', ({ session_id }) => sessionManager.stopById(session_id));
  * `DISABLE_WINDOW_CHROME=true`.
  */
 handle('hasMacOSChrome', () =>
-  process.env.DISABLE_WINDOW_CHROME ? false : isMac()
+  process.env.DISABLE_WINDOW_CHROME ? false : isMac(),
 );
 
 /**
@@ -91,7 +91,7 @@ handle('hasMacOSChrome', () =>
  * `DISABLE_WINDOW_CHROME=true`.
  */
 handle('showWindowActions', () =>
-  process.env.DISABLE_WINDOW_CHROME ? false : !isMac()
+  process.env.DISABLE_WINDOW_CHROME ? false : !isMac(),
 );
 
 /**
@@ -116,6 +116,15 @@ handle('closeWindow', () => app.quit());
  * Return the location of where a user's binary for a command is. If it isn't found, return null.
  */
 handle('checkCommand', async (command) => which(command, { nothrow: true }));
+
+/**
+ * Return an object containing helper fields for determining what OS we're running on
+ */
+handle('checkOS', () => ({
+  isLinux: isLinux(),
+  isMac: isMac(),
+  isWindows: isWindows(),
+}));
 
 /**
  * Handler to help create terminal windows. We don't use the helper `handle` method


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-11474)

## Description

Add custom key handler only for Windows OS so we achieve Ctrl+C to copy within the embedded terminal.

Used `attachCustomKeyEventHandler` from xterm.js. Info [here](https://github.com/xtermjs/xterm.js/blob/4375b3cdb9e36cd2746ff9a101fbeb48f7d0b794/typings/xterm.d.ts#L473-L482) and [here](https://xtermjs.org/docs/guides/hooks/)

## Screenshots:

Selecting text + (ctrl+c):
![Screenshot 2023-11-20 152608](https://github.com/hashicorp/boundary-ui/assets/9775006/b71b8321-118c-49a2-a3ba-92ea05aa7fd0)

Ctrl+v:
![Screenshot 2023-11-20 152618](https://github.com/hashicorp/boundary-ui/assets/9775006/6d16afee-c680-4583-8253-e591f93967dc)

## How to Test

- Run desktop client within windows machine.
- Stablish an ssh or tcp session with a target.
- Go to the shell tab and: select text + (ctrl+c) + (ctrl+v).
- Expected result: the selected text is pasted on the terminal.

## Checklist:
- [x] I have added before and after screenshots for UI changes
- ~~[ ] I have added JSON response output for API changes~~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- ~~[ ] My changes generate no new warnings~~
- [x] I have added tests that prove my fix is effective or that my feature works
