### PR TITLE
Icu 11825 replace `store.findAll` method with `store.query`

### DIFF
--- a/addons/api/addon/adapters/application.js
+++ b/addons/api/addon/adapters/application.js
@@ -108,16 +108,6 @@ export default class ApplicationAdapter extends RESTAdapter.extend(
 
   /**
    * Intercepts "empty" responses and adds an empty `items` array.
-   * @override
-   * @method findAll
-   * @return {Promise} promise
-   */
-  findAll() {
-    return super.findAll(...arguments).then(prenormalizeArrayResponse);
-  }
-
-  /**
-   * Intercepts "empty" responses and adds an empty `items` array.
    * This query method now supports pagination by checking the responseType and
    * passing in the refresh token if the responseType indicates more data
    * @override

--- a/addons/api/tests/dummy/app/routes/application.js
+++ b/addons/api/tests/dummy/app/routes/application.js
@@ -12,6 +12,6 @@ export default class ApplicationRoute extends Route {
   @service store;
 
   model() {
-    this.store.findAll('scope');
+    this.store.query('scope', {});
   }
 }

--- a/addons/api/tests/unit/adapters/application-test.js
+++ b/addons/api/tests/unit/adapters/application-test.js
@@ -67,7 +67,7 @@ module('Unit | Adapter | application', function (hooks) {
       'user',
       '1',
       mockSnapshot,
-      'findRecord'
+      'findRecord',
     );
     assert.strictEqual(findRecordURL, '/v1/users/1:my-custom-method');
     const findAllURL = adapter.buildURL('user', null, mockSnapshot, 'findAll');
@@ -76,28 +76,28 @@ module('Unit | Adapter | application', function (hooks) {
       'user',
       '2',
       mockSnapshot,
-      'findBelongsTo'
+      'findBelongsTo',
     );
     assert.strictEqual(findBelongsToURL, '/v1/users/2:my-custom-method');
     const createRecordURL = adapter.buildURL(
       'user',
       null,
       mockSnapshot,
-      'createRecord'
+      'createRecord',
     );
     assert.strictEqual(createRecordURL, '/v1/users:my-custom-method');
     const updateRecordURL = adapter.buildURL(
       'user',
       '3',
       mockSnapshot,
-      'updateRecord'
+      'updateRecord',
     );
     assert.strictEqual(updateRecordURL, '/v1/users/3:my-custom-method');
     const deleteRecordURL = adapter.buildURL(
       'user',
       '4',
       mockSnapshot,
-      'deleteRecord'
+      'deleteRecord',
     );
     assert.strictEqual(deleteRecordURL, '/v1/users/4:my-custom-method');
   });
@@ -109,7 +109,7 @@ module('Unit | Adapter | application', function (hooks) {
       assert.strictEqual(
         scope_id,
         'p_456',
-        'Scoped resource URL was requested.'
+        'Scoped resource URL was requested.',
       );
       return { items: [] };
     });
@@ -150,12 +150,7 @@ module('Unit | Adapter | application', function (hooks) {
     const adapter = this.owner.lookup('adapter:application');
     const store = this.owner.lookup('service:store');
     this.server.get('/v1/users', () => new Response({}));
-    const prenormalized = await adapter.findAll(
-      store,
-      { modelName: 'user' },
-      null,
-      []
-    );
+    const prenormalized = await adapter.query(store, { modelName: 'user' }, {});
     assert.deepEqual(prenormalized, { items: [] });
   });
 
@@ -209,7 +204,7 @@ module('Unit | Adapter | application', function (hooks) {
     assert.strictEqual(
       handledResponse.errors.length,
       2,
-      'A base error plus one field error'
+      'A base error plus one field error',
     );
   });
 });

--- a/addons/api/tests/unit/models/scope-test.js
+++ b/addons/api/tests/unit/models/scope-test.js
@@ -24,33 +24,33 @@ module('Unit | Model | scope', function (hooks) {
         { id: 'p_3', type: 'project', scope: { scope_id: 'o_2' } },
       ],
     }));
-    const scopes = await store.findAll('scope');
+    const scopes = await store.query('scope', {});
     // check integrity of scope relationships
     assert.notOk(await scopes[0].get('scope'), 'Global scope has no parent');
     assert.strictEqual(
       await scopes.objectAt(1).get('scope.scope_id'),
       'global',
-      'Org 1 parent scope is global'
+      'Org 1 parent scope is global',
     );
     assert.strictEqual(
       await scopes.objectAt(2).get('scope.scope_id'),
       'global',
-      'Org 2 parent scope is global'
+      'Org 2 parent scope is global',
     );
     assert.strictEqual(
       await scopes.objectAt(3).get('scope.scope_id'),
       'o_1',
-      'Project 1 parent scope is org 1'
+      'Project 1 parent scope is org 1',
     );
     assert.strictEqual(
       await scopes.objectAt(4).get('scope.scope_id'),
       'o_1',
-      'Project 2 parent scope is org 1'
+      'Project 2 parent scope is org 1',
     );
     assert.strictEqual(
       await scopes.objectAt(5).get('scope.scope_id'),
       'o_2',
-      'Project 3 parent scope is org 2'
+      'Project 3 parent scope is org 2',
     );
   });
 

--- a/ui/admin/app/routes/scopes.js
+++ b/ui/admin/app/routes/scopes.js
@@ -31,6 +31,6 @@ export default class ScopesRoute extends Route {
     });
     // NOTE:  In the absence of a `scope_id` query parameter, this endpoint is
     // expected to default to the global scope, thus returning org scopes.
-    return this.store.findAll('scope').catch(() => A([]));
+    return this.store.query('scope', {}).catch(() => A([]));
   }
 }

--- a/ui/desktop/app/routes/scopes.js
+++ b/ui/desktop/app/routes/scopes.js
@@ -26,6 +26,6 @@ export default class ScopesRoute extends Route {
   model() {
     // NOTE:  In the absence of a `scope_id` query parameter, this endpoint is
     // expected to default to the global scope, thus returning org scopes.
-    return this.store.findAll('scope').catch(() => A([]));
+    return this.store.query('scope', {}).catch(() => A([]));
   }
 }


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-11825)

## Description

<!-- Add a brief description of changes here -->
Refactor `store.findAll` to use `store.query`. Most list endpoints use store.query to retrieve `items` array. The only resources that use `findAll` are scopes. Scopes resource is also paginated so instead of modifying the adapter findAll method to handle pagination we decided to remove it and use query instead. The reason is that findAll is being deprecated by Ember v5. 

## How to Test

<!-- Add steps to test this change. Include any other necessary relevant links -->
Initiate a boundary dev instance using the `llb-list-pagination` branch and make sure no new errors or warnings are generated. 

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [X] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
