### PR TITLE
Reformat codebase with trailing commas in functions

### DIFF
--- a/addons/api/addon/abilities/channel-recording.js
+++ b/addons/api/addon/abilities/channel-recording.js
@@ -18,7 +18,7 @@ export default class ChannelRecordingAbility extends ModelAbility {
     const sessionRecording = this.model.connection_recording.session_recording;
     const sessionRecordingAbility = this.abilities.abilityFor(
       'session-recording',
-      sessionRecording
+      sessionRecording,
     );
 
     return this.model.isAsciicast && sessionRecordingAbility.canDownload;

--- a/addons/api/addon/abilities/role.js
+++ b/addons/api/addon/abilities/role.js
@@ -54,7 +54,7 @@ export default class RoleAbility extends ModelAbility {
       type === 'user' || type === 'group' || type === 'managed-group';
     if (!typeIsValid)
       throw new InvalidRolePrincipalTypeError(
-        `Expected a role principal of type 'user', 'group', or 'managed-group'.  Got '${type}'.`
+        `Expected a role principal of type 'user', 'group', or 'managed-group'.  Got '${type}'.`,
       );
     return this.can.can(`read ${type}`, this.model);
   }

--- a/addons/api/addon/adapters/application.js
+++ b/addons/api/addon/adapters/application.js
@@ -45,7 +45,7 @@ function prenormalizeArrayResponse(response) {
 }
 
 export default class ApplicationAdapter extends RESTAdapter.extend(
-  AdapterBuildURLMixin
+  AdapterBuildURLMixin,
 ) {
   // =attributes
 

--- a/addons/api/addon/adapters/session-recording.js
+++ b/addons/api/addon/adapters/session-recording.js
@@ -55,7 +55,7 @@ export default class SessionRecordingAdapter extends ApplicationAdapter {
       throw this.handleResponse(
         response.status,
         response.headers,
-        await response.text()
+        await response.text(),
       );
     }
   }

--- a/addons/api/addon/models/account.js
+++ b/addons/api/addon/models/account.js
@@ -87,7 +87,7 @@ export default class AccountModel extends GeneratedAccountModel {
   changePassword(
     currentPassword,
     newPassword,
-    options = { adapterOptions: {} }
+    options = { adapterOptions: {} },
   ) {
     const defaultAdapterOptions = {
       method: 'change-password',

--- a/addons/api/addon/models/role.js
+++ b/addons/api/addon/models/role.js
@@ -138,7 +138,7 @@ export default class RoleModel extends GeneratedRoleModel {
       const authMethods = this.resourceFilterStore.queryBy(
         'auth-method',
         { type: [TYPE_AUTH_METHOD_OIDC, TYPE_AUTH_METHOD_LDAP] },
-        { scope_id: 'global', recursive: true }
+        { scope_id: 'global', recursive: true },
       );
 
       // For each auth method, query all managed groups with IDs
@@ -149,9 +149,9 @@ export default class RoleModel extends GeneratedRoleModel {
             methods.map(({ id: auth_method_id }) =>
               this.resourceFilterStore
                 .queryBy('managed-group', { id: ids }, { auth_method_id })
-                .then((models) => models.map((model) => model))
-            )
-          )
+                .then((models) => models.map((model) => model)),
+            ),
+          ),
         )
         // The result is an array of arrays of model instances (grouped by
         // auth methods), so these must be flattened.

--- a/addons/api/addon/models/session.js
+++ b/addons/api/addon/models/session.js
@@ -76,7 +76,7 @@ class SessionCredential {
     if (this.#payloadSecret?.decoded) {
       const secretJSON = this.#payloadSecret.decoded;
       return Object.keys(secretJSON).map(
-        (key) => new SessionCredential.SecretItem(key, secretJSON[key])
+        (key) => new SessionCredential.SecretItem(key, secretJSON[key]),
       );
     } else {
       // decode from base64

--- a/addons/api/addon/models/target.js
+++ b/addons/api/addon/models/target.js
@@ -122,7 +122,7 @@ export default class TargetModel extends GeneratedTargetModel {
    */
   get isActive() {
     const pendingOrActiveSessions = this.sessions.filter(
-      (s) => s.isActive || s.isPending
+      (s) => s.isActive || s.isPending,
     );
     return Boolean(pendingOrActiveSessions.length);
   }
@@ -195,7 +195,7 @@ export default class TargetModel extends GeneratedTargetModel {
    */
   addBrokeredCredentialSources(
     brokeredCredentialSourceIDs,
-    options = { adapterOptions: {} }
+    options = { adapterOptions: {} },
   ) {
     const defaultAdapterOptions = {
       method: 'add-credential-sources',
@@ -221,7 +221,7 @@ export default class TargetModel extends GeneratedTargetModel {
    */
   addInjectedApplicationCredentialSources(
     injectedApplicationCredentialSourceIDs,
-    options = { adapterOptions: {} }
+    options = { adapterOptions: {} },
   ) {
     const defaultAdapterOptions = {
       method: 'add-credential-sources',
@@ -247,7 +247,7 @@ export default class TargetModel extends GeneratedTargetModel {
    */
   removeBrokeredCredentialSources(
     brokeredCredentialSourceIDs,
-    options = { adapterOptions: {} }
+    options = { adapterOptions: {} },
   ) {
     const defaultAdapterOptions = {
       method: 'remove-credential-sources',
@@ -272,7 +272,7 @@ export default class TargetModel extends GeneratedTargetModel {
   removeBrokeredCredentialSource(brokeredCredentialSourceID, options) {
     return this.removeBrokeredCredentialSources(
       [brokeredCredentialSourceID],
-      options
+      options,
     );
   }
 
@@ -286,7 +286,7 @@ export default class TargetModel extends GeneratedTargetModel {
    */
   removeInjectedApplicationCredentialSources(
     injectedApplicationCredentialSourceIDs,
-    options = { adapterOptions: {} }
+    options = { adapterOptions: {} },
   ) {
     const defaultAdapterOptions = {
       method: 'remove-credential-sources',
@@ -310,11 +310,11 @@ export default class TargetModel extends GeneratedTargetModel {
    */
   removeInjectedApplicationCredentialSource(
     injectedApplicationCredentialSourceID,
-    options
+    options,
   ) {
     return this.removeInjectedApplicationCredentialSources(
       [injectedApplicationCredentialSourceID],
-      options
+      options,
     );
   }
 

--- a/addons/api/addon/models/worker.js
+++ b/addons/api/addon/models/worker.js
@@ -37,7 +37,7 @@ export default class WorkerModel extends GeneratedWorkerModel {
 
     return Object.values(this.config_tags).reduce(
       (previousCount, currentTags) => previousCount + currentTags.length,
-      0
+      0,
     );
   }
 
@@ -51,7 +51,7 @@ export default class WorkerModel extends GeneratedWorkerModel {
     }
 
     return Object.entries(this.config_tags).flatMap(([key, value]) =>
-      value.map((tag) => ({ key, value: tag }))
+      value.map((tag) => ({ key, value: tag })),
     );
   }
 

--- a/addons/api/addon/serializers/account.js
+++ b/addons/api/addon/serializers/account.js
@@ -110,7 +110,7 @@ export default class AccountSerializer extends ApplicationSerializer {
       serialized = this.serializeForChangePassword(
         snapshot,
         currentPassword,
-        newPassword
+        newPassword,
       );
     }
     return serialized;

--- a/addons/api/addon/serializers/application.js
+++ b/addons/api/addon/serializers/application.js
@@ -145,7 +145,7 @@ export default class ApplicationSerializer extends RESTSerializer {
     const transformedPayload = {};
     // Find the Ember-data-expected root key name.
     const payloadKey = this.payloadKeyFromModelName(
-      primaryModelClass.modelName
+      primaryModelClass.modelName,
     );
     // Copy the data rooted under `items` in the existing payload into the new
     // payload under the expected root key name.
@@ -156,7 +156,7 @@ export default class ApplicationSerializer extends RESTSerializer {
       primaryModelClass,
       transformedPayload,
       id,
-      requestType
+      requestType,
     );
   }
 
@@ -183,7 +183,7 @@ export default class ApplicationSerializer extends RESTSerializer {
     const transformedPayload = {};
     // Find the Ember-data-expected root key name.
     const payloadKey = this.payloadKeyFromModelName(
-      primaryModelClass.modelName
+      primaryModelClass.modelName,
     );
     // Copy the unrooted payload under the expected root key name.
     transformedPayload[payloadKey] = payload;
@@ -193,7 +193,7 @@ export default class ApplicationSerializer extends RESTSerializer {
       primaryModelClass,
       transformedPayload,
       id,
-      requestType
+      requestType,
     );
   }
 
@@ -318,7 +318,7 @@ export default class ApplicationSerializer extends RESTSerializer {
     primaryModelClass,
     payload,
     id,
-    requestType
+    requestType,
   ) {
     const newPayload = structuredClone(payload);
 
@@ -338,7 +338,7 @@ export default class ApplicationSerializer extends RESTSerializer {
       primaryModelClass,
       newPayload,
       id,
-      requestType
+      requestType,
     );
   }
 }

--- a/addons/api/addon/serializers/auth-method.js
+++ b/addons/api/addon/serializers/auth-method.js
@@ -74,7 +74,7 @@ export default class AuthMethodSerializer extends ApplicationSerializer {
   normalizeArrayResponse() {
     const normalized = super.normalizeArrayResponse(...arguments);
     normalized.data = normalized.data.sort((a) =>
-      a.attributes.is_primary ? -1 : 1
+      a.attributes.is_primary ? -1 : 1,
     );
     return normalized;
   }

--- a/addons/api/addon/serializers/connection-recording.js
+++ b/addons/api/addon/serializers/connection-recording.js
@@ -7,7 +7,7 @@ import ApplicationSerializer from './application';
 import { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
 
 export default class ConnectionSerializer extends ApplicationSerializer.extend(
-  EmbeddedRecordsMixin
+  EmbeddedRecordsMixin,
 ) {
   attrs = {
     channel_recordings: { embedded: 'always' },

--- a/addons/api/addon/serializers/credential.js
+++ b/addons/api/addon/serializers/credential.js
@@ -24,7 +24,7 @@ export default class CredentialSerializer extends ApplicationSerializer {
 
       if (serialized?.attributes?.json_object) {
         serialized.attributes.object = JSON.parse(
-          serialized.attributes.json_object
+          serialized.attributes.json_object,
         );
         delete serialized.attributes.json_object;
       }

--- a/addons/api/addon/serializers/session-recording.js
+++ b/addons/api/addon/serializers/session-recording.js
@@ -6,7 +6,7 @@
 import ApplicationSerializer from './application';
 import { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
 export default class RecordingSerializer extends ApplicationSerializer.extend(
-  EmbeddedRecordsMixin
+  EmbeddedRecordsMixin,
 ) {
   attrs = {
     connection_recordings: { embedded: 'always' },

--- a/addons/api/addon/serializers/target.js
+++ b/addons/api/addon/serializers/target.js
@@ -36,12 +36,12 @@ export default class TargetSerializer extends ApplicationSerializer {
     if (brokeredCredentialSourceIDs)
       serialized = this.serializeWithBrokeredCredentialSources(
         snapshot,
-        brokeredCredentialSourceIDs
+        brokeredCredentialSourceIDs,
       );
     if (injectedApplicationCredentialSourceIDs)
       serialized = this.serializeWithInjectedApplicationCredentialSources(
         snapshot,
-        injectedApplicationCredentialSourceIDs
+        injectedApplicationCredentialSourceIDs,
       );
 
     // Delete session recording related fields from non-SSH targets
@@ -75,7 +75,7 @@ export default class TargetSerializer extends ApplicationSerializer {
    */
   serializeWithBrokeredCredentialSources(
     snapshot,
-    brokered_credential_source_ids
+    brokered_credential_source_ids,
   ) {
     return {
       version: snapshot.attr('version'),
@@ -92,7 +92,7 @@ export default class TargetSerializer extends ApplicationSerializer {
    */
   serializeWithInjectedApplicationCredentialSources(
     snapshot,
-    injected_application_credential_source_ids
+    injected_application_credential_source_ids,
   ) {
     return {
       version: snapshot.attr('version'),

--- a/addons/api/addon/serializers/worker.js
+++ b/addons/api/addon/serializers/worker.js
@@ -22,7 +22,7 @@ export default class WorkerSerializer extends ApplicationSerializer {
     if (workerGeneratedAuthToken)
       serialized = this.serializeWithGeneratedToken(
         snapshot,
-        workerGeneratedAuthToken
+        workerGeneratedAuthToken,
       );
     return serialized;
   }

--- a/addons/api/addon/services/resource-filter-store.js
+++ b/addons/api/addon/services/resource-filter-store.js
@@ -42,8 +42,8 @@ export class ResourceFilter {
                 return this.in(value.contains, key);
               }
               return this.equals(key, value);
-            })
-          )
+            }),
+          ),
         );
       })
       .flat()

--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -74,7 +74,7 @@ function routes() {
         });
       }
       return resultSet.filter(makeBooleanFilter(filter));
-    }
+    },
   );
   this.post('/scopes', function ({ scopes }) {
     // Parent scope comes through the payload via `scope_id`, but this needs
@@ -107,11 +107,11 @@ function routes() {
         });
       } else {
         resultSet = authMethods.where(
-          (authMethod) => authMethod.scopeId === scope_id
+          (authMethod) => authMethod.scopeId === scope_id,
         );
       }
       return resultSet.filter(makeBooleanFilter(filter));
-    }
+    },
   );
   this.post('/auth-methods', function ({ authMethods }) {
     const attrs = this.normalizedRequestAttrs();
@@ -130,7 +130,7 @@ function routes() {
       }
 
       return authMethods.find(id).update(attrs);
-    }
+    },
   );
   this.del('/auth-methods/:id', ({ authMethods }, { params: { id } }) => {
     const authMethod = authMethods.find(id);
@@ -149,7 +149,7 @@ function routes() {
     '/accounts',
     (
       { accounts },
-      { queryParams: { auth_method_id: authMethodId, filter } }
+      { queryParams: { auth_method_id: authMethodId, filter } },
     ) => {
       let resultSet;
       if (authMethodId) {
@@ -158,7 +158,7 @@ function routes() {
         resultSet = accounts.all();
       }
       return resultSet.filter(makeBooleanFilter(filter));
-    }
+    },
   );
   this.post('/accounts');
   this.get('/accounts/:id');
@@ -184,7 +184,7 @@ function routes() {
         updatedAttrs.attributes.password = attrs.new_password;
       }
       return account.update(updatedAttrs);
-    }
+    },
   );
 
   // Authenticate + auth methods custom routes
@@ -211,7 +211,7 @@ function routes() {
         resultSet = users.where((user) => user.scopeId === scope_id);
       }
       return resultSet.filter(makeBooleanFilter(filter));
-    }
+    },
   );
   this.post('/users');
   this.get('/users/:id');
@@ -262,7 +262,7 @@ function routes() {
         resultSet = groups.where((group) => group.scopeId === scope_id);
       }
       return resultSet.filter(makeBooleanFilter(filter));
-    }
+    },
   );
   this.post('/groups');
   this.get('/groups/:id');
@@ -294,7 +294,7 @@ function routes() {
         });
       }
       return group.update(updatedAttrs);
-    }
+    },
   );
 
   // IAM: Roles
@@ -309,7 +309,7 @@ function routes() {
     '/roles/:idMethod',
     function (
       { roles, users, groups, managedGroups },
-      { params: { idMethod } }
+      { params: { idMethod } },
     ) {
       const attrs = this.normalizedRequestAttrs();
       const id = idMethod.split(':')[0];
@@ -361,7 +361,7 @@ function routes() {
         updatedAttrs.managedGroupIds = updatedAttrs.managedGroupIds.filter(
           (id) => {
             return !attrs.principalIds.includes(id);
-          }
+          },
         );
       }
 
@@ -373,7 +373,7 @@ function routes() {
       }
 
       return role.update(updatedAttrs);
-    }
+    },
   );
 
   // Other resources
@@ -383,7 +383,7 @@ function routes() {
     '/host-catalogs',
     ({ hostCatalogs }, { queryParams: { scope_id: scopeId } }) => {
       return hostCatalogs.where({ scopeId });
-    }
+    },
   );
   this.post(
     '/host-catalogs',
@@ -396,7 +396,7 @@ function routes() {
         };
       }
       return hostCatalogs.create(attrs);
-    }
+    },
   );
   this.get('/host-catalogs/:id');
   this.patch('/host-catalogs/:id');
@@ -408,7 +408,7 @@ function routes() {
     '/hosts',
     function ({ hosts }, { queryParams: { host_catalog_id: hostCatalogId } }) {
       return hosts.where({ hostCatalogId });
-    }
+    },
   );
   this.post('/hosts', function ({ hostCatalogs, hosts }) {
     const attrs = this.normalizedRequestAttrs();
@@ -426,10 +426,10 @@ function routes() {
     '/host-sets',
     function (
       { hostSets },
-      { queryParams: { host_catalog_id: hostCatalogId } }
+      { queryParams: { host_catalog_id: hostCatalogId } },
     ) {
       return hostSets.where({ hostCatalogId });
-    }
+    },
   );
 
   this.post('/host-sets', function ({ hostCatalogs, hostSets }) {
@@ -477,7 +477,7 @@ function routes() {
       }
 
       return hostSet.update(updatedAttrs);
-    }
+    },
   );
 
   // target
@@ -500,7 +500,7 @@ function routes() {
         resultSet = targets.where((target) => target.scopeId === scope_id);
       }
       return resultSet.filter(makeBooleanFilter(filter));
-    }
+    },
   );
   this.post('/targets', function ({ targets }) {
     const attrs = this.normalizedRequestAttrs();
@@ -548,7 +548,7 @@ function routes() {
         resultSet = sessions.where((session) => session.scopeId === scope_id);
       }
       return resultSet.filter(makeBooleanFilter(filter));
-    }
+    },
   );
   this.get('/sessions/:id', function ({ sessions }, { params: { id } }) {
     const session = sessions.find(id);
@@ -573,7 +573,7 @@ function routes() {
         updatedAttrs.status = 'canceling';
       }
       return session.update(updatedAttrs);
-    }
+    },
   );
 
   // auth-tokens
@@ -589,7 +589,7 @@ function routes() {
   this.get(
     '/credential-stores',
     ({ credentialStores }, { queryParams: { scope_id: scopeId } }) =>
-      credentialStores.where({ scopeId })
+      credentialStores.where({ scopeId }),
   );
 
   this.get('/credential-stores/:id');
@@ -603,8 +603,8 @@ function routes() {
     '/credential-libraries',
     (
       { credentialLibraries },
-      { queryParams: { credential_store_id: credentialStoreId } }
-    ) => credentialLibraries.where({ credentialStoreId })
+      { queryParams: { credential_store_id: credentialStoreId } },
+    ) => credentialLibraries.where({ credentialStoreId }),
   );
   this.get('/credential-libraries/:id');
   this.post(
@@ -614,7 +614,7 @@ function routes() {
       const credentialStore = credentialStores.find(attrs.credentialStoreId);
       attrs.scopeId = credentialStore.scope.id;
       return credentialLibraries.create(attrs);
-    }
+    },
   );
   this.del('/credential-libraries/:id');
   this.patch('/credential-libraries/:id');
@@ -625,8 +625,8 @@ function routes() {
     '/credentials',
     (
       { credentials },
-      { queryParams: { credential_store_id: credentialStoreId } }
-    ) => credentials.where({ credentialStoreId })
+      { queryParams: { credential_store_id: credentialStoreId } },
+    ) => credentials.where({ credentialStoreId }),
   );
   this.get('/credentials/:id');
   this.post('/credentials', function ({ credentialStores, credentials }) {
@@ -644,7 +644,7 @@ function routes() {
     '/managed-groups',
     (
       { managedGroups },
-      { queryParams: { auth_method_id: authMethodId, filter } }
+      { queryParams: { auth_method_id: authMethodId, filter } },
     ) => {
       let resultSet;
       if (authMethodId) {
@@ -653,7 +653,7 @@ function routes() {
         resultSet = managedGroups.all();
       }
       return resultSet.filter(makeBooleanFilter(filter));
-    }
+    },
   );
   this.post('/managed-groups');
   this.get('/managed-groups/:id');
@@ -665,7 +665,7 @@ function routes() {
     '/workers',
     ({ workers }, { queryParams: { scope_id: scopeId } }) => {
       return workers.where({ scopeId });
-    }
+    },
   );
   this.get('/workers/:id');
   this.del('/workers/:id');
@@ -689,7 +689,7 @@ function routes() {
         return storageBuckets.all();
       }
       return storageBuckets.where({ scopeId });
-    }
+    },
   );
   this.get('/storage-buckets/:id');
   this.del('/storage-buckets/:id');
@@ -708,7 +708,7 @@ function routes() {
       delete attrs.secrets;
 
       return storageBuckets.create(attrs);
-    }
+    },
   );
 
   // session recordings
@@ -716,13 +716,13 @@ function routes() {
     '/session-recordings',
     (
       { sessionRecordings },
-      { queryParams: { scope_id: scopeId, recursive } }
+      { queryParams: { scope_id: scopeId, recursive } },
     ) => {
       if (recursive && scopeId === 'global') {
         return sessionRecordings.all();
       }
       return sessionRecordings.where({ scopeId });
-    }
+    },
   );
   this.get(
     '/session-recordings/:idMethod',
@@ -735,7 +735,7 @@ function routes() {
       } else {
         return sessionRecordings.find(id);
       }
-    }
+    },
   );
 
   /* Uncomment the following line and the Response import above

--- a/addons/api/mirage/factories/host-catalog.js
+++ b/addons/api/mirage/factories/host-catalog.js
@@ -54,7 +54,7 @@ export default factory.extend({
         return {
           disable_credential_rotation: faker.datatype.boolean(),
           region: `us-${faker.location.cardinalDirection()}-${faker.number.int(
-            9
+            9,
           )}`,
         };
       case 'azure':

--- a/addons/api/mirage/factories/scope.js
+++ b/addons/api/mirage/factories/scope.js
@@ -61,7 +61,7 @@ export default factory.extend({
             type: 'org',
             scope: { id: record.id, type: record.type },
           },
-          'withChildren'
+          'withChildren',
         );
       }
       if (record.type === 'org') {

--- a/addons/api/mirage/factories/session-recording.js
+++ b/addons/api/mirage/factories/session-recording.js
@@ -57,7 +57,8 @@ export default factory.extend({
       const session = pickRandomElement(server.schema.sessions.all().models);
       session.id = 'deleted_session';
       const target = pickRandomElement(
-        server.schema.targets.where((target) => target.storage_bucket_id).models
+        server.schema.targets.where((target) => target.storage_bucket_id)
+          .models,
       );
       target.id = 'deleted_target';
 
@@ -77,7 +78,8 @@ export default factory.extend({
       const user = pickRandomElement(server.schema.users.all().models);
       const session = pickRandomElement(server.schema.sessions.all().models);
       const target = pickRandomElement(
-        server.schema.targets.where((target) => target.storage_bucket_id).models
+        server.schema.targets.where((target) => target.storage_bucket_id)
+          .models,
       );
 
       sessionRecording.update({

--- a/addons/api/mirage/factories/storage-bucket.js
+++ b/addons/api/mirage/factories/storage-bucket.js
@@ -46,7 +46,7 @@ export default factory.extend({
       case TYPE_STORAGE_BUCKET_PLUGIN_AWS_S3:
         return {
           region: `us-${faker.location.cardinalDirection()}-${faker.number.int(
-            9
+            9,
           )}`,
           disable_credential_rotation: faker.datatype.boolean(),
         };

--- a/addons/api/mirage/factories/target.js
+++ b/addons/api/mirage/factories/target.js
@@ -60,7 +60,7 @@ export default factory.extend({
 
       randomlySelectedCredentialLibraries = server.schema.credentialLibraries
         .where(
-          (credentialLibrary) => credentialLibrary.scopeId === target.scope.id
+          (credentialLibrary) => credentialLibrary.scopeId === target.scope.id,
         )
         .models.filter(() => randomBoolean())
         .map((cred) => cred.id);

--- a/addons/api/mirage/generated/factories/auth-method.js
+++ b/addons/api/mirage/generated/factories/auth-method.js
@@ -51,7 +51,7 @@ export default Factory.extend({
           certificates: [faker.string.alphanumeric(50)],
           client_certificate: faker.string.alphanumeric(50),
           client_certificate_key: `---Begin Certificate --- ${faker.string.alphanumeric(
-            170
+            170,
           )} ---End Certificate ---`,
           client_certificate_key_hmac: faker.string.alphanumeric(50),
           enable_groups: true,

--- a/addons/api/mirage/generated/factories/worker.js
+++ b/addons/api/mirage/generated/factories/worker.js
@@ -22,6 +22,6 @@ export default Factory.extend({
   active_connection_count: () => faker.number.int(10),
   release_version: () =>
     `Boundary v${faker.number.int(11)}.${faker.number.int(
-      50
+      50,
     )}.${faker.number.int(12)}`,
 });

--- a/addons/api/mirage/helpers/id.js
+++ b/addons/api/mirage/helpers/id.js
@@ -39,7 +39,7 @@ export default function (prefix = '') {
   let result = '';
   for (let i = 0; i < 10; i++) {
     result = result.concat(
-      characters[Math.floor(random() * characters.length)]
+      characters[Math.floor(random() * characters.length)],
     );
   }
   return prefix.concat(result);

--- a/addons/api/mirage/helpers/permissions.js
+++ b/addons/api/mirage/helpers/permissions.js
@@ -35,13 +35,13 @@ class ToggledCapabilities {
   // Find the value of a pair with key `authorized_actions`
   // Safe-ish when the item is not present
   #rawAuthorizedActions = (this.#queryPairs.find(
-    (item) => item[0] === 'authorized_actions'
+    (item) => item[0] === 'authorized_actions',
   ) || [])[1];
 
   // Safe-ish when the value is not present
   #authorizedActions =
     JSON.parse(
-      decodeURIComponent(this.#rawAuthorizedActions || '') || 'null'
+      decodeURIComponent(this.#rawAuthorizedActions || '') || 'null',
     ) || {};
 
   // =methods

--- a/addons/api/mirage/route-handlers/auth.js
+++ b/addons/api/mirage/route-handlers/auth.js
@@ -56,7 +56,7 @@ const commandHandlers = {
               last_used_time: '',
               expiration_time: '',
             },
-          }
+          },
         );
       }
     },
@@ -82,7 +82,7 @@ const commandHandlers = {
             auth_url: 'https://www.duckduckgo.com',
             token_id: 'token_1234',
           },
-        }
+        },
       ),
     token: (_, scopeAttrs) => {
       oidcAttemptCounter++;
@@ -105,7 +105,7 @@ const commandHandlers = {
               last_used_time: '',
               expiration_time: '',
             },
-          }
+          },
         );
       }
     },
@@ -115,7 +115,7 @@ const commandHandlers = {
 // Handles all custom methods on /auth-methods/:id route
 export function authHandler({ scopes, authMethods }, request) {
   const [, id, method] = request.params.id_method.match(
-    /(?<id>.[^:]*):(?<method>(.*))/
+    /(?<id>.[^:]*):(?<method>(.*))/,
   );
   const authMethod = authMethods.find(id);
 

--- a/addons/api/mirage/route-handlers/target.js
+++ b/addons/api/mirage/route-handlers/target.js
@@ -40,7 +40,7 @@ export function targetHandler({ targets }, { params: { idMethod } }) {
     if (selectedHostSourceIds) {
       const listOfHostSources = addToSourcesList(
         originHostSetIds,
-        selectedHostSourceIds
+        selectedHostSourceIds,
       );
       if (listOfHostSources?.length) {
         updatedAttrs.hostSetIds = listOfHostSources;
@@ -52,7 +52,7 @@ export function targetHandler({ targets }, { params: { idMethod } }) {
     if (selectedHostSourceIds) {
       const removedHostSources = removeFromSourcesList(
         originHostSetIds,
-        selectedHostSourceIds
+        selectedHostSourceIds,
       );
       updatedAttrs.hostSetIds = removedHostSources;
     }
@@ -62,7 +62,7 @@ export function targetHandler({ targets }, { params: { idMethod } }) {
     if (selectedBrokeredCredentials) {
       const listOfBrokeredCredentialSources = addToSourcesList(
         originalBrokeredCredentials,
-        selectedBrokeredCredentials
+        selectedBrokeredCredentials,
       );
       if (listOfBrokeredCredentialSources?.length) {
         updatedAttrs.brokeredCredentialSourceIds =
@@ -73,7 +73,7 @@ export function targetHandler({ targets }, { params: { idMethod } }) {
     if (selectedInjectedCredentials) {
       const listOfInjectedCredentialSources = addToSourcesList(
         originalInjectedCredentials,
-        selectedInjectedCredentials
+        selectedInjectedCredentials,
       );
       if (listOfInjectedCredentialSources?.length) {
         updatedAttrs.injectedApplicationCredentialSourceIds =
@@ -86,7 +86,7 @@ export function targetHandler({ targets }, { params: { idMethod } }) {
     if (selectedBrokeredCredentials) {
       const removedCredentialSources = removeFromSourcesList(
         originalBrokeredCredentials,
-        selectedBrokeredCredentials
+        selectedBrokeredCredentials,
       );
       updatedAttrs.brokeredCredentialSourceIds = removedCredentialSources;
     }
@@ -94,7 +94,7 @@ export function targetHandler({ targets }, { params: { idMethod } }) {
     if (selectedInjectedCredentials) {
       const removedCredentialSources = removeFromSourcesList(
         originalInjectedCredentials,
-        selectedInjectedCredentials
+        selectedInjectedCredentials,
       );
       updatedAttrs.injectedApplicationCredentialSourceIds =
         removedCredentialSources;

--- a/addons/api/mirage/scenarios/default.js
+++ b/addons/api/mirage/scenarios/default.js
@@ -21,7 +21,7 @@ export default function (server) {
       type: 'org',
       scope: { id: globalScope.id, type: globalScope.type },
     },
-    'withChildren'
+    'withChildren',
   )[0];
 
   // Auth
@@ -29,13 +29,13 @@ export default function (server) {
     'auth-method',
     5,
     { scope: globalScope },
-    'withAccountsAndUsersAndManagedGroups'
+    'withAccountsAndUsersAndManagedGroups',
   );
   const orgAuthMethods = server.createList(
     'auth-method',
     3,
     { scope: orgScope },
-    'withAccountsAndUsersAndManagedGroups'
+    'withAccountsAndUsersAndManagedGroups',
   );
   // Authenticated user/account
   const user = server.create('user', {
@@ -62,13 +62,13 @@ export default function (server) {
     'role',
     1,
     { scope: globalScope },
-    'withPrincipals'
+    'withPrincipals',
   );
   //create managed groups for role/principals in globalScope
   globalScopeRoles.forEach((role) => {
     const { scope } = role;
     const oidcAuthMethod = globalAuthMethods.filter(
-      (auth) => auth.type === TYPE_AUTH_METHOD_OIDC
+      (auth) => auth.type === TYPE_AUTH_METHOD_OIDC,
     )[0];
     const { type } = oidcAuthMethod;
     const managedGroups = server.createList('managed-group', 2, {
@@ -83,13 +83,13 @@ export default function (server) {
     'role',
     5,
     { scope: orgScope },
-    'withPrincipals'
+    'withPrincipals',
   );
   //create managed groups for role/principals in orgScope
   orgScopeRoles.forEach((role) => {
     const { scope } = role;
     const oidcAuthMethod = orgAuthMethods.filter(
-      (auth) => auth.type === TYPE_AUTH_METHOD_OIDC
+      (auth) => auth.type === TYPE_AUTH_METHOD_OIDC,
     )[0];
     const { type } = oidcAuthMethod;
     const managedGroups = server.createList('managed-group', 2, {
@@ -129,19 +129,19 @@ export default function (server) {
     3,
     { scope: globalScope },
     'withConnectionAndChannels',
-    'withExistingUserAndTarget'
+    'withExistingUserAndTarget',
   );
   server.create(
     'session-recording',
     { scope: globalScope },
     'withConnectionAndChannels',
-    'withNonExistingUserAndTarget'
+    'withNonExistingUserAndTarget',
   );
   server.createList(
     'session-recording',
     2,
     { scope: orgScope },
     'withConnectionAndChannels',
-    'withExistingUserAndTarget'
+    'withExistingUserAndTarget',
   );
 }

--- a/addons/api/mirage/serializers/account.js
+++ b/addons/api/mirage/serializers/account.js
@@ -11,7 +11,7 @@ export default ApplicationSerializer.extend({
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     json.auth_method_id = model.authMethodId;
     delete json.attributes?.password;

--- a/addons/api/mirage/serializers/application.js
+++ b/addons/api/mirage/serializers/application.js
@@ -38,7 +38,7 @@ export default RestSerializer.extend({
 
   keyForRelationshipId(relationshipName) {
     return `${this._container.inflector.singularize(
-      underscore(relationshipName)
+      underscore(relationshipName),
     )}_id`;
   },
 

--- a/addons/api/mirage/serializers/auth-method.js
+++ b/addons/api/mirage/serializers/auth-method.js
@@ -11,7 +11,7 @@ export default ApplicationSerializer.extend({
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     // If the scope marks this auth method as primary, designate it
     // as such with a read-only boolean field (this is how the API behaves).

--- a/addons/api/mirage/serializers/connection-recording.js
+++ b/addons/api/mirage/serializers/connection-recording.js
@@ -11,7 +11,7 @@ export default ApplicationSerializer.extend({
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     const { channelRecordings } = this.schema;
     if (model.channelRecordingIds) {

--- a/addons/api/mirage/serializers/credential-library.js
+++ b/addons/api/mirage/serializers/credential-library.js
@@ -11,7 +11,7 @@ export default ApplicationSerializer.extend({
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     json.credential_store_id = model.credentialStoreId;
     return json;

--- a/addons/api/mirage/serializers/credential-store.js
+++ b/addons/api/mirage/serializers/credential-store.js
@@ -11,7 +11,7 @@ export default ApplicationSerializer.extend({
   _hashForModel(/* model */) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     // in a real API, the following fields are set-only and returned in
     // associated HMAC fields

--- a/addons/api/mirage/serializers/credential.js
+++ b/addons/api/mirage/serializers/credential.js
@@ -11,7 +11,7 @@ export default ApplicationSerializer.extend({
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     json.credential_store_id = model.credentialStoreId;
 

--- a/addons/api/mirage/serializers/group.js
+++ b/addons/api/mirage/serializers/group.js
@@ -11,14 +11,14 @@ export default ApplicationSerializer.extend({
 
   keyForRelationshipIds(relationshipName) {
     return `${this._container.inflector.singularize(
-      underscore(relationshipName)
+      underscore(relationshipName),
     )}_ids`;
   },
 
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     if (model.memberIds.length) json.member_ids = model.memberIds;
     return json;

--- a/addons/api/mirage/serializers/host-set.js
+++ b/addons/api/mirage/serializers/host-set.js
@@ -11,14 +11,14 @@ export default ApplicationSerializer.extend({
 
   keyForRelationshipIds(relationshipName) {
     return `${this._container.inflector.singularize(
-      underscore(relationshipName)
+      underscore(relationshipName),
     )}_ids`;
   },
 
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     json.host_catalog_id = model.hostCatalogId;
     if (model.hostIds?.length) {

--- a/addons/api/mirage/serializers/host.js
+++ b/addons/api/mirage/serializers/host.js
@@ -11,7 +11,7 @@ export default ApplicationSerializer.extend({
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     json.host_catalog_id = model.hostCatalogId;
     return json;

--- a/addons/api/mirage/serializers/managed-group.js
+++ b/addons/api/mirage/serializers/managed-group.js
@@ -11,7 +11,7 @@ export default ApplicationSerializer.extend({
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     json.auth_method_id = model.authMethodId;
     return json;

--- a/addons/api/mirage/serializers/role.js
+++ b/addons/api/mirage/serializers/role.js
@@ -11,7 +11,7 @@ export default ApplicationSerializer.extend({
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     const serializedUsers = model.users.models.map((user) => ({
       scope_id: model.scope.id,
@@ -28,7 +28,7 @@ export default ApplicationSerializer.extend({
         scope_id: model.scope.id,
         id: managedGroup.id,
         type: 'managed group',
-      })
+      }),
     );
     json.principals = [
       ...serializedUsers,

--- a/addons/api/mirage/serializers/session-recording.js
+++ b/addons/api/mirage/serializers/session-recording.js
@@ -12,7 +12,7 @@ export default ApplicationSerializer.extend({
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     const { connectionRecordings, scopes } = this.schema;
 
@@ -22,7 +22,7 @@ export default ApplicationSerializer.extend({
         const connection = connectionRecordings.find(id);
         return ConnectionRecordingSerializer.prototype._hashForModel.apply(
           this,
-          [connection]
+          [connection],
         );
       });
     }

--- a/addons/api/mirage/serializers/session.js
+++ b/addons/api/mirage/serializers/session.js
@@ -11,14 +11,14 @@ export default ApplicationSerializer.extend({
 
   keyForRelationshipId(relationshipName) {
     return `${this._container.inflector.singularize(
-      underscore(relationshipName)
+      underscore(relationshipName),
     )}_id`;
   },
 
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     json.user_id = model.userId;
     json.target_id = model.targetId;

--- a/addons/api/mirage/serializers/target.js
+++ b/addons/api/mirage/serializers/target.js
@@ -11,14 +11,14 @@ export default ApplicationSerializer.extend({
 
   keyForRelationshipIds(relationshipName) {
     return `${this._container.inflector.singularize(
-      underscore(relationshipName)
+      underscore(relationshipName),
     )}_ids`;
   },
 
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     const { hostSets } = this.schema;
     if (model.hostSetIds?.length) {

--- a/addons/api/mirage/serializers/user.js
+++ b/addons/api/mirage/serializers/user.js
@@ -11,14 +11,14 @@ export default ApplicationSerializer.extend({
 
   keyForRelationshipIds(relationshipName) {
     return `${this._container.inflector.singularize(
-      underscore(relationshipName)
+      underscore(relationshipName),
     )}_ids`;
   },
 
   _hashForModel(model) {
     const json = ApplicationSerializer.prototype._hashForModel.apply(
       this,
-      arguments
+      arguments,
     );
     if (model.accountIds.length) json.account_ids = model.accountIds;
     return json;

--- a/addons/api/tests/unit/abilities/channel-recording-test.js
+++ b/addons/api/tests/unit/abilities/channel-recording-test.js
@@ -35,7 +35,7 @@ module('Unit | Ability | channel-recording', function (hooks) {
       'connection-recording',
       {
         session_recording: sessionRecordingModel,
-      }
+      },
     );
     const channelRecordingModel = store.createRecord('channel-recording', {
       mime_types: [MIME_TYPE_ASCIICAST],
@@ -43,7 +43,7 @@ module('Unit | Ability | channel-recording', function (hooks) {
     });
 
     assert.true(
-      canService.can('getAsciicast channel-recording', channelRecordingModel)
+      canService.can('getAsciicast channel-recording', channelRecordingModel),
     );
   });
 
@@ -58,7 +58,7 @@ module('Unit | Ability | channel-recording', function (hooks) {
       'connection-recording',
       {
         session_recording: sessionRecordingModel,
-      }
+      },
     );
     const channelRecordingModel = store.createRecord('channel-recording', {
       mime_types: ['unknown'],
@@ -66,7 +66,7 @@ module('Unit | Ability | channel-recording', function (hooks) {
     });
 
     assert.false(
-      canService.can('getAsciicast channel-recording', channelRecordingModel)
+      canService.can('getAsciicast channel-recording', channelRecordingModel),
     );
   });
 });

--- a/addons/api/tests/unit/abilities/session-recording-test.js
+++ b/addons/api/tests/unit/abilities/session-recording-test.js
@@ -29,26 +29,26 @@ module('Unit | Ability | session-recording', function (hooks) {
       'session-recording',
       {
         authorized_actions: ['download'],
-      }
+      },
     );
     const recordingWithoutAuthorizedAction = store.createRecord(
       'session-recording',
       {
         authorized_actions: [],
-      }
+      },
     );
 
     assert.true(
       canService.can(
         'download session-recording',
-        recordingWithAuthorizedAction
-      )
+        recordingWithAuthorizedAction,
+      ),
     );
     assert.false(
       canService.can(
         'download session-recording',
-        recordingWithoutAuthorizedAction
-      )
+        recordingWithoutAuthorizedAction,
+      ),
     );
   });
 });

--- a/addons/api/tests/unit/abilities/target-test.js
+++ b/addons/api/tests/unit/abilities/target-test.js
@@ -80,19 +80,19 @@ module('Unit | Abilities | Target', function (hooks) {
     };
 
     assert.true(
-      canService.can('addInjectedApplicationCredentialSources target', model)
+      canService.can('addInjectedApplicationCredentialSources target', model),
     );
     assert.false(
       canService.can(
         'addInjectedApplicationCredentialSources target',
-        modelWithoutAuthorizedActions
-      )
+        modelWithoutAuthorizedActions,
+      ),
     );
     assert.false(
       canService.can(
         'addInjectedApplicationCredentialSources target',
-        modelWithoutSSHType
-      )
+        modelWithoutSSHType,
+      ),
     );
   });
 });

--- a/addons/api/tests/unit/abilities/user-test.js
+++ b/addons/api/tests/unit/abilities/user-test.js
@@ -37,25 +37,25 @@ module('Unit | Abilities | User', function (hooks) {
     assert.true(
       canService.can('addAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = TYPE_AUTH_METHOD_PASSWORD;
     assert.true(
       canService.can('addAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = TYPE_AUTH_METHOD_LDAP;
     assert.true(
       canService.can('addAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = 'no-such-type';
     assert.false(
       canService.can('addAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
   });
 
@@ -67,25 +67,25 @@ module('Unit | Abilities | User', function (hooks) {
     assert.false(
       canService.can('addAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = TYPE_AUTH_METHOD_PASSWORD;
     assert.false(
       canService.can('addAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = TYPE_AUTH_METHOD_LDAP;
     assert.false(
       canService.can('addAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = 'no-such-type';
     assert.false(
       canService.can('addAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
   });
 
@@ -97,25 +97,25 @@ module('Unit | Abilities | User', function (hooks) {
     assert.true(
       canService.can('removeAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = TYPE_AUTH_METHOD_PASSWORD;
     assert.true(
       canService.can('removeAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = TYPE_AUTH_METHOD_LDAP;
     assert.true(
       canService.can('removeAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = 'no-such-type';
     assert.false(
       canService.can('removeAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
   });
 
@@ -127,25 +127,25 @@ module('Unit | Abilities | User', function (hooks) {
     assert.false(
       canService.can('addAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = TYPE_AUTH_METHOD_PASSWORD;
     assert.false(
       canService.can('removeAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = TYPE_AUTH_METHOD_LDAP;
     assert.false(
       canService.can('removeAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = 'no-such-type';
     assert.false(
       canService.can('removeAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
   });
 });

--- a/addons/api/tests/unit/adapters/application-test.js
+++ b/addons/api/tests/unit/adapters/application-test.js
@@ -67,7 +67,7 @@ module('Unit | Adapter | application', function (hooks) {
       'user',
       '1',
       mockSnapshot,
-      'findRecord'
+      'findRecord',
     );
     assert.strictEqual(findRecordURL, '/v1/users/1:my-custom-method');
     const findAllURL = adapter.buildURL('user', null, mockSnapshot, 'findAll');
@@ -76,28 +76,28 @@ module('Unit | Adapter | application', function (hooks) {
       'user',
       '2',
       mockSnapshot,
-      'findBelongsTo'
+      'findBelongsTo',
     );
     assert.strictEqual(findBelongsToURL, '/v1/users/2:my-custom-method');
     const createRecordURL = adapter.buildURL(
       'user',
       null,
       mockSnapshot,
-      'createRecord'
+      'createRecord',
     );
     assert.strictEqual(createRecordURL, '/v1/users:my-custom-method');
     const updateRecordURL = adapter.buildURL(
       'user',
       '3',
       mockSnapshot,
-      'updateRecord'
+      'updateRecord',
     );
     assert.strictEqual(updateRecordURL, '/v1/users/3:my-custom-method');
     const deleteRecordURL = adapter.buildURL(
       'user',
       '4',
       mockSnapshot,
-      'deleteRecord'
+      'deleteRecord',
     );
     assert.strictEqual(deleteRecordURL, '/v1/users/4:my-custom-method');
   });
@@ -109,7 +109,7 @@ module('Unit | Adapter | application', function (hooks) {
       assert.strictEqual(
         scope_id,
         'p_456',
-        'Scoped resource URL was requested.'
+        'Scoped resource URL was requested.',
       );
       return { items: [] };
     });
@@ -154,7 +154,7 @@ module('Unit | Adapter | application', function (hooks) {
       store,
       { modelName: 'user' },
       null,
-      []
+      [],
     );
     assert.deepEqual(prenormalized, { items: [] });
   });
@@ -209,7 +209,7 @@ module('Unit | Adapter | application', function (hooks) {
     assert.strictEqual(
       handledResponse.errors.length,
       2,
-      'A base error plus one field error'
+      'A base error plus one field error',
     );
   });
 });

--- a/addons/api/tests/unit/adapters/host-catalog-test.js
+++ b/addons/api/tests/unit/adapters/host-catalog-test.js
@@ -25,7 +25,7 @@ module('Unit | Adapter | host catalog', function (hooks) {
       'host-catalog',
       null,
       mockSnapshot,
-      'createRecord'
+      'createRecord',
     );
     assert.strictEqual(createRecordURL, '/v1/host-catalogs');
   });
@@ -46,7 +46,7 @@ module('Unit | Adapter | host catalog', function (hooks) {
       'host-catalog',
       null,
       mockSnapshot,
-      'createRecord'
+      'createRecord',
     );
     assert.strictEqual(createRecordURL, '/v1/host-catalogs?plugin_name=aws');
   });

--- a/addons/api/tests/unit/adapters/session-recording-test.js
+++ b/addons/api/tests/unit/adapters/session-recording-test.js
@@ -25,11 +25,11 @@ module('Unit | Adapter | session recording', function (hooks) {
       'sr_id',
       mockSnapshot,
       'findRecord',
-      queryObject
+      queryObject,
     );
     assert.strictEqual(
       createRecordURL,
-      '/v1/session-recordings/sr_id:download?mime_type=mimeType'
+      '/v1/session-recordings/sr_id:download?mime_type=mimeType',
     );
   });
 
@@ -40,7 +40,7 @@ module('Unit | Adapter | session recording', function (hooks) {
       'session-recording',
       'sr_id',
       {},
-      'findRecord'
+      'findRecord',
     );
     assert.strictEqual(createRecordURL, '/v1/session-recordings/sr_id');
   });

--- a/addons/api/tests/unit/adapters/storage-bucket-test.js
+++ b/addons/api/tests/unit/adapters/storage-bucket-test.js
@@ -25,11 +25,11 @@ module('Unit | Adapter | storage bucket', function (hooks) {
       'storage-bucket',
       null,
       mockSnapshot,
-      'createRecord'
+      'createRecord',
     );
     assert.strictEqual(
       createRecordURL,
-      '/v1/storage-buckets?plugin_name=aws_s3'
+      '/v1/storage-buckets?plugin_name=aws_s3',
     );
   });
 });

--- a/addons/api/tests/unit/models/auth-method-test.js
+++ b/addons/api/tests/unit/models/auth-method-test.js
@@ -40,7 +40,7 @@ module('Unit | Model | auth method', function (hooks) {
           version: 1,
         });
         return { id: '123abc' };
-      }
+      },
     );
     store.push({
       data: {

--- a/addons/api/tests/unit/models/group-test.js
+++ b/addons/api/tests/unit/models/group-test.js
@@ -27,12 +27,12 @@ module('Unit | Model | group', function (hooks) {
     assert.strictEqual(
       group.member_ids.length,
       2,
-      'Group has two entires in member_ids'
+      'Group has two entires in member_ids',
     );
     assert.strictEqual(
       group.members.length,
       0,
-      'Group has no resolved members because they are not loaded yet'
+      'Group has no resolved members because they are not loaded yet',
     );
     store.push({
       data: {
@@ -53,12 +53,12 @@ module('Unit | Model | group', function (hooks) {
     assert.strictEqual(
       group.member_ids.length,
       2,
-      'Group has two entires in member_ids'
+      'Group has two entires in member_ids',
     );
     assert.strictEqual(
       group.members.length,
       2,
-      'Group has two resolved members'
+      'Group has two resolved members',
     );
   });
 
@@ -168,7 +168,7 @@ module('Unit | Model | group', function (hooks) {
     assert.strictEqual(
       group.member_ids.length,
       0,
-      'Group has empty member_ids by default'
+      'Group has empty member_ids by default',
     );
   });
 });

--- a/addons/api/tests/unit/models/role-test.js
+++ b/addons/api/tests/unit/models/role-test.js
@@ -94,7 +94,7 @@ module('Unit | Model | role', function (hooks) {
           version: 1,
         });
         return { id: '123abc' };
-      }
+      },
     );
     const store = this.owner.lookup('service:store');
     store.push({
@@ -132,7 +132,7 @@ module('Unit | Model | role', function (hooks) {
           version: 1,
         });
         return { id: '123abc' };
-      }
+      },
     );
     const store = this.owner.lookup('service:store');
     store.push({

--- a/addons/api/tests/unit/models/scope-test.js
+++ b/addons/api/tests/unit/models/scope-test.js
@@ -30,27 +30,27 @@ module('Unit | Model | scope', function (hooks) {
     assert.strictEqual(
       await scopes.objectAt(1).get('scope.scope_id'),
       'global',
-      'Org 1 parent scope is global'
+      'Org 1 parent scope is global',
     );
     assert.strictEqual(
       await scopes.objectAt(2).get('scope.scope_id'),
       'global',
-      'Org 2 parent scope is global'
+      'Org 2 parent scope is global',
     );
     assert.strictEqual(
       await scopes.objectAt(3).get('scope.scope_id'),
       'o_1',
-      'Project 1 parent scope is org 1'
+      'Project 1 parent scope is org 1',
     );
     assert.strictEqual(
       await scopes.objectAt(4).get('scope.scope_id'),
       'o_1',
-      'Project 2 parent scope is org 1'
+      'Project 2 parent scope is org 1',
     );
     assert.strictEqual(
       await scopes.objectAt(5).get('scope.scope_id'),
       'o_2',
-      'Project 3 parent scope is org 2'
+      'Project 3 parent scope is org 2',
     );
   });
 

--- a/addons/api/tests/unit/models/storage-bucket-test.js
+++ b/addons/api/tests/unit/models/storage-bucket-test.js
@@ -110,7 +110,7 @@ module('Unit | Model | storage bucket', function (hooks) {
     assert.strictEqual(modelPlugin.type, 'plugin');
     assert.strictEqual(
       modelPlugin.plugin.name,
-      TYPE_STORAGE_BUCKET_PLUGIN_AWS_S3
+      TYPE_STORAGE_BUCKET_PLUGIN_AWS_S3,
     );
   });
 });

--- a/addons/api/tests/unit/models/target-test.js
+++ b/addons/api/tests/unit/models/target-test.js
@@ -31,12 +31,12 @@ module('Unit | Model | target', function (hooks) {
     assert.strictEqual(
       target.host_sources.length,
       2,
-      'Target has two entires in host_sources'
+      'Target has two entires in host_sources',
     );
     assert.strictEqual(
       target.hostSets.length,
       0,
-      'Target has no resolved hostSets because they are not loaded yet'
+      'Target has no resolved hostSets because they are not loaded yet',
     );
     store.push({
       data: {
@@ -55,16 +55,16 @@ module('Unit | Model | target', function (hooks) {
     assert.strictEqual(
       target.host_sources.length,
       2,
-      'Target has two entires in host_sources'
+      'Target has two entires in host_sources',
     );
     assert.strictEqual(
       target.hostSets.length,
       2,
-      'Target has two resolved hostSets'
+      'Target has two resolved hostSets',
     );
     assert.notOk(
       target.hostSets[0].hostCatalog,
-      'Host catalog was not resolved because it is not loaded yet'
+      'Host catalog was not resolved because it is not loaded yet',
     );
     store.push({
       data: {
@@ -89,7 +89,7 @@ module('Unit | Model | target', function (hooks) {
           version: 1,
         });
         return { id: '123abc' };
-      }
+      },
     );
     const store = this.owner.lookup('service:store');
     store.push({
@@ -126,7 +126,7 @@ module('Unit | Model | target', function (hooks) {
           version: 1,
         });
         return { id: '123abc' };
-      }
+      },
     );
     const store = this.owner.lookup('service:store');
     store.push({
@@ -163,7 +163,7 @@ module('Unit | Model | target', function (hooks) {
           version: 1,
         });
         return { id: '123abc' };
-      }
+      },
     );
     const store = this.owner.lookup('service:store');
     store.push({
@@ -224,12 +224,12 @@ module('Unit | Model | target', function (hooks) {
     assert.strictEqual(
       store.peekAll('session').length,
       3,
-      'There are 3 sessions loaded in the store'
+      'There are 3 sessions loaded in the store',
     );
     assert.strictEqual(
       target.sessions.length,
       2,
-      'Target has two associated sessions loaded in the store'
+      'Target has two associated sessions loaded in the store',
     );
   });
 
@@ -249,12 +249,12 @@ module('Unit | Model | target', function (hooks) {
     assert.strictEqual(
       target.brokered_credential_source_ids.length,
       2,
-      'Target has two entires in brokered_credential_source_ids'
+      'Target has two entires in brokered_credential_source_ids',
     );
     assert.strictEqual(
       target.brokeredCredentialSources.length,
       0,
-      'Target has no resolved credentialSources, because they are not yet loaded'
+      'Target has no resolved credentialSources, because they are not yet loaded',
     );
     store.push({
       data: {
@@ -274,12 +274,12 @@ module('Unit | Model | target', function (hooks) {
     assert.strictEqual(
       target.brokered_credential_source_ids.length,
       2,
-      'Target has two entires in brokered_credential_source_ids'
+      'Target has two entires in brokered_credential_source_ids',
     );
     assert.strictEqual(
       target.brokeredCredentialSources.length,
       2,
-      'Target has two resolved credentialSources'
+      'Target has two resolved credentialSources',
     );
   });
 
@@ -294,7 +294,7 @@ module('Unit | Model | target', function (hooks) {
           version: 1,
         });
         return { id: '123abc' };
-      }
+      },
     );
     const store = this.owner.lookup('service:store');
     store.push({
@@ -328,7 +328,7 @@ module('Unit | Model | target', function (hooks) {
           version: 1,
         });
         return { id: '123abc' };
-      }
+      },
     );
     const store = this.owner.lookup('service:store');
     store.push({
@@ -362,7 +362,7 @@ module('Unit | Model | target', function (hooks) {
           version: 1,
         });
         return { id: '123abc' };
-      }
+      },
     );
     const store = this.owner.lookup('service:store');
     store.push({

--- a/addons/api/tests/unit/models/user-test.js
+++ b/addons/api/tests/unit/models/user-test.js
@@ -117,7 +117,7 @@ module('Unit | Model | user', function (hooks) {
     assert.strictEqual(
       user.account_ids.length,
       0,
-      'User has empty account_ids by default'
+      'User has empty account_ids by default',
     );
   });
 

--- a/addons/api/tests/unit/serializers/application-test.js
+++ b/addons/api/tests/unit/serializers/application-test.js
@@ -205,7 +205,7 @@ module('Unit | Serializer | application', function (hooks) {
     const normalizedArray = serializer.normalizeArrayResponse(
       store,
       userModelClass,
-      payload
+      payload,
     );
     assert.deepEqual(normalizedArray, {
       included: [],
@@ -254,7 +254,7 @@ module('Unit | Serializer | application', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       userModelClass,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       included: [],
@@ -285,7 +285,7 @@ module('Unit | Serializer | application', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       target,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       included: [],
@@ -318,7 +318,7 @@ module('Unit | Serializer | application', function (hooks) {
     const normalized = serializer.normalizeUpdateRecordResponse(
       store,
       user,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       included: [],

--- a/addons/api/tests/unit/serializers/auth-method-test.js
+++ b/addons/api/tests/unit/serializers/auth-method-test.js
@@ -36,7 +36,7 @@ module('Unit | Serializer | auth method', function (hooks) {
     assert.ok(serializedRecord);
     assert.notOk(
       serializedRecord.attributes,
-      'Password should not have attributes'
+      'Password should not have attributes',
     );
   });
 
@@ -327,7 +327,7 @@ module('Unit | Serializer | auth method', function (hooks) {
     const normalizedArray = serializer.normalizeArrayResponse(
       store,
       modelClass,
-      payload
+      payload,
     );
     assert.ok(payload.items[1].is_primary, 'Second payload item is primary');
     assert.deepEqual(
@@ -370,7 +370,7 @@ module('Unit | Serializer | auth method', function (hooks) {
           },
         ],
       },
-      'First normalized item is primary'
+      'First normalized item is primary',
     );
   });
 
@@ -432,7 +432,7 @@ module('Unit | Serializer | auth method', function (hooks) {
     assert.strictEqual(record.client_id, clientId);
     assert.strictEqual(
       record.disable_discovered_config_validation,
-      disableDiscoveredConfigValidation
+      disableDiscoveredConfigValidation,
     );
     assert.strictEqual(record.dry_run, dryRun);
     assert.strictEqual(record.issuer, issuer);

--- a/addons/api/tests/unit/serializers/credential-library-test.js
+++ b/addons/api/tests/unit/serializers/credential-library-test.js
@@ -143,7 +143,7 @@ module('Unit | Serializer | credential library', function (hooks) {
         name: null,
         type: TYPE_CREDENTIAL_LIBRARY_VAULT_GENERIC,
       },
-      'http_request_body attribute is not expected'
+      'http_request_body attribute is not expected',
     );
 
     record.http_method = 'POST';
@@ -161,7 +161,7 @@ module('Unit | Serializer | credential library', function (hooks) {
         name: null,
         type: TYPE_CREDENTIAL_LIBRARY_VAULT_GENERIC,
       },
-      'http_request_body attribute is expected'
+      'http_request_body attribute is expected',
     );
   });
 

--- a/addons/api/tests/unit/serializers/credential-store-test.js
+++ b/addons/api/tests/unit/serializers/credential-store-test.js
@@ -161,7 +161,7 @@ module('Unit | Serializer | credential store', function (hooks) {
         name: null,
         type: 'vault',
       },
-      'token attribute is not expected'
+      'token attribute is not expected',
     );
   });
 
@@ -198,7 +198,7 @@ module('Unit | Serializer | credential store', function (hooks) {
         name: null,
         type: 'vault',
       },
-      'client certificate key attribute is not expected'
+      'client certificate key attribute is not expected',
     );
 
     record.client_certificate_key = 'client-cert-key-456';
@@ -221,7 +221,7 @@ module('Unit | Serializer | credential store', function (hooks) {
         name: null,
         type: 'vault',
       },
-      'client certificate key attribute is expected'
+      'client certificate key attribute is expected',
     );
   });
 

--- a/addons/api/tests/unit/serializers/group-test.js
+++ b/addons/api/tests/unit/serializers/group-test.js
@@ -63,7 +63,7 @@ module('Unit | Serializer | group', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       group,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       included: [],

--- a/addons/api/tests/unit/serializers/host-catalog-test.js
+++ b/addons/api/tests/unit/serializers/host-catalog-test.js
@@ -184,7 +184,7 @@ module('Unit | Serializer | host catalog', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       hostCatalog,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       data: {
@@ -234,7 +234,7 @@ module('Unit | Serializer | host catalog', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       hostCatalog,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       data: {
@@ -293,7 +293,7 @@ module('Unit | Serializer | host catalog', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       hostCatalog,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       data: {

--- a/addons/api/tests/unit/serializers/host-set-test.js
+++ b/addons/api/tests/unit/serializers/host-set-test.js
@@ -116,7 +116,7 @@ module('Unit | Serializer | host set', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       hostSetModelClass,
-      payload
+      payload,
     );
 
     assert.deepEqual(normalized, {
@@ -153,7 +153,7 @@ module('Unit | Serializer | host set', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       hostSet,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       included: [],
@@ -191,7 +191,7 @@ module('Unit | Serializer | host set', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       hostSetModelClass,
-      payload
+      payload,
     );
 
     assert.deepEqual(normalized, {

--- a/addons/api/tests/unit/serializers/managed-group-test.js
+++ b/addons/api/tests/unit/serializers/managed-group-test.js
@@ -204,7 +204,7 @@ module('Unit | Serializer | Managed group', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       hostSetModelClass,
-      payload
+      payload,
     );
 
     assert.deepEqual(normalized, {

--- a/addons/api/tests/unit/serializers/role-test.js
+++ b/addons/api/tests/unit/serializers/role-test.js
@@ -64,7 +64,7 @@ module('Unit | Serializer | role', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       roleModelClass,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       included: [],

--- a/addons/api/tests/unit/serializers/storage-bucket-test.js
+++ b/addons/api/tests/unit/serializers/storage-bucket-test.js
@@ -248,7 +248,7 @@ module('Unit | Serializer | storage bucket', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       hostSetModelClass,
-      payload
+      payload,
     );
 
     assert.deepEqual(normalized, {

--- a/addons/api/tests/unit/serializers/target-test.js
+++ b/addons/api/tests/unit/serializers/target-test.js
@@ -354,7 +354,7 @@ module('Unit | Serializer | target', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       targetModelClass,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       included: [],
@@ -391,7 +391,7 @@ module('Unit | Serializer | target', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       targetModelClass,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       included: [],
@@ -424,7 +424,7 @@ module('Unit | Serializer | target', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       target,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       included: [],
@@ -457,7 +457,7 @@ module('Unit | Serializer | target', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       target,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       included: [],
@@ -490,7 +490,7 @@ module('Unit | Serializer | target', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       target,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       included: [],
@@ -523,7 +523,7 @@ module('Unit | Serializer | target', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       target,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       included: [],
@@ -557,7 +557,7 @@ module('Unit | Serializer | target', function (hooks) {
     const normalized = serializer.normalizeSingleResponse(
       store,
       target,
-      payload
+      payload,
     );
     assert.deepEqual(normalized, {
       included: [],

--- a/addons/core/addon/decorators/notify.js
+++ b/addons/core/addon/decorators/notify.js
@@ -57,7 +57,7 @@ export function notifySuccess(notification) {
  */
 export function notifyError(
   notification,
-  options = { catch: false, sticky: true }
+  options = { catch: false, sticky: true },
 ) {
   return function (_target, _propertyKey, desc) {
     const method = desc.value;

--- a/addons/core/addon/decorators/resource-filter.js
+++ b/addons/core/addon/decorators/resource-filter.js
@@ -68,8 +68,8 @@ class RouteResourceFilter extends EmberObject {
       ? value
           .map((serializedValue) =>
             this.allowedValues.find((item) =>
-              this.deserializeValue(item, serializedValue)
-            )
+              this.deserializeValue(item, serializedValue),
+            ),
           )
           .filter((value) => value !== undefined)
       : null;
@@ -161,7 +161,7 @@ class RouteResourceFilter extends EmberObject {
     allowed,
     defaultValue,
     serialize,
-    findBySerialized
+    findBySerialized,
   ) {
     const owner = getOwner(routeInstance);
     const containerKey = `resource-filter:${name}@${routeInstance.routeName}`;
@@ -237,7 +237,7 @@ export function resourceFilter({
     RouteResourceFilter.setupRouteQueryParams(
       target,
       name,
-      refreshRouteOnChange
+      refreshRouteOnChange,
     );
 
     let instance;
@@ -254,7 +254,7 @@ export function resourceFilter({
           allowed,
           defaultValue,
           serialize,
-          findBySerialized
+          findBySerialized,
         );
         return instance.value;
       },

--- a/addons/core/addon/helpers/doc-url.js
+++ b/addons/core/addon/helpers/doc-url.js
@@ -19,7 +19,7 @@ export default class extends Helper {
         Documentation for "${docKey}" could not be found. Please ensure that
         this key exists under "documentation" in your app config.
       `,
-        configuredPath
+        configuredPath,
       );
     }
     const path = configuredPath || '';

--- a/addons/core/addon/helpers/has-resource-filter-selections.js
+++ b/addons/core/addon/helpers/has-resource-filter-selections.js
@@ -60,7 +60,7 @@ export default class HasRouteResourceFilterSelectionsHelper extends Helper {
     const selectedValues = names.map((name) => route[name] || null).flat();
     const anyTruthy = selectedValues.reduce(
       (previousValue, currentValue) => previousValue || currentValue,
-      false
+      false,
     );
     return Boolean(anyTruthy);
   }

--- a/addons/core/addon/helpers/relative-datetime-live.js
+++ b/addons/core/addon/helpers/relative-datetime-live.js
@@ -59,7 +59,7 @@ export default class extends Helper {
           ? previousValue
           : currentValue;
       },
-      unitMappings[0]
+      unitMappings[0],
     );
     const scaledDelta =
       delta < 0

--- a/addons/core/addon/helpers/route-action.js
+++ b/addons/core/addon/helpers/route-action.js
@@ -48,7 +48,7 @@ export default class RouteActionHelper extends Helper {
         [boundary-core-helper-route-action]
         Unable to find action ${actionName}
       `,
-        handler
+        handler,
       );
     });
 

--- a/addons/core/tests/integration/components/error/message-test.js
+++ b/addons/core/tests/integration/components/error/message-test.js
@@ -17,41 +17,41 @@ module('Integration | Component | error/message', function (hooks) {
     await render(hbs`<Error::Message @status='401' />`);
     assert.strictEqual(
       find('.rose-message-title').textContent.trim(),
-      'You are not signed in'
+      'You are not signed in',
     );
     assert.strictEqual(
       find('.rose-message-subtitle').textContent.trim(),
-      'Error 401'
+      'Error 401',
     );
     assert.strictEqual(
       find('.rose-message-description').textContent.trim(),
-      'You are not signed in. Please sign in and try again later.'
+      'You are not signed in. Please sign in and try again later.',
     );
     await render(hbs`<Error::Message @status='403' />`);
     assert.strictEqual(
       find('.rose-message-title').textContent.trim(),
-      'You are not authorized'
+      'You are not authorized',
     );
     assert.strictEqual(
       find('.rose-message-subtitle').textContent.trim(),
-      'Error 403'
+      'Error 403',
     );
     assert.strictEqual(
       find('.rose-message-description').textContent.trim(),
-      'You must be granted permissions to view this data. Ask your administrator if you think you should have access.'
+      'You must be granted permissions to view this data. Ask your administrator if you think you should have access.',
     );
     await render(hbs`<Error::Message @status='404' />`);
     assert.strictEqual(
       find('.rose-message-title').textContent.trim(),
-      'Resource not found'
+      'Resource not found',
     );
     assert.strictEqual(
       find('.rose-message-subtitle').textContent.trim(),
-      'Error 404'
+      'Error 404',
     );
     assert.strictEqual(
       find('.rose-message-description').textContent.trim(),
-      'We could not find the requested resource. You can ask your administrator or try again later.'
+      'We could not find the requested resource. You can ask your administrator or try again later.',
     );
   });
 
@@ -59,15 +59,15 @@ module('Integration | Component | error/message', function (hooks) {
     await render(hbs`<Error::Message @status='599' />`);
     assert.strictEqual(
       find('.rose-message-title').textContent.trim(),
-      'Something went wrong'
+      'Something went wrong',
     );
     assert.strictEqual(
       find('.rose-message-subtitle').textContent.trim(),
-      'Error 599'
+      'Error 599',
     );
     assert.strictEqual(
       find('.rose-message-description').textContent.trim(),
-      "We're not sure what happened.  Please contact your administrator or try again later."
+      "We're not sure what happened.  Please contact your administrator or try again later.",
     );
   });
 });

--- a/addons/core/tests/integration/helpers/company-copyright-test.js
+++ b/addons/core/tests/integration/helpers/company-copyright-test.js
@@ -12,7 +12,7 @@ module('Integration | Helper | company-copyright', function (hooks) {
     await render(hbs`{{company-copyright}}`);
     assert.strictEqual(
       this.element.textContent.trim(),
-      `© ${currentYear} Company Name`
+      `© ${currentYear} Company Name`,
     );
   });
 });

--- a/addons/core/tests/integration/helpers/format-date-iso-test.js
+++ b/addons/core/tests/integration/helpers/format-date-iso-test.js
@@ -18,7 +18,7 @@ module('Integration | Helper | format-date-iso', function (hooks) {
 
     assert.strictEqual(
       this.element.textContent.trim(),
-      '2020-01-01T00:00:00.999Z'
+      '2020-01-01T00:00:00.999Z',
     );
   });
 

--- a/addons/core/tests/integration/helpers/truncate-list-test.js
+++ b/addons/core/tests/integration/helpers/truncate-list-test.js
@@ -29,11 +29,11 @@ module('Integration | Helper | truncate-list', function (hooks) {
     this.set('inputValue', list);
     this.set('limit', limit);
     await render(
-      hbs`{{truncate-list 'actions.more' this.inputValue this.limit}}`
+      hbs`{{truncate-list 'actions.more' this.inputValue this.limit}}`,
     );
     assert.strictEqual(
       this.element.textContent.trim(),
-      'boundary, consul, packer, +1 more'
+      'boundary, consul, packer, +1 more',
     );
   });
 

--- a/addons/core/tests/unit/authenticators/password-test.js
+++ b/addons/core/tests/unit/authenticators/password-test.js
@@ -39,7 +39,7 @@ module('Unit | Authenticator | password', function (hooks) {
     authenticator.restore(mockData);
     assert.strictEqual(
       applicationAdapter.headers.Authorization,
-      'Bearer token1234'
+      'Bearer token1234',
     );
   });
 
@@ -54,7 +54,7 @@ module('Unit | Authenticator | password', function (hooks) {
     await authenticator.authenticate(creds, null, { scope, authMethod });
     assert.strictEqual(
       applicationAdapter.headers.Authorization,
-      'Bearer thetokenstring'
+      'Bearer thetokenstring',
     );
   });
 });

--- a/addons/core/tests/unit/services/confirm-test.js
+++ b/addons/core/tests/unit/services/confirm-test.js
@@ -26,13 +26,13 @@ module('Unit | Service | confirm', function (hooks) {
     assert.strictEqual(
       service.pending.length,
       0,
-      'No pending confirmations yet'
+      'No pending confirmations yet',
     );
     const confirmation = service.confirm();
     assert.strictEqual(
       service.pending.length,
       1,
-      'One pending confirmation created'
+      'One pending confirmation created',
     );
     confirmation.confirm();
     assert.strictEqual(service.pending.length, 0, 'Confirmation was confirmed');

--- a/addons/rose/addon/components/rose/form/checkbox/group/index.js
+++ b/addons/rose/addon/components/rose/form/checkbox/group/index.js
@@ -51,7 +51,7 @@ export default class RoseFormCheckboxGroupComponent extends Component {
 
     if (this.args.itemEqualityFunc) {
       return currentItems.some((element) =>
-        this.args.itemEqualityFunc(element, item)
+        this.args.itemEqualityFunc(element, item),
       );
     }
 
@@ -69,7 +69,7 @@ export default class RoseFormCheckboxGroupComponent extends Component {
 
     if (this.args.itemEqualityFunc) {
       return currentItems.findIndex((element) =>
-        this.args.itemEqualityFunc(element, item)
+        this.args.itemEqualityFunc(element, item),
       );
     }
 

--- a/addons/rose/addon/modifiers/on-click-inside.js
+++ b/addons/rose/addon/modifiers/on-click-inside.js
@@ -24,5 +24,5 @@ export default modifier(
       element.removeEventListener('click', handleClick, false);
     };
   },
-  { eager: false }
+  { eager: false },
 );

--- a/addons/rose/addon/modifiers/on-click-outside.js
+++ b/addons/rose/addon/modifiers/on-click-outside.js
@@ -24,5 +24,5 @@ export default modifier(
       document.removeEventListener('click', handleClick, false);
     };
   },
-  { eager: false }
+  { eager: false },
 );

--- a/addons/rose/app/styles/rose/components/_notification.scss
+++ b/addons/rose/app/styles/rose/components/_notification.scss
@@ -18,7 +18,8 @@
   margin-bottom: sizing.rems(m);
   border: sizing.rems(xxxxs) solid;
   border-radius: $xxxs;
-  box-shadow: 0 $xs $s rgba(var(--stark-components), var(--opacity-3)),
+  box-shadow:
+    0 $xs $s rgba(var(--stark-components), var(--opacity-3)),
     0 $xxs $xxs rgba(var(--stark-components), var(--opacity-4));
 
   .rose-notification-icon {

--- a/addons/rose/app/styles/rose/components/card/_link.scss
+++ b/addons/rose/app/styles/rose/components/card/_link.scss
@@ -35,7 +35,8 @@ $xxxs: sizing.rems(xxxs); // 2
   display: inline-flex;
   flex-direction: column;
   margin: 0 sizing.rems(m) sizing.rems(m) 0;
-  box-shadow: 0 $xxxs $xxxs rgba(var(--stark-components), var(--opacity-4)),
+  box-shadow:
+    0 $xxxs $xxxs rgba(var(--stark-components), var(--opacity-4)),
     0 $xxxs $xxxs rgba(var(--stark-components), var(--opacity-4));
   background-color: var(--background-color);
 
@@ -57,7 +58,8 @@ $xxxs: sizing.rems(xxxs); // 2
 
     border-color: var(--ui-gray);
     background-color: var(--ui-gray-subtler-5);
-    box-shadow: 0 $xs $s rgba(var(--stark-components), var(--opacity-3)),
+    box-shadow:
+      0 $xs $s rgba(var(--stark-components), var(--opacity-3)),
       0 $xxs $xxs rgba(var(--stark-components), var(--opacity-4));
 
     .rose-card-link-description,

--- a/addons/rose/app/styles/rose/components/dialog/_dialog.scss
+++ b/addons/rose/app/styles/rose/components/dialog/_dialog.scss
@@ -22,7 +22,8 @@ $xxxxs: sizing.rems(xxxxs); // 1
 
   border-radius: $xxxs;
   background-color: var(--subtle);
-  box-shadow: 0 $xs $s rgba(var(--stark-components), var(--opacity-2)),
+  box-shadow:
+    0 $xs $s rgba(var(--stark-components), var(--opacity-2)),
     0 $xxs $xxs rgba(var(--stark-components), var(--opacity-3));
 
   &.rose-dialog-success {

--- a/addons/rose/app/styles/rose/components/dropdown/_dropdown.scss
+++ b/addons/rose/app/styles/rose/components/dropdown/_dropdown.scss
@@ -105,7 +105,8 @@ $chevron-grey: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%236
     border: 1px solid var(--ui-gray-subtler-2);
     border-radius: sizing.rems(xxxs);
     background: var(--subtle);
-    box-shadow: 0 $xxs $xxs rgba(var(--stark-components), var(--opacity-3)),
+    box-shadow:
+      0 $xxs $xxs rgba(var(--stark-components), var(--opacity-3)),
       0 $xxs $xs rgba(var(--stark-components), var(--opacity-4));
     z-index: 99;
   }

--- a/addons/rose/app/styles/rose/variables/_typography.scss
+++ b/addons/rose/app/styles/rose/variables/_typography.scss
@@ -11,9 +11,19 @@
  * SASS variables defining typography.
  */
 
-$family-primary: system-ui, -apple-system, blinkmacsystemfont, 'Segoe UI',
-  'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
-  'Helvetica Neue', sans-serif;
+$family-primary:
+  system-ui,
+  -apple-system,
+  blinkmacsystemfont,
+  'Segoe UI',
+  'Roboto',
+  'Oxygen',
+  'Ubuntu',
+  'Cantarell',
+  'Fira Sans',
+  'Droid Sans',
+  'Helvetica Neue',
+  sans-serif;
 $family-monospace: 'SFMono-Regular', consolas, 'Liberation Mono', menlo, courier,
   monospace;
 

--- a/addons/rose/index.js
+++ b/addons/rose/index.js
@@ -62,7 +62,7 @@ module.exports = {
    */
   includeFlightIcons(app) {
     const iconPackagePath = path.resolve(
-      '../../node_modules/@hashicorp/flight-icons'
+      '../../node_modules/@hashicorp/flight-icons',
     );
     const iconsPath = path.resolve(iconPackagePath, '..');
 

--- a/addons/rose/tests/dummy/config/ember-try.js
+++ b/addons/rose/tests/dummy/config/ember-try.js
@@ -10,7 +10,7 @@ const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
   return {
-   scenarios: [
+    scenarios: [
       {
         name: 'ember-lts-4.4',
         npm: {

--- a/addons/rose/tests/integration/components/rose/code-editor/field-editor-test.js
+++ b/addons/rose/tests/integration/components/rose/code-editor/field-editor-test.js
@@ -70,5 +70,5 @@ module(
       assert.dom(editorSelector).includesText(myNewCode);
       assert.true(this.called);
     });
-  }
+  },
 );

--- a/addons/rose/tests/integration/components/rose/dropdown-test.js
+++ b/addons/rose/tests/integration/components/rose/dropdown-test.js
@@ -27,7 +27,7 @@ module('Integration | Component | rose/dropdown', function (hooks) {
     await render(hbs`<Rose::Dropdown @text="Click me" />`);
     assert.strictEqual(
       find('.rose-dropdown-trigger').textContent.trim(),
-      'Click me'
+      'Click me',
     );
   });
 
@@ -38,7 +38,7 @@ module('Integration | Component | rose/dropdown', function (hooks) {
 
   test('it supports an icon', async function (assert) {
     await render(
-      hbs`<Rose::Dropdown @icon="flight-icons/svg/user-circle-16" />`
+      hbs`<Rose::Dropdown @icon="flight-icons/svg/user-circle-16" />`,
     );
     assert.ok(find('svg'));
   });

--- a/addons/rose/tests/integration/components/rose/dropdown/key-value-test.js
+++ b/addons/rose/tests/integration/components/rose/dropdown/key-value-test.js
@@ -22,7 +22,7 @@ module('Integration | Component | rose/dropdown/key-value', function (hooks) {
     assert.strictEqual(find('.rose-dropdown-key').textContent.trim(), 'key');
     assert.strictEqual(
       find('.rose-dropdown-value').textContent.trim(),
-      'value'
+      'value',
     );
   });
 });

--- a/addons/rose/tests/integration/components/rose/dropdown/link-test.js
+++ b/addons/rose/tests/integration/components/rose/dropdown/link-test.js
@@ -28,7 +28,7 @@ module('Integration | Component | rose/dropdown/link', function (hooks) {
     </Rose::Dropdown::Link>`);
     assert.strictEqual(
       find('.rose-dropdown-link').textContent.trim(),
-      'content'
+      'content',
     );
   });
 

--- a/addons/rose/tests/integration/components/rose/dropdown/section-test.js
+++ b/addons/rose/tests/integration/components/rose/dropdown/section-test.js
@@ -29,7 +29,7 @@ module('Integration | Component | rose/dropdown/section', function (hooks) {
     `);
     assert.strictEqual(
       find('.rose-dropdown-section-title').textContent.trim(),
-      'Section Title'
+      'Section Title',
     );
   });
 });

--- a/addons/rose/tests/integration/components/rose/form-test.js
+++ b/addons/rose/tests/integration/components/rose/form-test.js
@@ -93,7 +93,7 @@ module('Integration | Component | rose/form', function (hooks) {
     this.cancel = () => {
       assert.ok(
         true,
-        'cancel function may still be passed even for @showEditToggle'
+        'cancel function may still be passed even for @showEditToggle',
       );
     };
     this.submit = () => {};
@@ -123,7 +123,7 @@ module('Integration | Component | rose/form', function (hooks) {
     assert.strictEqual(find('[type="submit"]').textContent.trim(), 'Save');
     assert.strictEqual(
       find('button:not([type="submit"])').textContent.trim(),
-      'Cancel'
+      'Cancel',
     );
     // After canceling, fields are disabled again and the edit mode button is displayed
     await click('button:not([type="submit"])');
@@ -161,7 +161,7 @@ module('Integration | Component | rose/form', function (hooks) {
     assert.strictEqual(find('[type="submit"]').textContent.trim(), 'Save');
     assert.strictEqual(
       find('button:not([type="submit"])').textContent.trim(),
-      'Cancel'
+      'Cancel',
     );
     // After saving with failure, fields are enabled and save/cancel buttons are displayed
     this.submit = () => reject();
@@ -170,7 +170,7 @@ module('Integration | Component | rose/form', function (hooks) {
     assert.strictEqual(find('[type="submit"]').textContent.trim(), 'Save');
     assert.strictEqual(
       find('button:not([type="submit"])').textContent.trim(),
-      'Cancel'
+      'Cancel',
     );
     // After saving with success, fields are disabled again and the edit mode button is displayed
     this.submit = () => resolve();

--- a/addons/rose/tests/integration/components/rose/form/checkbox-test.js
+++ b/addons/rose/tests/integration/components/rose/form/checkbox-test.js
@@ -22,15 +22,15 @@ module('Integration | Component | rose/form/checkbox', function (hooks) {
   test('it renders optional description paragraph', async function (assert) {
     assert.expect(3);
     await render(
-      hbs`<Rose::Form::Checkbox @label="Label" @description="Hello world" />`
+      hbs`<Rose::Form::Checkbox @label="Label" @description="Hello world" />`,
     );
     assert.strictEqual(
       find('.rose-form-checkbox-label-text').textContent.trim(),
-      'Label'
+      'Label',
     );
     assert.strictEqual(
       find('.rose-form-checkbox-label-description').textContent.trim(),
-      'Hello world'
+      'Hello world',
     );
     assert.ok(find('input'));
   });
@@ -38,11 +38,11 @@ module('Integration | Component | rose/form/checkbox', function (hooks) {
   test('it renders optional helper text', async function (assert) {
     assert.expect(1);
     await render(
-      hbs`<Rose::Form::Checkbox @label="Label" @helperText="Hello world" />`
+      hbs`<Rose::Form::Checkbox @label="Label" @helperText="Hello world" />`,
     );
     assert.strictEqual(
       find('.rose-form-helper-text').textContent.trim(),
-      'Hello world'
+      'Hello world',
     );
   });
 
@@ -62,7 +62,7 @@ module('Integration | Component | rose/form/checkbox', function (hooks) {
     assert.strictEqual(errorMessageEl.textContent.trim(), 'An error occurred.');
     assert.strictEqual(
       fieldEl.getAttribute('aria-describedby').trim(),
-      errorsId
+      errorsId,
     );
   });
 

--- a/addons/rose/tests/integration/components/rose/form/errors-test.js
+++ b/addons/rose/tests/integration/components/rose/form/errors-test.js
@@ -22,11 +22,11 @@ module('Integration | Component | rose/form/errors', function (hooks) {
     assert.ok(find('.rose-form-errors'));
     assert.strictEqual(
       find('.rose-form-error-message:first-child').textContent.trim(),
-      'An error occurred.'
+      'An error occurred.',
     );
     assert.strictEqual(
       find('.rose-form-error-message:last-child').textContent.trim(),
-      'Another error occurred.'
+      'Another error occurred.',
     );
   });
 });

--- a/addons/rose/tests/integration/components/rose/form/fieldset-test.js
+++ b/addons/rose/tests/integration/components/rose/form/fieldset-test.js
@@ -42,15 +42,15 @@ module('Integration | Component | rose/form/fieldset', function (hooks) {
     assert.ok(find('.rose-form-fieldset'));
     assert.strictEqual(
       find('.rose-form-fieldset-title').textContent.trim(),
-      this.mockTitle
+      this.mockTitle,
     );
     assert.strictEqual(
       find('.rose-form-fieldset-description').textContent.trim(),
-      this.mockDescription
+      this.mockDescription,
     );
     assert.strictEqual(
       find('.rose-form-fieldset-body').textContent.trim(),
-      this.mockBody
+      this.mockBody,
     );
   });
 
@@ -60,12 +60,12 @@ module('Integration | Component | rose/form/fieldset', function (hooks) {
     assert.ok(find('.rose-form-fieldset'));
     assert.strictEqual(
       find('.rose-form-fieldset-title').textContent.trim(),
-      this.mockTitle
+      this.mockTitle,
     );
     assert.notOk(find('.rose-form-fieldset-description'));
     assert.strictEqual(
       find('.rose-form-fieldset-body').textContent.trim(),
-      this.mockBody
+      this.mockBody,
     );
   });
 
@@ -78,7 +78,7 @@ module('Integration | Component | rose/form/fieldset', function (hooks) {
     assert.strictEqual(
       fieldsetElement.getAttribute('aria-describedby'),
       descriptionElement.id,
-      'Fieldset is described by description'
+      'Fieldset is described by description',
     );
   });
 

--- a/addons/rose/tests/integration/components/rose/form/helper-text-test.js
+++ b/addons/rose/tests/integration/components/rose/form/helper-text-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | rose/form/helper-text', function (hooks) {
     assert.ok(find('.rose-form-helper-text'));
     assert.strictEqual(
       find('.rose-form-helper-text').textContent.trim(),
-      'Helper text'
+      'Helper text',
     );
   });
 });

--- a/addons/rose/tests/integration/components/rose/form/input-test.js
+++ b/addons/rose/tests/integration/components/rose/form/input-test.js
@@ -27,7 +27,7 @@ module('Integration | Component | rose/form/input', function (hooks) {
     assert.strictEqual(helperTextEl.id, helperId);
     assert.strictEqual(
       fieldEl.getAttribute('aria-describedby').trim(),
-      helperId
+      helperId,
     );
   });
 
@@ -47,7 +47,7 @@ module('Integration | Component | rose/form/input', function (hooks) {
     assert.strictEqual(errorMessageEl.textContent.trim(), 'An error occurred.');
     assert.strictEqual(
       fieldEl.getAttribute('aria-describedby').split(' ')[1],
-      errorsId
+      errorsId,
     );
   });
 
@@ -95,7 +95,7 @@ module('Integration | Component | rose/form/input', function (hooks) {
     `);
     assert.notOk(
       find('.rose-form-input'),
-      'The form field wrapper element is not present in contextual mode'
+      'The form field wrapper element is not present in contextual mode',
     );
     assert.ok(find('.rose-form-label.error'));
     assert.ok(find('.rose-form-helper-text.error'));

--- a/addons/rose/tests/integration/components/rose/form/label-test.js
+++ b/addons/rose/tests/integration/components/rose/form/label-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | rose/form/label', function (hooks) {
     assert.ok(find('.rose-form-label'));
     assert.strictEqual(
       find('.rose-form-label').textContent.trim(),
-      'Form Label'
+      'Form Label',
     );
   });
 });

--- a/addons/rose/tests/integration/components/rose/form/radio/radio-test.js
+++ b/addons/rose/tests/integration/components/rose/form/radio/radio-test.js
@@ -24,14 +24,14 @@ module('Integration | Component | rose/form/radio/radio', function (hooks) {
 
   test('it supports an icon', async function (assert) {
     await render(
-      hbs`<Rose::Form::Radio::Radio @icon="flight-icons/svg/user-circle-16" />`
+      hbs`<Rose::Form::Radio::Radio @icon="flight-icons/svg/user-circle-16" />`,
     );
     assert.ok(find('svg'));
   });
 
   test('it is checked when @value and @selectedValue values match', async function (assert) {
     await render(
-      hbs`<Rose::Form::Radio::Radio @value="tree" @selectedValue="tree"/>`
+      hbs`<Rose::Form::Radio::Radio @value="tree" @selectedValue="tree"/>`,
     );
     assert.true(await find('input').checked);
   });
@@ -44,7 +44,7 @@ module('Integration | Component | rose/form/radio/radio', function (hooks) {
     assert.false(await find('input').checked);
 
     await render(
-      hbs`<Rose::Form::Radio::Radio @value="root" @selectedValue="tree"/>`
+      hbs`<Rose::Form::Radio::Radio @value="root" @selectedValue="tree"/>`,
     );
     assert.false(await find('input').checked);
   });

--- a/addons/rose/tests/integration/components/rose/header/brand-test.js
+++ b/addons/rose/tests/integration/components/rose/header/brand-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | rose/header/brand', function (hooks) {
     assert.ok(find('.rose-header-brand svg'));
     assert.strictEqual(
       find('.rose-header-brand-text').textContent.trim(),
-      'Product Name'
+      'Product Name',
     );
   });
 });

--- a/addons/rose/tests/integration/components/rose/icon-test.js
+++ b/addons/rose/tests/integration/components/rose/icon-test.js
@@ -18,7 +18,7 @@ module('Integration | Component | rose/icon', function (hooks) {
 
   test('it supports optional @size', async function (assert) {
     await render(
-      hbs`<Rose::Icon @name="flight-icons/svg/globe-16" @size="small" />`
+      hbs`<Rose::Icon @name="flight-icons/svg/globe-16" @size="small" />`,
     );
     assert.ok(find('.small'));
   });

--- a/addons/rose/tests/integration/components/rose/layout/centered-test.js
+++ b/addons/rose/tests/integration/components/rose/layout/centered-test.js
@@ -29,7 +29,7 @@ module('Integration | Component | rose/layout/centered', function (hooks) {
     </Rose::Layout::Centered>`);
     assert.strictEqual(
       find('.rose-layout-centered').textContent.trim(),
-      'Layout content'
+      'Layout content',
     );
   });
 });

--- a/addons/rose/tests/integration/components/rose/link-button-test.js
+++ b/addons/rose/tests/integration/components/rose/link-button-test.js
@@ -25,11 +25,11 @@ module('Integration | Component | rose/link-button', function (hooks) {
 
   test('it renders with content', async function (assert) {
     await render(
-      hbs`<Rose::LinkButton @route="index">Link button content</Rose::LinkButton>`
+      hbs`<Rose::LinkButton @route="index">Link button content</Rose::LinkButton>`,
     );
     assert.ok(
       find('.rose-link-button').textContent.trim(),
-      'Link button content'
+      'Link button content',
     );
   });
 
@@ -40,7 +40,7 @@ module('Integration | Component | rose/link-button', function (hooks) {
 
   test('it supports left icon with @iconLeft', async function (assert) {
     await render(
-      hbs`<Rose::LinkButton @route="index" @iconLeft="flight-icons/svg/chevron-left-16" />`
+      hbs`<Rose::LinkButton @route="index" @iconLeft="flight-icons/svg/chevron-left-16" />`,
     );
     assert.ok(find('.rose-icon'));
     assert.ok(find('.has-icon-left'));
@@ -48,7 +48,7 @@ module('Integration | Component | rose/link-button', function (hooks) {
 
   test('it supports left icon with @iconRight', async function (assert) {
     await render(
-      hbs`<Rose::LinkButton @route="index" @iconRight="flight-icons/svg/entry-point-16" />`
+      hbs`<Rose::LinkButton @route="index" @iconRight="flight-icons/svg/entry-point-16" />`,
     );
     assert.ok(find('.rose-icon'));
     assert.ok(find('.has-icon-right'));
@@ -56,7 +56,7 @@ module('Integration | Component | rose/link-button', function (hooks) {
 
   test('it supports only icon with @iconOnly', async function (assert) {
     await render(
-      hbs`<Rose::LinkButton @route="index" @iconOnly="flight-icons/svg/help-16" />`
+      hbs`<Rose::LinkButton @route="index" @iconOnly="flight-icons/svg/help-16" />`,
     );
     assert.ok(find('.rose-icon'));
     assert.ok(find('.has-icon-only'));

--- a/addons/rose/tests/integration/components/rose/list/key-value-test.js
+++ b/addons/rose/tests/integration/components/rose/list/key-value-test.js
@@ -26,18 +26,18 @@ module('Integration | Component | rose/list/key-value', function (hooks) {
       </Rose::List::KeyValue>
     `);
     const itemLabelledBy = find(
-      '.rose-list-key-value-item:first-child'
+      '.rose-list-key-value-item:first-child',
     ).getAttribute('aria-labelledby');
     assert.strictEqual(
       findAll('.rose-list-key-value-item').length,
       2,
-      'it has two items'
+      'it has two items',
     );
     assert.ok(
       find(
-        `.rose-list-key-value-item:first-child > .rose-list-key-value-item-cell:first-child#${itemLabelledBy}`
+        `.rose-list-key-value-item:first-child > .rose-list-key-value-item-cell:first-child#${itemLabelledBy}`,
       ),
-      'The key cell has an ID associated with the `aria-labelledby` attribute of its parent item element'
+      'The key cell has an ID associated with the `aria-labelledby` attribute of its parent item element',
     );
   });
 });

--- a/addons/rose/tests/integration/components/rose/message-test.js
+++ b/addons/rose/tests/integration/components/rose/message-test.js
@@ -24,11 +24,11 @@ module('Integration | Component | rose/message', function (hooks) {
     assert.strictEqual(find('.rose-message-title').textContent.trim(), 'Title');
     assert.strictEqual(
       find('.rose-message-subtitle').textContent.trim(),
-      'Subtitle'
+      'Subtitle',
     );
     assert.strictEqual(
       find('.rose-message-description').textContent.trim(),
-      'Description'
+      'Description',
     );
 
     assert.strictEqual(find('a').textContent.trim(), 'Link');

--- a/addons/rose/tests/integration/components/rose/notification-test.js
+++ b/addons/rose/tests/integration/components/rose/notification-test.js
@@ -23,7 +23,7 @@ module('Integration | Component | rose/notification', function (hooks) {
     assert.ok(find('.rose-notification'));
     assert.strictEqual(
       find('.rose-notification-body').textContent.trim(),
-      'An error occurred.'
+      'An error occurred.',
     );
   });
 

--- a/ui/admin/app/components/form/auth-method/ldap/index.js
+++ b/ui/admin/app/components/form/auth-method/ldap/index.js
@@ -63,7 +63,7 @@ export default class FormAuthMethodLdapComponent extends Component {
       this.args.addAccountMapItem(
         'account_attribute_maps',
         this.newFromAttribute,
-        this.newToAttribute
+        this.newToAttribute,
       );
     }
     this.newFromAttribute = '';

--- a/ui/admin/app/components/form/host-catalog/aws/index.js
+++ b/ui/admin/app/components/form/host-catalog/aws/index.js
@@ -20,7 +20,7 @@ export default class FormHostCatalogAwsComponent extends Component {
   get mapResourceTypeWithIcon() {
     return pluginTypes.reduce(
       (obj, plugin, i) => ({ ...obj, [plugin]: icons[i] }),
-      {}
+      {},
     );
   }
   // =actions

--- a/ui/admin/app/components/form/host-catalog/azure/index.js
+++ b/ui/admin/app/components/form/host-catalog/azure/index.js
@@ -19,7 +19,7 @@ export default class FormAzureHostCatalogAwsComponent extends Component {
   get mapResourceTypeWithIcon() {
     return pluginTypes.reduce(
       (obj, plugin, i) => ({ ...obj, [plugin]: icons[i] }),
-      {}
+      {},
     );
   }
 }

--- a/ui/admin/app/components/form/host-catalog/static/index.js
+++ b/ui/admin/app/components/form/host-catalog/static/index.js
@@ -19,7 +19,7 @@ export default class FormStaticHostCatalogAwsComponent extends Component {
   get mapResourceTypeWithIcon() {
     return pluginTypes.reduce(
       (obj, plugin, i) => ({ ...obj, [plugin]: icons[i] }),
-      {}
+      {},
     );
   }
 }

--- a/ui/admin/app/components/form/host-set/add-hosts/index.js
+++ b/ui/admin/app/components/form/host-set/add-hosts/index.js
@@ -33,7 +33,7 @@ export default class FormHostSetAddHostsIndexComponent extends Component {
   @computed('args.{model,model.host_ids,hosts}')
   get filteredHosts() {
     return this.args.hosts.filter(
-      ({ id }) => !this.args.model.host_ids.includes(id)
+      ({ id }) => !this.args.model.host_ids.includes(id),
     );
   }
 

--- a/ui/admin/app/components/form/role/add-principals/index.js
+++ b/ui/admin/app/components/form/role/add-principals/index.js
@@ -35,18 +35,18 @@ export default class FormRoleAddPrincipalsIndexComponent extends Component {
   get filteredPrincipals() {
     // Retrieve principal IDs assigned to current role
     const currentPrincipalIDs = this.args.model.principals.map(
-      (principal) => principal.principal_id
+      (principal) => principal.principal_id,
     );
 
     // Retrieve principal IDs not assigned to current role
     const unassignedUsers = this.args.users.filter(
-      ({ id }) => !currentPrincipalIDs.includes(id)
+      ({ id }) => !currentPrincipalIDs.includes(id),
     );
     const unassignedGroups = this.args.groups.filter(
-      ({ id }) => !currentPrincipalIDs.includes(id)
+      ({ id }) => !currentPrincipalIDs.includes(id),
     );
     const unassignedManagedGroups = this.args.managedGroups.filter(
-      ({ id }) => !currentPrincipalIDs.includes(id)
+      ({ id }) => !currentPrincipalIDs.includes(id),
     );
 
     return [

--- a/ui/admin/app/components/form/storage-bucket/index.js
+++ b/ui/admin/app/components/form/storage-bucket/index.js
@@ -19,7 +19,7 @@ export default class FormStorageBucketComponent extends Component {
   @service intl;
 
   @tracked scopeFieldDescription = this.intl.t(
-    'resources.storage-bucket.form.scope.help'
+    'resources.storage-bucket.form.scope.help',
   );
 
   @tracked selectedCredentialType = this.args.model.credentialType;
@@ -54,11 +54,11 @@ export default class FormStorageBucketComponent extends Component {
   updateScopeFieldDescription() {
     if (this.args.model.scopeModel.isGlobal) {
       this.scopeFieldDescription = this.intl.t(
-        'resources.storage-bucket.form.scope.help_global'
+        'resources.storage-bucket.form.scope.help_global',
       );
     } else {
       this.scopeFieldDescription = this.intl.t(
-        'resources.storage-bucket.form.scope.help_org'
+        'resources.storage-bucket.form.scope.help_org',
       );
     }
   }
@@ -67,7 +67,7 @@ export default class FormStorageBucketComponent extends Component {
   updateScope(event) {
     const selectedScopeId = event.target.value;
     const selectedScopeModel = this.args.scopes.find(
-      (element) => element.model.id === selectedScopeId
+      (element) => element.model.id === selectedScopeId,
     ).model;
     this.args.model.scopeModel = selectedScopeModel;
     this.updateScopeFieldDescription();

--- a/ui/admin/app/components/form/target/add-host-sets/index.js
+++ b/ui/admin/app/components/form/target/add-host-sets/index.js
@@ -42,10 +42,10 @@ export default class FormTargetAddHostSetsComponent extends Component {
   get filteredHostSets() {
     // Get IDs for host sets already added to the current target
     const alreadyAddedHostSetIDs = this.args.model.host_sources.map(
-      ({ host_source_id }) => host_source_id
+      ({ host_source_id }) => host_source_id,
     );
     const notAddedHostSets = this.args.hostSets.filter(
-      ({ id }) => !alreadyAddedHostSetIDs.includes(id)
+      ({ id }) => !alreadyAddedHostSetIDs.includes(id),
     );
     return notAddedHostSets;
   }
@@ -75,13 +75,13 @@ export default class FormTargetAddHostSetsComponent extends Component {
       try {
         await this.confirm.confirm(
           this.intl.t(
-            'resources.target.host-source.questions.delete-address.message'
+            'resources.target.host-source.questions.delete-address.message',
           ),
           {
             title:
               'resources.target.host-source.questions.delete-address.title',
             confirm: 'resources.target.actions.remove-address',
-          }
+          },
         );
       } catch (e) {
         // if the user denies, do nothing and return

--- a/ui/admin/app/components/form/user/add-accounts/index.js
+++ b/ui/admin/app/components/form/user/add-accounts/index.js
@@ -36,7 +36,7 @@ export default class FormUserAddAccountsComponent extends Component {
     const notAddedAccounts = this.args.accounts.filter(
       (account) =>
         !alreadyAddedAccountIDs.includes(account.id) &&
-        this.can.can('addAccount user', this.args.model, { account })
+        this.can.can('addAccount user', this.args.model, { account }),
     );
     return notAddedAccounts;
   }

--- a/ui/admin/app/components/form/worker/create-worker-led/index.js
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.js
@@ -181,7 +181,9 @@ unzip *.zip ;\\
     return this.workerTags
       .map(
         (tag) =>
-          `${tag.key} = [${this.convertCommaSeparatedValuesToArray(tag.value)}]`
+          `${tag.key} = [${this.convertCommaSeparatedValuesToArray(
+            tag.value,
+          )}]`,
       )
       .join('\n    ');
   }

--- a/ui/admin/app/controllers/scopes/scope/targets/target/add-brokered-credential-sources.js
+++ b/ui/admin/app/controllers/scopes/scope/targets/target/add-brokered-credential-sources.js
@@ -26,15 +26,15 @@ export default class ScopesScopeTargetsTargetAddBrokeredCredentialSourcesControl
     // Get IDs for credential sources already added to the current target
     const currentCredentialSourceIDs = new Set(
       this.model.target.brokered_credential_source_ids.map(
-        (source) => source.value
-      )
+        (source) => source.value,
+      ),
     );
 
     const notAddedCredentialLibraries = this.model.credentialLibraries.filter(
-      ({ id }) => !currentCredentialSourceIDs.has(id)
+      ({ id }) => !currentCredentialSourceIDs.has(id),
     );
     const notAddedCredentials = this.model.credentials.filter(
-      ({ id }) => !currentCredentialSourceIDs.has(id)
+      ({ id }) => !currentCredentialSourceIDs.has(id),
     );
     return [...notAddedCredentialLibraries, ...notAddedCredentials];
   }

--- a/ui/admin/app/controllers/scopes/scope/targets/target/add-injected-application-credential-sources.js
+++ b/ui/admin/app/controllers/scopes/scope/targets/target/add-injected-application-credential-sources.js
@@ -26,14 +26,14 @@ export default class ScopesScopeTargetsTargetAddInjectedApplicationCredentialSou
     // Get IDs for credential sources already added to the current target
     const currentCredentialSourceIDs = new Set(
       this.model.target.injected_application_credential_source_ids.map(
-        (source) => source.value
-      )
+        (source) => source.value,
+      ),
     );
     const notAddedCredentialLibraries = this.model.credentialLibraries.filter(
-      ({ id }) => !currentCredentialSourceIDs.has(id)
+      ({ id }) => !currentCredentialSourceIDs.has(id),
     );
     const notAddedCredentials = this.model.credentials.filter(
-      ({ id, type }) => !currentCredentialSourceIDs.has(id) && type !== 'json'
+      ({ id, type }) => !currentCredentialSourceIDs.has(id) && type !== 'json',
     );
     return [...notAddedCredentialLibraries, ...notAddedCredentials];
   }

--- a/ui/admin/app/helpers/can.js
+++ b/ui/admin/app/helpers/can.js
@@ -37,14 +37,14 @@ class DevelopmentCanHelper extends CanHelper {
   observeAllFlags() {
     this.features.flags.forEach((flag) =>
       /* eslint-disable-next-line ember/no-observers */
-      this.features.addObserver(flag, this, 'recompute')
+      this.features.addObserver(flag, this, 'recompute'),
     );
   }
 
   removeAllFlags() {
     this.features.flags.forEach((flag) =>
       /* eslint-disable-next-line ember/no-observers */
-      this.features.removeObserver(flag, this, 'recompute')
+      this.features.removeObserver(flag, this, 'recompute'),
     );
   }
 }

--- a/ui/admin/app/router.js
+++ b/ui/admin/app/router.js
@@ -67,7 +67,7 @@ Router.map(function () {
               { path: ':managed_group_id' },
               function () {
                 this.route('members');
-              }
+              },
             );
             this.route('new');
           });
@@ -121,7 +121,7 @@ Router.map(function () {
               this.route(
                 'credential-library',
                 { path: ':credential_library_id' },
-                function () {}
+                function () {},
               );
             });
             this.route('credentials', function () {
@@ -129,10 +129,10 @@ Router.map(function () {
               this.route(
                 'credential',
                 { path: ':credential_id' },
-                function () {}
+                function () {},
               );
             });
-          }
+          },
         );
         this.route('new');
       });
@@ -148,7 +148,7 @@ Router.map(function () {
             this.route('channels-by-connection', function () {
               this.route('channel', { path: ':channel_id' }, function () {});
             });
-          }
+          },
         );
       });
       this.route('storage-buckets', function () {
@@ -156,7 +156,7 @@ Router.map(function () {
         this.route(
           'storage-bucket',
           { path: ':storage_bucket_id' },
-          function () {}
+          function () {},
         );
       });
     });

--- a/ui/admin/app/routes/scopes/index.js
+++ b/ui/admin/app/routes/scopes/index.js
@@ -24,7 +24,7 @@ export default class ScopesIndexRoute extends Route {
   redirect() {
     const authenticatedScopeID = get(
       this.session,
-      'data.authenticated.scope.id'
+      'data.authenticated.scope.id',
     );
     if (authenticatedScopeID) {
       this.router.transitionTo('scopes.scope', authenticatedScopeID);

--- a/ui/admin/app/routes/scopes/scope.js
+++ b/ui/admin/app/routes/scopes/scope.js
@@ -127,7 +127,7 @@ export default class ScopesScopeRoute extends Route {
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(scope) {
     const { isNew } = scope;

--- a/ui/admin/app/routes/scopes/scope/auth-methods.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods.js
@@ -47,7 +47,7 @@ export default class ScopesScopeAuthMethodsRoute extends Route {
       return this.resourceFilterStore.queryBy(
         'auth-method',
         { type },
-        { scope_id }
+        { scope_id },
       );
     }
   }
@@ -72,14 +72,14 @@ export default class ScopesScopeAuthMethodsRoute extends Route {
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(authMethod) {
     await authMethod.save();
     if (this.can.can('read model', authMethod)) {
       await this.router.transitionTo(
         'scopes.scope.auth-methods.auth-method',
-        authMethod
+        authMethod,
       );
     } else {
       await this.router.transitionTo('scopes.scope.auth-methods');
@@ -145,7 +145,7 @@ export default class ScopesScopeAuthMethodsRoute extends Route {
   })
   @notifyError(({ message }) => message, { catch: true })
   @notifySuccess(
-    'resources.auth-method.notifications.remove-as-primary-success'
+    'resources.auth-method.notifications.remove-as-primary-success',
   )
   async removeAsPrimary(authMethod) {
     const scopeModel = this.modelFor('scopes.scope');

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method.js
@@ -43,7 +43,7 @@ export default class ScopesScopeAuthMethodsAuthMethodRoute extends Route {
         transition.to.name,
         authMethod.scopeID,
         authMethod.id,
-        ...paramValues
+        ...paramValues,
       );
     }
   }
@@ -67,12 +67,12 @@ export default class ScopesScopeAuthMethodsAuthMethodRoute extends Route {
     }
     if (authMethod.signing_algorithms) {
       authMethod.signing_algorithms = structuredClone(
-        authMethod.signing_algorithms
+        authMethod.signing_algorithms,
       );
     }
     if (authMethod.allowed_audiences) {
       authMethod.allowed_audiences = structuredClone(
-        authMethod.allowed_audiences
+        authMethod.allowed_audiences,
       );
     }
     if (authMethod.idp_ca_certs) {
@@ -80,7 +80,7 @@ export default class ScopesScopeAuthMethodsAuthMethodRoute extends Route {
     }
     if (authMethod.account_claim_maps) {
       authMethod.account_claim_maps = structuredClone(
-        authMethod.account_claim_maps
+        authMethod.account_claim_maps,
       );
     }
     if (authMethod.certificates) {
@@ -88,7 +88,7 @@ export default class ScopesScopeAuthMethodsAuthMethodRoute extends Route {
     }
     if (authMethod.account_attribute_maps) {
       authMethod.account_attribute_maps = structuredClone(
-        authMethod.account_attribute_maps
+        authMethod.account_attribute_maps,
       );
     }
   }

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/accounts.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/accounts.js
@@ -55,7 +55,7 @@ export default class ScopesScopeAuthMethodsAuthMethodAccountsRoute extends Route
     account.rollbackAttributes();
     if (isNew)
       this.router.transitionTo(
-        'scopes.scope.auth-methods.auth-method.accounts'
+        'scopes.scope.auth-methods.auth-method.accounts',
       );
   }
 
@@ -67,7 +67,7 @@ export default class ScopesScopeAuthMethodsAuthMethodAccountsRoute extends Route
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(account, password) {
     const { isNew } = account;
@@ -79,11 +79,11 @@ export default class ScopesScopeAuthMethodsAuthMethodAccountsRoute extends Route
     if (this.can.can('read model', account)) {
       await this.router.transitionTo(
         'scopes.scope.auth-methods.auth-method.accounts.account',
-        account
+        account,
       );
     } else {
       await this.router.transitionTo(
-        'scopes.scope.auth-methods.auth-method.accounts'
+        'scopes.scope.auth-methods.auth-method.accounts',
       );
     }
     this.refresh();
@@ -101,7 +101,7 @@ export default class ScopesScopeAuthMethodsAuthMethodAccountsRoute extends Route
   async deleteAccount(account) {
     await account.destroyRecord();
     await this.router.replaceWith(
-      'scopes.scope.auth-methods.auth-method.accounts'
+      'scopes.scope.auth-methods.auth-method.accounts',
     );
     this.refresh();
   }

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/accounts/account/set-password.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/accounts/account/set-password.js
@@ -30,7 +30,7 @@ export default class ScopesScopeAuthMethodsAuthMethodAccountsAccountSettingsRout
   async setPassword(account, password) {
     await account.setPassword(password);
     await this.router.replaceWith(
-      'scopes.scope.auth-methods.auth-method.accounts.account.set-password'
+      'scopes.scope.auth-methods.auth-method.accounts.account.set-password',
     );
   }
 }

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/accounts/new.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/accounts/new.js
@@ -33,7 +33,7 @@ export default class ScopesScopeAuthMethodsAuthMethodAccountsNewRoute extends Ro
    */
   model() {
     const { id: auth_method_id, type } = this.modelFor(
-      'scopes.scope.auth-methods.auth-method'
+      'scopes.scope.auth-methods.auth-method',
     );
     return this.store.createRecord('account', {
       type,

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups.js
@@ -55,7 +55,7 @@ export default class ScopesScopeAuthMethodsAuthMethodManagedGroupsRoute extends 
     managedGroup.rollbackAttributes();
     if (isNew) {
       this.router.transitionTo(
-        'scopes.scope.auth-methods.auth-method.managed-groups'
+        'scopes.scope.auth-methods.auth-method.managed-groups',
       );
     }
   }
@@ -68,18 +68,18 @@ export default class ScopesScopeAuthMethodsAuthMethodManagedGroupsRoute extends 
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(managedGroup) {
     await managedGroup.save();
     if (this.can.can('read model', managedGroup)) {
       await this.router.transitionTo(
         'scopes.scope.auth-methods.auth-method.managed-groups.managed-group',
-        managedGroup
+        managedGroup,
       );
     } else {
       await this.router.transitionTo(
-        'scopes.scope.auth-methods.auth-method.managed-groups'
+        'scopes.scope.auth-methods.auth-method.managed-groups',
       );
     }
     this.refresh();
@@ -97,7 +97,7 @@ export default class ScopesScopeAuthMethodsAuthMethodManagedGroupsRoute extends 
   async deleteManagedGroup(managedGroup) {
     await managedGroup.destroyRecord();
     await this.router.replaceWith(
-      'scopes.scope.auth-methods.auth-method.managed-groups'
+      'scopes.scope.auth-methods.auth-method.managed-groups',
     );
     this.refresh();
   }

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group.js
@@ -40,7 +40,7 @@ export default class ScopesScopeAuthMethodsAuthMethodManagedGroupsManagedGroupRo
       this.router.replaceWith(
         transition.to.name,
         auth_method_id,
-        managedGroup.id
+        managedGroup.id,
       );
     }
   }

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group/members.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group/members.js
@@ -19,7 +19,7 @@ export default class ScopesScopeAuthMethodsAuthMethodManagedGroupsManagedGroupMe
    */
   async model() {
     const managedGroup = this.modelFor(
-      'scopes.scope.auth-methods.auth-method.managed-groups.managed-group'
+      'scopes.scope.auth-methods.auth-method.managed-groups.managed-group',
     );
     const { auth_method_id, member_ids } = managedGroup;
 
@@ -29,7 +29,7 @@ export default class ScopesScopeAuthMethodsAuthMethodManagedGroupsManagedGroupMe
         ? await this.resourceFilterStore.queryBy(
             'account',
             { id: member_ids },
-            { auth_method_id }
+            { auth_method_id },
           )
         : [],
     };

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups/new.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups/new.js
@@ -26,14 +26,14 @@ export default class ScopesScopeAuthMethodsAuthMethodManagedGroupsNewRoute exten
       })
     ) {
       this.router.replaceWith(
-        'scopes.scope.auth-methods.auth-method.managed-groups'
+        'scopes.scope.auth-methods.auth-method.managed-groups',
       );
     }
   }
 
   model() {
     const { id: auth_method_id, type } = this.modelFor(
-      'scopes.scope.auth-methods.auth-method'
+      'scopes.scope.auth-methods.auth-method',
     );
     return this.store.createRecord('managed-group', {
       type,

--- a/ui/admin/app/routes/scopes/scope/authenticate.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate.js
@@ -35,7 +35,7 @@ export default class ScopesScopeAuthenticateRoute extends Route {
       },
       {
         scope_id,
-      }
+      },
     );
     // Preload all authenticatable auth methods into the store
     const authMethodsForAllScopes = await this.resourceFilterStore.queryBy(
@@ -46,14 +46,14 @@ export default class ScopesScopeAuthenticateRoute extends Route {
       {
         scope_id: 'global',
         recursive: true,
-      }
+      },
     );
     // Fetch org scopes
     // and filter out any that have no auth methods
     const scopes = this.modelFor('scopes').filter(
       ({ id: scope_id, isOrg }) =>
         isOrg &&
-        authMethodsForAllScopes.filter((i) => i.scopeID === scope_id).length
+        authMethodsForAllScopes.filter((i) => i.scopeID === scope_id).length,
     );
     return hash({
       scope: this.modelFor('scopes.scope'),

--- a/ui/admin/app/routes/scopes/scope/authenticate/index.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate/index.js
@@ -24,7 +24,7 @@ export default class ScopesScopeAuthenticateIndexRoute extends Route {
     if (firstAuthMethod) {
       this.router.transitionTo(
         'scopes.scope.authenticate.method',
-        firstAuthMethod
+        firstAuthMethod,
       );
     }
   }

--- a/ui/admin/app/routes/scopes/scope/authenticate/method.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate/method.js
@@ -73,7 +73,7 @@ export default class ScopesScopeAuthenticateMethodRoute extends Route {
           authenticatorName,
           creds,
           requestCookies,
-          { scope, authMethod }
+          { scope, authMethod },
         );
         this.router.transitionTo('index');
         break;

--- a/ui/admin/app/routes/scopes/scope/credential-stores.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores.js
@@ -49,7 +49,7 @@ export default class ScopesScopeCredentialStoresRoute extends Route {
     await credentialStore.save();
     await this.router.transitionTo(
       'scopes.scope.credential-stores.credential-store',
-      credentialStore
+      credentialStore,
     );
     this.refresh();
   }

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store.js
@@ -34,13 +34,13 @@ export default class ScopesScopeCredentialStoresCredentialStoreRoute extends Rou
     if (credentialStore.scopeID !== scope.id) {
       let paramValues = paramValueFinder(
         'credential-store',
-        transition.to.parent
+        transition.to.parent,
       );
       this.router.replaceWith(
         transition.to.name,
         credentialStore.scopeID,
         credentialStore.id,
-        ...paramValues
+        ...paramValues,
       );
     }
   }

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries.js
@@ -25,7 +25,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
    */
   model() {
     const credentialStore = this.modelFor(
-      'scopes.scope.credential-stores.credential-store'
+      'scopes.scope.credential-stores.credential-store',
     );
     const { id: credential_store_id } = credentialStore;
     if (
@@ -49,7 +49,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
     credentialLibrary.rollbackAttributes();
     if (isNew)
       this.router.transitionTo(
-        'scopes.scope.credential-stores.credential-store.credential-libraries'
+        'scopes.scope.credential-stores.credential-store.credential-libraries',
       );
   }
 
@@ -61,18 +61,18 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(credentialLibrary) {
     await credentialLibrary.save();
     if (this.can.can('read model', credentialLibrary)) {
       await this.router.transitionTo(
         'scopes.scope.credential-stores.credential-store.credential-libraries.credential-library',
-        credentialLibrary
+        credentialLibrary,
       );
     } else {
       await this.router.transitionTo(
-        'scopes.scope.credential-stores.credential-store.credential-libraries'
+        'scopes.scope.credential-stores.credential-store.credential-libraries',
       );
     }
     this.refresh();
@@ -90,7 +90,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
   async deleteCredentialLibrary(credentialLibrary) {
     await credentialLibrary.destroyRecord();
     await this.router.replaceWith(
-      'scopes.scope.credential-stores.credential-store.credential-libraries'
+      'scopes.scope.credential-stores.credential-store.credential-libraries',
     );
     this.refresh();
   }

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library.js
@@ -34,14 +34,14 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
    */
   redirect(credentialLibrary) {
     const credentialStore = this.modelFor(
-      'scopes.scope.credential-stores.credential-store'
+      'scopes.scope.credential-stores.credential-store',
     );
     const { credential_store_id } = credentialLibrary;
     if (credential_store_id !== credentialStore.id) {
       this.router.replaceWith(
         'scopes.scope.credential-stores.credential-store.credential-libraries.credential-library',
         credential_store_id,
-        credentialLibrary.id
+        credentialLibrary.id,
       );
     }
   }

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/index.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/index.js
@@ -10,7 +10,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
 
   setupController(controller) {
     const credentialStore = this.modelFor(
-      'scopes.scope.credential-stores.credential-store'
+      'scopes.scope.credential-stores.credential-store',
     );
     super.setupController(...arguments);
     controller.setProperties({ credentialStore });

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/new.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/new.js
@@ -31,7 +31,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
    */
   beforeModel() {
     const credentialStore = this.modelFor(
-      'scopes.scope.credential-stores.credential-store'
+      'scopes.scope.credential-stores.credential-store',
     );
     if (
       this.can.cannot('create model', credentialStore, {
@@ -39,7 +39,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
       })
     ) {
       this.router.replaceWith(
-        'scopes.scope.credential-stores.credential-store.credential-libraries'
+        'scopes.scope.credential-stores.credential-store.credential-libraries',
       );
     }
   }
@@ -50,7 +50,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
    */
   model({ type = TYPE_CREDENTIAL_LIBRARY_VAULT_GENERIC }) {
     const { id: credential_store_id } = this.modelFor(
-      'scopes.scope.credential-stores.credential-store'
+      'scopes.scope.credential-stores.credential-store',
     );
 
     // Set the type to generic vault if feature flag isn't enabled in cases where

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials.js
@@ -25,7 +25,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialsRoute 
    */
   model() {
     const credentialStore = this.modelFor(
-      'scopes.scope.credential-stores.credential-store'
+      'scopes.scope.credential-stores.credential-store',
     );
     const { id: credential_store_id } = credentialStore;
     if (
@@ -49,7 +49,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialsRoute 
     credential.rollbackAttributes();
     if (isNew)
       this.router.transitionTo(
-        'scopes.scope.credential-stores.credential-store.credentials'
+        'scopes.scope.credential-stores.credential-store.credentials',
       );
   }
 
@@ -61,18 +61,18 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialsRoute 
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(credential) {
     await credential.save();
     if (this.can.can('read model', credential)) {
       await this.router.transitionTo(
         'scopes.scope.credential-stores.credential-store.credentials.credential',
-        credential
+        credential,
       );
     } else {
       await this.router.transitionTo(
-        'scopes.scope.credential-stores.credential-store.credentials'
+        'scopes.scope.credential-stores.credential-store.credentials',
       );
     }
     this.refresh();
@@ -89,7 +89,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialsRoute 
   async deleteCredential(credential) {
     await credential.destroyRecord();
     await this.router.replaceWith(
-      'scopes.scope.credential-stores.credential-store.credentials'
+      'scopes.scope.credential-stores.credential-store.credentials',
     );
     this.refresh();
   }

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials/credential.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials/credential.js
@@ -33,14 +33,14 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialsCreden
    */
   redirect(credential) {
     const credentialStore = this.modelFor(
-      'scopes.scope.credential-stores.credential-store'
+      'scopes.scope.credential-stores.credential-store',
     );
     const { credential_store_id } = credential;
     if (credential_store_id !== credentialStore.id) {
       this.router.replaceWith(
         'scopes.scope.credential-stores.credential-store.credentials.credential',
         credential_store_id,
-        credential.id
+        credential.id,
       );
     }
   }

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials/index.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials/index.js
@@ -10,7 +10,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialsIndexR
 
   setupController(controller) {
     const credentialStore = this.modelFor(
-      'scopes.scope.credential-stores.credential-store'
+      'scopes.scope.credential-stores.credential-store',
     );
     super.setupController(...arguments);
     controller.setProperties({ credentialStore });

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials/new.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials/new.js
@@ -29,7 +29,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialsNewRou
    */
   beforeModel() {
     const credentialStore = this.modelFor(
-      'scopes.scope.credential-stores.credential-store'
+      'scopes.scope.credential-stores.credential-store',
     );
     if (
       this.can.cannot('create model', credentialStore, {
@@ -37,7 +37,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialsNewRou
       })
     ) {
       this.router.replaceWith(
-        'scopes.scope.credential-stores.credential-store.credentials'
+        'scopes.scope.credential-stores.credential-store.credentials',
       );
     }
   }
@@ -50,7 +50,7 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialsNewRou
    */
   model({ type = 'username_password' }) {
     const { id: credential_store_id } = this.modelFor(
-      'scopes.scope.credential-stores.credential-store'
+      'scopes.scope.credential-stores.credential-store',
     );
     let name, description;
 

--- a/ui/admin/app/routes/scopes/scope/groups.js
+++ b/ui/admin/app/routes/scopes/scope/groups.js
@@ -60,7 +60,7 @@ export default class ScopesScopeGroupsRoute extends Route {
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(group) {
     await group.save();

--- a/ui/admin/app/routes/scopes/scope/groups/group/add-members.js
+++ b/ui/admin/app/routes/scopes/scope/groups/group/add-members.js
@@ -59,7 +59,7 @@ export default class ScopesScopeGroupsGroupAddMembersRoute extends Route {
           {
             scope_id: 'global',
             recursive: true,
-          }
+          },
         )
       : this.store.query('user', { scope_id: 'global', recursive: true });
     return hash({ group, users, scopes });

--- a/ui/admin/app/routes/scopes/scope/groups/group/members.js
+++ b/ui/admin/app/routes/scopes/scope/groups/group/members.js
@@ -32,7 +32,7 @@ export default class ScopesScopeGroupsGroupMembersRoute extends Route {
         ? this.resourceFilterStore.queryBy(
             'user',
             { id: group.member_ids },
-            { scope_id: 'global', recursive: true }
+            { scope_id: 'global', recursive: true },
           )
         : [],
     });

--- a/ui/admin/app/routes/scopes/scope/host-catalogs.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs.js
@@ -62,13 +62,13 @@ export default class ScopesScopeHostCatalogsRoute extends Route {
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(hostCatalog) {
     await hostCatalog.save();
     await this.router.transitionTo(
       'scopes.scope.host-catalogs.host-catalog',
-      hostCatalog
+      hostCatalog,
     );
     this.refresh();
   }

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog.js
@@ -41,7 +41,7 @@ export default class ScopesScopeHostCatalogsHostCatalogRoute extends Route {
         transition.to.name,
         hostCatalog.scopeID,
         hostCatalog.id,
-        ...paramValues
+        ...paramValues,
       );
     }
   }

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets.js
@@ -26,7 +26,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsRoute extends Rou
    */
   async model() {
     const hostCatalog = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     );
     const { id: host_catalog_id } = hostCatalog;
     let hostSets;
@@ -57,7 +57,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsRoute extends Rou
     hostSet.rollbackAttributes();
     if (isNew)
       this.router.transitionTo(
-        'scopes.scope.host-catalogs.host-catalog.host-sets'
+        'scopes.scope.host-catalogs.host-catalog.host-sets',
       );
   }
 
@@ -70,18 +70,18 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsRoute extends Rou
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(hostSet) {
     await hostSet.save();
     if (this.can.can('read model', hostSet)) {
       await this.router.transitionTo(
         'scopes.scope.host-catalogs.host-catalog.host-sets.host-set',
-        hostSet
+        hostSet,
       );
     } else {
       await this.router.transitionTo(
-        'scopes.scope.host-catalogs.host-catalog.host-sets'
+        'scopes.scope.host-catalogs.host-catalog.host-sets',
       );
     }
     this.refresh();
@@ -99,7 +99,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsRoute extends Rou
   async deleteHostSet(hostSet) {
     await hostSet.destroyRecord();
     await this.router.replaceWith(
-      'scopes.scope.host-catalogs.host-catalog.host-sets'
+      'scopes.scope.host-catalogs.host-catalog.host-sets',
     );
   }
 }

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set.js
@@ -34,7 +34,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetRoute exte
    */
   redirect(hostSet, transition) {
     const hostCatalog = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     );
     const { host_catalog_id } = hostSet;
     if (host_catalog_id !== hostCatalog.id) {
@@ -43,7 +43,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetRoute exte
         transition.to.name,
         host_catalog_id,
         hostSet.id,
-        ...paramValues
+        ...paramValues,
       );
     }
   }
@@ -62,7 +62,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetRoute exte
   edit(hostSet) {
     if (hostSet.preferred_endpoints) {
       hostSet.preferred_endpoints = structuredClone(
-        hostSet.preferred_endpoints
+        hostSet.preferred_endpoints,
       );
     }
     if (hostSet.filters) {

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/add-hosts.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/add-hosts.js
@@ -32,11 +32,11 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetAddHostsRo
    */
   async model() {
     const { id: host_catalog_id } = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     );
     return hash({
       hostSet: this.modelFor(
-        'scopes.scope.host-catalogs.host-catalog.host-sets.host-set'
+        'scopes.scope.host-catalogs.host-catalog.host-sets.host-set',
       ),
       hosts: this.store.query('host', { host_catalog_id }),
     });
@@ -55,7 +55,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetAddHostsRo
   async addHosts(hostSet, hostIDs) {
     await hostSet.addHosts(hostIDs);
     await this.router.replaceWith(
-      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts'
+      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts',
     );
   }
 
@@ -65,7 +65,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetAddHostsRo
   @action
   cancel() {
     this.router.replaceWith(
-      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts'
+      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts',
     );
   }
 }

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/create-and-add-host.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/create-and-add-host.js
@@ -24,11 +24,11 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetCreateAndA
    */
   beforeModel() {
     const hostCatalog = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     );
     if (this.can.cannot('create model', hostCatalog, { collection: 'hosts' })) {
       this.router.replaceWith(
-        'scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts'
+        'scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts',
       );
     }
   }
@@ -39,7 +39,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetCreateAndA
    */
   async model() {
     const { id: host_catalog_id } = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     );
 
     return this.store.createRecord('host', {
@@ -60,12 +60,12 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetCreateAndA
   @notifySuccess('notifications.add-success')
   async save(host) {
     const hostSet = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set'
+      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set',
     );
     await host.save();
     await hostSet.addHost(host.id);
     await this.router.replaceWith(
-      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts'
+      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts',
     );
   }
 
@@ -75,7 +75,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetCreateAndA
   @action
   cancel() {
     this.router.replaceWith(
-      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts'
+      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts',
     );
   }
 }

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts.js
@@ -25,14 +25,14 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetHostsRoute
    */
   async model() {
     const hostSet = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set'
+      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set',
     );
     return hash({
       hostSet,
       hosts: all(
         hostSet.host_ids.map((hostID) =>
-          this.store.findRecord('host', hostID, { reload: true })
-        )
+          this.store.findRecord('host', hostID, { reload: true }),
+        ),
       ),
     });
   }
@@ -50,7 +50,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetHostsRoute
   async removeHost(hostSet, host) {
     const scopeID = this.modelFor('scopes.scope').id;
     const hostCatalogID = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     ).id;
     await hostSet.removeHost(host.id, {
       adapterOptions: { scopeID, hostCatalogID },

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host.js
@@ -31,13 +31,13 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetHostsHostR
    */
   redirect(host) {
     const hostSet = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set'
+      'scopes.scope.host-catalogs.host-catalog.host-sets.host-set',
     );
     if (host.host_set_ids !== hostSet.id) {
       this.router.replaceWith(
         'scopes.scope.host-catalogs.host-catalog.host-sets.host-set.hosts.host',
         host.host_set_ids[0],
-        host.id
+        host.id,
       );
     }
   }

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/index.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/index.js
@@ -8,7 +8,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsIndexRoute extend
   // =methods
   setupController(controller) {
     const hostCatalog = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     );
     super.setupController(...arguments);
     controller.setProperties({ hostCatalog });

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/new.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/new.js
@@ -20,13 +20,13 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsNewRoute extends 
    */
   beforeModel() {
     const hostCatalog = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     );
     if (
       this.can.cannot('create model', hostCatalog, { collection: 'host-sets' })
     ) {
       this.router.replaceWith(
-        'scopes.scope.host-catalogs.host-catalog.host-sets'
+        'scopes.scope.host-catalogs.host-catalog.host-sets',
       );
     }
   }
@@ -37,7 +37,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostSetsNewRoute extends 
    */
   model() {
     const { id: host_catalog_id, compositeType } = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     );
     return this.store.createRecord('host-set', {
       compositeType,

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts.js
@@ -26,7 +26,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostsRoute extends Route 
    */
   async model() {
     const hostCatalog = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     );
     const { id: host_catalog_id } = hostCatalog;
     let hosts;
@@ -68,18 +68,18 @@ export default class ScopesScopeHostCatalogsHostCatalogHostsRoute extends Route 
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(host) {
     await host.save();
     if (this.can.can('read model', host)) {
       await this.router.transitionTo(
         'scopes.scope.host-catalogs.host-catalog.hosts.host',
-        host
+        host,
       );
     } else {
       await this.router.transitionTo(
-        'scopes.scope.host-catalogs.host-catalog.hosts'
+        'scopes.scope.host-catalogs.host-catalog.hosts',
       );
     }
     this.refresh();
@@ -97,7 +97,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostsRoute extends Route 
   async deleteHost(host) {
     await host.destroyRecord();
     await this.router.replaceWith(
-      'scopes.scope.host-catalogs.host-catalog.hosts'
+      'scopes.scope.host-catalogs.host-catalog.hosts',
     );
     this.refresh();
   }

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts/host.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts/host.js
@@ -31,14 +31,14 @@ export default class ScopesScopeHostCatalogsHostCatalogHostsHostRoute extends Ro
    */
   redirect(host) {
     const hostCatalog = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     );
     const { host_catalog_id } = host;
     if (host_catalog_id !== hostCatalog.id) {
       this.router.replaceWith(
         'scopes.scope.host-catalogs.host-catalog.hosts.host',
         host_catalog_id,
-        host.id
+        host.id,
       );
     }
   }

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts/index.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts/index.js
@@ -8,7 +8,7 @@ import Route from '@ember/routing/route';
 export default class ScopesScopeHostCatalogsHostCatalogHostsIndexRoute extends Route {
   setupController(controller) {
     const hostCatalog = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     );
     super.setupController(...arguments);
     controller.setProperties({ hostCatalog });

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts/new.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts/new.js
@@ -20,7 +20,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostsNewRoute extends Rou
    */
   beforeModel() {
     const hostCatalog = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     );
     if (this.can.cannot('create model', hostCatalog, { collection: 'hosts' })) {
       this.router.replaceWith('scopes.scope.host-catalogs.host-catalog.hosts');
@@ -33,7 +33,7 @@ export default class ScopesScopeHostCatalogsHostCatalogHostsNewRoute extends Rou
    */
   model() {
     const { id: host_catalog_id } = this.modelFor(
-      'scopes.scope.host-catalogs.host-catalog'
+      'scopes.scope.host-catalogs.host-catalog',
     );
     return this.store.createRecord('host', {
       type: 'static',

--- a/ui/admin/app/routes/scopes/scope/roles.js
+++ b/ui/admin/app/routes/scopes/scope/roles.js
@@ -60,7 +60,7 @@ export default class ScopesScopeRolesRoute extends Route {
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(role) {
     await role.save();

--- a/ui/admin/app/routes/scopes/scope/roles/role/add-principals.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/add-principals.js
@@ -60,7 +60,7 @@ export default class ScopesScopeRolesRoleAddPrincipalsRoute extends Route {
           {
             scope_id: 'global',
             recursive: true,
-          }
+          },
         )
       : this.store.query('user', { scope_id: 'global', recursive: true });
     const groups = scopeIDs?.length
@@ -72,7 +72,7 @@ export default class ScopesScopeRolesRoleAddPrincipalsRoute extends Route {
           {
             scope_id: 'global',
             recursive: true,
-          }
+          },
         )
       : this.store.query('group', { scope_id: 'global', recursive: true });
     //query authmethods from all the scopes
@@ -83,20 +83,20 @@ export default class ScopesScopeRolesRoleAddPrincipalsRoute extends Route {
             scope_id: scopeIDs,
             type: [TYPE_AUTH_METHOD_OIDC, TYPE_AUTH_METHOD_LDAP],
           },
-          { scope_id: 'global', recursive: true }
+          { scope_id: 'global', recursive: true },
         )
       : await this.resourceFilterStore.queryBy(
           'auth-method',
           { type: [TYPE_AUTH_METHOD_OIDC, TYPE_AUTH_METHOD_LDAP] },
-          { scope_id: 'global', recursive: true }
+          { scope_id: 'global', recursive: true },
         );
     //extract oidc and ldap authMethod IDs
     const authMethodIDs = authMethods.map(({ id }) => id);
     //query all the managed groups for each auth method id
     const managedGroups = await all(
       authMethodIDs.map((auth_method_id) =>
-        this.store.query('managed-group', { auth_method_id })
-      )
+        this.store.query('managed-group', { auth_method_id }),
+      ),
     );
     const managedGroupModels = managedGroups
       .map((models) => models.map((model) => model))

--- a/ui/admin/app/routes/scopes/scope/roles/role/grants.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/grants.js
@@ -37,7 +37,7 @@ export default class ScopesScopeRolesRoleGrantsRoute extends Route {
   @action
   removeGrant(role, grantString) {
     role.grant_strings = role.grant_strings.filter(
-      (str) => str !== grantString
+      (str) => str !== grantString,
     );
   }
 

--- a/ui/admin/app/routes/scopes/scope/roles/role/index.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/index.js
@@ -29,7 +29,7 @@ export default class ScopesScopeRolesRoleIndexRoute extends Route {
           subScopes: !scope.isProject
             ? await this.store.query('scope', { scope_id: scope.id })
             : [],
-        }))
+        })),
       );
     }
 

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording.js
@@ -33,7 +33,7 @@ export default class ScopesScopeSessionRecordingsSessionRecordingRoute extends R
       session_recording_id,
       // Set reload to true to always force an API call. The downstream peekRecord
       // for channels will resolve before the session recording is returned otherwise.
-      { reload: true }
+      { reload: true },
     );
 
     return sessionRecording;
@@ -49,13 +49,13 @@ export default class ScopesScopeSessionRecordingsSessionRecordingRoute extends R
     if (sessionRecording.scopeID !== scope.id) {
       const paramValues = paramValueFinder(
         'session-recording',
-        transition.to.parent
+        transition.to.parent,
       );
       this.router.replaceWith(
         transition.to.name,
         sessionRecording.scopeID,
         sessionRecording.id,
-        ...paramValues
+        ...paramValues,
       );
     }
   }

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection.js
@@ -28,7 +28,7 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
     let storageBucket = null;
 
     const sessionRecording = this.modelFor(
-      'scopes.scope.session-recordings.session-recording'
+      'scopes.scope.session-recordings.session-recording',
     );
 
     try {
@@ -36,7 +36,7 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
         const { storage_bucket_id } = sessionRecording;
         storageBucket = await this.store.findRecord(
           'storage-bucket',
-          storage_bucket_id
+          storage_bucket_id,
         );
       }
     } catch (e) {

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel.js
@@ -20,11 +20,11 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
    */
   model({ channel_id }) {
     const { sessionRecording, storageBucket } = this.modelFor(
-      'scopes.scope.session-recordings.session-recording.channels-by-connection'
+      'scopes.scope.session-recordings.session-recording.channels-by-connection',
     );
     const channelRecording = this.store.peekRecord(
       'channel-recording',
-      channel_id
+      channel_id,
     );
 
     return {
@@ -46,7 +46,7 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
       this.router.replaceWith(
         'scopes.scope.session-recordings.session-recording.channels-by-connection.channel',
         session_recording_id,
-        channelRecording.id
+        channelRecording.id,
       );
     }
   }

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index.js
@@ -17,7 +17,7 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
   async model() {
     let asciicast;
     const { sessionRecording, storageBucket, channelRecording } = this.modelFor(
-      'scopes.scope.session-recordings.session-recording.channels-by-connection.channel'
+      'scopes.scope.session-recordings.session-recording.channels-by-connection.channel',
     );
 
     if (this.can.can('getAsciicast channel-recording', channelRecording)) {

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/index.js
@@ -21,7 +21,7 @@ export default class ScopesScopeSessionRecordingsSessionRecordingIndexRoute exte
     if (sessionRecording.isSSH) {
       this.router.transitionTo(
         'scopes.scope.session-recordings.session-recording.channels-by-connection',
-        sessionRecording.id
+        sessionRecording.id,
       );
     }
   }

--- a/ui/admin/app/routes/scopes/scope/sessions.js
+++ b/ui/admin/app/routes/scopes/scope/sessions.js
@@ -60,7 +60,7 @@ export default class ScopesScopeSessionsRoute extends Route {
     const sessions = await this.resourceFilterStore.queryBy(
       'session',
       filters,
-      options
+      options,
     );
 
     const sessionAggregates = await all(
@@ -75,21 +75,21 @@ export default class ScopesScopeSessionsRoute extends Route {
             ? this.store.peekRecord('target', session.target_id) ||
               this.store.findRecord('target', session.target_id)
             : null,
-        })
-      )
+        }),
+      ),
     );
     // Sort sessions by time created...
     let sortedSessionAggregates = sortBy(
       sessionAggregates,
-      'session.created_time'
+      'session.created_time',
     ).reverse();
     // Then move active sessions to the top...
     sortedSessionAggregates = [
       ...sortedSessionAggregates.filter(
-        (aggregate) => aggregate.session.status === 'active'
+        (aggregate) => aggregate.session.status === 'active',
       ),
       ...sortedSessionAggregates.filter(
-        (aggregate) => aggregate.session.status !== 'active'
+        (aggregate) => aggregate.session.status !== 'active',
       ),
     ];
     return sortedSessionAggregates;

--- a/ui/admin/app/routes/scopes/scope/storage-buckets.js
+++ b/ui/admin/app/routes/scopes/scope/storage-buckets.js
@@ -59,7 +59,7 @@ export default class ScopesScopeStorageBucketsRoute extends Route {
     await storageBucket.save();
     await this.router.transitionTo(
       'scopes.scope.storage-buckets.storage-bucket',
-      storageBucket
+      storageBucket,
     );
     this.refresh();
   }

--- a/ui/admin/app/routes/scopes/scope/storage-buckets/storage-bucket.js
+++ b/ui/admin/app/routes/scopes/scope/storage-buckets/storage-bucket.js
@@ -37,7 +37,7 @@ export default class ScopesScopeStorageBucketsStorageBucketRoute extends Route {
       this.router.replaceWith(
         'scopes.scope.storage-buckets.storage-bucket',
         storageBucket.scopeID,
-        storageBucket.id
+        storageBucket.id,
       );
     }
   }

--- a/ui/admin/app/routes/scopes/scope/targets.js
+++ b/ui/admin/app/routes/scopes/scope/targets.js
@@ -62,7 +62,7 @@ export default class ScopesScopeTargetsRoute extends Route {
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(target) {
     await target.save();
@@ -121,11 +121,11 @@ export default class ScopesScopeTargetsRoute extends Route {
 
     if (hostSourceCount) {
       const hostSourceIDs = target.host_sources.map(
-        ({ host_source_id }) => host_source_id
+        ({ host_source_id }) => host_source_id,
       );
       const confirmMessage = this.intl.t(
         'resources.target.questions.delete-host-sources.message',
-        { hostSourceCount }
+        { hostSourceCount },
       );
 
       // Ask for confirmation

--- a/ui/admin/app/routes/scopes/scope/targets/target/add-brokered-credential-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/add-brokered-credential-sources.js
@@ -48,7 +48,7 @@ export default class ScopesScopeTargetsTargetAddBrokeredCredentialSourcesRoute e
             credential_store_id,
           });
         }
-      })
+      }),
     );
     const credentialLibraries = this.store.peekAll('credential-library');
     const credentials = this.store.peekAll('credential');
@@ -74,7 +74,7 @@ export default class ScopesScopeTargetsTargetAddBrokeredCredentialSourcesRoute e
   async save(target, credentialLibraryIDs) {
     await target.addBrokeredCredentialSources(credentialLibraryIDs);
     this.router.replaceWith(
-      'scopes.scope.targets.target.brokered-credential-sources'
+      'scopes.scope.targets.target.brokered-credential-sources',
     );
   }
 
@@ -84,7 +84,7 @@ export default class ScopesScopeTargetsTargetAddBrokeredCredentialSourcesRoute e
   @action
   cancel() {
     this.router.replaceWith(
-      'scopes.scope.targets.target.brokered-credential-sources'
+      'scopes.scope.targets.target.brokered-credential-sources',
     );
   }
 }

--- a/ui/admin/app/routes/scopes/scope/targets/target/add-host-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/add-host-sources.js
@@ -36,8 +36,8 @@ export default class ScopesScopeTargetsTargetAddHostSourcesRoute extends Route {
     const hostCatalogs = await this.store.query('host-catalog', { scope_id });
     await all(
       hostCatalogs.map(({ id: host_catalog_id }) =>
-        this.store.query('host-set', { host_catalog_id })
-      )
+        this.store.query('host-set', { host_catalog_id }),
+      ),
     );
     const hostSets = this.store.peekAll('host-set');
     return {

--- a/ui/admin/app/routes/scopes/scope/targets/target/add-injected-application-credential-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/add-injected-application-credential-sources.js
@@ -48,7 +48,7 @@ export default class ScopesScopeTargetsTargetAddInjectedApplicationCredentialSou
             credential_store_id,
           });
         }
-      })
+      }),
     );
     const credentialLibraries = this.store.peekAll('credential-library');
     const credentials = this.store.peekAll('credential');
@@ -73,7 +73,7 @@ export default class ScopesScopeTargetsTargetAddInjectedApplicationCredentialSou
   async save(target, credentialLibraryIDs) {
     await target.addInjectedApplicationCredentialSources(credentialLibraryIDs);
     this.router.replaceWith(
-      'scopes.scope.targets.target.injected-application-credential-sources'
+      'scopes.scope.targets.target.injected-application-credential-sources',
     );
   }
 
@@ -83,7 +83,7 @@ export default class ScopesScopeTargetsTargetAddInjectedApplicationCredentialSou
   @action
   cancel() {
     this.router.replaceWith(
-      'scopes.scope.targets.target.injected-application-credential-sources'
+      'scopes.scope.targets.target.injected-application-credential-sources',
     );
   }
 }

--- a/ui/admin/app/routes/scopes/scope/targets/target/brokered-credential-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/brokered-credential-sources.js
@@ -24,7 +24,7 @@ export default class ScopesScopeTargetsTargetBrokeredCredentialSourcesRoute exte
    */
   beforeModel() {
     const { brokered_credential_source_ids: sourceIDFragments } = this.modelFor(
-      'scopes.scope.targets.target'
+      'scopes.scope.targets.target',
     );
     return all(
       sourceIDFragments.map(({ value }) => {
@@ -38,7 +38,7 @@ export default class ScopesScopeTargetsTargetBrokeredCredentialSourcesRoute exte
             reload: true,
           });
         }
-      })
+      }),
     );
   }
 

--- a/ui/admin/app/routes/scopes/scope/targets/target/enable-session-recording/create-storage-bucket.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/enable-session-recording/create-storage-bucket.js
@@ -68,7 +68,7 @@ export default class ScopesScopeTargetsTargetEnableSessionRecordingCreateStorage
   async save(storageBucket) {
     await storageBucket.save();
     await this.router.transitionTo(
-      'scopes.scope.targets.target.enable-session-recording'
+      'scopes.scope.targets.target.enable-session-recording',
     );
     this.refresh();
   }
@@ -81,7 +81,7 @@ export default class ScopesScopeTargetsTargetEnableSessionRecordingCreateStorage
   cancel(storageBucket) {
     storageBucket.rollbackAttributes();
     this.router.transitionTo(
-      'scopes.scope.targets.target.enable-session-recording'
+      'scopes.scope.targets.target.enable-session-recording',
     );
   }
 }

--- a/ui/admin/app/routes/scopes/scope/targets/target/host-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/host-sources.js
@@ -26,7 +26,7 @@ export default class ScopesScopeTargetsTargetHostSourcesRoute extends Route {
    */
   beforeModel() {
     const { scopeID, host_sources } = this.modelFor(
-      'scopes.scope.targets.target'
+      'scopes.scope.targets.target',
     );
     const promises = host_sources.map(
       ({ host_source_id, host_catalog_id: hostCatalogID }) =>
@@ -40,7 +40,7 @@ export default class ScopesScopeTargetsTargetHostSourcesRoute extends Route {
           hostSet: this.store.findRecord('host-set', host_source_id, {
             adapterOptions: { scopeID, hostCatalogID },
           }),
-        })
+        }),
     );
     return all(promises);
   }

--- a/ui/admin/app/routes/scopes/scope/targets/target/index.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/index.js
@@ -24,7 +24,7 @@ export default class ScopesScopeTargetsTargetIndexRoute extends Route {
       const { storage_bucket_id } = target;
       const storageBucket = await this.store.findRecord(
         'storage-bucket',
-        storage_bucket_id
+        storage_bucket_id,
       );
       const storage_bucket_name = storageBucket.displayName;
       controller.set('storage_bucket_name', storage_bucket_name);

--- a/ui/admin/app/routes/scopes/scope/targets/target/injected-application-credential-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/injected-application-credential-sources.js
@@ -37,7 +37,7 @@ export default class ScopesScopeTargetsTargetInjectedApplicationCredentialSource
             reload: true,
           });
         }
-      })
+      }),
     );
   }
 

--- a/ui/admin/app/routes/scopes/scope/users.js
+++ b/ui/admin/app/routes/scopes/scope/users.js
@@ -60,7 +60,7 @@ export default class ScopesScopeUsersRoute extends Route {
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(user) {
     await user.save();

--- a/ui/admin/app/routes/scopes/scope/users/user/accounts.js
+++ b/ui/admin/app/routes/scopes/scope/users/user/accounts.js
@@ -29,8 +29,8 @@ export default class ScopesScopeUsersUserAccountsRoute extends Route {
       user,
       accounts: all(
         user.account_ids.map((id) =>
-          this.store.findRecord('account', id, { adapterOptions: { scopeID } })
-        )
+          this.store.findRecord('account', id, { adapterOptions: { scopeID } }),
+        ),
       ),
     });
   }

--- a/ui/admin/app/routes/scopes/scope/users/user/add-accounts.js
+++ b/ui/admin/app/routes/scopes/scope/users/user/add-accounts.js
@@ -36,8 +36,8 @@ export default class ScopesScopeUsersUserAddAccountsRoute extends Route {
     const authMethods = await this.store.query('auth-method', { scope_id });
     await all(
       authMethods.map(({ id: auth_method_id }) =>
-        this.store.query('account', { auth_method_id })
-      )
+        this.store.query('account', { auth_method_id }),
+      ),
     );
     const accounts = this.store.peekAll('account');
     return { user, authMethods, accounts };

--- a/ui/admin/app/routes/scopes/scope/workers.js
+++ b/ui/admin/app/routes/scopes/scope/workers.js
@@ -63,7 +63,7 @@ export default class ScopesScopeWorkersRoute extends Route {
   @loading
   @notifyError(({ message }) => message)
   @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success'
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
   )
   async save(worker) {
     await worker.save();

--- a/ui/admin/app/routes/scopes/scope/workers/index.js
+++ b/ui/admin/app/routes/scopes/scope/workers/index.js
@@ -25,7 +25,7 @@ export default class ScopesScopeWorkersIndexRoute extends Route {
       // Filter out duplicate tags
       return configTags.reduce((uniqueConfigTags, currentTag) => {
         const isDuplicateTag = uniqueConfigTags.some(
-          (tag) => tag.key === currentTag.key && tag.value === currentTag.value
+          (tag) => tag.key === currentTag.key && tag.value === currentTag.value,
         );
 
         if (!isDuplicateTag) {
@@ -45,7 +45,7 @@ export default class ScopesScopeWorkersIndexRoute extends Route {
   model() {
     const workers = sortBy(
       this.modelFor('scopes.scope.workers'),
-      'displayName'
+      'displayName',
     );
 
     if (this.tags?.length) {
@@ -60,8 +60,8 @@ export default class ScopesScopeWorkersIndexRoute extends Route {
         return this.tags.some((tag) =>
           workerTags.some(
             (workerTag) =>
-              tag.key === workerTag.key && tag.value === workerTag.value
-          )
+              tag.key === workerTag.key && tag.value === workerTag.value,
+          ),
         );
       });
     }

--- a/ui/admin/app/routes/scopes/scope/workers/worker.js
+++ b/ui/admin/app/routes/scopes/scope/workers/worker.js
@@ -35,7 +35,7 @@ export default class ScopesScopeWorkersWorkerRoute extends Route {
       this.router.replaceWith(
         'scopes.scope.workers.worker',
         worker.scopeID,
-        worker.id
+        worker.id,
       );
     }
   }

--- a/ui/admin/app/services/breadcrumbs.js
+++ b/ui/admin/app/services/breadcrumbs.js
@@ -23,7 +23,7 @@ export default class BreadcrumbsService extends Service {
   registerContainer(container) {
     assert(
       'A breadcrumb container with the same DOM element has already been registered before.',
-      !this.#isContainerRegistered(container)
+      !this.#isContainerRegistered(container),
     );
     this.#containers = [...this.#containers, container];
     this.containers = this.#containers;
@@ -32,7 +32,7 @@ export default class BreadcrumbsService extends Service {
   unregisterContainer(container) {
     assert(
       'No breadcrumb container was found with this DOM element.',
-      this.#isContainerRegistered(container)
+      this.#isContainerRegistered(container),
     );
 
     this.#containers = this.#containers.filter((registeredContainer) => {

--- a/ui/admin/tests/acceptance/accounts/change-password-test.js
+++ b/ui/admin/tests/acceptance/accounts/change-password-test.js
@@ -66,7 +66,7 @@ module('Acceptance | accounts | change password', function (hooks) {
     await click('.rose-header-utilities .rose-dropdown summary');
     // Find first element in dropdown - should be change password link
     await click(
-      '.rose-header-utilities .rose-dropdown .rose-dropdown-content a'
+      '.rose-header-utilities .rose-dropdown .rose-dropdown-content a',
     );
     assert.strictEqual(currentURL(), urls.changePassword);
   });
@@ -80,16 +80,16 @@ module('Acceptance | accounts | change password', function (hooks) {
         assert.strictEqual(
           attrs.current_password,
           'current password',
-          'current password is provided'
+          'current password is provided',
         );
         assert.strictEqual(
           attrs.new_password,
           'new password',
-          'new password is provided'
+          'new password is provided',
         );
         const id = idMethod.split(':')[0];
         return { id };
-      }
+      },
     );
     await visit(urls.changePassword);
     await fillIn('[name="currentPassword"]', 'current password');
@@ -117,7 +117,7 @@ module('Acceptance | accounts | change password', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.changePassword);

--- a/ui/admin/tests/acceptance/accounts/create-test.js
+++ b/ui/admin/tests/acceptance/accounts/create-test.js
@@ -97,7 +97,7 @@ module('Acceptance | accounts | create', function (hooks) {
     await click('form [type="submit"]:not(:disabled)');
     assert.strictEqual(
       this.server.schema.accounts.all().models.length,
-      accountsCount + 1
+      accountsCount + 1,
     );
   });
 
@@ -107,8 +107,8 @@ module('Acceptance | accounts | create', function (hooks) {
     await visit(urls.authMethod);
     assert.notOk(
       instances.authMethod.authorized_collection_actions.accounts.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.notOk(find(`.rose-layout-page-actions [href="${urls.newAccount}"]`));
   });
@@ -118,8 +118,8 @@ module('Acceptance | accounts | create', function (hooks) {
     await visit(urls.accounts);
     assert.ok(
       instances.authMethod.authorized_collection_actions.accounts.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.ok(find(`[href="${urls.newAccount}"]`));
   });
@@ -130,8 +130,8 @@ module('Acceptance | accounts | create', function (hooks) {
     await visit(urls.accounts);
     assert.notOk(
       instances.authMethod.authorized_collection_actions.accounts.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.notOk(find(`[href="${urls.newAccount}"]`));
   });
@@ -174,7 +174,7 @@ module('Acceptance | accounts | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.newAccount);
@@ -184,12 +184,12 @@ module('Acceptance | accounts | create', function (hooks) {
     assert.strictEqual(
       find('.rose-notification-body').textContent.trim(),
       'The request was invalid.',
-      'Displays primary error message.'
+      'Displays primary error message.',
     );
     assert.strictEqual(
       find('.rose-form-error-message').textContent.trim(),
       'Name is required.',
-      'Displays field-level errors.'
+      'Displays field-level errors.',
     );
   });
 
@@ -197,15 +197,15 @@ module('Acceptance | accounts | create', function (hooks) {
     assert.expect(2);
     instances.authMethod.authorized_collection_actions.accounts =
       instances.authMethod.authorized_collection_actions.accounts.filter(
-        (item) => item !== 'create'
+        (item) => item !== 'create',
       );
 
     await visit(urls.newAccount);
 
     assert.false(
       instances.authMethod.authorized_collection_actions.accounts.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.strictEqual(currentURL(), urls.accounts);
   });

--- a/ui/admin/tests/acceptance/accounts/delete-test.js
+++ b/ui/admin/tests/acceptance/accounts/delete-test.js
@@ -78,7 +78,7 @@ module('Acceptance | accounts | delete', function (hooks) {
       instances.account.authorized_actions.filter((item) => item !== 'delete');
     await visit(urls.account);
     assert.notOk(
-      find('.rose-layout-page-actions .rose-dropdown-button-danger')
+      find('.rose-layout-page-actions .rose-dropdown-button-danger'),
     );
   });
 
@@ -92,7 +92,7 @@ module('Acceptance | accounts | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.account);
@@ -101,7 +101,7 @@ module('Acceptance | accounts | delete', function (hooks) {
     assert.strictEqual(
       find('.rose-notification-body').textContent.trim(),
       'Oops.',
-      'Displays primary error message.'
+      'Displays primary error message.',
     );
   });
 });

--- a/ui/admin/tests/acceptance/accounts/list-test.js
+++ b/ui/admin/tests/acceptance/accounts/list-test.js
@@ -69,8 +69,8 @@ module('Acceptance | accounts | list', function (hooks) {
     await visit(urls.authMethod);
     assert.ok(
       instances.authMethod.authorized_collection_actions.accounts.includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.ok(find(`[href="${urls.accounts}"]`));
   });
@@ -81,8 +81,8 @@ module('Acceptance | accounts | list', function (hooks) {
     await visit(urls.authMethod);
     assert.notOk(
       instances.authMethod.authorized_collection_actions.accounts.includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.notOk(find(`[href="${urls.accounts}"]`));
   });

--- a/ui/admin/tests/acceptance/accounts/set-password-test.js
+++ b/ui/admin/tests/acceptance/accounts/set-password-test.js
@@ -69,19 +69,19 @@ module('Acceptance | accounts | set password', function (hooks) {
     assert.expect(1);
     await visit(urls.account);
     assert.ok(
-      find(`.rose-layout-page-navigation [href="${urls.setPassword}"]`)
+      find(`.rose-layout-page-navigation [href="${urls.setPassword}"]`),
     );
   });
 
   test('cannot navigate to route without proper authorization', async function (assert) {
     assert.expect(1);
     const authorized_actions = instances.account.authorized_actions.filter(
-      (item) => item !== 'set-password'
+      (item) => item !== 'set-password',
     );
     instances.account.update({ authorized_actions });
     await visit(urls.account);
     assert.notOk(
-      find(`.rose-layout-page-navigation [href="${urls.setPassword}"]`)
+      find(`.rose-layout-page-navigation [href="${urls.setPassword}"]`),
     );
   });
 
@@ -94,11 +94,11 @@ module('Acceptance | accounts | set password', function (hooks) {
         assert.strictEqual(
           attrs.password,
           'update password',
-          'new password is set'
+          'new password is set',
         );
         const id = idMethod.split(':')[0];
         return { id };
-      }
+      },
     );
     await visit(urls.setPassword);
     await fillIn('[name="password"]', 'update password');
@@ -127,7 +127,7 @@ module('Acceptance | accounts | set password', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.setPassword);

--- a/ui/admin/tests/acceptance/accounts/update-test.js
+++ b/ui/admin/tests/acceptance/accounts/update-test.js
@@ -82,11 +82,11 @@ module('Acceptance | accounts | update', function (hooks) {
     await click('form [type="submit"]:not(:disabled)');
     assert.strictEqual(
       this.server.schema.accounts.all().models[0].name,
-      'updated name'
+      'updated name',
     );
     assert.strictEqual(
       this.server.schema.accounts.all().models[0].description,
-      'updated desc'
+      'updated desc',
     );
   });
 
@@ -117,7 +117,7 @@ module('Acceptance | accounts | update', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.account);
@@ -128,7 +128,7 @@ module('Acceptance | accounts | update', function (hooks) {
     assert.strictEqual(
       find('.rose-notification-body').textContent.trim(),
       'Oops.',
-      'Displays primary error message.'
+      'Displays primary error message.',
     );
   });
 
@@ -150,7 +150,7 @@ module('Acceptance | accounts | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.account);
@@ -161,12 +161,12 @@ module('Acceptance | accounts | update', function (hooks) {
     assert.strictEqual(
       find('.rose-notification-body').textContent.trim(),
       'The request was invalid.',
-      'Displays primary error message.'
+      'Displays primary error message.',
     );
     assert.strictEqual(
       find('.rose-form-error-message').textContent.trim(),
       'Name is required.',
-      'Displays field-level errors.'
+      'Displays field-level errors.',
     );
   });
 });

--- a/ui/admin/tests/acceptance/auth-methods/create-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/create-test.js
@@ -72,7 +72,7 @@ module('Acceptance | auth-methods | create', function (hooks) {
         type: 'org',
         scope: { id: 'global', type: 'global' },
       },
-      'withChildren'
+      'withChildren',
     );
 
     instances.scopes.project = this.server.create('scope', {
@@ -199,7 +199,7 @@ module('Acceptance | auth-methods | create', function (hooks) {
     assert.deepEqual(ldapAuthMethod.attributes.certificates, ['certificate']);
     assert.strictEqual(
       ldapAuthMethod.attributes.client_certificate,
-      'client cert'
+      'client cert',
     );
     assert.notOk(ldapAuthMethod.attributes.client_certificate_key);
     assert.true(ldapAuthMethod.attributes.start_tls);
@@ -234,8 +234,8 @@ module('Acceptance | auth-methods | create', function (hooks) {
 
     assert.true(
       instances.orgScope.authorized_collection_actions['auth-methods'].includes(
-        'create'
-      )
+        'create',
+      ),
     );
 
     await click(NEW_DROPDOWN_SELECTOR);
@@ -252,8 +252,8 @@ module('Acceptance | auth-methods | create', function (hooks) {
 
     assert.false(
       instances.orgScope.authorized_collection_actions['auth-methods'].includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.dom(NEW_DROPDOWN_SELECTOR).doesNotExist();
   });
@@ -271,8 +271,8 @@ module('Acceptance | auth-methods | create', function (hooks) {
 
     assert.true(
       instances.orgScope.authorized_collection_actions['auth-methods'].includes(
-        'create'
-      )
+        'create',
+      ),
     );
 
     await click(NEW_DROPDOWN_SELECTOR);
@@ -292,8 +292,8 @@ module('Acceptance | auth-methods | create', function (hooks) {
 
     assert.true(
       instances.orgScope.authorized_collection_actions['auth-methods'].includes(
-        'create'
-      )
+        'create',
+      ),
     );
 
     await click(NEW_DROPDOWN_SELECTOR);
@@ -320,7 +320,7 @@ module('Acceptance | auth-methods | create', function (hooks) {
     assert.expect(2);
     assert.notOk(
       instances.orgScope.primaryAuthMethodId,
-      'Primary auth method is not yet set.'
+      'Primary auth method is not yet set.',
     );
     await visit(urls.authMethod);
     await click(MAKE_PRIMARY_SELECTOR);
@@ -328,7 +328,7 @@ module('Acceptance | auth-methods | create', function (hooks) {
     assert.strictEqual(
       scope.primaryAuthMethodId,
       instances.authMethod.id,
-      'Primary auth method is set.'
+      'Primary auth method is set.',
     );
   });
 
@@ -342,12 +342,12 @@ module('Acceptance | auth-methods | create', function (hooks) {
           status: 400,
           code: 'fail',
           message: 'Sorry!',
-        }
+        },
       );
     });
     assert.notOk(
       instances.orgScope.primaryAuthMethodId,
-      'Primary auth method is not yet set.'
+      'Primary auth method is not yet set.',
     );
     await visit(urls.authMethod);
     await click(MAKE_PRIMARY_SELECTOR);
@@ -361,7 +361,7 @@ module('Acceptance | auth-methods | create', function (hooks) {
     });
     assert.ok(
       instances.orgScope.primaryAuthMethodId,
-      'Primary auth method is set.'
+      'Primary auth method is set.',
     );
     await visit(urls.authMethod);
     await click(MAKE_PRIMARY_SELECTOR);
@@ -379,7 +379,7 @@ module('Acceptance | auth-methods | create', function (hooks) {
           status: 400,
           code: 'fail',
           message: 'Sorry!',
-        }
+        },
       );
     });
     instances.orgScope.update({
@@ -388,7 +388,7 @@ module('Acceptance | auth-methods | create', function (hooks) {
 
     assert.strictEqual(
       instances.orgScope.primaryAuthMethodId,
-      instances.authMethod.id
+      instances.authMethod.id,
     );
 
     await visit(urls.authMethod);
@@ -401,7 +401,7 @@ module('Acceptance | auth-methods | create', function (hooks) {
     assert.expect(4);
     assert.notOk(
       instances.orgScope.primaryAuthMethodId,
-      'Primary auth method is not yet set.'
+      'Primary auth method is not yet set.',
     );
     await visit(urls.authMethods);
 
@@ -414,7 +414,7 @@ module('Acceptance | auth-methods | create', function (hooks) {
     assert.strictEqual(
       scope.primaryAuthMethodId,
       instances.authMethod.id,
-      'Primary auth method is set.'
+      'Primary auth method is set.',
     );
     await click(DROPDOWN_SELECTOR_ICON);
 
@@ -443,7 +443,7 @@ module('Acceptance | auth-methods | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.authMethods);
@@ -467,8 +467,8 @@ module('Acceptance | auth-methods | create', function (hooks) {
 
     assert.false(
       instances.orgScope.authorized_collection_actions['auth-methods'].includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.strictEqual(currentURL(), urls.authMethods);
   });

--- a/ui/admin/tests/acceptance/auth-methods/delete-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/delete-test.js
@@ -104,7 +104,7 @@ module('Acceptance | auth-methods | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.authMethods);
@@ -127,7 +127,7 @@ module('Acceptance | auth-methods | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.authMethods);
@@ -143,7 +143,7 @@ module('Acceptance | auth-methods | delete', function (hooks) {
     assert.expect(1);
     instances.authMethod.authorized_actions =
       instances.authMethod.authorized_actions.filter(
-        (item) => item !== 'delete'
+        (item) => item !== 'delete',
       );
     await visit(urls.authMethods);
 
@@ -157,7 +157,7 @@ module('Acceptance | auth-methods | delete', function (hooks) {
     featuresService.enable('ldap-auth-methods');
     instances.ldapAuthMethod.authorized_actions =
       instances.ldapAuthMethod.authorized_actions.filter(
-        (item) => item !== 'delete'
+        (item) => item !== 'delete',
       );
     await visit(urls.authMethods);
 

--- a/ui/admin/tests/acceptance/auth-methods/list-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/list-test.js
@@ -42,7 +42,7 @@ module('Acceptance | auth-methods | list', function (hooks) {
         type: 'org',
         scope: { id: 'global', type: 'global' },
       },
-      'withChildren'
+      'withChildren',
     );
 
     urls.orgScope = `/scopes/${instances.orgScope.id}`;
@@ -55,8 +55,8 @@ module('Acceptance | auth-methods | list', function (hooks) {
     await visit(urls.orgScope);
     assert.ok(
       instances.orgScope.authorized_collection_actions['auth-methods'].includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.ok(find(`[href="${urls.authMethods}"]`));
   });
@@ -67,8 +67,8 @@ module('Acceptance | auth-methods | list', function (hooks) {
     await visit(urls.orgScope);
     assert.notOk(
       instances.orgScope.authorized_collection_actions['auth-methods'].includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.notOk(find(`[href="${urls.authMethods}"]`));
   });

--- a/ui/admin/tests/acceptance/auth-methods/oidc-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/oidc-test.js
@@ -72,7 +72,7 @@ module('Acceptance | auth-methods | oidc', function (hooks) {
     await click('.rose-layout-page-actions .rose-dropdown-trigger');
     assert.strictEqual(
       find('.rose-dropdown[open] input:checked').value,
-      instances.authMethod.attributes.state
+      instances.authMethod.attributes.state,
     );
   });
 
@@ -121,7 +121,7 @@ module('Acceptance | auth-methods | oidc', function (hooks) {
             status: 400,
             code: 'error',
             message: 'Sorry!',
-          }
+          },
         );
       }
       return request;
@@ -134,12 +134,12 @@ module('Acceptance | auth-methods | oidc', function (hooks) {
     assert.notEqual(
       newState,
       authMethod.attributes.state,
-      'Auth method state is not be updated.'
+      'Auth method state is not be updated.',
     );
     assert.ok(
       find('.rose-notification-body').textContent.trim(),
       'Sorry!',
-      'Displays error message.'
+      'Displays error message.',
     );
   });
 });

--- a/ui/admin/tests/acceptance/auth-methods/read-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/read-test.js
@@ -127,7 +127,7 @@ module('Acceptance | auth-methods | read', function (hooks) {
     assert.expect(1);
     instances.passwordAuthMethodOrg.authorized_actions =
       instances.passwordAuthMethodOrg.authorized_actions.filter(
-        (item) => item !== 'read'
+        (item) => item !== 'read',
       );
     await visit(urls.orgScope);
 
@@ -140,7 +140,7 @@ module('Acceptance | auth-methods | read', function (hooks) {
     assert.expect(1);
     instances.oidcAuthMethodGlobal.authorized_actions =
       instances.oidcAuthMethodGlobal.authorized_actions.filter(
-        (item) => item !== 'read'
+        (item) => item !== 'read',
       );
     await visit(urls.globalScope);
 

--- a/ui/admin/tests/acceptance/auth-methods/update-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/update-test.js
@@ -103,7 +103,7 @@ module('Acceptance | auth-methods | update', function (hooks) {
 
     assert.strictEqual(
       this.server.schema.authMethods.first().name,
-      'update name'
+      'update name',
     );
   });
 
@@ -126,8 +126,8 @@ module('Acceptance | auth-methods | update', function (hooks) {
     // Remove all signing algorithms
     await Promise.all(
       findAll('form fieldset:nth-of-type(1) [title="Remove"]').map((element) =>
-        click(element)
-      )
+        click(element),
+      ),
     );
     await select('form fieldset:nth-of-type(1) select', 'RS384');
     await click('form fieldset:nth-of-type(1) [title="Add"]');
@@ -142,7 +142,7 @@ module('Acceptance | auth-methods | update', function (hooks) {
 
     // Remove all claims scopes
     const claimsScopeList = await Promise.all(
-      findAll(CLAIMS_SCOPES_REMOVE_BTN_SELECTOR)
+      findAll(CLAIMS_SCOPES_REMOVE_BTN_SELECTOR),
     );
 
     for (const element of claimsScopeList) {
@@ -155,8 +155,8 @@ module('Acceptance | auth-methods | update', function (hooks) {
     // Remove all claim maps
     await Promise.all(
       findAll('form fieldset:nth-of-type(4) [title="Remove"]').map((element) =>
-        click(element)
-      )
+        click(element),
+      ),
     );
     await fillIn('[name="from_claim"]', 'from_claim');
     await select('form fieldset:nth-of-type(4) select', 'email');
@@ -226,8 +226,8 @@ module('Acceptance | auth-methods | update', function (hooks) {
     // Remove all attribute maps
     await Promise.all(
       findAll(
-        '[name="account_attribute_maps"] .hds-button--color-critical'
-      ).map((element) => click(element))
+        '[name="account_attribute_maps"] .hds-button--color-critical',
+      ).map((element) => click(element)),
     );
     await fillIn('[name="account_attribute_maps"] input', 'attribute');
     await select('[name="account_attribute_maps"] select', 'email');
@@ -292,7 +292,7 @@ module('Acceptance | auth-methods | update', function (hooks) {
     assert.deepEqual(ldapAuthMethod.attributes.certificates, certificates);
     assert.deepEqual(
       ldapAuthMethod.attributes.account_attribute_maps,
-      account_attribute_maps
+      account_attribute_maps,
     );
   });
 
@@ -300,7 +300,7 @@ module('Acceptance | auth-methods | update', function (hooks) {
     assert.expect(1);
     instances.authMethod.authorized_actions =
       instances.authMethod.authorized_actions.filter(
-        (item) => item !== 'update'
+        (item) => item !== 'update',
       );
     await visit(urls.authMethods);
 
@@ -314,7 +314,7 @@ module('Acceptance | auth-methods | update', function (hooks) {
     featuresService.enable('ldap-auth-methods');
     instances.ldapAuthMethod.authorized_actions =
       instances.ldapAuthMethod.authorized_actions.filter(
-        (item) => item !== 'update'
+        (item) => item !== 'update',
       );
     await visit(urls.authMethods);
 
@@ -341,7 +341,7 @@ module('Acceptance | auth-methods | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.authMethods);
@@ -374,7 +374,7 @@ module('Acceptance | auth-methods | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.authMethods);

--- a/ui/admin/tests/acceptance/authentication-test.js
+++ b/ui/admin/tests/acceptance/authentication-test.js
@@ -74,7 +74,7 @@ module('Acceptance | authentication', function (hooks) {
         type: 'org',
         scope: { id: globalScope.id, type: globalScope.type },
       },
-      'withChildren'
+      'withChildren',
     );
     scope = { id: orgScope.id, type: orgScope.type };
     globalAuthMethod = this.server.create('auth-method', {
@@ -309,7 +309,7 @@ module('Acceptance | authentication', function (hooks) {
     await click('.rose-header-utilities .rose-dropdown summary');
     // Find and click on last element in dropdown - should be deauthenticate button
     const menu = findAll(
-      '.rose-header-utilities .rose-dropdown .rose-dropdown-content button'
+      '.rose-header-utilities .rose-dropdown .rose-dropdown-content button',
     );
     await click(menu[menu.length - 1]);
     assert.notOk(currentSession().isAuthenticated);
@@ -324,13 +324,13 @@ module('Acceptance | authentication', function (hooks) {
     await visit(orgsURL);
     assert.ok(
       currentSession().isAuthenticated,
-      'Session begins authenticated, before encountering 401'
+      'Session begins authenticated, before encountering 401',
     );
     this.server.get('/users', () => new Response(401));
     await visit(usersURL);
     assert.notOk(
       currentSession().isAuthenticated,
-      'Session is unauthenticated, after encountering 401'
+      'Session is unauthenticated, after encountering 401',
     );
   });
 
@@ -358,7 +358,7 @@ module('Acceptance | authentication', function (hooks) {
     await click('[name="theme"][value="system-default-theme"]');
     assert.strictEqual(
       currentSession().get('data.theme'),
-      'system-default-theme'
+      'system-default-theme',
     );
     assert.notOk(getRootElement().classList.contains('rose-theme-light'));
     assert.notOk(getRootElement().classList.contains('rose-theme-dark'));
@@ -380,7 +380,7 @@ module('Acceptance | authentication', function (hooks) {
             },
           };
         }
-      }
+      },
     );
     await visit(authMethodOIDCAuthenticateURL);
     await click('form [type="submit"]');

--- a/ui/admin/tests/acceptance/credential-library/create-test.js
+++ b/ui/admin/tests/acceptance/credential-library/create-test.js
@@ -114,20 +114,20 @@ module('Acceptance | credential-libraries | create', function (hooks) {
     await fillIn('[name="key_id"]', 'key_id');
     await fillIn(
       '[name="critical_options"] tbody td:nth-of-type(1) input',
-      'co_key'
+      'co_key',
     );
     await fillIn(
       '[name="critical_options"] tbody td:nth-of-type(2) input',
-      'co_value'
+      'co_value',
     );
     await click('[name="critical_options"] button');
     await fillIn(
       '[name="extensions"] tbody td:nth-of-type(1) input',
-      'ext_key'
+      'ext_key',
     );
     await fillIn(
       '[name="extensions"] tbody td:nth-of-type(2) input',
-      'ext_value'
+      'ext_value',
     );
     await click('[name="extensions"] button');
     await click('[type="submit"]');
@@ -136,7 +136,7 @@ module('Acceptance | credential-libraries | create', function (hooks) {
       this.server.schema.credentialLibraries.where({
         type: TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE,
       }).length,
-      1
+      1,
     );
     const credentialLibrary = this.server.schema.credentialLibraries.findBy({
       type: TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE,
@@ -179,7 +179,7 @@ module('Acceptance | credential-libraries | create', function (hooks) {
     assert.notOk(
       instances.credentialStore.authorized_collection_actions[
         'credential-libraries'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.notOk(find(`[href="${urls.newCredentialLibrary}"]`));
   });
@@ -212,18 +212,18 @@ module('Acceptance | credential-libraries | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.newCredentialLibrary);
     await click('[type="submit"]');
     assert.ok(
       find('[role="alert"]').textContent.trim(),
-      'The request was invalid.'
+      'The request was invalid.',
     );
     assert.ok(
       find('.hds-form-error__message').textContent.trim(),
-      'Name is required.'
+      'Name is required.',
     );
   });
 
@@ -247,7 +247,7 @@ module('Acceptance | credential-libraries | create', function (hooks) {
     assert.false(
       instances.credentialStore.authorized_collection_actions[
         'credential-libraries'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.strictEqual(currentURL(), urls.credentialLibraries);
   });

--- a/ui/admin/tests/acceptance/credential-library/delete-test.js
+++ b/ui/admin/tests/acceptance/credential-library/delete-test.js
@@ -84,11 +84,11 @@ module('Acceptance | credential-libraries | delete', function (hooks) {
     assert.expect(1);
     instances.credentialLibrary.authorized_actions =
       instances.credentialLibrary.authorized_actions.filter(
-        (item) => item !== 'delete'
+        (item) => item !== 'delete',
       );
     await visit(urls.credentialLibrary);
     assert.notOk(
-      find('.rose-layout-page-actions .rose-dropdown-button-danger')
+      find('.rose-layout-page-actions .rose-dropdown-button-danger'),
     );
   });
 
@@ -126,7 +126,7 @@ module('Acceptance | credential-libraries | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.credentialLibrary);

--- a/ui/admin/tests/acceptance/credential-library/list-test.js
+++ b/ui/admin/tests/acceptance/credential-library/list-test.js
@@ -70,7 +70,7 @@ module('Acceptance | credential-libraries | list', function (hooks) {
     assert.ok(
       instances.credentialStore.authorized_collection_actions[
         'credential-libraries'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.ok(find(`[href="${urls.credentialLibraries}"]`));
   });
@@ -84,7 +84,7 @@ module('Acceptance | credential-libraries | list', function (hooks) {
     assert.notOk(
       instances.credentialStore.authorized_collection_actions[
         'credential-libraries'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.notOk(find(`[href="${urls.credentialLibraries}"]`));
   });

--- a/ui/admin/tests/acceptance/credential-library/read-test.js
+++ b/ui/admin/tests/acceptance/credential-library/read-test.js
@@ -78,7 +78,7 @@ module('Acceptance | credential-libraries | read', function (hooks) {
     assert.expect(1);
     instances.credentialLibrary.authorized_actions =
       instances.credentialLibrary.authorized_actions.filter(
-        (item) => item !== 'read'
+        (item) => item !== 'read',
       );
     await visit(urls.credentialLibraries);
     assert.notOk(find('main tbody .rose-table-header-cell a'));
@@ -92,7 +92,7 @@ module('Acceptance | credential-libraries | read', function (hooks) {
       type: TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE,
     });
     await visit(
-      `${urls.credentialLibraries}/${instances.credentialLibrary.id}`
+      `${urls.credentialLibraries}/${instances.credentialLibrary.id}`,
     );
     await visit(urls.credentialLibraries);
     const featuresService = this.owner.lookup('service:features');

--- a/ui/admin/tests/acceptance/credential-library/update-test.js
+++ b/ui/admin/tests/acceptance/credential-library/update-test.js
@@ -83,7 +83,7 @@ module('Acceptance | credential-libraries | update', function (hooks) {
     assert.strictEqual(currentURL(), urls.credentialLibrary);
     assert.strictEqual(
       this.server.schema.credentialLibraries.all().models[0].name,
-      'random string'
+      'random string',
     );
   });
 
@@ -91,7 +91,7 @@ module('Acceptance | credential-libraries | update', function (hooks) {
     assert.expect(1);
     instances.credentialLibrary.authorized_actions =
       instances.credentialLibrary.authorized_actions.filter(
-        (item) => item !== 'update'
+        (item) => item !== 'update',
       );
     await visit(urls.credentialLibrary);
     assert.notOk(find('form [type="button"]'));
@@ -105,11 +105,11 @@ module('Acceptance | credential-libraries | update', function (hooks) {
     await click('.rose-form-actions [type="button"]');
     assert.notEqual(
       this.server.schema.credentialLibraries.all().models[0].name,
-      'random string'
+      'random string',
     );
     assert.strictEqual(
       find('[name="name"]').value,
-      instances.credentialLibrary.name
+      instances.credentialLibrary.name,
     );
   });
 
@@ -131,7 +131,7 @@ module('Acceptance | credential-libraries | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.credentialLibrary);
@@ -140,11 +140,11 @@ module('Acceptance | credential-libraries | update', function (hooks) {
     await click('[type="submit"]');
     assert.ok(
       find('[role="alert"]').textContent.trim(),
-      'The request was invalid.'
+      'The request was invalid.',
     );
     assert.ok(
       find('.hds-form-error__message').textContent.trim(),
-      'Name is required.'
+      'Name is required.',
     );
   });
 
@@ -167,7 +167,7 @@ module('Acceptance | credential-libraries | update', function (hooks) {
       assert.strictEqual(currentURL(), urls.credentialLibraries);
       assert.notEqual(
         this.server.schema.credentialLibraries.all().models[0].name,
-        'random string'
+        'random string',
       );
     }
   });
@@ -190,7 +190,7 @@ module('Acceptance | credential-libraries | update', function (hooks) {
       assert.strictEqual(currentURL(), urls.credentialLibrary);
       assert.notEqual(
         this.server.schema.credentialLibraries.all().models[0].name,
-        'random string'
+        'random string',
       );
     }
   });
@@ -203,7 +203,7 @@ module('Acceptance | credential-libraries | update', function (hooks) {
       type: TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE,
     });
     await visit(
-      `${urls.credentialLibraries}/${instances.credentialLibrary.id}`
+      `${urls.credentialLibraries}/${instances.credentialLibrary.id}`,
     );
     await click('form [type="button"]:not(:disabled)', 'Activate edit mode');
     await fillIn('[name="name"]', 'name');
@@ -216,20 +216,20 @@ module('Acceptance | credential-libraries | update', function (hooks) {
     await fillIn('[name="key_id"]', 'key_id');
     await fillIn(
       '[name="critical_options"] tbody td:nth-of-type(1) input',
-      'co_key'
+      'co_key',
     );
     await fillIn(
       '[name="critical_options"] tbody td:nth-of-type(2) input',
-      'co_value'
+      'co_value',
     );
     await click('[name="critical_options"] button');
     await fillIn(
       '[name="extensions"] tbody td:nth-of-type(1) input',
-      'ext_key'
+      'ext_key',
     );
     await fillIn(
       '[name="extensions"] tbody td:nth-of-type(2) input',
-      'ext_value'
+      'ext_value',
     );
     await click('[name="extensions"] button');
     await click('[type="submit"]');

--- a/ui/admin/tests/acceptance/credential-store/create-test.js
+++ b/ui/admin/tests/acceptance/credential-store/create-test.js
@@ -106,7 +106,7 @@ module('Acceptance | credential-stores | create', function (hooks) {
     assert.notOk(
       instances.scopes.project.authorized_collection_actions[
         'credential-stores'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.notOk(find(`[href="${urls.newCredentialStore}"]`));
   });
@@ -129,18 +129,18 @@ module('Acceptance | credential-stores | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.newCredentialStore);
     await click('[type="submit"]');
     assert.ok(
       find('[role="alert"]').textContent.trim(),
-      'The request was invalid.'
+      'The request was invalid.',
     );
     assert.ok(
       find('.rose-form-error-message').textContent.trim(),
-      'Name is required.'
+      'Name is required.',
     );
   });
 
@@ -149,8 +149,8 @@ module('Acceptance | credential-stores | create', function (hooks) {
     await visit(urls.newCredentialStore);
     assert.ok(
       find(
-        `[href="https://boundaryproject.io/help/admin-ui/credential-stores"]`
-      )
+        `[href="https://boundaryproject.io/help/admin-ui/credential-stores"]`,
+      ),
     );
   });
 
@@ -167,7 +167,7 @@ module('Acceptance | credential-stores | create', function (hooks) {
     assert.false(
       instances.scopes.project.authorized_collection_actions[
         'credential-stores'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.strictEqual(currentURL(), urls.credentialStores);
   });

--- a/ui/admin/tests/acceptance/credential-store/credentials/create-test.js
+++ b/ui/admin/tests/acceptance/credential-store/credentials/create-test.js
@@ -92,7 +92,7 @@ module(
       assert.strictEqual(getCredentialsCount(), credentialsCount + 1);
       assert.strictEqual(
         getUsernamePasswordCredentialCount(),
-        usernamePasswordCredentialCount + 1
+        usernamePasswordCredentialCount + 1,
       );
     });
 
@@ -111,7 +111,7 @@ module(
       assert.strictEqual(getCredentialsCount(), credentialsCount + 1);
       assert.strictEqual(
         getUsernameKeyPairCredentialCount(),
-        usernameKeyPairCredentialCount + 1
+        usernameKeyPairCredentialCount + 1,
       );
     });
 
@@ -199,7 +199,7 @@ module(
         instances.staticCredentialStore.authorized_collection_actions.credentials.filter(
           (item) => {
             item !== 'create';
-          }
+          },
         );
       await visit(urls.credentialStores);
 
@@ -207,8 +207,8 @@ module(
 
       assert.false(
         instances.staticCredentialStore.authorized_collection_actions.credentials.includes(
-          'create'
-        )
+          'create',
+        ),
       );
       assert.dom('.rose-layout-page-actions a').doesNotExist();
     });
@@ -233,7 +233,7 @@ module(
                 },
               ],
             },
-          }
+          },
         );
       });
 
@@ -268,7 +268,7 @@ module(
                 },
               ],
             },
-          }
+          },
         );
       });
 
@@ -304,7 +304,7 @@ module(
                 },
               ],
             },
-          }
+          },
         );
       });
 
@@ -325,8 +325,8 @@ module(
       assert.false(featuresService.isEnabled('json-credentials'));
       assert.true(
         instances.staticCredentialStore.authorized_collection_actions.credentials.includes(
-          'create'
-        )
+          'create',
+        ),
       );
       assert.dom('.hds-form-radio-card').exists({ count: 2 });
       assert
@@ -341,17 +341,17 @@ module(
       assert.expect(2);
       instances.staticCredentialStore.authorized_collection_actions.credentials =
         instances.staticCredentialStore.authorized_collection_actions.credentials.filter(
-          (item) => item !== 'create'
+          (item) => item !== 'create',
         );
 
       await visit(urls.newCredential);
 
       assert.false(
         instances.staticCredentialStore.authorized_collection_actions.credentials.includes(
-          'create'
-        )
+          'create',
+        ),
       );
       assert.strictEqual(currentURL(), urls.credentials);
     });
-  }
+  },
 );

--- a/ui/admin/tests/acceptance/credential-store/credentials/delete-test.js
+++ b/ui/admin/tests/acceptance/credential-store/credentials/delete-test.js
@@ -99,7 +99,7 @@ module(
       assert.strictEqual(currentURL(), urls.credentials);
       assert.strictEqual(
         getUsernamePasswordCredentialCount(),
-        usernamePasswordCredentialCount - 1
+        usernamePasswordCredentialCount - 1,
       );
     });
 
@@ -112,7 +112,7 @@ module(
       assert.strictEqual(currentURL(), urls.credentials);
       assert.strictEqual(
         getUsernameKeyPairCredentialCount(),
-        usernameKeyPairCredentialCount - 1
+        usernameKeyPairCredentialCount - 1,
       );
     });
 
@@ -131,7 +131,7 @@ module(
         getUsernamePasswordCredentialCount();
       instances.usernamePasswordCredential.authorized_actions =
         instances.usernamePasswordCredential.authorized_actions.filter(
-          (item) => item !== 'delete'
+          (item) => item !== 'delete',
         );
       await visit(urls.usernamePasswordCredential);
       assert.strictEqual(currentURL(), urls.usernamePasswordCredential);
@@ -140,7 +140,7 @@ module(
         .doesNotExist();
       assert.strictEqual(
         getUsernamePasswordCredentialCount(),
-        usernamePasswordCredentialCount
+        usernamePasswordCredentialCount,
       );
     });
 
@@ -150,7 +150,7 @@ module(
         getUsernameKeyPairCredentialCount();
       instances.usernameKeyPairCredential.authorized_actions =
         instances.usernameKeyPairCredential.authorized_actions.filter(
-          (item) => item !== 'delete'
+          (item) => item !== 'delete',
         );
       await visit(urls.usernameKeyPairCredential);
       assert.strictEqual(currentURL(), urls.usernameKeyPairCredential);
@@ -159,7 +159,7 @@ module(
         .doesNotExist();
       assert.strictEqual(
         getUsernamePasswordCredentialCount(),
-        usernameKeyPairCredentialCount
+        usernameKeyPairCredentialCount,
       );
     });
 
@@ -168,7 +168,7 @@ module(
       const jsonCredentialCount = getJSONCredentialCount();
       instances.jsonCredential.authorized_actions =
         instances.jsonCredential.authorized_actions.filter(
-          (item) => item !== 'delete'
+          (item) => item !== 'delete',
         );
       await visit(urls.jsonCredential);
       assert.strictEqual(currentURL(), urls.jsonCredential);
@@ -190,7 +190,7 @@ module(
       assert.strictEqual(currentURL(), urls.credentials);
       assert.strictEqual(
         getUsernamePasswordCredentialCount(),
-        usernamePasswordCredentialCount - 1
+        usernamePasswordCredentialCount - 1,
       );
     });
 
@@ -206,7 +206,7 @@ module(
       assert.strictEqual(currentURL(), urls.credentials);
       assert.strictEqual(
         getUsernameKeyPairCredentialCount(),
-        usernameKeyPairCredentialCount - 1
+        usernameKeyPairCredentialCount - 1,
       );
     });
 
@@ -234,7 +234,7 @@ module(
       assert.strictEqual(currentURL(), urls.usernamePasswordCredential);
       assert.strictEqual(
         getUsernamePasswordCredentialCount(),
-        usernamePasswordCredentialCount
+        usernamePasswordCredentialCount,
       );
     });
 
@@ -250,7 +250,7 @@ module(
       assert.strictEqual(currentURL(), urls.usernameKeyPairCredential);
       assert.strictEqual(
         getUsernameKeyPairCredentialCount(),
-        usernameKeyPairCredentialCount
+        usernameKeyPairCredentialCount,
       );
     });
 
@@ -276,7 +276,7 @@ module(
             status: 490,
             code: 'error',
             message: 'Oops.',
-          }
+          },
         );
       });
       await visit(urls.usernamePasswordCredential);
@@ -294,7 +294,7 @@ module(
             status: 490,
             code: 'error',
             message: 'Oops.',
-          }
+          },
         );
       });
       await visit(urls.usernameKeyPairCredential);
@@ -312,12 +312,12 @@ module(
             status: 490,
             code: 'error',
             message: 'Oops.',
-          }
+          },
         );
       });
       await visit(urls.jsonCredential);
       await click('.rose-layout-page-actions .rose-dropdown-button-danger');
       assert.ok(find('[role="alert"]').textContent.trim(), 'Oops.');
     });
-  }
+  },
 );

--- a/ui/admin/tests/acceptance/credential-store/credentials/list-test.js
+++ b/ui/admin/tests/acceptance/credential-store/credentials/list-test.js
@@ -75,8 +75,8 @@ module('Acceptance | credential-stores | credentials | list', function (hooks) {
     await visit(urls.staticCredentialStore);
     assert.ok(
       instances.staticCredentialStore.authorized_collection_actions.credentials.includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.dom(`[href="${urls.credentials}"]`).isVisible();
     await click(`[href="${urls.credentials}"]`);
@@ -93,13 +93,13 @@ module('Acceptance | credential-stores | credentials | list', function (hooks) {
     await visit(urls.staticCredentialStore);
     assert.notOk(
       instances.staticCredentialStore.authorized_collection_actions.credentials.includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.notOk(
       instances.staticCredentialStore.authorized_collection_actions.credentials.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.dom('.rose-nav-tabs a:nth-child(2)').doesNotExist();
   });

--- a/ui/admin/tests/acceptance/credential-store/credentials/read-test.js
+++ b/ui/admin/tests/acceptance/credential-store/credentials/read-test.js
@@ -118,7 +118,7 @@ module('Acceptance | credential-stores | credentials | read', function (hooks) {
     assert.expect(1);
     instances.usernamePasswordCredential.authorized_actions =
       instances.usernamePasswordCredential.authorized_actions.filter(
-        (item) => item != 'read'
+        (item) => item != 'read',
       );
     await visit(urls.credentials);
     assert.dom('.rose-table-body  tr:first-child a').doesNotExist();
@@ -128,7 +128,7 @@ module('Acceptance | credential-stores | credentials | read', function (hooks) {
     assert.expect(1);
     instances.usernameKeyPairCredential.authorized_actions =
       instances.usernameKeyPairCredential.authorized_actions.filter(
-        (item) => item != 'read'
+        (item) => item != 'read',
       );
     await visit(urls.credentials);
     assert.dom('.rose-table-body  tr:nth-child(2) a').doesNotExist();
@@ -138,7 +138,7 @@ module('Acceptance | credential-stores | credentials | read', function (hooks) {
     assert.expect(1);
     instances.jsonCredential.authorized_actions =
       instances.jsonCredential.authorized_actions.filter(
-        (item) => item != 'read'
+        (item) => item != 'read',
       );
     await visit(urls.credentials);
     assert.dom('.rose-table-body  tr:nth-child(3) a').doesNotExist();
@@ -162,7 +162,7 @@ module('Acceptance | credential-stores | credentials | read', function (hooks) {
     assert.expect(1);
     await visit(urls.usernamePasswordCredential);
     assert.ok(
-      find(`[href="https://boundaryproject.io/help/admin-ui/credentials"]`)
+      find(`[href="https://boundaryproject.io/help/admin-ui/credentials"]`),
     );
   });
 

--- a/ui/admin/tests/acceptance/credential-store/credentials/update-test.js
+++ b/ui/admin/tests/acceptance/credential-store/credentials/update-test.js
@@ -98,7 +98,7 @@ module(
       assert.strictEqual(
         this.server.schema.credentials.where({ type: 'username_password' })
           .models[0].name,
-        mockInput
+        mockInput,
       );
     });
 
@@ -114,7 +114,7 @@ module(
       assert.strictEqual(
         this.server.schema.credentials.where({ type: 'ssh_private_key' })
           .models[0].name,
-        mockInput
+        mockInput,
       );
     });
 
@@ -129,7 +129,7 @@ module(
       assert.strictEqual(currentURL(), urls.jsonCredential);
       assert.strictEqual(
         this.server.schema.credentials.where({ type: 'json' }).models[0].name,
-        mockInput
+        mockInput,
       );
     });
 
@@ -137,7 +137,7 @@ module(
       assert.expect(1);
       instances.usernamePasswordCredential.authorized_actions =
         instances.usernamePasswordCredential.authorized_actions.filter(
-          (item) => item !== 'update'
+          (item) => item !== 'update',
         );
       await visit(urls.usernamePasswordCredential);
       assert
@@ -149,7 +149,7 @@ module(
       assert.expect(1);
       instances.usernameKeyPairCredential.authorized_actions =
         instances.usernameKeyPairCredential.authorized_actions.filter(
-          (item) => item !== 'update'
+          (item) => item !== 'update',
         );
       await visit(urls.usernameKeyPairCredential);
       assert
@@ -161,7 +161,7 @@ module(
       assert.expect(1);
       instances.jsonCredential.authorized_actions =
         instances.jsonCredential.authorized_actions.filter(
-          (item) => item !== 'update'
+          (item) => item !== 'update',
         );
       await visit(urls.jsonCredential);
       assert
@@ -179,7 +179,7 @@ module(
       assert.notEqual(instances.usernamePasswordCredential.name, mockInput);
       assert.strictEqual(
         find('[name="name"]').value,
-        instances.usernamePasswordCredential.name
+        instances.usernamePasswordCredential.name,
       );
     });
 
@@ -193,7 +193,7 @@ module(
       assert.notEqual(instances.usernameKeyPairCredential.name, mockInput);
       assert.strictEqual(
         find('[name="name"]').value,
-        instances.usernameKeyPairCredential.name
+        instances.usernameKeyPairCredential.name,
       );
     });
 
@@ -207,7 +207,7 @@ module(
       assert.notEqual(instances.jsonCredential.name, mockInput);
       assert.strictEqual(
         find('[name="name"]').value,
-        instances.jsonCredential.name
+        instances.jsonCredential.name,
       );
     });
 
@@ -230,7 +230,7 @@ module(
                 },
               ],
             },
-          }
+          },
         );
       });
       await visit(urls.usernamePasswordCredential);
@@ -239,11 +239,11 @@ module(
       await click('[type="submit"]');
       assert.ok(
         find('[role="alert"]').textContent.trim(),
-        'Error in provided request.'
+        'Error in provided request.',
       );
       assert.ok(
         find('.rose-form-error-message').textContent.trim(),
-        'Name is required.'
+        'Name is required.',
       );
     });
 
@@ -266,7 +266,7 @@ module(
                 },
               ],
             },
-          }
+          },
         );
       });
       await visit(urls.usernameKeyPairCredential);
@@ -275,11 +275,11 @@ module(
       await click('[type="submit"]');
       assert.ok(
         find('[role="alert"]').textContent.trim(),
-        'Error in provided request.'
+        'Error in provided request.',
       );
       assert.ok(
         find('.rose-form-error-message').textContent.trim(),
-        'Name is required.'
+        'Name is required.',
       );
     });
 
@@ -302,7 +302,7 @@ module(
                 },
               ],
             },
-          }
+          },
         );
       });
       await visit(urls.jsonCredential);
@@ -311,11 +311,11 @@ module(
       await click('[type="submit"]');
       assert.ok(
         find('[role="alert"]').textContent.trim(),
-        'Error in provided request.'
+        'Error in provided request.',
       );
       assert.ok(
         find('.rose-form-error-message').textContent.trim(),
-        'Name is required.'
+        'Name is required.',
       );
     });
 
@@ -335,13 +335,13 @@ module(
         assert.dom('.rose-dialog').isVisible();
         await click(
           '.rose-dialog-footer button:first-of-type',
-          'Click Discard'
+          'Click Discard',
         );
         assert.strictEqual(currentURL(), urls.credentials);
         assert.notEqual(
           this.server.schema.credentials.where({ type: 'username_password' })
             .models[0].name,
-          mockInput
+          mockInput,
         );
       }
     });
@@ -362,13 +362,13 @@ module(
         assert.dom('.rose-dialog').isVisible();
         await click(
           '.rose-dialog-footer button:first-of-type',
-          'Click Discard'
+          'Click Discard',
         );
         assert.strictEqual(currentURL(), urls.credentials);
         assert.notEqual(
           this.server.schema.credentials.where({ type: 'ssh_private_key' })
             .models[0].name,
-          mockInput
+          mockInput,
         );
       }
     });
@@ -389,12 +389,12 @@ module(
         assert.dom('.rose-dialog').isVisible();
         await click(
           '.rose-dialog-footer button:first-of-type',
-          'Click Discard'
+          'Click Discard',
         );
         assert.strictEqual(currentURL(), urls.credentials);
         assert.notEqual(
           this.server.schema.credentials.where({ type: 'json' }).models[0].name,
-          mockInput
+          mockInput,
         );
       }
     });
@@ -420,7 +420,7 @@ module(
         assert.strictEqual(
           this.server.schema.credentials.where({ type: 'username_password' })
             .models[0].name,
-          credentialName
+          credentialName,
         );
       }
     });
@@ -446,7 +446,7 @@ module(
         assert.strictEqual(
           this.server.schema.credentials.where({ type: 'ssh_private_key' })
             .models[0].name,
-          credentialName
+          credentialName,
         );
       }
     });
@@ -471,7 +471,7 @@ module(
         assert.strictEqual(find('[name="name"]').value, mockInput);
         assert.strictEqual(
           this.server.schema.credentials.where({ type: 'json' }).models[0].name,
-          credentialName
+          credentialName,
         );
       }
     });
@@ -513,10 +513,10 @@ module(
       assert.dom('.secret-editor-skeleton-message button').isVisible();
       await click(
         '.secret-editor-skeleton-message button',
-        'Enter editing mode'
+        'Enter editing mode',
       );
       assert.dom('.secret-editor-skeleton-message button').doesNotExist();
       await waitUntil(() => assert.dom('.CodeMirror').isVisible());
     });
-  }
+  },
 );

--- a/ui/admin/tests/acceptance/credential-store/delete-test.js
+++ b/ui/admin/tests/acceptance/credential-store/delete-test.js
@@ -94,11 +94,11 @@ module('Acceptance | credential-stores | delete', function (hooks) {
     assert.expect(1);
     instances.vaultCredentialStore.authorized_actions =
       instances.vaultCredentialStore.authorized_actions.filter(
-        (item) => item !== 'delete'
+        (item) => item !== 'delete',
       );
     await visit(urls.vaultCredentialStore);
     assert.notOk(
-      find('.rose-layout-page-actions .rose-dropdown-button-danger')
+      find('.rose-layout-page-actions .rose-dropdown-button-danger'),
     );
   });
 
@@ -106,11 +106,11 @@ module('Acceptance | credential-stores | delete', function (hooks) {
     assert.expect(1);
     instances.staticCredentialStore.authorized_actions =
       instances.staticCredentialStore.authorized_actions.filter(
-        (item) => item !== 'delete'
+        (item) => item !== 'delete',
       );
     await visit(urls.staticCredentialStore);
     assert.notOk(
-      find('.rose-layout-page-actions .rose-dropdown-button-danger')
+      find('.rose-layout-page-actions .rose-dropdown-button-danger'),
     );
   });
 
@@ -172,7 +172,7 @@ module('Acceptance | credential-stores | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.staticCredentialStore);
@@ -190,7 +190,7 @@ module('Acceptance | credential-stores | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.vaultCredentialStore);

--- a/ui/admin/tests/acceptance/credential-store/list-test.js
+++ b/ui/admin/tests/acceptance/credential-store/list-test.js
@@ -59,7 +59,7 @@ module('Acceptance | credential-stores | list', function (hooks) {
     assert.ok(
       instances.scopes.project.authorized_collection_actions[
         'credential-stores'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.ok(find(`[href="${urls.credentialStores}"]`));
   });
@@ -73,7 +73,7 @@ module('Acceptance | credential-stores | list', function (hooks) {
     assert.notOk(
       instances.scopes.project.authorized_collection_actions[
         'credential-stores'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.notOk(find(`[href="${urls.credentialStores}"]`));
   });
@@ -92,8 +92,8 @@ module('Acceptance | credential-stores | list', function (hooks) {
     await visit(urls.credentialStores);
     assert.ok(
       find(
-        `[href="https://boundaryproject.io/help/admin-ui/credential-stores"]`
-      )
+        `[href="https://boundaryproject.io/help/admin-ui/credential-stores"]`,
+      ),
     );
   });
 });

--- a/ui/admin/tests/acceptance/credential-store/read-test.js
+++ b/ui/admin/tests/acceptance/credential-store/read-test.js
@@ -97,7 +97,7 @@ module('Acceptance | credential-stores | read', function (hooks) {
     await visit(urls.projectScope);
     instances.staticCredentialStore.authorized_actions =
       instances.staticCredentialStore.authorized_actions.filter(
-        (item) => item !== 'read'
+        (item) => item !== 'read',
       );
 
     await click(`[href="${urls.credentialStores}"]`);
@@ -112,7 +112,7 @@ module('Acceptance | credential-stores | read', function (hooks) {
     await visit(urls.projectScope);
     instances.vaultCredentialStore.authorized_actions =
       instances.vaultCredentialStore.authorized_actions.filter(
-        (item) => item !== 'read'
+        (item) => item !== 'read',
       );
 
     await click(`[href="${urls.credentialStores}"]`);
@@ -138,7 +138,7 @@ module('Acceptance | credential-stores | read', function (hooks) {
 
     assert
       .dom(
-        `[href="https://boundaryproject.io/help/admin-ui/credential-stores"]`
+        `[href="https://boundaryproject.io/help/admin-ui/credential-stores"]`,
       )
       .exists();
   });

--- a/ui/admin/tests/acceptance/credential-store/update-test.js
+++ b/ui/admin/tests/acceptance/credential-store/update-test.js
@@ -71,7 +71,7 @@ module('Acceptance | credential-stores | update', function (hooks) {
     assert.strictEqual(
       this.server.schema.credentialStores.where({ type: 'static' }).models[0]
         .name,
-      'random string'
+      'random string',
     );
   });
 
@@ -86,7 +86,7 @@ module('Acceptance | credential-stores | update', function (hooks) {
     assert.strictEqual(
       this.server.schema.credentialStores.where({ type: 'vault' }).models[0]
         .name,
-      'random string'
+      'random string',
     );
   });
 
@@ -94,7 +94,7 @@ module('Acceptance | credential-stores | update', function (hooks) {
     assert.expect(1);
     instances.staticCredentialStore.authorized_actions =
       instances.staticCredentialStore.authorized_actions.filter(
-        (item) => item !== 'update'
+        (item) => item !== 'update',
       );
     await visit(urls.staticCredentialStore);
     assert.notOk(find('.rose-layout-page-actions .rose-button-secondary'));
@@ -104,7 +104,7 @@ module('Acceptance | credential-stores | update', function (hooks) {
     assert.expect(1);
     instances.vaultCredentialStore.authorized_actions =
       instances.vaultCredentialStore.authorized_actions.filter(
-        (item) => item !== 'update'
+        (item) => item !== 'update',
       );
     await visit(urls.vaultCredentialStore);
     assert.notOk(find('.rose-layout-page-actions .rose-button-secondary'));
@@ -119,7 +119,7 @@ module('Acceptance | credential-stores | update', function (hooks) {
     assert.notEqual(instances.staticCredentialStore.name, 'random string');
     assert.strictEqual(
       find('[name="name"]').value,
-      instances.staticCredentialStore.name
+      instances.staticCredentialStore.name,
     );
   });
 
@@ -132,7 +132,7 @@ module('Acceptance | credential-stores | update', function (hooks) {
     assert.notEqual(instances.vaultCredentialStore.name, 'random string');
     assert.strictEqual(
       find('[name="name"]').value,
-      instances.vaultCredentialStore.name
+      instances.vaultCredentialStore.name,
     );
   });
 
@@ -154,7 +154,7 @@ module('Acceptance | credential-stores | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.staticCredentialStore);
@@ -163,11 +163,11 @@ module('Acceptance | credential-stores | update', function (hooks) {
     await click('[type="submit"]');
     assert.ok(
       find('[role="alert"]').textContent.trim(),
-      'The request was invalid.'
+      'The request was invalid.',
     );
     assert.ok(
       find('.rose-form-error-message').textContent.trim(),
-      'Name is required.'
+      'Name is required.',
     );
   });
 
@@ -189,7 +189,7 @@ module('Acceptance | credential-stores | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.vaultCredentialStore);
@@ -198,11 +198,11 @@ module('Acceptance | credential-stores | update', function (hooks) {
     await click('[type="submit"]');
     assert.ok(
       find('[role="alert"]').textContent.trim(),
-      'The request was invalid.'
+      'The request was invalid.',
     );
     assert.ok(
       find('.rose-form-error-message').textContent.trim(),
-      'Name is required.'
+      'Name is required.',
     );
   });
 
@@ -226,7 +226,7 @@ module('Acceptance | credential-stores | update', function (hooks) {
       assert.notEqual(
         this.server.schema.credentialStores.where({ type: 'static' }).models[0]
           .name,
-        'random string'
+        'random string',
       );
     }
   });
@@ -251,7 +251,7 @@ module('Acceptance | credential-stores | update', function (hooks) {
       assert.notEqual(
         this.server.schema.credentialStores.where({ type: 'vault' }).models[0]
           .name,
-        'random string'
+        'random string',
       );
     }
   });
@@ -275,7 +275,7 @@ module('Acceptance | credential-stores | update', function (hooks) {
       assert.notEqual(
         this.server.schema.credentialStores.where({ type: 'static' }).models[0]
           .name,
-        'random string'
+        'random string',
       );
     }
   });
@@ -299,7 +299,7 @@ module('Acceptance | credential-stores | update', function (hooks) {
       assert.notEqual(
         this.server.schema.credentialStores.where({ type: 'vault' }).models[0]
           .name,
-        'random string'
+        'random string',
       );
     }
   });

--- a/ui/admin/tests/acceptance/groups/create-test.js
+++ b/ui/admin/tests/acceptance/groups/create-test.js
@@ -39,7 +39,7 @@ module('Acceptance | groups | create', function (hooks) {
         type: 'org',
         scope: { id: 'global', type: 'global' },
       },
-      'withChildren'
+      'withChildren',
     );
     instances.group = this.server.create('group', {
       scope: instances.scopes.org,
@@ -63,8 +63,8 @@ module('Acceptance | groups | create', function (hooks) {
     await visit(urls.groups);
     assert.ok(
       instances.scopes.org.authorized_collection_actions.groups.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.ok(find(`[href="${urls.newGroup}"]`));
   });
@@ -75,8 +75,8 @@ module('Acceptance | groups | create', function (hooks) {
     await visit(urls.groups);
     assert.false(
       instances.scopes.org.authorized_collection_actions.groups.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.notOk(find(`[href="${urls.newGroup}"]`));
   });
@@ -108,7 +108,7 @@ module('Acceptance | groups | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.newGroup);
@@ -117,12 +117,12 @@ module('Acceptance | groups | create', function (hooks) {
     assert.strictEqual(
       find('.rose-notification-body').textContent.trim(),
       'The request was invalid.',
-      'Displays primary error message.'
+      'Displays primary error message.',
     );
     assert.strictEqual(
       find('.rose-form-error-message').textContent.trim(),
       'Name is required.',
-      'Displays field-level errors.'
+      'Displays field-level errors.',
     );
   });
 
@@ -130,15 +130,15 @@ module('Acceptance | groups | create', function (hooks) {
     assert.expect(2);
     instances.scopes.org.authorized_collection_actions.groups =
       instances.scopes.org.authorized_collection_actions.groups.filter(
-        (item) => item !== 'create'
+        (item) => item !== 'create',
       );
 
     await visit(urls.newGroup);
 
     assert.false(
       instances.scopes.org.authorized_collection_actions.groups.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.strictEqual(currentURL(), urls.groups);
   });

--- a/ui/admin/tests/acceptance/groups/delete-test.js
+++ b/ui/admin/tests/acceptance/groups/delete-test.js
@@ -62,7 +62,7 @@ module('Acceptance | groups | delete', function (hooks) {
       instances.group.authorized_actions.filter((item) => item !== 'delete');
     await visit(urls.group);
     assert.notOk(
-      find('.rose-layout-page-actions .rose-dropdown-button-danger')
+      find('.rose-layout-page-actions .rose-dropdown-button-danger'),
     );
   });
 
@@ -76,7 +76,7 @@ module('Acceptance | groups | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.group);
@@ -84,7 +84,7 @@ module('Acceptance | groups | delete', function (hooks) {
     assert.strictEqual(
       find('.rose-notification-body').textContent.trim(),
       'Oops.',
-      'Displays primary error message.'
+      'Displays primary error message.',
     );
   });
 });

--- a/ui/admin/tests/acceptance/groups/list-test.js
+++ b/ui/admin/tests/acceptance/groups/list-test.js
@@ -42,7 +42,7 @@ module('Acceptance | groups | list', function (hooks) {
         type: 'org',
         scope: { id: 'global', type: 'global' },
       },
-      'withChildren'
+      'withChildren',
     );
     instances.group = this.server.create('group', {
       scope: instances.orgScope,
@@ -57,7 +57,7 @@ module('Acceptance | groups | list', function (hooks) {
     assert.expect(2);
     await visit(orgURL);
     assert.ok(
-      instances.orgScope.authorized_collection_actions.groups.includes('list')
+      instances.orgScope.authorized_collection_actions.groups.includes('list'),
     );
     assert.ok(find(`[href="${urls.groups}"]`));
   });
@@ -67,7 +67,7 @@ module('Acceptance | groups | list', function (hooks) {
     instances.orgScope.authorized_collection_actions.groups = [];
     await visit(orgURL);
     assert.notOk(
-      instances.orgScope.authorized_collection_actions.groups.includes('list')
+      instances.orgScope.authorized_collection_actions.groups.includes('list'),
     );
     assert.notOk(find(`[href="${urls.groups}"]`));
   });

--- a/ui/admin/tests/acceptance/groups/members-test.js
+++ b/ui/admin/tests/acceptance/groups/members-test.js
@@ -48,7 +48,7 @@ module('Acceptance | groups | members', function (hooks) {
       {
         scope: instances.scopes.org,
       },
-      'withMembers'
+      'withMembers',
     );
     membersCount = instances.group.memberIds.length;
     urls.groups = `/scopes/${instances.scopes.org.id}/groups`;
@@ -77,7 +77,7 @@ module('Acceptance | groups | members', function (hooks) {
   test('cannot remove a member without proper authorization', async function (assert) {
     assert.expect(1);
     const authorized_actions = instances.group.authorized_actions.filter(
-      (item) => item !== 'remove-members'
+      (item) => item !== 'remove-members',
     );
     instances.group.update({ authorized_actions });
     await visit(urls.members);
@@ -95,7 +95,7 @@ module('Acceptance | groups | members', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     await visit(urls.members);
@@ -121,7 +121,7 @@ module('Acceptance | groups | members', function (hooks) {
   test('cannot navigate to add members without proper authorization', async function (assert) {
     assert.expect(1);
     const authorized_actions = instances.group.authorized_actions.filter(
-      (item) => item !== 'add-members'
+      (item) => item !== 'add-members',
     );
     instances.group.update({ authorized_actions });
     await visit(urls.group);
@@ -170,7 +170,7 @@ module('Acceptance | groups | members', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     instances.group.update({ memberIds: [] });

--- a/ui/admin/tests/acceptance/groups/update-test.js
+++ b/ui/admin/tests/acceptance/groups/update-test.js
@@ -93,7 +93,7 @@ module('Acceptance | groups | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.group);
@@ -103,12 +103,12 @@ module('Acceptance | groups | update', function (hooks) {
     assert.strictEqual(
       find('.rose-notification-body').textContent.trim(),
       'The request was invalid.',
-      'Displays primary error message.'
+      'Displays primary error message.',
     );
     assert.strictEqual(
       find('.rose-form-error-message').textContent.trim(),
       'Name is required.',
-      'Displays field-level errors.'
+      'Displays field-level errors.',
     );
   });
 });

--- a/ui/admin/tests/acceptance/host-catalogs/create-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/create-test.js
@@ -50,7 +50,7 @@ module('Acceptance | host-catalogs | create', function (hooks) {
         type: 'org',
         scope: { id: 'global', type: 'global' },
       },
-      'withChildren'
+      'withChildren',
     );
     instances.scopes.org = this.server.create('scope', {
       type: 'org',
@@ -151,7 +151,7 @@ module('Acceptance | host-catalogs | create', function (hooks) {
     assert.ok(
       instances.scopes.project.authorized_collection_actions[
         'host-catalogs'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.ok(find(`[href="${urls.newHostCatalog}"]`));
   });
@@ -164,7 +164,7 @@ module('Acceptance | host-catalogs | create', function (hooks) {
     assert.notOk(
       instances.scopes.project.authorized_collection_actions[
         'host-catalogs'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.notOk(find(`[href="${urls.newStaticHostCatalog}"]`));
   });
@@ -187,18 +187,18 @@ module('Acceptance | host-catalogs | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.newStaticHostCatalog);
     await click('[type="submit"]');
     assert.ok(
       find('[role="alert"]').textContent.trim(),
-      'The request was invalid.'
+      'The request was invalid.',
     );
     assert.ok(
       find('.rose-form-error-message').textContent.trim(),
-      'Name is required.'
+      'Name is required.',
     );
   });
 
@@ -214,7 +214,7 @@ module('Acceptance | host-catalogs | create', function (hooks) {
     assert.false(
       instances.scopes.project.authorized_collection_actions[
         'host-catalogs'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.strictEqual(currentURL(), urls.hostCatalogs);
   });

--- a/ui/admin/tests/acceptance/host-catalogs/delete-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/delete-test.js
@@ -79,7 +79,7 @@ module('Acceptance | host-catalogs | delete', function (hooks) {
     await visit(urls.hostCatalogs);
     instances.hostCatalog.authorized_actions =
       instances.hostCatalog.authorized_actions.filter(
-        (item) => item !== 'delete'
+        (item) => item !== 'delete',
       );
 
     await click(`[href="${urls.hostCatalog}"]`);
@@ -131,7 +131,7 @@ module('Acceptance | host-catalogs | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
 

--- a/ui/admin/tests/acceptance/host-catalogs/host-sets/create-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/host-sets/create-test.js
@@ -109,7 +109,7 @@ module('Acceptance | host-catalogs | host sets | create', function (hooks) {
 
     const count = getHostSetCount();
     await visit(
-      `${urls.hostCatalogs}/${instances.hostCatalog.id}/host-sets/new`
+      `${urls.hostCatalogs}/${instances.hostCatalog.id}/host-sets/new`,
     );
     const name = 'aws host set';
     await fillIn(NAME_SELECTOR, name);
@@ -141,7 +141,7 @@ module('Acceptance | host-catalogs | host sets | create', function (hooks) {
 
     const count = getHostSetCount();
     await visit(
-      `${urls.hostCatalogs}/${instances.hostCatalog.id}/host-sets/new`
+      `${urls.hostCatalogs}/${instances.hostCatalog.id}/host-sets/new`,
     );
     const name = 'azure host set';
     await fillIn(NAME_SELECTOR, name);
@@ -164,8 +164,8 @@ module('Acceptance | host-catalogs | host sets | create', function (hooks) {
     await visit(urls.hostCatalog);
     assert.notOk(
       instances.hostCatalog.authorized_collection_actions['host-sets'].includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.notOk(find(`.rose-layout-page-actions [href="${urls.newHostSet}"]`));
   });
@@ -176,8 +176,8 @@ module('Acceptance | host-catalogs | host sets | create', function (hooks) {
     await visit(urls.hostSets);
     assert.notOk(
       instances.hostCatalog.authorized_collection_actions['host-sets'].includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.notOk(find(`[href="${urls.newHostSet}"]`));
   });
@@ -210,18 +210,18 @@ module('Acceptance | host-catalogs | host sets | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.newHostSet);
     await click(SUBMIT_BTN_SELECTOR);
     assert.ok(
       find('[role="alert"]').textContent.trim(),
-      'The request was invalid.'
+      'The request was invalid.',
     );
     assert.ok(
       find('.rose-form-error-message').textContent.trim(),
-      'Name is required.'
+      'Name is required.',
     );
   });
 
@@ -229,15 +229,15 @@ module('Acceptance | host-catalogs | host sets | create', function (hooks) {
     assert.expect(2);
     instances.hostCatalog.authorized_collection_actions['host-sets'] =
       instances.hostCatalog.authorized_collection_actions['host-sets'].filter(
-        (item) => item !== 'create'
+        (item) => item !== 'create',
       );
 
     await visit(urls.newHostSet);
 
     assert.false(
       instances.hostCatalog.authorized_collection_actions['host-sets'].includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.strictEqual(currentURL(), urls.hostSets);
   });

--- a/ui/admin/tests/acceptance/host-catalogs/host-sets/delete-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/host-sets/delete-test.js
@@ -103,7 +103,7 @@ module('Acceptance | host-catalogs | host sets | delete', function (hooks) {
       instances.hostSet.authorized_actions.filter((item) => item !== 'delete');
     await visit(urls.hostSet);
     assert.notOk(
-      find('.rose-layout-page-actions .rose-dropdown-button-danger')
+      find('.rose-layout-page-actions .rose-dropdown-button-danger'),
     );
   });
 
@@ -129,7 +129,7 @@ module('Acceptance | host-catalogs | host sets | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.hostSet);

--- a/ui/admin/tests/acceptance/host-catalogs/host-sets/hosts-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/host-sets/hosts-test.js
@@ -67,7 +67,7 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
       {
         scope: instances.scopes.project,
       },
-      'withChildren'
+      'withChildren',
     );
     instances.hostSet = this.server.schema.hostSets.all().models[0];
     // Generate route URLs for resources
@@ -107,7 +107,7 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
   test('cannot remove a host without proper authorization', async function (assert) {
     assert.expect(1);
     const authorized_actions = instances.hostSet.authorized_actions.filter(
-      (item) => item !== 'remove-hosts'
+      (item) => item !== 'remove-hosts',
     );
     instances.hostSet.update({ authorized_actions });
     await visit(urls.hostSetHosts);
@@ -125,7 +125,7 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     await visit(urls.hostSetHosts);
@@ -150,7 +150,7 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
   test('cannot navigate to add hosts without proper authorization', async function (assert) {
     assert.expect(1);
     const authorized_actions = instances.hostSet.authorized_actions.filter(
-      (item) => item !== 'add-hosts'
+      (item) => item !== 'add-hosts',
     );
     instances.hostSet.update({ authorized_actions });
     await visit(urls.hostSet);
@@ -199,7 +199,7 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     instances.hostSet.update({ hostIds: [] });
@@ -248,7 +248,7 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     instances.hostSet.update({ hostIds: [] });
@@ -269,7 +269,7 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     instances.hostSet.update({ hostIds: [] });

--- a/ui/admin/tests/acceptance/host-catalogs/host-sets/list-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/host-sets/list-test.js
@@ -73,8 +73,8 @@ module('Acceptance | host-catalogs | host sets | list', function (hooks) {
     await visit(urls.hostCatalog);
     assert.ok(
       instances.hostCatalog.authorized_collection_actions['host-sets'].includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.ok(find(`[href="${urls.hostSets}"]`));
   });
@@ -85,8 +85,8 @@ module('Acceptance | host-catalogs | host sets | list', function (hooks) {
     await visit(urls.hostCatalog);
     assert.notOk(
       instances.hostCatalog.authorized_collection_actions['host-sets'].includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.notOk(find(`[href="${urls.hostSets}"]`));
   });

--- a/ui/admin/tests/acceptance/host-catalogs/host-sets/update-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/host-sets/update-test.js
@@ -145,18 +145,18 @@ module('Acceptance | host-catalogs | host sets | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.newHostSet);
     await click(SUBMIT_BTN_SELECTOR);
     assert.ok(
       find('[role="alert"]').textContent.trim(),
-      'The request was invalid.'
+      'The request was invalid.',
     );
     assert.ok(
       find('.rose-form-error-message').textContent.trim(),
-      'Name is required.'
+      'Name is required.',
     );
   });
 
@@ -170,7 +170,7 @@ module('Acceptance | host-catalogs | host sets | update', function (hooks) {
     assert.strictEqual(currentURL(), urls.hostSet);
     assert.strictEqual(
       this.server.schema.hostSets.first().name,
-      'random string'
+      'random string',
     );
   });
 
@@ -192,7 +192,7 @@ module('Acceptance | host-catalogs | host sets | update', function (hooks) {
 
     assert.strictEqual(
       findAll(PREFERRED_ENDPOINT_REMOVE_BUTTON_SELECTOR).length,
-      0
+      0,
     );
 
     await fillIn(PREFERRED_ENDPOINT_TEXT_INPUT_SELECTOR, 'sample endpoint');
@@ -200,7 +200,7 @@ module('Acceptance | host-catalogs | host sets | update', function (hooks) {
 
     // Remove all the filters
     const filterList = await Promise.all(
-      findAll(FILTER_REMOVE_BUTTON_SELECTOR)
+      findAll(FILTER_REMOVE_BUTTON_SELECTOR),
     );
     for (const element of filterList) {
       await click(element);
@@ -241,7 +241,7 @@ module('Acceptance | host-catalogs | host sets | update', function (hooks) {
 
     assert.strictEqual(
       findAll(PREFERRED_ENDPOINT_REMOVE_BUTTON_SELECTOR).length,
-      0
+      0,
     );
     await fillIn(PREFERRED_ENDPOINT_TEXT_INPUT_SELECTOR, 'sample endpoints');
     await click(PREFERRED_ENDPOINT_BUTTON_SELECTOR);
@@ -294,7 +294,7 @@ module('Acceptance | host-catalogs | host sets | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.hostSet);
@@ -303,11 +303,11 @@ module('Acceptance | host-catalogs | host sets | update', function (hooks) {
     await click(SUBMIT_BTN_SELECTOR);
     assert.ok(
       find('[role="alert"]').textContent.trim(),
-      'The request was invalid.'
+      'The request was invalid.',
     );
     assert.ok(
       find('.rose-form-error-message').textContent.trim(),
-      'Name is required.'
+      'Name is required.',
     );
   });
 
@@ -328,7 +328,7 @@ module('Acceptance | host-catalogs | host sets | update', function (hooks) {
       assert.strictEqual(currentURL(), urls.hostSets);
       assert.notEqual(
         this.server.schema.hostSets.first().name,
-        'random string'
+        'random string',
       );
     }
   });

--- a/ui/admin/tests/acceptance/host-catalogs/hosts/create-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/hosts/create-test.js
@@ -91,8 +91,8 @@ module('Acceptance | host-catalogs | hosts | create', function (hooks) {
     await visit(urls.hostCatalog);
     assert.notOk(
       instances.hostCatalog.authorized_collection_actions.hosts.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.notOk(find(`.rose-layout-page-actions [href="${urls.newHost}"]`));
   });
@@ -101,8 +101,8 @@ module('Acceptance | host-catalogs | hosts | create', function (hooks) {
     await visit(urls.hosts);
     assert.ok(
       instances.hostCatalog.authorized_collection_actions.hosts.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.ok(find(`[href="${urls.newHost}"]`));
   });
@@ -113,8 +113,8 @@ module('Acceptance | host-catalogs | hosts | create', function (hooks) {
     await visit(urls.hosts);
     assert.notOk(
       instances.hostCatalog.authorized_collection_actions.hosts.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.notOk(find(`[href="${urls.newHost}"]`));
   });
@@ -147,18 +147,18 @@ module('Acceptance | host-catalogs | hosts | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.newHost);
     await click('[type="submit"]');
     assert.ok(
       find('[role="alert"]').textContent.trim(),
-      'The request was invalid.'
+      'The request was invalid.',
     );
     assert.ok(
       find('.rose-form-error-message').textContent.trim(),
-      'Name is required.'
+      'Name is required.',
     );
   });
 
@@ -166,15 +166,15 @@ module('Acceptance | host-catalogs | hosts | create', function (hooks) {
     assert.expect(2);
     instances.hostCatalog.authorized_collection_actions.hosts =
       instances.hostCatalog.authorized_collection_actions.hosts.filter(
-        (item) => item !== 'create'
+        (item) => item !== 'create',
       );
 
     await visit(urls.newHost);
 
     assert.false(
       instances.hostCatalog.authorized_collection_actions.hosts.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.strictEqual(currentURL(), urls.hosts);
   });

--- a/ui/admin/tests/acceptance/host-catalogs/hosts/delete-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/hosts/delete-test.js
@@ -91,7 +91,7 @@ module('Acceptance | host-catalogs | hosts | delete', function (hooks) {
       instances.host.authorized_actions.filter((item) => item !== 'delete');
     await visit(urls.host);
     assert.notOk(
-      find('.rose-layout-page-actions .rose-dropdown-button-danger')
+      find('.rose-layout-page-actions .rose-dropdown-button-danger'),
     );
   });
 
@@ -129,7 +129,7 @@ module('Acceptance | host-catalogs | hosts | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.host);

--- a/ui/admin/tests/acceptance/host-catalogs/hosts/list-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/hosts/list-test.js
@@ -73,7 +73,9 @@ module('Acceptance | host-catalogs | hosts | list', function (hooks) {
     assert.expect(2);
     await visit(urls.hostCatalog);
     assert.ok(
-      instances.hostCatalog.authorized_collection_actions.hosts.includes('list')
+      instances.hostCatalog.authorized_collection_actions.hosts.includes(
+        'list',
+      ),
     );
     assert.ok(find(`[href="${urls.hosts}"]`));
   });
@@ -83,7 +85,9 @@ module('Acceptance | host-catalogs | hosts | list', function (hooks) {
     instances.hostCatalog.authorized_collection_actions.hosts = [];
     await visit(urls.hostCatalog);
     assert.notOk(
-      instances.hostCatalog.authorized_collection_actions.hosts.includes('list')
+      instances.hostCatalog.authorized_collection_actions.hosts.includes(
+        'list',
+      ),
     );
     assert.notOk(find(`[href="${urls.hosts}"]`));
   });

--- a/ui/admin/tests/acceptance/host-catalogs/hosts/update-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/hosts/update-test.js
@@ -82,7 +82,7 @@ module('Acceptance | host-catalogs | hosts | update', function (hooks) {
     assert.strictEqual(currentURL(), urls.host);
     assert.strictEqual(
       this.server.schema.hosts.all().models[0].name,
-      'random string'
+      'random string',
     );
   });
 
@@ -122,7 +122,7 @@ module('Acceptance | host-catalogs | hosts | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.host);
@@ -131,11 +131,11 @@ module('Acceptance | host-catalogs | hosts | update', function (hooks) {
     await click('[type="submit"]');
     assert.ok(
       find('[role="alert"]').textContent.trim(),
-      'The request was invalid.'
+      'The request was invalid.',
     );
     assert.ok(
       find('.rose-form-error-message').textContent.trim(),
-      'Name is required.'
+      'Name is required.',
     );
   });
 
@@ -156,7 +156,7 @@ module('Acceptance | host-catalogs | hosts | update', function (hooks) {
       assert.strictEqual(currentURL(), urls.hosts);
       assert.notEqual(
         this.server.schema.hosts.all().models[0].name,
-        'random string'
+        'random string',
       );
     }
   });
@@ -178,7 +178,7 @@ module('Acceptance | host-catalogs | hosts | update', function (hooks) {
       assert.strictEqual(currentURL(), urls.host);
       assert.notEqual(
         this.server.schema.hosts.all().models[0].name,
-        'random string'
+        'random string',
       );
     }
   });

--- a/ui/admin/tests/acceptance/host-catalogs/list-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/list-test.js
@@ -66,12 +66,12 @@ module('Acceptance | host-catalogs | list', function (hooks) {
     assert.true(
       instances.scopes.project.authorized_collection_actions[
         'host-catalogs'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.true(
       instances.scopes.project.authorized_collection_actions[
         'host-catalogs'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.dom(`[href="${urls.hostCatalogs}"]`).exists();
   });
@@ -87,12 +87,12 @@ module('Acceptance | host-catalogs | list', function (hooks) {
     assert.false(
       instances.scopes.project.authorized_collection_actions[
         'host-catalogs'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.false(
       instances.scopes.project.authorized_collection_actions[
         'host-catalogs'
-      ].includes('create')
+      ].includes('create'),
     );
     assert
       .dom('[title="Resources"] a:nth-of-type(3)')
@@ -112,12 +112,12 @@ module('Acceptance | host-catalogs | list', function (hooks) {
     assert.false(
       instances.scopes.project.authorized_collection_actions[
         'host-catalogs'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.true(
       instances.scopes.project.authorized_collection_actions[
         'host-catalogs'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.dom(`[href="${urls.hostCatalogs}"]`).exists();
 
@@ -139,12 +139,12 @@ module('Acceptance | host-catalogs | list', function (hooks) {
     assert.false(
       instances.scopes.project.authorized_collection_actions[
         'host-catalogs'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.true(
       instances.scopes.project.authorized_collection_actions[
         'host-catalogs'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.dom(`[href="${urls.hostCatalogs}"]`).exists();
 

--- a/ui/admin/tests/acceptance/host-catalogs/read-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/read-test.js
@@ -78,7 +78,7 @@ module('Acceptance | host-catalogs | read', function (hooks) {
     await visit(urls.projectScope);
     instances.hostCatalog.authorized_actions =
       instances.hostCatalog.authorized_actions.filter(
-        (item) => item !== 'read'
+        (item) => item !== 'read',
       );
 
     await click(`[href="${urls.hostCatalogs}"]`);

--- a/ui/admin/tests/acceptance/host-catalogs/update-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/update-test.js
@@ -70,7 +70,7 @@ module('Acceptance | host-catalogs | update', function (hooks) {
     assert.strictEqual(currentURL(), urls.hostCatalog);
     assert.strictEqual(
       this.server.schema.hostCatalogs.all().models[0].name,
-      'random string'
+      'random string',
     );
   });
 
@@ -79,7 +79,7 @@ module('Acceptance | host-catalogs | update', function (hooks) {
     await visit(urls.hostCatalogs);
     instances.hostCatalog.authorized_actions =
       instances.hostCatalog.authorized_actions.filter(
-        (item) => item !== 'update'
+        (item) => item !== 'update',
       );
 
     await click(`[href="${urls.hostCatalog}"]`);
@@ -117,7 +117,7 @@ module('Acceptance | host-catalogs | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
 
@@ -147,7 +147,7 @@ module('Acceptance | host-catalogs | update', function (hooks) {
     assert.strictEqual(currentURL(), urls.hostCatalogs);
     assert.notEqual(
       this.server.schema.hostCatalogs.first().name,
-      'random string'
+      'random string',
     );
   });
 
@@ -168,7 +168,7 @@ module('Acceptance | host-catalogs | update', function (hooks) {
     assert.strictEqual(currentURL(), urls.hostCatalog);
     assert.notEqual(
       this.server.schema.hostCatalogs.all().models[0].name,
-      'random string'
+      'random string',
     );
   });
 });

--- a/ui/admin/tests/acceptance/managed-groups/create-test.js
+++ b/ui/admin/tests/acceptance/managed-groups/create-test.js
@@ -129,7 +129,7 @@ module('Acceptance | managed-groups | create', function (hooks) {
     assert.false(
       instances.authMethod.authorized_collection_actions[
         'managed-groups'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.dom(`[href="${urls.newManagedGroup}"]`).doesNotExist();
   });
@@ -148,7 +148,7 @@ module('Acceptance | managed-groups | create', function (hooks) {
     assert.false(
       instances.ldapAuthMethod.authorized_collection_actions[
         'managed-groups'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.dom(`[href="${urls.newLdapManagedGroup}"]`).doesNotExist();
   });
@@ -197,7 +197,7 @@ module('Acceptance | managed-groups | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.authMethod);
@@ -229,7 +229,7 @@ module('Acceptance | managed-groups | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.ldapAuthMethod);
@@ -255,7 +255,7 @@ module('Acceptance | managed-groups | create', function (hooks) {
     assert.false(
       instances.authMethod.authorized_collection_actions[
         'managed-groups'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.strictEqual(currentURL(), urls.managedGroups);
   });

--- a/ui/admin/tests/acceptance/managed-groups/delete-test.js
+++ b/ui/admin/tests/acceptance/managed-groups/delete-test.js
@@ -112,7 +112,7 @@ module('Acceptance | managed-groups | delete', function (hooks) {
     assert.expect(1);
     instances.managedGroup.authorized_actions =
       instances.managedGroup.authorized_actions.filter(
-        (item) => item !== 'delete'
+        (item) => item !== 'delete',
       );
     await visit(urls.managedGroups);
 
@@ -125,7 +125,7 @@ module('Acceptance | managed-groups | delete', function (hooks) {
     assert.expect(1);
     instances.ldapManagedGroup.authorized_actions =
       instances.ldapManagedGroup.authorized_actions.filter(
-        (item) => item !== 'delete'
+        (item) => item !== 'delete',
       );
     await visit(urls.ldapManagedGroups);
 
@@ -144,7 +144,7 @@ module('Acceptance | managed-groups | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.managedGroups);
@@ -167,7 +167,7 @@ module('Acceptance | managed-groups | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.ldapManagedGroups);

--- a/ui/admin/tests/acceptance/managed-groups/list-test.js
+++ b/ui/admin/tests/acceptance/managed-groups/list-test.js
@@ -80,12 +80,12 @@ module('Acceptance | managed-groups | list', function (hooks) {
     assert.true(
       instances.authMethod.authorized_collection_actions[
         'managed-groups'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.true(
       instances.authMethod.authorized_collection_actions[
         'managed-groups'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.dom(`[href="${urls.managedGroups}"]`).exists();
   });
@@ -100,12 +100,12 @@ module('Acceptance | managed-groups | list', function (hooks) {
     assert.true(
       instances.ldapAuthMethod.authorized_collection_actions[
         'managed-groups'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.true(
       instances.ldapAuthMethod.authorized_collection_actions[
         'managed-groups'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.dom(`[href="${urls.ldapManagedGroups}"]`).exists();
   });
@@ -120,12 +120,12 @@ module('Acceptance | managed-groups | list', function (hooks) {
     assert.false(
       instances.authMethod.authorized_collection_actions[
         'managed-groups'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.false(
       instances.authMethod.authorized_collection_actions[
         'managed-groups'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.dom(`[href="${urls.managedGroups}"]`).doesNotExist();
   });
@@ -142,12 +142,12 @@ module('Acceptance | managed-groups | list', function (hooks) {
     assert.false(
       instances.ldapAuthMethod.authorized_collection_actions[
         'managed-groups'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.false(
       instances.ldapAuthMethod.authorized_collection_actions[
         'managed-groups'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.dom(`[href="${urls.ldapManagedGroups}"]`).doesNotExist();
   });

--- a/ui/admin/tests/acceptance/managed-groups/members-test.js
+++ b/ui/admin/tests/acceptance/managed-groups/members-test.js
@@ -50,7 +50,7 @@ module('Acceptance | managed-groups | members', function (hooks) {
         scope: instances.scopes.org,
         type: TYPE_AUTH_METHOD_OIDC,
       },
-      'withAccountsAndUsersAndManagedGroups'
+      'withAccountsAndUsersAndManagedGroups',
     );
 
     instances.managedGroup = this.server.db.managedGroups[0];

--- a/ui/admin/tests/acceptance/managed-groups/read-test.js
+++ b/ui/admin/tests/acceptance/managed-groups/read-test.js
@@ -97,7 +97,7 @@ module('Acceptance | managed-groups | read', function (hooks) {
     assert.expect(1);
     instances.managedGroup.authorized_actions =
       instances.managedGroup.authorized_actions.filter(
-        (item) => item !== 'read'
+        (item) => item !== 'read',
       );
     await visit(urls.authMethod);
 
@@ -110,7 +110,7 @@ module('Acceptance | managed-groups | read', function (hooks) {
     assert.expect(1);
     instances.ldapManagedGroup.authorized_actions =
       instances.ldapManagedGroup.authorized_actions.filter(
-        (item) => item !== 'read'
+        (item) => item !== 'read',
       );
     await visit(urls.ldapAuthMethod);
 

--- a/ui/admin/tests/acceptance/roles/create-test.js
+++ b/ui/admin/tests/acceptance/roles/create-test.js
@@ -43,7 +43,7 @@ module('Acceptance | roles | create', function (hooks) {
         type: 'org',
         scope: { id: 'global', type: 'global' },
       },
-      'withChildren'
+      'withChildren',
     );
 
     // The project scope is not yet used for role tests (though it will be
@@ -58,7 +58,7 @@ module('Acceptance | roles | create', function (hooks) {
       {
         scope: instances.scopes.org,
       },
-      'withPrincipals'
+      'withPrincipals',
     );
     urls.roles = `/scopes/${instances.scopes.org.id}/roles`;
     urls.role = `${urls.roles}/${instances.role.id}`;
@@ -80,8 +80,8 @@ module('Acceptance | roles | create', function (hooks) {
     await visit(urls.roles);
     assert.ok(
       instances.scopes.org.authorized_collection_actions.roles.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.ok(find(`[href="${urls.newRole}"]`));
   });
@@ -92,8 +92,8 @@ module('Acceptance | roles | create', function (hooks) {
     await visit(urls.roles);
     assert.notOk(
       instances.scopes.org.authorized_collection_actions.roles.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.notOk(find(`[href="${urls.newRole}"]`));
   });
@@ -126,7 +126,7 @@ module('Acceptance | roles | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.newRole);
@@ -141,15 +141,15 @@ module('Acceptance | roles | create', function (hooks) {
     assert.expect(2);
     instances.scopes.org.authorized_collection_actions.roles =
       instances.scopes.org.authorized_collection_actions.roles.filter(
-        (item) => item !== 'create'
+        (item) => item !== 'create',
       );
 
     await visit(urls.newRole);
 
     assert.false(
       instances.scopes.org.authorized_collection_actions.roles.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.strictEqual(currentURL(), urls.roles);
   });

--- a/ui/admin/tests/acceptance/roles/delete-test.js
+++ b/ui/admin/tests/acceptance/roles/delete-test.js
@@ -53,7 +53,7 @@ module('Acceptance | roles | delete', function (hooks) {
       {
         scope: instances.scopes.org,
       },
-      'withPrincipals'
+      'withPrincipals',
     );
     urls.roles = `/scopes/${instances.scopes.org.id}/roles`;
     urls.role = `${urls.roles}/${instances.role.id}`;
@@ -74,7 +74,7 @@ module('Acceptance | roles | delete', function (hooks) {
       instances.role.authorized_actions.filter((item) => item !== 'delete');
     await visit(urls.role);
     assert.notOk(
-      find('.rose-layout-page-actions .rose-dropdown-button-danger')
+      find('.rose-layout-page-actions .rose-dropdown-button-danger'),
     );
   });
 
@@ -88,7 +88,7 @@ module('Acceptance | roles | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.role);
@@ -96,7 +96,7 @@ module('Acceptance | roles | delete', function (hooks) {
     assert.strictEqual(
       find('.rose-notification-body').textContent.trim(),
       'Oops.',
-      'Displays primary error message.'
+      'Displays primary error message.',
     );
   });
 });

--- a/ui/admin/tests/acceptance/roles/grants-test.js
+++ b/ui/admin/tests/acceptance/roles/grants-test.js
@@ -67,25 +67,25 @@ module('Acceptance | roles | grants', function (hooks) {
     assert.strictEqual(currentURL(), urls.grants);
     assert.strictEqual(
       findAll(`${grantsForm} [name="grant"]`).length,
-      grantsCount
+      grantsCount,
     );
   });
 
   test('cannot set grants without proper authorization', async function (assert) {
     assert.expect(4);
     const authorized_actions = instances.role.authorized_actions.filter(
-      (item) => item !== 'set-grants'
+      (item) => item !== 'set-grants',
     );
     instances.role.update({ authorized_actions });
     await visit(urls.grants);
     assert.strictEqual(
       findAll('main form').length,
       1,
-      'New grant form is not displayed.'
+      'New grant form is not displayed.',
     );
     assert.notOk(
       find('main form button:not([type="submit"])'),
-      'Grant delete button is not displayed.'
+      'Grant delete button is not displayed.',
     );
     assert.notOk(find('.rose-form-actions'), 'Form actions are not displayed.');
     assert.ok(find('main form input[disabled]'), 'Grant fields are disabled.');
@@ -100,11 +100,11 @@ module('Acceptance | roles | grants', function (hooks) {
         assert.strictEqual(
           attrs.grant_strings[0],
           'id=123,action=delete',
-          'A grant is updated'
+          'A grant is updated',
         );
         const id = idMethod.split(':')[0];
         return { id };
-      }
+      },
     );
     await visit(urls.grants);
     await fillIn(`${grantsForm} [name="grant"]`, 'id=123,action=delete');
@@ -118,7 +118,7 @@ module('Acceptance | roles | grants', function (hooks) {
     await click('.rose-form-actions button:not([type="submit"])');
     assert.notEqual(
       find(`${grantsForm} [name="grant"]`).value,
-      'id=123,action=delete'
+      'id=123,action=delete',
     );
   });
 
@@ -133,13 +133,13 @@ module('Acceptance | roles | grants', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     await visit(urls.grants);
     assert.strictEqual(
       findAll(`${grantsForm} [name="grant"]`).length,
-      grantsCount
+      grantsCount,
     );
     await fillIn(`${grantsForm} [name="grant"]`, 'id=123,action=delete');
     await click('.rose-form-actions [type="submit"]:not(:disabled)');
@@ -155,11 +155,11 @@ module('Acceptance | roles | grants', function (hooks) {
         assert.strictEqual(
           attrs.grant_strings.length,
           grantsCount + 1,
-          'A grant is created'
+          'A grant is created',
         );
         const id = idMethod.split(':')[0];
         return { id };
-      }
+      },
     );
     await visit(urls.grants);
     await fillIn(`${newGrantForm} [name="grant"]`, 'id=123,action=delete');
@@ -187,13 +187,13 @@ module('Acceptance | roles | grants', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     await visit(urls.grants);
     assert.strictEqual(
       findAll(`${grantsForm} [name="grant"]`).length,
-      grantsCount
+      grantsCount,
     );
     await fillIn(`${newGrantForm} [name="grant"]`, 'id=123,action=delete');
     await click(`${newGrantForm} [type="submit"]:not(:disabled)`);
@@ -208,7 +208,7 @@ module('Acceptance | roles | grants', function (hooks) {
     await click('.rose-form-actions [type="submit"]:not(:disabled)');
     assert.strictEqual(
       findAll(`${grantsForm} [name="grant"]`).length,
-      grantsCount - 1
+      grantsCount - 1,
     );
   });
 
@@ -219,7 +219,7 @@ module('Acceptance | roles | grants', function (hooks) {
     await click('.rose-form-actions button:not([type="submit"])');
     assert.strictEqual(
       findAll(`${grantsForm} [name="grant"]`).length,
-      grantsCount
+      grantsCount,
     );
   });
 
@@ -234,13 +234,13 @@ module('Acceptance | roles | grants', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     await visit(urls.grants);
     assert.strictEqual(
       findAll(`${grantsForm} [name="grant"]`).length,
-      grantsCount
+      grantsCount,
     );
     await click(`${grantsForm} button:not([type="submit"])`);
     await click('.rose-form-actions [type="submit"]:not(:disabled)');

--- a/ui/admin/tests/acceptance/roles/list-test.js
+++ b/ui/admin/tests/acceptance/roles/list-test.js
@@ -51,7 +51,7 @@ module('Acceptance | roles | list', function (hooks) {
     assert.expect(2);
     await visit(urls.scopes.org);
     assert.ok(
-      instances.scopes.org.authorized_collection_actions.roles.includes('list')
+      instances.scopes.org.authorized_collection_actions.roles.includes('list'),
     );
     assert.ok(find(`[href="${urls.roles}"]`));
   });
@@ -61,7 +61,7 @@ module('Acceptance | roles | list', function (hooks) {
     instances.scopes.org.authorized_collection_actions.roles = [];
     await visit(urls.scopes.org);
     assert.notOk(
-      instances.scopes.org.authorized_collection_actions.roles.includes('list')
+      instances.scopes.org.authorized_collection_actions.roles.includes('list'),
     );
     assert.notOk(find(`[href="${urls.roles}"]`));
   });

--- a/ui/admin/tests/acceptance/roles/principals-test.js
+++ b/ui/admin/tests/acceptance/roles/principals-test.js
@@ -47,7 +47,7 @@ module('Acceptance | roles | principals', function (hooks) {
       {
         scope: instances.scopes.org,
       },
-      'withPrincipals'
+      'withPrincipals',
     );
     principalsCount =
       this.server.db.roles[0].userIds.length +
@@ -79,7 +79,7 @@ module('Acceptance | roles | principals', function (hooks) {
   test('principal cannot be removed from a role without proper authorization', async function (assert) {
     assert.expect(1);
     const authorized_actions = instances.role.authorized_actions.filter(
-      (item) => item !== 'remove-principals'
+      (item) => item !== 'remove-principals',
     );
     instances.role.update({ authorized_actions });
     await visit(urls.rolePrincipals);
@@ -97,7 +97,7 @@ module('Acceptance | roles | principals', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     await visit(urls.rolePrincipals);
@@ -110,7 +110,7 @@ module('Acceptance | roles | principals', function (hooks) {
   test('cannot navigate to add principals without proper authorization', async function (assert) {
     assert.expect(1);
     const authorized_actions = instances.role.authorized_actions.filter(
-      (item) => item !== 'add-principals'
+      (item) => item !== 'add-principals',
     );
     instances.role.update({ authorized_actions });
     await visit(urls.rolePrincipals);
@@ -160,7 +160,7 @@ module('Acceptance | roles | principals', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     instances.role.update({ userIds: [], groupIds: [], managedGroupIds: [] });

--- a/ui/admin/tests/acceptance/roles/read-test.js
+++ b/ui/admin/tests/acceptance/roles/read-test.js
@@ -53,7 +53,7 @@ module('Acceptance | roles | read', function (hooks) {
       {
         scope: instances.scopes.org,
       },
-      'withPrincipals'
+      'withPrincipals',
     );
     urls.roles = `/scopes/${instances.scopes.org.id}/roles`;
     urls.role = `${urls.roles}/${instances.role.id}`;

--- a/ui/admin/tests/acceptance/roles/update-test.js
+++ b/ui/admin/tests/acceptance/roles/update-test.js
@@ -53,7 +53,7 @@ module('Acceptance | roles | update', function (hooks) {
       {
         scope: instances.scopes.org,
       },
-      'withPrincipals'
+      'withPrincipals',
     );
     urls.roles = `/scopes/${instances.scopes.org.id}/roles`;
     urls.role = `${urls.roles}/${instances.role.id}`;
@@ -105,7 +105,7 @@ module('Acceptance | roles | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.role);
@@ -115,12 +115,12 @@ module('Acceptance | roles | update', function (hooks) {
     assert.strictEqual(
       find('.rose-notification-body').textContent.trim(),
       'The request was invalid.',
-      'Displays primary error message.'
+      'Displays primary error message.',
     );
     assert.strictEqual(
       find('.hds-form-error__message').textContent.trim(),
       'Name is required.',
-      'Displays field-level errors.'
+      'Displays field-level errors.',
     );
   });
 });

--- a/ui/admin/tests/acceptance/scopes-test.js
+++ b/ui/admin/tests/acceptance/scopes-test.js
@@ -130,7 +130,7 @@ module('Acceptance | scopes', function (hooks) {
     await a11yAudit();
     assert.strictEqual(currentURL(), urls.projectScopeEdit);
     await click(
-      '.rose-header-nav .rose-dropdown + .rose-dropdown a:nth-child(2)'
+      '.rose-header-nav .rose-dropdown + .rose-dropdown a:nth-child(2)',
     );
     assert.strictEqual(currentURL(), urls.project2ScopeEdit);
   });
@@ -191,7 +191,7 @@ module('Acceptance | scopes', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.newOrgScope);

--- a/ui/admin/tests/acceptance/scopes/delete-test.js
+++ b/ui/admin/tests/acceptance/scopes/delete-test.js
@@ -72,7 +72,7 @@ module('Acceptance | scopes | delete', function (hooks) {
     assert.expect(2);
     instances.scopes.org.update({
       authorized_actions: instances.scopes.org.authorized_actions.filter(
-        (item) => item !== 'delete'
+        (item) => item !== 'delete',
       ),
     });
     await visit(urls.orgScope);
@@ -126,7 +126,7 @@ module('Acceptance | scopes | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
 

--- a/ui/admin/tests/acceptance/scopes/read-test.js
+++ b/ui/admin/tests/acceptance/scopes/read-test.js
@@ -59,7 +59,7 @@ module('Acceptance | scopes | read', function (hooks) {
     assert.expect(2);
     instances.scopes.org.update({
       authorized_actions: instances.scopes.org.authorized_actions.filter(
-        (item) => item !== 'read'
+        (item) => item !== 'read',
       ),
     });
     await visit(urls.orgScope);

--- a/ui/admin/tests/acceptance/scopes/update-test.js
+++ b/ui/admin/tests/acceptance/scopes/update-test.js
@@ -69,7 +69,7 @@ module('Acceptance | scopes | update', function (hooks) {
     assert.strictEqual(currentURL(), urls.orgScopeEdit);
     assert.strictEqual(
       this.server.schema.scopes.where({ type: 'org' }).models[0].name,
-      'random string'
+      'random string',
     );
   });
 
@@ -77,7 +77,7 @@ module('Acceptance | scopes | update', function (hooks) {
     assert.expect(2);
     instances.scopes.org.update({
       authorized_actions: instances.scopes.org.authorized_actions.filter(
-        (item) => item !== 'update'
+        (item) => item !== 'update',
       ),
     });
     await visit(urls.orgScope);
@@ -120,7 +120,7 @@ module('Acceptance | scopes | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
 
@@ -151,7 +151,7 @@ module('Acceptance | scopes | update', function (hooks) {
     assert.strictEqual(currentURL(), urls.globalScope);
     assert.notEqual(
       this.server.schema.scopes.where({ type: 'org' }).models[0].name,
-      'random string'
+      'random string',
     );
   });
 
@@ -173,7 +173,7 @@ module('Acceptance | scopes | update', function (hooks) {
     assert.strictEqual(currentURL(), urls.orgScopeEdit);
     assert.notEqual(
       this.server.schema.scopes.where({ type: 'org' }).models[0].name,
-      'random string'
+      'random string',
     );
   });
 });

--- a/ui/admin/tests/acceptance/session-recordings/list-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/list-test.js
@@ -66,7 +66,7 @@ module('Acceptance | session recordings | list', function (hooks) {
     assert.true(
       instances.scopes.global.authorized_collection_actions[
         'session-recordings'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.dom(`[href="${urls.sessionRecordings}"]`).exists();
     assert.dom('[title="General"]').includesText(SESSION_RECORDING_TITLE);
@@ -87,7 +87,7 @@ module('Acceptance | session recordings | list', function (hooks) {
     assert.false(
       instances.scopes.global.authorized_collection_actions[
         'session-recordings'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.dom('[title="General"]').doesNotIncludeText(SESSION_RECORDING_TITLE);
     assert.dom(`[href="${urls.sessionRecordings}"]`).doesNotExist();

--- a/ui/admin/tests/acceptance/session-recordings/read-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/read-test.js
@@ -96,7 +96,7 @@ module('Acceptance | session-recordings | read', function (hooks) {
     featuresService.enable('ssh-session-recording');
     instances.sessionRecording.authorized_actions =
       instances.sessionRecording.authorized_actions.filter(
-        (item) => item !== 'read'
+        (item) => item !== 'read',
       );
     // Visit session recordings
     await visit(urls.sessionRecordings);

--- a/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
@@ -50,7 +50,7 @@ module(
         'connection-recording',
         {
           session_recording: instances.sessionRecording,
-        }
+        },
       );
       instances.channelRecording = this.server.create('channel-recording', {
         connection_recording: instances.connectionRecording,
@@ -95,7 +95,7 @@ module(
       assert.expect(1);
       instances.sessionRecording.authorized_actions =
         instances.sessionRecording.authorized_actions.filter(
-          (item) => item !== 'download'
+          (item) => item !== 'download',
         );
 
       // Visit channel
@@ -117,8 +117,8 @@ module(
               status: 500,
               code: 'api_error',
               message: 'rpc error: code = Unknown',
-            }
-          )
+            },
+          ),
       );
 
       // Visit channel
@@ -154,5 +154,5 @@ module(
       assert.notEqual(currentURL(), incorrectUrl);
       assert.strictEqual(currentURL(), urls.channelRecording);
     });
-  }
+  },
 );

--- a/ui/admin/tests/acceptance/sessions-test.js
+++ b/ui/admin/tests/acceptance/sessions-test.js
@@ -47,13 +47,13 @@ module('Acceptance | sessions', function (hooks) {
       'group',
       1,
       { scope: instances.scopes.org },
-      'withMembers'
+      'withMembers',
     );
     this.server.createList(
       'target',
       1,
       { scope: instances.scopes.project },
-      'withAssociations'
+      'withAssociations',
     );
     instances.sessions = this.server.createList(
       'session',
@@ -62,7 +62,7 @@ module('Acceptance | sessions', function (hooks) {
         scope: instances.scopes.project,
         status: 'active',
       },
-      'withAssociations'
+      'withAssociations',
     );
     urls.orgScope = `/scopes/${instances.scopes.org.id}/scopes`;
     urls.projectScope = `/scopes/${instances.scopes.project.id}`;
@@ -89,15 +89,15 @@ module('Acceptance | sessions', function (hooks) {
     await a11yAudit();
     instances.scopes.project.authorized_collection_actions.sessions =
       instances.scopes.project.authorized_collection_actions.sessions.filter(
-        (item) => item !== 'list'
+        (item) => item !== 'list',
       );
 
     await click(`[href="${urls.projectScope}"]`);
 
     assert.false(
       instances.scopes.project.authorized_collection_actions.sessions.includes(
-        'list'
-      )
+        'list',
+      ),
     );
 
     assert
@@ -113,8 +113,8 @@ module('Acceptance | sessions', function (hooks) {
 
     assert.true(
       instances.scopes.project.authorized_collection_actions.sessions.includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.dom(`[href="${urls.sessions}"]`).exists();
   });

--- a/ui/admin/tests/acceptance/storage-buckets/create-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/create-test.js
@@ -188,7 +188,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.storageBuckets);
@@ -213,7 +213,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     assert.false(
       instances.scopes.global.authorized_collection_actions[
         'storage-buckets'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.strictEqual(currentURL(), urls.storageBuckets);
   });

--- a/ui/admin/tests/acceptance/storage-buckets/delete-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/delete-test.js
@@ -111,14 +111,16 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
     assert
       .dom(DIALOG_TITLE_SELECTOR)
       .hasText(
-        intl.t('resources.storage-bucket.questions.delete-storage-bucket.title')
+        intl.t(
+          'resources.storage-bucket.questions.delete-storage-bucket.title',
+        ),
       );
     assert
       .dom(DIALOG_MESSAGE_SELECTOR)
       .hasText(
         intl.t(
-          'resources.storage-bucket.questions.delete-storage-bucket.message'
-        )
+          'resources.storage-bucket.questions.delete-storage-bucket.message',
+        ),
       );
 
     await click(DIALOG_CANCEL_BTN_SELECTOR);
@@ -132,7 +134,7 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
     await visit(urls.globalScope);
     instances.storageBucket.authorized_actions =
       instances.storageBucket.authorized_actions.filter(
-        (item) => item !== 'delete'
+        (item) => item !== 'delete',
       );
 
     await click(`[href="${urls.storageBuckets}"]`);
@@ -152,7 +154,7 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
 

--- a/ui/admin/tests/acceptance/storage-buckets/list-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/list-test.js
@@ -59,12 +59,12 @@ module('Acceptance | storage-buckets | list', function (hooks) {
     assert.true(
       instances.scopes.global.authorized_collection_actions[
         'storage-buckets'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.true(
       instances.scopes.global.authorized_collection_actions[
         'storage-buckets'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.dom(`[href="${urls.storageBuckets}"]`).exists();
 
@@ -90,12 +90,12 @@ module('Acceptance | storage-buckets | list', function (hooks) {
     assert.false(
       instances.scopes.global.authorized_collection_actions[
         'storage-buckets'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.false(
       instances.scopes.global.authorized_collection_actions[
         'storage-buckets'
-      ].includes('create')
+      ].includes('create'),
     );
     assert
       .dom('[title="General"] a:nth-of-type(3)')
@@ -107,7 +107,7 @@ module('Acceptance | storage-buckets | list', function (hooks) {
     assert.dom(MESSAGE_DESCRIPTION_SELECTOR).hasText(
       intl.t('descriptions.neither-list-nor-create', {
         resource: STORAGE_BUCKET_TITLE,
-      })
+      }),
     );
     assert.dom(MESSAGE_LINK_SELECTOR).doesNotExist();
   });
@@ -126,12 +126,12 @@ module('Acceptance | storage-buckets | list', function (hooks) {
     assert.false(
       instances.scopes.global.authorized_collection_actions[
         'storage-buckets'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.true(
       instances.scopes.global.authorized_collection_actions[
         'storage-buckets'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.dom(`[href="${urls.storageBuckets}"]`).exists();
 
@@ -141,7 +141,7 @@ module('Acceptance | storage-buckets | list', function (hooks) {
     assert.dom(MESSAGE_DESCRIPTION_SELECTOR).hasText(
       intl.t('descriptions.create-but-not-list', {
         resource: STORAGE_BUCKET_TITLE,
-      })
+      }),
     );
     assert.dom(MESSAGE_LINK_SELECTOR).exists();
   });
@@ -160,12 +160,12 @@ module('Acceptance | storage-buckets | list', function (hooks) {
     assert.true(
       instances.scopes.global.authorized_collection_actions[
         'storage-buckets'
-      ].includes('list')
+      ].includes('list'),
     );
     assert.false(
       instances.scopes.global.authorized_collection_actions[
         'storage-buckets'
-      ].includes('create')
+      ].includes('create'),
     );
     assert.dom(`[href="${urls.storageBuckets}"]`).exists();
 

--- a/ui/admin/tests/acceptance/storage-buckets/read-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/read-test.js
@@ -71,7 +71,7 @@ module('Acceptance | storage-buckets | read', function (hooks) {
     await visit(urls.globalScope);
     instances.storageBucket.authorized_actions =
       instances.storageBucket.authorized_actions.filter(
-        (item) => item !== 'read'
+        (item) => item !== 'read',
       );
 
     await click(`[href="${urls.storageBuckets}"]`);

--- a/ui/admin/tests/acceptance/storage-buckets/update-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/update-test.js
@@ -114,7 +114,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     await fillIn(ACCESS_KEY_ID_FIELD_SELECTOR, ACCESS_KEY_ID_FIELD_TEXT);
     await fillIn(
       SECRET_ACCESS_KEY_FIELD_SELECTOR,
-      SECRET_ACCESS_KEY_FIELD_TEXT
+      SECRET_ACCESS_KEY_FIELD_TEXT,
     );
     await click(SAVE_BUTTON_SELECTOR, 'Click save');
 
@@ -134,12 +134,12 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     await fillIn(ACCESS_KEY_ID_FIELD_SELECTOR, ACCESS_KEY_ID_FIELD_TEXT);
     await fillIn(
       SECRET_ACCESS_KEY_FIELD_SELECTOR,
-      SECRET_ACCESS_KEY_FIELD_TEXT
+      SECRET_ACCESS_KEY_FIELD_TEXT,
     );
     await click(SECRET_FIELD_BUTTON_SELECTOR, 'Click cancel button');
     await click(
       findAll(SECRET_FIELD_BUTTON_SELECTOR)[1],
-      'Click cancel button'
+      'Click cancel button',
     );
     await click(SAVE_BUTTON_SELECTOR, 'Click save');
 
@@ -167,7 +167,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
 

--- a/ui/admin/tests/acceptance/targets/brokered-credential-sources-test.js
+++ b/ui/admin/tests/acceptance/targets/brokered-credential-sources-test.js
@@ -79,7 +79,7 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
       {
         scope: instances.scopes.project,
         credentialStore: instances.vaultCredentialStore,
-      }
+      },
     );
     instances.credentialLibrary = instances.credentialLibraries[0];
     instances.credential = instances.credentials[0];
@@ -191,7 +191,7 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
     await visit(urls.addBrokeredCredentialSources);
     assert.strictEqual(
       find('.rose-message-title').textContent.trim(),
-      'No Brokered Credential Sources Available'
+      'No Brokered Credential Sources Available',
     );
   });
 
@@ -256,7 +256,7 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
     assert.expect(1);
     instances.target.authorized_actions =
       instances.target.authorized_actions.filter(
-        (item) => item !== 'add-credential-sources'
+        (item) => item !== 'add-credential-sources',
       );
     await visit(urls.brokeredCredentialSources);
     assert.dom('.rose-dropdown-content a:nth-child(2)').doesNotExist();
@@ -304,7 +304,7 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     instances.target.update({
@@ -332,7 +332,7 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
     await visit(urls.addBrokeredCredentialSources);
     assert.strictEqual(
       findAll('tbody tr').length,
-      availableCredentialsCount + 1
+      availableCredentialsCount + 1,
     );
   });
 
@@ -351,7 +351,7 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
     await visit(urls.addBrokeredCredentialSources);
     assert.strictEqual(
       findAll('tbody tr').length,
-      availableCredentialsCount + 1
+      availableCredentialsCount + 1,
     );
   });
 
@@ -359,7 +359,7 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
     assert.expect(1);
     instances.target.authorized_actions =
       instances.target.authorized_actions.filter(
-        (item) => item !== 'remove-credential-sources'
+        (item) => item !== 'remove-credential-sources',
       );
     await visit(urls.brokeredCredentialSources);
     assert.dom('tbody tr .hds-dropdown-list-item button').doesNotExist();
@@ -379,7 +379,7 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     const count = getCredentialLibraryCount();
@@ -404,7 +404,7 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     const count = getCredentialCount();

--- a/ui/admin/tests/acceptance/targets/create-test.js
+++ b/ui/admin/tests/acceptance/targets/create-test.js
@@ -110,12 +110,12 @@ module('Acceptance | targets | create', function (hooks) {
     assert.strictEqual(getTargetCount(), targetCount + 1);
     assert.strictEqual(
       this.server.schema.targets.all().models[getTargetCount() - 1].name,
-      'random string'
+      'random string',
     );
     assert.strictEqual(
       this.server.schema.targets.all().models[getTargetCount() - 1]
         .workerFilter,
-      'random filter'
+      'random filter',
     );
   });
 
@@ -133,7 +133,7 @@ module('Acceptance | targets | create', function (hooks) {
     await fillIn('[name="name"]', 'random string');
     await click(
       '[name="target-worker-filter-toggle-egress_worker_filter"]',
-      'Egress toggle'
+      'Egress toggle',
     );
     await fillIn('[name="egress_worker_filter"]', 'random filter');
     await click('[type="submit"]');
@@ -142,12 +142,12 @@ module('Acceptance | targets | create', function (hooks) {
     assert.strictEqual(getTargetCount(), targetCount + 1);
     assert.strictEqual(
       this.server.schema.targets.all().models[getTargetCount() - 1].name,
-      'random string'
+      'random string',
     );
     assert.strictEqual(
       this.server.schema.targets.all().models[getTargetCount() - 1]
         .egressWorkerFilter,
-      'random filter'
+      'random filter',
     );
   });
 
@@ -171,12 +171,12 @@ module('Acceptance | targets | create', function (hooks) {
     assert.strictEqual(getTCPTargetCount(), tcpTargetCount + 1);
     assert.strictEqual(
       this.server.schema.targets.all().models[getTargetCount() - 1].name,
-      'random string'
+      'random string',
     );
     assert.strictEqual(
       this.server.schema.targets.all().models[getTargetCount() - 1]
         .workerFilter,
-      'random filter'
+      'random filter',
     );
   });
 
@@ -194,7 +194,7 @@ module('Acceptance | targets | create', function (hooks) {
     await fillIn('[name="name"]', 'random string');
     await click(
       '[name="target-worker-filter-toggle-egress_worker_filter"]',
-      'Egress toggle'
+      'Egress toggle',
     );
     await fillIn('[name="egress_worker_filter"]', 'random filter');
 
@@ -204,12 +204,12 @@ module('Acceptance | targets | create', function (hooks) {
     assert.strictEqual(getTCPTargetCount(), tcpTargetCount + 1);
     assert.strictEqual(
       this.server.schema.targets.all().models[getTargetCount() - 1].name,
-      'random string'
+      'random string',
     );
     assert.strictEqual(
       this.server.schema.targets.all().models[getTargetCount() - 1]
         .egressWorkerFilter,
-      'random filter'
+      'random filter',
     );
   });
 
@@ -227,11 +227,11 @@ module('Acceptance | targets | create', function (hooks) {
     await click('[value="tcp"]');
     await fillIn('[name="name"]', 'random string');
     await click(
-      '[data-test-filter="egress_worker_filter"] .hds-form-toggle__control'
+      '[data-test-filter="egress_worker_filter"] .hds-form-toggle__control',
     );
     await fillIn('[name="egress_worker_filter"]', 'random filter');
     await click(
-      '[data-test-filter="ingress_worker_filter"] .hds-form-toggle__control'
+      '[data-test-filter="ingress_worker_filter"] .hds-form-toggle__control',
     );
     await fillIn('[name="ingress_worker_filter"]', 'random filter');
 
@@ -241,12 +241,12 @@ module('Acceptance | targets | create', function (hooks) {
     assert.strictEqual(getTCPTargetCount(), tcpTargetCount + 1);
     assert.strictEqual(
       this.server.schema.targets.all().models[getTargetCount() - 1].name,
-      'random string'
+      'random string',
     );
     assert.strictEqual(
       this.server.schema.targets.all().models[getTargetCount() - 1]
         .egressWorkerFilter,
-      'random filter'
+      'random filter',
     );
   });
 
@@ -273,8 +273,8 @@ module('Acceptance | targets | create', function (hooks) {
 
     assert.true(
       instances.scopes.project.authorized_collection_actions.targets.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.dom(`[href="${urls.newTarget}"]`).exists();
   });
@@ -283,7 +283,7 @@ module('Acceptance | targets | create', function (hooks) {
     assert.expect(2);
     instances.scopes.project.authorized_collection_actions.targets =
       instances.scopes.project.authorized_collection_actions.targets.filter(
-        (item) => item !== 'create'
+        (item) => item !== 'create',
       );
     await visit(urls.projectScope);
 
@@ -291,8 +291,8 @@ module('Acceptance | targets | create', function (hooks) {
 
     assert.false(
       instances.scopes.project.authorized_collection_actions.targets.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.dom('.rose-layout-page-actions a').doesNotExist();
   });
@@ -305,8 +305,8 @@ module('Acceptance | targets | create', function (hooks) {
     assert.false(featuresService.isEnabled('ssh-target'));
     assert.true(
       instances.scopes.project.authorized_collection_actions.targets.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.dom('.info-field').exists({ count: 1 });
     assert.dom('.info-field .hds-form-helper-text').includesText('TCP');
@@ -325,7 +325,7 @@ module('Acceptance | targets | create', function (hooks) {
     await fillIn('[name="name"]', 'random string');
     await click(
       '[name="target-worker-filter-toggle-egress_worker_filter"]',
-      'Egress toggle'
+      'Egress toggle',
     );
     await fillIn('[name="egress_worker_filter"]', 'random filter');
     await click('.rose-form-actions [type="button"]');
@@ -349,7 +349,7 @@ module('Acceptance | targets | create', function (hooks) {
     await click('[value="ssh"]');
     await click(
       '[name="target-worker-filter-toggle-egress_worker_filter"]',
-      'Egress toggle'
+      'Egress toggle',
     );
     await fillIn('[name="egress_worker_filter"]', 'random filter');
     await click('.rose-form-actions [type="button"]');
@@ -377,7 +377,7 @@ module('Acceptance | targets | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
 
@@ -406,7 +406,7 @@ module('Acceptance | targets | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.newSSHTarget);
@@ -432,7 +432,7 @@ module('Acceptance | targets | create', function (hooks) {
     assert.strictEqual(getTargetCount(), targetCount + 1);
     assert.strictEqual(
       this.server.schema.targets.all().models[getTargetCount() - 1].address,
-      '0.0.0.0'
+      '0.0.0.0',
     );
   });
 
@@ -448,15 +448,15 @@ module('Acceptance | targets | create', function (hooks) {
     assert.expect(2);
     instances.scopes.project.authorized_collection_actions.targets =
       instances.scopes.project.authorized_collection_actions.targets.filter(
-        (item) => item !== 'create'
+        (item) => item !== 'create',
       );
 
     await visit(urls.newSSHTarget);
 
     assert.false(
       instances.scopes.project.authorized_collection_actions.targets.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.strictEqual(currentURL(), urls.targets);
   });

--- a/ui/admin/tests/acceptance/targets/delete-test.js
+++ b/ui/admin/tests/acceptance/targets/delete-test.js
@@ -128,7 +128,7 @@ module('Acceptance | targets | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
 

--- a/ui/admin/tests/acceptance/targets/enable-session-recording-test.js
+++ b/ui/admin/tests/acceptance/targets/enable-session-recording-test.js
@@ -206,7 +206,7 @@ module('Acceptance | targets | enable session recording', function (hooks) {
 
     assert.strictEqual(
       find(LINK_LIST_SELECTOR_ITEM_TEXT).textContent.trim(),
-      storageBucketTwo.name
+      storageBucketTwo.name,
     );
   });
 
@@ -230,7 +230,7 @@ module('Acceptance | targets | enable session recording', function (hooks) {
 
     assert.strictEqual(
       find(LINK_LIST_SELECTOR_ITEM_TEXT).textContent.trim(),
-      storageBucketOne.name
+      storageBucketOne.name,
     );
   });
 });

--- a/ui/admin/tests/acceptance/targets/enable-session-recording/create-storage-bucket-test.js
+++ b/ui/admin/tests/acceptance/targets/enable-session-recording/create-storage-bucket-test.js
@@ -155,7 +155,7 @@ module(
                 },
               ],
             },
-          }
+          },
         );
       });
       await visit(urls.enableSessionRecording);
@@ -167,5 +167,5 @@ module(
       assert.dom(ALERT_TEXT_SELECTOR).hasText('The request was invalid.');
       assert.dom(FIELD_ERROR_TEXT_SELECTOR).hasText('Name is required.');
     });
-  }
+  },
 );

--- a/ui/admin/tests/acceptance/targets/enable-session-recording/index-test.js
+++ b/ui/admin/tests/acceptance/targets/enable-session-recording/index-test.js
@@ -206,7 +206,7 @@ module('Acceptance | targets | enable session recording', function (hooks) {
 
     assert.strictEqual(
       find(LINK_LIST_SELECTOR_ITEM_TEXT).textContent.trim(),
-      storageBucketTwo.name
+      storageBucketTwo.name,
     );
   });
 
@@ -230,7 +230,7 @@ module('Acceptance | targets | enable session recording', function (hooks) {
 
     assert.strictEqual(
       find(LINK_LIST_SELECTOR_ITEM_TEXT).textContent.trim(),
-      storageBucketOne.name
+      storageBucketOne.name,
     );
   });
 });

--- a/ui/admin/tests/acceptance/targets/host-sources-test.js
+++ b/ui/admin/tests/acceptance/targets/host-sources-test.js
@@ -58,7 +58,7 @@ module('Acceptance | targets | host-sources', function (hooks) {
       {
         scope: instances.scopes.project,
       },
-      'withChildren'
+      'withChildren',
     );
     // creates "unknown" host-set for target host sources
     instances.hostCatalogPlugin = this.server.create(
@@ -68,7 +68,7 @@ module('Acceptance | targets | host-sources', function (hooks) {
         plugin: { name: 'shh' },
         scope: instances.scopes.project,
       },
-      'withChildren'
+      'withChildren',
     );
     instances.target = this.server.create('target', {
       scope: instances.scopes.project,
@@ -139,7 +139,7 @@ module('Acceptance | targets | host-sources', function (hooks) {
     assert.expect(1);
     instances.target.authorized_actions =
       instances.target.authorized_actions.filter(
-        (item) => item !== 'remove-host-sources'
+        (item) => item !== 'remove-host-sources',
       );
     await visit(urls.target);
 
@@ -159,7 +159,7 @@ module('Acceptance | targets | host-sources', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     const targetHostSetCount = getTargetHostSetCount();
@@ -199,7 +199,7 @@ module('Acceptance | targets | host-sources', function (hooks) {
     assert.expect(1);
     instances.target.authorized_actions =
       instances.target.authorized_actions.filter(
-        (item) => item !== 'add-host-sources'
+        (item) => item !== 'add-host-sources',
       );
     await visit(urls.target);
 
@@ -244,7 +244,7 @@ module('Acceptance | targets | host-sources', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     await visit(urls.targetHostSources);
@@ -273,7 +273,7 @@ module('Acceptance | targets | host-sources', function (hooks) {
       .hostSets.models.length;
     assert.strictEqual(
       this.server.schema.targets.find(target.id).address,
-      '0.0.0.0'
+      '0.0.0.0',
     );
 
     const targetUrl = `${urls.targets}/${target.id}`;
@@ -289,11 +289,11 @@ module('Acceptance | targets | host-sources', function (hooks) {
 
     assert.strictEqual(
       this.server.schema.targets.find(target.id).address,
-      null
+      null,
     );
     assert.strictEqual(
       this.server.schema.targets.find(target.id).hostSets.models.length,
-      targetHostSetCount + 1
+      targetHostSetCount + 1,
     );
   });
 
@@ -309,7 +309,7 @@ module('Acceptance | targets | host-sources', function (hooks) {
       .hostSets.models.length;
     assert.strictEqual(
       this.server.schema.targets.find(target.id).address,
-      '0.0.0.0'
+      '0.0.0.0',
     );
 
     const targetUrl = `${urls.targets}/${target.id}`;
@@ -323,16 +323,16 @@ module('Acceptance | targets | host-sources', function (hooks) {
     assert.dom('.rose-dialog').isVisible();
     await click(
       '.rose-dialog-footer .rose-button-secondary',
-      'Remove resources'
+      'Remove resources',
     );
 
     assert.strictEqual(
       this.server.schema.targets.find(target.id).address,
-      '0.0.0.0'
+      '0.0.0.0',
     );
     assert.strictEqual(
       this.server.schema.targets.find(target.id).hostSets.models.length,
-      targetHostSetCount
+      targetHostSetCount,
     );
   });
 });

--- a/ui/admin/tests/acceptance/targets/injected-application-credential-sources-test.js
+++ b/ui/admin/tests/acceptance/targets/injected-application-credential-sources-test.js
@@ -78,7 +78,7 @@ module(
         {
           scope: instances.scopes.project,
           credentialStore: instances.vaultCredentialStore,
-        }
+        },
       );
       instances.credentialLibrary = instances.credentialLibraries[0];
       instances.credential = instances.credentials[0];
@@ -125,7 +125,7 @@ module(
       await a11yAudit();
       assert.strictEqual(
         currentURL(),
-        urls.injectedApplicationCredentialSources
+        urls.injectedApplicationCredentialSources,
       );
       assert.strictEqual(findAll('tbody tr').length, credentialSourceCount);
     });
@@ -157,7 +157,7 @@ module(
       await a11yAudit();
       assert.strictEqual(
         currentURL(),
-        urls.addInjectedApplicationCredentialSources
+        urls.addInjectedApplicationCredentialSources,
       );
     });
 
@@ -181,7 +181,7 @@ module(
       await visit(urls.addInjectedApplicationCredentialSources);
       assert.strictEqual(
         findAll('tbody tr').length,
-        getCredentialLibraryCount()
+        getCredentialLibraryCount(),
       );
       assert.dom('.rose-message-title').doesNotExist();
     });
@@ -191,7 +191,7 @@ module(
       await visit(urls.addInjectedApplicationCredentialSources);
       assert.strictEqual(
         find('.rose-message-title').textContent.trim(),
-        'No Injected Application Credential Sources Available'
+        'No Injected Application Credential Sources Available',
       );
     });
 
@@ -205,7 +205,7 @@ module(
       await click(find('.rose-message > .rose-message-body > a'));
       assert.strictEqual(
         currentURL(),
-        urls.addInjectedApplicationCredentialSources
+        urls.addInjectedApplicationCredentialSources,
       );
     });
 
@@ -222,7 +222,7 @@ module(
       await click('form [type="submit"]');
       assert.strictEqual(
         currentURL(),
-        urls.injectedApplicationCredentialSources
+        urls.injectedApplicationCredentialSources,
       );
       assert.strictEqual(findAll('tbody tr').length, 1);
     });
@@ -240,7 +240,7 @@ module(
       await click('form [type="submit"]');
       assert.strictEqual(
         currentURL(),
-        urls.injectedApplicationCredentialSources
+        urls.injectedApplicationCredentialSources,
       );
       assert.strictEqual(findAll('tbody tr').length, 1);
     });
@@ -259,7 +259,7 @@ module(
       await click('form [type="submit"]');
       assert.strictEqual(
         currentURL(),
-        urls.injectedApplicationCredentialSources
+        urls.injectedApplicationCredentialSources,
       );
       assert.strictEqual(findAll('tbody tr').length, 2);
     });
@@ -268,7 +268,7 @@ module(
       assert.expect(1);
       instances.target.authorized_actions =
         instances.target.authorized_actions.filter(
-          (item) => item !== 'add-credential-sources'
+          (item) => item !== 'add-credential-sources',
         );
       await visit(urls.injectedApplicationCredentialSources);
 
@@ -288,7 +288,7 @@ module(
       await click('form [type="button"]');
       assert.strictEqual(
         currentURL(),
-        urls.injectedApplicationCredentialSources
+        urls.injectedApplicationCredentialSources,
       );
       assert.strictEqual(findAll('tbody tr').length, 0);
     });
@@ -307,7 +307,7 @@ module(
       await click('form [type="button"]');
       assert.strictEqual(
         currentURL(),
-        urls.injectedApplicationCredentialSources
+        urls.injectedApplicationCredentialSources,
       );
       assert.strictEqual(findAll('tbody tr').length, 0);
     });
@@ -323,7 +323,7 @@ module(
             code: 'invalid_argument',
             message: 'The request was invalid.',
             details: {},
-          }
+          },
         );
       });
       instances.target.update({
@@ -350,12 +350,12 @@ module(
       await click('tbody tr .hds-dropdown-list-item button');
       assert.strictEqual(
         findAll('tbody tr').length,
-        credentialLibraryCount - 1
+        credentialLibraryCount - 1,
       );
       await visit(urls.addInjectedApplicationCredentialSources);
       assert.strictEqual(
         findAll('tbody tr').length,
-        credentialLibraryCount + 1
+        credentialLibraryCount + 1,
       );
     });
 
@@ -380,7 +380,7 @@ module(
       assert.expect(1);
       instances.target.authorized_actions =
         instances.target.authorized_actions.filter(
-          (item) => item !== 'remove-credential-sources'
+          (item) => item !== 'remove-credential-sources',
         );
       await visit(urls.injectedApplicationCredentialSources);
       assert.dom('tbody tr .rose-dropdown-button-danger').doesNotExist();
@@ -402,7 +402,7 @@ module(
             code: 'invalid_argument',
             message: 'The request was invalid.',
             details: {},
-          }
+          },
         );
       });
       const count = getCredentialLibraryCount();
@@ -429,7 +429,7 @@ module(
             code: 'invalid_argument',
             message: 'The request was invalid.',
             details: {},
-          }
+          },
         );
       });
       const count = getCredentialCount();
@@ -439,5 +439,5 @@ module(
       await click('tbody tr .hds-dropdown-list-item button');
       assert.dom('[role="alert"]').isVisible();
     });
-  }
+  },
 );

--- a/ui/admin/tests/acceptance/targets/list-test.js
+++ b/ui/admin/tests/acceptance/targets/list-test.js
@@ -60,13 +60,13 @@ module('Acceptance | targets | list', function (hooks) {
 
     assert.true(
       instances.scopes.project.authorized_collection_actions.targets.includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.true(
       instances.scopes.project.authorized_collection_actions.targets.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.dom(`[href="${urls.targets}"]`).exists();
   });
@@ -80,13 +80,13 @@ module('Acceptance | targets | list', function (hooks) {
 
     assert.false(
       instances.scopes.project.authorized_collection_actions.targets.includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.false(
       instances.scopes.project.authorized_collection_actions.targets.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert
       .dom('[title="Resources"] a:nth-of-type(2)')
@@ -97,7 +97,7 @@ module('Acceptance | targets | list', function (hooks) {
     assert.expect(3);
     instances.scopes.project.authorized_collection_actions.targets =
       instances.scopes.project.authorized_collection_actions.targets.filter(
-        (item) => item !== 'list'
+        (item) => item !== 'list',
       );
     await visit(urls.orgScope);
 
@@ -105,13 +105,13 @@ module('Acceptance | targets | list', function (hooks) {
 
     assert.true(
       instances.scopes.project.authorized_collection_actions.targets.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.false(
       instances.scopes.project.authorized_collection_actions.targets.includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.dom(`[href="${urls.targets}"]`).exists();
   });
@@ -120,7 +120,7 @@ module('Acceptance | targets | list', function (hooks) {
     assert.expect(3);
     instances.scopes.project.authorized_collection_actions.targets =
       instances.scopes.project.authorized_collection_actions.targets.filter(
-        (item) => item !== 'create'
+        (item) => item !== 'create',
       );
     await visit(urls.orgScope);
 
@@ -128,13 +128,13 @@ module('Acceptance | targets | list', function (hooks) {
 
     assert.false(
       instances.scopes.project.authorized_collection_actions.targets.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.true(
       instances.scopes.project.authorized_collection_actions.targets.includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.dom(`[href="${urls.targets}"]`).exists();
   });

--- a/ui/admin/tests/acceptance/targets/update-test.js
+++ b/ui/admin/tests/acceptance/targets/update-test.js
@@ -78,11 +78,11 @@ module('Acceptance | targets | update', function (hooks) {
     assert.strictEqual(currentURL(), urls.target);
     assert.strictEqual(
       this.server.schema.targets.first().name,
-      'random string'
+      'random string',
     );
     assert.strictEqual(
       this.server.schema.targets.first().workerFilter,
-      'random filter'
+      'random filter',
     );
   });
 
@@ -128,7 +128,7 @@ module('Acceptance | targets | update', function (hooks) {
     await click('.hds-button[type="button"]', 'Update Filter');
     assert.strictEqual(
       this.server.schema.targets.first().egressWorkerFilter,
-      worker_filter_value
+      worker_filter_value,
     );
   });
 
@@ -143,11 +143,11 @@ module('Acceptance | targets | update', function (hooks) {
     await click('.hds-button[type="button"]', 'Update Filter');
     assert.strictEqual(
       this.server.schema.targets.first().egressWorkerFilter,
-      worker_filter_value
+      worker_filter_value,
     );
     assert.strictEqual(
       this.server.schema.targets.first().ingressWorkerFilter,
-      worker_filter_value
+      worker_filter_value,
     );
   });
 
@@ -169,7 +169,7 @@ module('Acceptance | targets | update', function (hooks) {
     await click('.hds-button[type="button"]', 'Update Filter');
     await click(
       '[name="target-worker-filter-toggle-egress_worker_filter"]',
-      'Egress toggle'
+      'Egress toggle',
     );
     assert.dom('[name=egress_worker_filter]').isNotVisible();
   });
@@ -186,12 +186,12 @@ module('Acceptance | targets | update', function (hooks) {
     assert.strictEqual(currentURL(), urls.target);
     assert.strictEqual(
       this.server.schema.targets.first().egressWorkerFilter,
-      'random filter string'
+      'random filter string',
     );
     await click('.rose-form-actions [type="button"]', 'Activate edit mode');
     await click(
       '[name="target-worker-filter-toggle-egress_worker_filter"]',
-      'Egress toggle'
+      'Egress toggle',
     );
     await click('.rose-form-actions [type="submit"]');
     //clear egress_worker_filter when the toggle is off
@@ -199,7 +199,7 @@ module('Acceptance | targets | update', function (hooks) {
     assert.dom('[name=egress_worker_filter]').doesNotExist();
     assert.strictEqual(
       this.server.schema.targets.first().egressWorkerFilter,
-      null
+      null,
     );
   });
 
@@ -236,7 +236,7 @@ module('Acceptance | targets | update', function (hooks) {
     assert.strictEqual(currentURL(), urls.target);
     assert.strictEqual(
       this.server.schema.targets.first().ingressWorkerFilter,
-      'random filter string'
+      'random filter string',
     );
     await click('.rose-form-actions [type="button"]', 'Activate edit mode');
     await click('.hds-form-toggle__control', 'Ingress worker filter');
@@ -246,7 +246,7 @@ module('Acceptance | targets | update', function (hooks) {
     assert.dom('[name=ingress_worker_filter]').doesNotExist();
     assert.strictEqual(
       this.server.schema.targets.first().ingressWorkerFilter,
-      null
+      null,
     );
   });
 
@@ -281,7 +281,7 @@ module('Acceptance | targets | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
 
@@ -302,7 +302,7 @@ module('Acceptance | targets | update', function (hooks) {
     assert.notEqual(instances.target.name, 'random string');
     assert.notEqual(
       instances.target.egressWorkerFilter,
-      'random worker string'
+      'random worker string',
     );
     await visit(urls.targets);
 
@@ -320,7 +320,7 @@ module('Acceptance | targets | update', function (hooks) {
     assert.notEqual(this.server.schema.targets.first().name, 'random string');
     assert.notEqual(
       this.server.schema.targets.first().egressWorkerFilter,
-      'random worker string'
+      'random worker string',
     );
   });
 
@@ -347,7 +347,7 @@ module('Acceptance | targets | update', function (hooks) {
     assert.notEqual(this.server.schema.targets.first().name, 'random string');
     assert.notEqual(
       this.server.schema.targets.first().egressWorkerFilter,
-      'random string'
+      'random string',
     );
   });
 
@@ -372,18 +372,18 @@ module('Acceptance | targets | update', function (hooks) {
       'host-catalog',
       8,
       { scope: instances.scopes.project },
-      'withChildren'
+      'withChildren',
     );
     this.server.createList(
       'credential-store',
       3,
       { scope: instances.scopes.project },
-      'withAssociations'
+      'withAssociations',
     );
     const target = this.server.create(
       'target',
       { scope: instances.scopes.project },
-      'withAssociations'
+      'withAssociations',
     );
     assert.true(this.server.schema.targets.find(target.id).hostSets.length > 0);
 
@@ -400,11 +400,11 @@ module('Acceptance | targets | update', function (hooks) {
 
     assert.strictEqual(
       this.server.schema.targets.find(target.id).address,
-      '0.0.0.0'
+      '0.0.0.0',
     );
     assert.strictEqual(
       this.server.schema.targets.find(target.id).hostSets.length,
-      0
+      0,
     );
   });
 
@@ -418,18 +418,18 @@ module('Acceptance | targets | update', function (hooks) {
       'host-catalog',
       8,
       { scope: instances.scopes.project },
-      'withChildren'
+      'withChildren',
     );
     this.server.createList(
       'credential-store',
       3,
       { scope: instances.scopes.project },
-      'withAssociations'
+      'withAssociations',
     );
     const target = this.server.create(
       'target',
       { scope: instances.scopes.project },
-      'withAssociations'
+      'withAssociations',
     );
     assert.true(this.server.schema.targets.find(target.id).hostSets.length > 0);
 
@@ -446,7 +446,7 @@ module('Acceptance | targets | update', function (hooks) {
 
     assert.strictEqual(
       this.server.schema.targets.find(target.id).address,
-      undefined
+      undefined,
     );
     assert.true(this.server.schema.targets.find(target.id).hostSets.length > 0);
   });

--- a/ui/admin/tests/acceptance/users/accounts-test.js
+++ b/ui/admin/tests/acceptance/users/accounts-test.js
@@ -61,7 +61,7 @@ module('Acceptance | users | accounts', function (hooks) {
       {
         scope: instances.scopes.org,
       },
-      'withAccountsAndUsersAndManagedGroups'
+      'withAccountsAndUsersAndManagedGroups',
     );
     instances.user = this.server.schema.users.first();
     accountsCount = instances.user.accountIds.length;
@@ -98,7 +98,7 @@ module('Acceptance | users | accounts', function (hooks) {
   test('cannot remove an account without proper authorization', async function (assert) {
     assert.expect(1);
     const authorized_actions = instances.user.authorized_actions.filter(
-      (item) => item !== 'remove-accounts'
+      (item) => item !== 'remove-accounts',
     );
     instances.user.update({ authorized_actions });
     await visit(urls.user);
@@ -160,7 +160,7 @@ module('Acceptance | users | accounts', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     await visit(urls.user);
@@ -194,7 +194,7 @@ module('Acceptance | users | accounts', function (hooks) {
   test('cannot navigate to add accounts without proper authorization', async function (assert) {
     assert.expect(1);
     const authorized_actions = instances.user.authorized_actions.filter(
-      (item) => item !== 'add-accounts'
+      (item) => item !== 'add-accounts',
     );
     instances.user.update({ authorized_actions });
     await visit(urls.user);
@@ -298,7 +298,7 @@ module('Acceptance | users | accounts', function (hooks) {
           code: 'invalid_argument',
           message: 'The request was invalid.',
           details: {},
-        }
+        },
       );
     });
     instances.user.update({ accountIds: [] });

--- a/ui/admin/tests/acceptance/users/create-test.js
+++ b/ui/admin/tests/acceptance/users/create-test.js
@@ -75,8 +75,8 @@ module('Acceptance | users | create', function (hooks) {
 
     assert.true(
       instances.scopes.org.authorized_collection_actions.users.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.dom(`[href="${urls.newUser}"]`).exists();
   });
@@ -85,7 +85,7 @@ module('Acceptance | users | create', function (hooks) {
     assert.expect(2);
     instances.scopes.org.authorized_collection_actions.users =
       instances.scopes.org.authorized_collection_actions.users.filter(
-        (item) => item !== 'create'
+        (item) => item !== 'create',
       );
     await visit(urls.orgScope);
 
@@ -93,8 +93,8 @@ module('Acceptance | users | create', function (hooks) {
 
     assert.false(
       instances.scopes.org.authorized_collection_actions.users.includes(
-        'create'
-      )
+        'create',
+      ),
     );
 
     assert.dom('.rose-button-primary').doesNotExist();
@@ -133,7 +133,7 @@ module('Acceptance | users | create', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
 
@@ -150,15 +150,15 @@ module('Acceptance | users | create', function (hooks) {
     assert.expect(2);
     instances.scopes.org.authorized_collection_actions.users =
       instances.scopes.org.authorized_collection_actions.users.filter(
-        (item) => item !== 'create'
+        (item) => item !== 'create',
       );
 
     await visit(urls.newUser);
 
     assert.false(
       instances.scopes.org.authorized_collection_actions.users.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.strictEqual(currentURL(), urls.users);
   });

--- a/ui/admin/tests/acceptance/users/delete-test.js
+++ b/ui/admin/tests/acceptance/users/delete-test.js
@@ -116,7 +116,7 @@ module('Acceptance | users | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
 

--- a/ui/admin/tests/acceptance/users/list-test.js
+++ b/ui/admin/tests/acceptance/users/list-test.js
@@ -56,12 +56,12 @@ module('Acceptance | users | list', function (hooks) {
     await click(`[href="${urls.orgScope}"]`);
 
     assert.true(
-      instances.scopes.org.authorized_collection_actions.users.includes('list')
+      instances.scopes.org.authorized_collection_actions.users.includes('list'),
     );
     assert.true(
       instances.scopes.org.authorized_collection_actions.users.includes(
-        'create'
-      )
+        'create',
+      ),
     );
 
     assert.dom(`[href="${urls.users}"]`).exists();
@@ -76,11 +76,11 @@ module('Acceptance | users | list', function (hooks) {
 
     assert.false(
       instances.scopes.org.authorized_collection_actions.users.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.false(
-      instances.scopes.org.authorized_collection_actions.users.includes('list')
+      instances.scopes.org.authorized_collection_actions.users.includes('list'),
     );
     assert.dom(`nav [href="${urls.users}"]`).doesNotExist();
   });
@@ -89,19 +89,19 @@ module('Acceptance | users | list', function (hooks) {
     assert.expect(4);
     instances.scopes.org.authorized_collection_actions.users =
       instances.scopes.org.authorized_collection_actions.users.filter(
-        (item) => item !== 'list'
+        (item) => item !== 'list',
       );
     await visit(urls.globalScope);
 
     await click(`[href="${urls.orgScope}"]`);
 
     assert.false(
-      instances.scopes.org.authorized_collection_actions.users.includes('list')
+      instances.scopes.org.authorized_collection_actions.users.includes('list'),
     );
     assert.true(
       instances.scopes.org.authorized_collection_actions.users.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.dom(`[href="${urls.users}"]`).exists();
 
@@ -114,19 +114,19 @@ module('Acceptance | users | list', function (hooks) {
     assert.expect(4);
     instances.scopes.org.authorized_collection_actions.users =
       instances.scopes.org.authorized_collection_actions.users.filter(
-        (item) => item !== 'create'
+        (item) => item !== 'create',
       );
     await visit(urls.globalScope);
 
     await click(`[href="${urls.orgScope}"]`);
 
     assert.true(
-      instances.scopes.org.authorized_collection_actions.users.includes('list')
+      instances.scopes.org.authorized_collection_actions.users.includes('list'),
     );
     assert.false(
       instances.scopes.org.authorized_collection_actions.users.includes(
-        'create'
-      )
+        'create',
+      ),
     );
     assert.dom(`[href="${urls.users}"]`).exists();
 

--- a/ui/admin/tests/acceptance/users/update-test.js
+++ b/ui/admin/tests/acceptance/users/update-test.js
@@ -61,7 +61,7 @@ module('Acceptance | users | update', function (hooks) {
     assert.strictEqual(currentURL(), urls.user);
     assert.strictEqual(
       this.server.schema.users.first().name,
-      'Updated user name'
+      'Updated user name',
     );
   });
 
@@ -109,7 +109,7 @@ module('Acceptance | users | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
 

--- a/ui/admin/tests/acceptance/workers/create-test.js
+++ b/ui/admin/tests/acceptance/workers/create-test.js
@@ -79,12 +79,12 @@ module('Acceptance | workers | create', function (hooks) {
     assert
       .dom(createSection[1])
       .includesText(
-        'curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add - ;'
+        'curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add - ;',
       );
     assert
       .dom(createSection[1])
       .doesNotIncludeText(
-        'wget -q "$(curl -fsSL "https://api.releases.hashicorp.com/v1/releases/boundary/latest?license_class=enterprise"'
+        'wget -q "$(curl -fsSL "https://api.releases.hashicorp.com/v1/releases/boundary/latest?license_class=enterprise"',
       );
   });
 
@@ -97,12 +97,12 @@ module('Acceptance | workers | create', function (hooks) {
     assert
       .dom(createSection[1])
       .includesText(
-        'wget -q "$(curl -fsSL "https://api.releases.hashicorp.com/v1/releases/boundary/latest?license_class=enterprise"'
+        'wget -q "$(curl -fsSL "https://api.releases.hashicorp.com/v1/releases/boundary/latest?license_class=enterprise"',
       );
     assert
       .dom(createSection[1])
       .doesNotIncludeText(
-        'curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add - ;'
+        'curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add - ;',
       );
   });
 
@@ -111,8 +111,8 @@ module('Acceptance | workers | create', function (hooks) {
     await visit(workersURL);
     assert.ok(
       globalScope.authorized_collection_actions.workers.includes(
-        'create:worker-led'
-      )
+        'create:worker-led',
+      ),
     );
     assert.dom(`[href="${newWorkerURL}"]`).isVisible();
   });
@@ -123,8 +123,8 @@ module('Acceptance | workers | create', function (hooks) {
     await visit(workersURL);
     assert.notOk(
       globalScope.authorized_collection_actions.users.includes(
-        'create:worker-led'
-      )
+        'create:worker-led',
+      ),
     );
     assert.dom(`[href="${newWorkerURL}"]`).isNotVisible();
   });
@@ -139,7 +139,7 @@ module('Acceptance | workers | create', function (hooks) {
           status: 500,
           code: 'api_error',
           message: 'rpc error: code = Unknown',
-        }
+        },
       );
     });
     await visit(newWorkerURL);
@@ -148,7 +148,7 @@ module('Acceptance | workers | create', function (hooks) {
     assert.strictEqual(
       find('.rose-notification-body').textContent.trim(),
       'rpc error: code = Unknown',
-      'Displays primary error message.'
+      'Displays primary error message.',
     );
   });
 
@@ -156,15 +156,15 @@ module('Acceptance | workers | create', function (hooks) {
     assert.expect(2);
     globalScope.authorized_collection_actions.workers =
       globalScope.authorized_collection_actions.workers.filter(
-        (item) => item !== 'create:worker-led'
+        (item) => item !== 'create:worker-led',
       );
 
     await visit(newWorkerURL);
 
     assert.false(
       globalScope.authorized_collection_actions.workers.includes(
-        'create:worker-led'
-      )
+        'create:worker-led',
+      ),
     );
     assert.strictEqual(currentURL(), workersURL);
   });

--- a/ui/admin/tests/acceptance/workers/delete-test.js
+++ b/ui/admin/tests/acceptance/workers/delete-test.js
@@ -103,7 +103,7 @@ module('Acceptance | workers | delete', function (hooks) {
           status: 490,
           code: 'error',
           message: 'Oops.',
-        }
+        },
       );
     });
     await visit(urls.worker);

--- a/ui/admin/tests/acceptance/workers/list-test.js
+++ b/ui/admin/tests/acceptance/workers/list-test.js
@@ -45,8 +45,8 @@ module('Acceptance | workers | list', function (hooks) {
     await visit(urls.globalScope);
     assert.ok(
       instances.scopes.global.authorized_collection_actions.workers.includes(
-        'list'
-      )
+        'list',
+      ),
     );
     assert.dom(`[href="${urls.workers}"]`).isVisible();
   });

--- a/ui/admin/tests/acceptance/workers/update-test.js
+++ b/ui/admin/tests/acceptance/workers/update-test.js
@@ -82,7 +82,7 @@ module('Acceptance | workers | update', function (hooks) {
               },
             ],
           },
-        }
+        },
       );
     });
     await visit(urls.worker);
@@ -92,12 +92,12 @@ module('Acceptance | workers | update', function (hooks) {
     assert.strictEqual(
       find('.rose-notification-body').textContent.trim(),
       'The request was invalid.',
-      'Displays primary error message.'
+      'Displays primary error message.',
     );
     assert.strictEqual(
       find('.rose-form-error-message').textContent.trim(),
       'Name is required',
-      'Displays field-level errors.'
+      'Displays field-level errors.',
     );
   });
 });

--- a/ui/admin/tests/e2e/helpers/boundary-cli.js
+++ b/ui/admin/tests/e2e/helpers/boundary-cli.js
@@ -31,7 +31,7 @@ exports.authenticateBoundaryCli = async () => {
         process.env.E2E_PASSWORD_AUTH_METHOD_ID +
         ' -login-name=' +
         process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME +
-        ' -password=env://E2E_PASSWORD_ADMIN_PASSWORD'
+        ' -password=env://E2E_PASSWORD_ADMIN_PASSWORD',
     );
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -59,7 +59,7 @@ exports.connectToTarget = async (targetId) => {
         ' -o StrictHostKeyChecking=no' +
         ' -o IdentitiesOnly=yes' + // forces the use of the provided key
         ' -p {{boundary.port}}' +
-        ' {{boundary.ip}}'
+        ' {{boundary.ip}}',
     );
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -80,8 +80,8 @@ exports.createNewOrgCli = async () => {
         `boundary scopes create \
          -name="${orgName}" \
          -scope-id=global \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -115,8 +115,8 @@ exports.createNewProjectCli = async (orgId) => {
         `boundary scopes create \
          -name="${projectName}" \
          -scope-id=${orgId} \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -136,8 +136,8 @@ exports.createNewControllerLedWorkerCli = async () => {
       execSync(
         `boundary workers create controller-led \
          -name="${workerName.toLowerCase()}" \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -159,8 +159,8 @@ exports.createNewPasswordAuthMethodCli = async (scopeId) => {
         `boundary auth-methods create password \
          -name "${authMethodName}" \
          -scope-id ${scopeId} \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -179,7 +179,7 @@ exports.makeAuthMethodPrimaryCli = async (scopeId, authMethodId) => {
       `boundary scopes update \
         -id=${scopeId} \
         -primary-auth-method-id ${authMethodId} \
-        -format json`
+        -format json`,
     );
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -202,8 +202,8 @@ exports.createNewPasswordAccountCli = async (authMethodId) => {
          -auth-method-id ${authMethodId} \
          -login-name ${login} \
          -password env://ACCOUNT_PASSWORD \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -225,8 +225,8 @@ exports.createNewRoleCli = async (scopeId) => {
         `boundary roles create \
          -scope-id ${scopeId} \
          -name ${roleName} \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -248,8 +248,8 @@ exports.createNewGroupCli = async (scopeId) => {
         `boundary groups create \
          -scope-id ${scopeId} \
          -name ${groupName} \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -271,8 +271,8 @@ exports.createNewUserCli = async (scopeId) => {
         `boundary users create \
          -scope-id ${scopeId} \
          -name ${userName} \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -294,8 +294,8 @@ exports.createNewStaticHostCatalogCli = async (projectId) => {
         `boundary host-catalogs create static \
          -scope-id ${projectId} \
          -name ${hostCatalogName} \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -322,8 +322,8 @@ exports.createDynamicAwsHostCatalogCli = async (projectId) => {
           -attr region=us-east-1 \
           -secret access_key_id=env://E2E_AWS_ACCESS_KEY_ID \
           -secret secret_access_key=env://E2E_AWS_SECRET_ACCESS_KEY \
-          -format json`
-      )
+          -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -346,8 +346,8 @@ exports.createNewStaticHostCli = async (hostCatalogId) => {
          -host-catalog-id ${hostCatalogId} \
          -name ${hostName} \
          -address localhost \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -369,8 +369,8 @@ exports.createNewHostSetCli = async (hostCatalogId) => {
         `boundary host-sets create static \
          -host-catalog-id ${hostCatalogId} \
          -name ${hostSetName} \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -392,8 +392,8 @@ exports.createNewStaticCredentialStoreCli = async (projectId) => {
         `boundary credential-stores create static \
          -scope-id ${projectId} \
          -name ${credentialStoreName} \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -411,15 +411,15 @@ exports.createNewStaticCredentialStoreCli = async (projectId) => {
 exports.createNewVaultCredentialStoreCli = async (
   projectId,
   secretPolicyName,
-  boundaryPolicyName
+  boundaryPolicyName,
 ) => {
   let credentialStore;
   try {
     execSync(
-      `vault policy write ${boundaryPolicyName} ./tests/e2e/tests/fixtures/boundary-controller-policy.hcl`
+      `vault policy write ${boundaryPolicyName} ./tests/e2e/tests/fixtures/boundary-controller-policy.hcl`,
     );
     execSync(
-      `vault policy write ${secretPolicyName} ./tests/e2e/tests/fixtures/kv-policy.hcl`
+      `vault policy write ${secretPolicyName} ./tests/e2e/tests/fixtures/kv-policy.hcl`,
     );
     const vaultToken = JSON.parse(
       execSync(
@@ -430,8 +430,8 @@ exports.createNewVaultCredentialStoreCli = async (
           -orphan=true \
           -period=20m \
           -renewable=true \
-          -format=json`
-      )
+          -format=json`,
+      ),
     );
     const clientToken = vaultToken.auth.client_token;
     const credentialStoreName = 'vault-credential-store-' + nanoid();
@@ -442,8 +442,8 @@ exports.createNewVaultCredentialStoreCli = async (
           -name ${credentialStoreName} \
           -vault-address ${process.env.E2E_VAULT_ADDR} \
           -vault-token ${clientToken} \
-          -format json`
-      )
+          -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -468,8 +468,8 @@ exports.createNewUsernamePasswordCredentialCli = async (credentialStoreId) => {
          -credential-store-id ${credentialStoreId} \
          -username ${login} \
          -password env://CREDENTIALS_PASSWORD \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -493,8 +493,8 @@ exports.createNewTcpTarget = async (projectId) => {
          -default-port ${defaultPort} \
          -name ${targetName} \
          -scope-id ${projectId} \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -518,8 +518,8 @@ exports.createNewSshTarget = async (projectId) => {
          -default-port ${defaultPort} \
          -name ${targetName} \
          -scope-id ${projectId} \
-         -format json`
-      )
+         -format json`,
+      ),
     ).item;
   } catch (e) {
     console.log(`${e.stderr}`);
@@ -540,17 +540,17 @@ exports.getSessionCli = async (orgName, projectName, targetName) => {
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     const org = orgs.items.filter((obj) => obj.name == orgName)[0];
     const projects = JSON.parse(
-      execSync(`boundary scopes list -format json -scope-id ${org.id}`)
+      execSync(`boundary scopes list -format json -scope-id ${org.id}`),
     );
     const project = projects.items.filter((obj) => obj.name == projectName)[0];
     const targets = JSON.parse(
-      execSync(`boundary targets list -format json -scope-id ${project.id}`)
+      execSync(`boundary targets list -format json -scope-id ${project.id}`),
     );
     const target = targets.items.filter((obj) => obj.name == targetName)[0];
     session = JSON.parse(
       execSync(
-        `boundary targets authorize-session -id ${target.id} -format json`
-      )
+        `boundary targets authorize-session -id ${target.id} -format json`,
+      ),
     );
   } catch (e) {
     console.log(`${e.stderr}`);

--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -23,13 +23,13 @@ exports.createNewOrg = async (page) => {
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: orgName })
+      .getByRole('link', { name: orgName }),
   ).toBeVisible();
 
   return orgName;
@@ -51,13 +51,13 @@ exports.createNewProject = async (page) => {
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: projectName })
+      .getByRole('link', { name: projectName }),
   ).toBeVisible();
 
   return projectName;
@@ -79,13 +79,13 @@ exports.createNewHostCatalog = async (page) => {
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: hostCatalogName })
+      .getByRole('link', { name: hostCatalogName }),
   ).toBeVisible();
 
   return hostCatalogName;
@@ -104,13 +104,13 @@ exports.createNewHostSet = async (page) => {
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: hostSetName })
+      .getByRole('link', { name: hostSetName }),
   ).toBeVisible();
 
   return hostSetName;
@@ -130,7 +130,7 @@ exports.createNewHostInHostSet = async (page) => {
   await page.getByLabel('Address').fill(process.env.E2E_TARGET_ADDRESS);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(page.getByRole('link', { name: hostName })).toBeVisible();
@@ -155,13 +155,13 @@ exports.createNewTarget = async (page) => {
   await page.getByLabel('Default Port').fill(process.env.E2E_TARGET_PORT);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: targetName })
+      .getByRole('link', { name: targetName }),
   ).toBeVisible();
 
   return targetName;
@@ -185,13 +185,13 @@ exports.createNewTargetWithAddress = async (page) => {
   await page.getByLabel('Default Port').fill(process.env.E2E_TARGET_PORT);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: targetName })
+      .getByRole('link', { name: targetName }),
   ).toBeVisible();
 
   return targetName;
@@ -208,7 +208,7 @@ exports.deleteResource = async (page) => {
   await page.getByRole('button', { name: /^(Delete|Remove Worker)/ }).click();
   await page.getByText('OK', { exact: true }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
 };
@@ -222,7 +222,7 @@ exports.removeAuthMethodAsPrimary = async (page) => {
   await page.getByRole('button', { name: 'Remove as primary' }).click();
   await page.getByText('OK', { exact: true }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
 };
@@ -245,7 +245,7 @@ exports.addHostSourceToTarget = async (page, hostSourceName) => {
     .click({ force: true });
   await page.getByRole('button', { name: 'Add Host Sources' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(page.getByRole('link', { name: hostSourceName })).toBeVisible();
@@ -289,7 +289,7 @@ exports.waitForSessionToBeVisible = async (page, targetName) => {
 exports.addBrokeredCredentialsToTarget = async (
   page,
   targetName,
-  credentialName
+  credentialName,
 ) => {
   await page
     .getByRole('navigation', { name: 'Resources' })
@@ -312,7 +312,7 @@ exports.addBrokeredCredentialsToTarget = async (
     .getByRole('button', { name: 'Add Brokered Credentials', exact: true })
     .click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(page.getByRole('link', { name: credentialName })).toBeVisible();
@@ -333,13 +333,13 @@ exports.createNewPasswordAuthMethod = async (page, authMethodName) => {
   await page.getByLabel('Name').fill(authMethodName);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: authMethodName })
+      .getByRole('link', { name: authMethodName }),
   ).toBeVisible();
 };
 
@@ -357,7 +357,7 @@ exports.makeAuthMethodPrimary = async (page) => {
   await page.getByText('Make Primary', { exact: true }).click();
   await page.getByText('OK', { exact: true }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
 };
@@ -381,13 +381,13 @@ exports.addAccountToAuthMethod = async (page, accountName, login, password) => {
   await page.getByLabel('Password').fill(password);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: accountName })
+      .getByRole('link', { name: accountName }),
   ).toBeVisible();
 };
 
@@ -402,7 +402,7 @@ exports.setPasswordToAccount = async (page, password) => {
   await page.getByLabel('Password').fill(password);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
 };
@@ -424,13 +424,13 @@ exports.createNewUser = async (page, userName) => {
   await page.getByLabel('Name').fill(userName);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: userName })
+      .getByRole('link', { name: userName }),
   ).toBeVisible();
 };
 
@@ -450,7 +450,7 @@ exports.addAccountToUser = async (page) => {
   await page.getByRole('checkbox').click();
   await page.getByRole('button', { name: 'Add Accounts', exact: true }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
 };
@@ -472,13 +472,13 @@ exports.createNewGroup = async (page, groupName) => {
   await page.getByLabel('Name').fill(groupName);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: groupName })
+      .getByRole('link', { name: groupName }),
   ).toBeVisible();
 };
 
@@ -496,7 +496,7 @@ exports.addMemberToGroup = async (page, userName) => {
   await page.getByRole('checkbox', { name: userName }).click();
   await page.getByRole('button', { name: 'Add Members', exact: true }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(page.getByRole('table').getByText(userName)).toBeVisible();
@@ -516,13 +516,13 @@ exports.createNewRole = async (page, roleName) => {
   await page.getByLabel('Name').fill(roleName);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: roleName })
+      .getByRole('link', { name: roleName }),
   ).toBeVisible();
 };
 
@@ -542,11 +542,11 @@ exports.addPrincipalToRole = async (page, principalName) => {
     .getByRole('button', { name: 'Add Principals', exact: true })
     .click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
-    page.getByRole('table').getByRole('link', { name: principalName })
+    page.getByRole('table').getByRole('link', { name: principalName }),
   ).toBeVisible();
 };
 
@@ -561,10 +561,10 @@ exports.addGrantsToGroup = async (page, grants) => {
   await page.getByRole('button', { name: 'Add', exact: true }).click();
   await page.getByRole('button', { name: 'Save', exact: true }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
-    page.getByRole('textbox', { name: 'Grant', exact: true })
+    page.getByRole('textbox', { name: 'Grant', exact: true }),
   ).toHaveValue(grants);
 };

--- a/ui/admin/tests/e2e/tests/auth-method.spec.js
+++ b/ui/admin/tests/e2e/tests/auth-method.spec.js
@@ -43,7 +43,7 @@ test('Verify new auth-method can be created and assigned to users', async ({
       page,
       'UI Test Account',
       'test-user',
-      'password'
+      'password',
     );
     await setPasswordToAccount(page, 'password2');
     await makeAuthMethodPrimary(page);

--- a/ui/admin/tests/e2e/tests/credential-store-static.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static.spec.js
@@ -63,11 +63,11 @@ test.beforeEach(async ({ page }) => {
   await page.getByRole('group', { name: 'Type' }).getByLabel('Static').click();
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
-    page.getByRole('link', { name: credentialStoreName })
+    page.getByRole('link', { name: credentialStoreName }),
   ).toBeVisible();
 });
 
@@ -90,7 +90,7 @@ test('Static Credential Store (User & Key Pair)', async ({ page }) => {
   await page.getByLabel('SSH Private Key', { exact: true }).fill(keyData);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(page.getByRole('link', { name: credentialName })).toBeVisible();
@@ -107,7 +107,7 @@ test('Static Credential Store (User & Key Pair)', async ({ page }) => {
       'Stored User does not match. EXPECTED: ' +
         process.env.E2E_SSH_USER +
         ', ACTUAL: ' +
-        retrievedUser
+        retrievedUser,
     );
   }
   if (keyData != retrievedKey) {
@@ -132,7 +132,7 @@ test('Static Credential Store (Username & Password)', async ({ page }) => {
   await page.getByLabel('Password', { exact: true }).fill(testPassword);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(page.getByRole('link', { name: credentialName })).toBeVisible();
@@ -149,7 +149,7 @@ test('Static Credential Store (Username & Password)', async ({ page }) => {
       'Stored User does not match. EXPECTED: ' +
         process.env.E2E_SSH_USER +
         ', ACTUAL: ' +
-        retrievedUser
+        retrievedUser,
     );
   }
   if (testPassword != retrievedPassword) {
@@ -157,7 +157,7 @@ test('Static Credential Store (Username & Password)', async ({ page }) => {
       'Stored Password does not match. EXPECTED: ' +
         testPassword +
         ', ACTUAL: ' +
-        retrievedPassword
+        retrievedPassword,
     );
   }
 });
@@ -176,11 +176,11 @@ test('Static Credential Store (JSON)', async ({ page }) => {
   await page.keyboard.type(
     `"username": "${testName}",
     "password": "${testPassword}",
-    "id": "${testId}"`
+    "id": "${testId}"`,
   );
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(page.getByRole('link', { name: credentialName })).toBeVisible();
@@ -198,7 +198,7 @@ test('Static Credential Store (JSON)', async ({ page }) => {
       'Stored User does not match. EXPECTED: ' +
         process.env.E2E_SSH_USER +
         ', ACTUAL: ' +
-        retrievedUser
+        retrievedUser,
     );
   }
   if (testPassword != retrievedPassword) {
@@ -206,7 +206,7 @@ test('Static Credential Store (JSON)', async ({ page }) => {
       'Stored Password does not match. EXPECTED: ' +
         testPassword +
         ', ACTUAL: ' +
-        retrievedPassword
+        retrievedPassword,
     );
   }
   if (testId != retrievedId) {
@@ -214,7 +214,7 @@ test('Static Credential Store (JSON)', async ({ page }) => {
       'Stored ID does not match. EXPECTED: ' +
         testId +
         ', ACTUAL: ' +
-        retrievedId
+        retrievedId,
     );
   }
 });

--- a/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
@@ -55,16 +55,16 @@ test.beforeEach(async ({ page }) => {
 
 test('Vault Credential Store (User & Key Pair)', async ({ page }) => {
   execSync(
-    `vault policy write ${boundaryPolicyName} ./tests/e2e/tests/fixtures/boundary-controller-policy.hcl`
+    `vault policy write ${boundaryPolicyName} ./tests/e2e/tests/fixtures/boundary-controller-policy.hcl`,
   );
   execSync(`vault secrets enable -path=${secretsPath} kv-v2`);
   execSync(
     `vault kv put -mount ${secretsPath} ${secretName} ` +
       ` username=${process.env.E2E_SSH_USER}` +
-      ` private_key=@${process.env.E2E_SSH_KEY_PATH}`
+      ` private_key=@${process.env.E2E_SSH_KEY_PATH}`,
   );
   execSync(
-    `vault policy write ${secretPolicyName} ./tests/e2e/tests/fixtures/kv-policy.hcl`
+    `vault policy write ${secretPolicyName} ./tests/e2e/tests/fixtures/kv-policy.hcl`,
   );
   const vaultToken = JSON.parse(
     execSync(
@@ -75,8 +75,8 @@ test('Vault Credential Store (User & Key Pair)', async ({ page }) => {
         ` -orphan=true` +
         ` -period=20m` +
         ` -renewable=true` +
-        ` -format=json`
-    )
+        ` -format=json`,
+    ),
   );
   const clientToken = vaultToken.auth.client_token;
 
@@ -103,11 +103,11 @@ test('Vault Credential Store (User & Key Pair)', async ({ page }) => {
   await page.getByLabel('Token', { exact: true }).fill(clientToken);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
-    page.getByRole('link', { name: credentialStoreName })
+    page.getByRole('link', { name: credentialStoreName }),
   ).toBeVisible();
 
   const credentialLibraryName = 'Credential Library ' + nanoid();
@@ -122,7 +122,7 @@ test('Vault Credential Store (User & Key Pair)', async ({ page }) => {
   await page.getByLabel('Vault Path').fill(`${secretsPath}/data/${secretName}`);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
 
@@ -147,27 +147,29 @@ test('Vault Credential Store (User & Key Pair)', async ({ page }) => {
     .getByRole('button', { name: 'Add Brokered Credentials', exact: true })
     .click();
   await expect(
-    page.getByRole('alert').getByText('Success', { exact: true })
+    page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
-    page.getByRole('link', { name: credentialLibraryName })
+    page.getByRole('link', { name: credentialLibraryName }),
   ).toBeVisible();
 
   await authenticateBoundaryCli();
   const orgs = JSON.parse(execSync('boundary scopes list -format json'));
   const org = orgs.items.filter((obj) => obj.name == orgName)[0];
   const projects = JSON.parse(
-    execSync(`boundary scopes list -format json -scope-id ${org.id}`)
+    execSync(`boundary scopes list -format json -scope-id ${org.id}`),
   );
   const project = projects.items.filter((obj) => obj.name == projectName)[0];
   const targets = JSON.parse(
-    execSync(`boundary targets list -format json -scope-id ${project.id}`)
+    execSync(`boundary targets list -format json -scope-id ${project.id}`),
   );
   const target = targets.items.filter((obj) => obj.name == targetName)[0];
 
   const session = JSON.parse(
-    execSync(`boundary targets authorize-session -id ${target.id} -format json`)
+    execSync(
+      `boundary targets authorize-session -id ${target.id} -format json`,
+    ),
   );
   const retrievedUser =
     session.item.credentials[0].secret.decoded.data.username;
@@ -178,7 +180,7 @@ test('Vault Credential Store (User & Key Pair)', async ({ page }) => {
       'Stored User does not match. EXPECTED: ' +
         process.env.E2E_SSH_USER +
         ', ACTUAL: ' +
-        retrievedUser
+        retrievedUser,
     );
   }
   const keyData = await readFile(process.env.E2E_SSH_KEY_PATH, {

--- a/ui/admin/tests/e2e/tests/delete-resources.spec.js
+++ b/ui/admin/tests/e2e/tests/delete-resources.spec.js
@@ -80,18 +80,16 @@ test('Verify resources can be deleted', async ({ page }) => {
     let groupId = await createNewGroupCli(orgId);
     let userId = await createNewUserCli(orgId);
     let staticHostCatalogId = await createNewStaticHostCatalogCli(projectId);
-    let dynamicAwsHostCatalogId = await createDynamicAwsHostCatalogCli(
-      projectId
-    );
+    let dynamicAwsHostCatalogId =
+      await createDynamicAwsHostCatalogCli(projectId);
     let staticHostId = await createNewStaticHostCli(staticHostCatalogId);
     let staticHostSetId = await createNewHostSetCli(staticHostCatalogId);
-    let staticCredentialStoreId = await createNewStaticCredentialStoreCli(
-      projectId
-    );
+    let staticCredentialStoreId =
+      await createNewStaticCredentialStoreCli(projectId);
     let vaultCredentialStoreId = await createNewVaultCredentialStoreCli(
       projectId,
       secretPolicyName,
-      boundaryPolicyName
+      boundaryPolicyName,
     );
     let usernamePasswordCredentialId =
       await createNewUsernamePasswordCredentialCli(staticCredentialStoreId);
@@ -103,43 +101,43 @@ test('Verify resources can be deleted', async ({ page }) => {
 
     // Delete username-password credentials
     await page.goto(
-      `/scopes/${projectId}/credential-stores/${staticCredentialStoreId}/credentials/${usernamePasswordCredentialId}`
+      `/scopes/${projectId}/credential-stores/${staticCredentialStoreId}/credentials/${usernamePasswordCredentialId}`,
     );
     await deleteResource(page);
 
     // Delete static credential store
     await page.goto(
-      `/scopes/${projectId}/credential-stores/${staticCredentialStoreId}`
+      `/scopes/${projectId}/credential-stores/${staticCredentialStoreId}`,
     );
     await deleteResource(page);
 
     // Delete vault credential store
     await page.goto(
-      `/scopes/${projectId}/credential-stores/${vaultCredentialStoreId}`
+      `/scopes/${projectId}/credential-stores/${vaultCredentialStoreId}`,
     );
     await deleteResource(page);
 
     // Delete static host set
     await page.goto(
-      `/scopes/${projectId}/host-catalogs/${staticHostCatalogId}/host-sets/${staticHostSetId}`
+      `/scopes/${projectId}/host-catalogs/${staticHostCatalogId}/host-sets/${staticHostSetId}`,
     );
     await deleteResource(page);
 
     // Delete static host
     await page.goto(
-      `/scopes/${projectId}/host-catalogs/${staticHostCatalogId}/hosts/${staticHostId}`
+      `/scopes/${projectId}/host-catalogs/${staticHostCatalogId}/hosts/${staticHostId}`,
     );
     await deleteResource(page);
 
     // Delete static host catalog
     await page.goto(
-      `/scopes/${projectId}/host-catalogs/${staticHostCatalogId}`
+      `/scopes/${projectId}/host-catalogs/${staticHostCatalogId}`,
     );
     await deleteResource(page);
 
     // Delete dynamic aws host catalog
     await page.goto(
-      `/scopes/${projectId}/host-catalogs/${dynamicAwsHostCatalogId}`
+      `/scopes/${projectId}/host-catalogs/${dynamicAwsHostCatalogId}`,
     );
     await deleteResource(page);
 
@@ -165,7 +163,7 @@ test('Verify resources can be deleted', async ({ page }) => {
 
     // Delete password account
     await page.goto(
-      `/scopes/${orgId}/auth-methods/${authMethodId}/accounts/${passwordAccountId}`
+      `/scopes/${orgId}/auth-methods/${authMethodId}/accounts/${passwordAccountId}`,
     );
     await deleteResource(page);
 

--- a/ui/admin/tests/e2e/tests/dynamic-host-catalog.spec.js
+++ b/ui/admin/tests/e2e/tests/dynamic-host-catalog.spec.js
@@ -57,13 +57,13 @@ test.describe('AWS', async () => {
     await page.getByLabel('Disable credential rotation').click({ force: true });
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(
-      page.getByRole('alert').getByText('Success', { exact: true })
+      page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();
     await page.getByRole('button', { name: 'Dismiss' }).click();
     await expect(
       page
         .getByRole('navigation', { name: 'breadcrumbs' })
-        .getByRole('link', { name: hostCatalogName })
+        .getByRole('link', { name: hostCatalogName }),
     ).toBeVisible();
 
     // Create first host set
@@ -82,20 +82,20 @@ test.describe('AWS', async () => {
       .click();
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(
-      page.getByRole('alert').getByText('Success', { exact: true })
+      page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();
     await page.getByRole('button', { name: 'Dismiss' }).click();
     await expect(
       page
         .getByRole('navigation', { name: 'breadcrumbs' })
-        .getByRole('link', { name: hostSetName1 })
+        .getByRole('link', { name: hostSetName1 }),
     ).toBeVisible();
 
     await page.getByRole('link', { name: 'Hosts' }).click();
     await expect(
       page
         .getByRole('navigation', { name: 'breadcrumbs' })
-        .getByRole('link', { name: 'Hosts' })
+        .getByRole('link', { name: 'Hosts' }),
     ).toBeVisible();
 
     // Check number of hosts in host set
@@ -128,7 +128,7 @@ test.describe('AWS', async () => {
         'Hosts are not visible. EXPECTED: ' +
           expectedHosts.length +
           ', ACTUAL: ' +
-          rowCount
+          rowCount,
       );
     }
 
@@ -147,7 +147,7 @@ test.describe('AWS', async () => {
       await expect(
         page
           .getByRole('navigation', { name: 'breadcrumbs' })
-          .getByRole('link', { name: hostName })
+          .getByRole('link', { name: hostName }),
       ).toBeVisible();
 
       await page

--- a/ui/admin/tests/e2e/tests/login.spec.js
+++ b/ui/admin/tests/e2e/tests/login.spec.js
@@ -18,7 +18,7 @@ test('Log in, log out, and then log back in', async ({ page }) => {
   await page.getByRole('button', { name: 'Sign In' }).click();
   await expect(page.getByRole('navigation', { name: 'General' })).toBeVisible();
   await expect(
-    page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME)
+    page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME),
   ).toBeEnabled();
 
   await page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME).click();
@@ -51,7 +51,7 @@ test.describe('Failure Cases', async () => {
     await expect(page.getByRole('alert').getByText('Error')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
     await expect(
-      page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME)
+      page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME),
     ).toBeHidden();
   });
 
@@ -61,7 +61,7 @@ test.describe('Failure Cases', async () => {
     await expect(page.getByRole('alert').getByText('Error')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
     await expect(
-      page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME)
+      page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME),
     ).toBeHidden();
   });
 
@@ -73,7 +73,7 @@ test.describe('Failure Cases', async () => {
     await expect(page.getByRole('alert').getByText('Error')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
     await expect(
-      page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME)
+      page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME),
     ).toBeHidden();
   });
 });

--- a/ui/admin/tests/e2e/tests/target.spec.js
+++ b/ui/admin/tests/e2e/tests/target.spec.js
@@ -57,11 +57,11 @@ test('Verify session created to target with host, then cancel the session', asyn
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     org = orgs.items.filter((obj) => obj.name == orgName)[0];
     const projects = JSON.parse(
-      execSync('boundary scopes list -format json -scope-id ' + org.id)
+      execSync('boundary scopes list -format json -scope-id ' + org.id),
     );
     const project = projects.items.filter((obj) => obj.name == projectName)[0];
     const targets = JSON.parse(
-      execSync('boundary targets list -format json -scope-id ' + project.id)
+      execSync('boundary targets list -format json -scope-id ' + project.id),
     );
     const target = targets.items.filter((obj) => obj.name == targetName)[0];
 
@@ -96,11 +96,11 @@ test('Verify session created to target with address, then cancel the session', a
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     org = orgs.items.filter((obj) => obj.name == orgName)[0];
     const projects = JSON.parse(
-      execSync('boundary scopes list -format json -scope-id ' + org.id)
+      execSync('boundary scopes list -format json -scope-id ' + org.id),
     );
     const project = projects.items.filter((obj) => obj.name == projectName)[0];
     const targets = JSON.parse(
-      execSync('boundary targets list -format json -scope-id ' + project.id)
+      execSync('boundary targets list -format json -scope-id ' + project.id),
     );
     const target = targets.items.filter((obj) => obj.name == targetName)[0];
 
@@ -144,7 +144,7 @@ test('Verify TCP target is updated', async ({ page }) => {
     await page.getByRole('button', { name: 'Save' }).click();
 
     await expect(
-      page.getByRole('alert').getByText('Success', { exact: true })
+      page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();
   } finally {
     await authenticateBoundaryCli();

--- a/ui/admin/tests/integration/components/breadcrumbs/container/index-test.js
+++ b/ui/admin/tests/integration/components/breadcrumbs/container/index-test.js
@@ -16,11 +16,11 @@ module(
     test('it renders', async function (assert) {
       assert.expect(2);
       await render(
-        hbs` <Breadcrumbs::Item @text='Orgs' @icon='org' @route='scopes.scope.scopes' @model='global' /> <Breadcrumbs::Container />`
+        hbs` <Breadcrumbs::Item @text='Orgs' @icon='org' @route='scopes.scope.scopes' @model='global' /> <Breadcrumbs::Container />`,
       );
 
       assert.dom('.hds-breadcrumb__text').hasText('Orgs');
       assert.dom('.hds-breadcrumb__icon').exists();
     });
-  }
+  },
 );

--- a/ui/admin/tests/integration/components/form/target/worker-filter-test.js
+++ b/ui/admin/tests/integration/components/form/target/worker-filter-test.js
@@ -18,7 +18,7 @@ module('Integration | Component | form/target/worker-filter', function (hooks) {
     this.onChange = () => {};
     this.toggleAction = () => {};
     await render(
-      hbs`<Form::Target::WorkerFilter @name='egress_worker_filter' @toggleEnabled={{false}} @toggleAction={{this.toggleAction}} @onChange={{this.onChange}}/>`
+      hbs`<Form::Target::WorkerFilter @name='egress_worker_filter' @toggleEnabled={{false}} @toggleAction={{this.toggleAction}} @onChange={{this.onChange}}/>`,
     );
 
     assert.dom('.hds-form-toggle').isVisible();
@@ -30,7 +30,7 @@ module('Integration | Component | form/target/worker-filter', function (hooks) {
     this.onChange = () => {};
     this.toggleAction = () => {};
     await render(
-      hbs`<Form::Target::WorkerFilter @name='egress_worker_filter' @toggleEnabled={{true}} @toggleAction={{this.toggleAction}} @onChange={{this.onChange}}/>`
+      hbs`<Form::Target::WorkerFilter @name='egress_worker_filter' @toggleEnabled={{true}} @toggleAction={{this.toggleAction}} @onChange={{this.onChange}}/>`,
     );
 
     assert.dom('.hds-form-toggle').isVisible();

--- a/ui/admin/tests/integration/components/form/worker/create-worker-led-test.js
+++ b/ui/admin/tests/integration/components/form/worker/create-worker-led-test.js
@@ -33,7 +33,7 @@ module(
       windowService.location.hostname = `${guid}.boundary.hcp.dev`;
 
       await render(
-        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @cancel={{this.cancel}} />`
+        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @cancel={{this.cancel}} />`,
       );
 
       assert.dom('[name="cluster_id"]').hasValue(guid);
@@ -49,7 +49,7 @@ module(
       windowService.location.hostname = `${guid}.boundary.hcp.to`;
 
       await render(
-        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @cancel={{this.cancel}} />`
+        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @cancel={{this.cancel}} />`,
       );
 
       assert.dom('[name="cluster_id"]').hasValue(guid);
@@ -65,7 +65,7 @@ module(
       windowService.location.hostname = `${guid}.boundary.hashicorp.cloud`;
 
       await render(
-        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @cancel={{this.cancel}} />`
+        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @cancel={{this.cancel}} />`,
       );
 
       assert.dom('[name="cluster_id"]').hasValue(guid);
@@ -80,10 +80,10 @@ module(
       windowService.location.hostname = `personal.website.com`;
 
       await render(
-        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @cancel={{this.cancel}} />`
+        hbs`<Form::Worker::CreateWorkerLed @model={{this.model}} @submit={{this.submit}} @cancel={{this.cancel}} />`,
       );
 
       assert.dom('[name="cluster_id"]').hasNoValue();
     });
-  }
+  },
 );

--- a/ui/admin/tests/integration/components/link-list-panel/index-test.js
+++ b/ui/admin/tests/integration/components/link-list-panel/index-test.js
@@ -92,7 +92,7 @@ module('Integration | Component | link-list-panel/index', function (hooks) {
       .dom('li.link-list-item > a')
       .hasAttribute(
         'href',
-        `/scopes/${this.modelA.scopeId}/users/${this.modelA.id}`
+        `/scopes/${this.modelA.scopeId}/users/${this.modelA.id}`,
       );
 
     // ScopeId org
@@ -106,7 +106,7 @@ module('Integration | Component | link-list-panel/index', function (hooks) {
       .dom('li.link-list-item > a')
       .hasAttribute(
         'href',
-        `/scopes/${this.modelB.scopeId}/users/${this.modelB.id}`
+        `/scopes/${this.modelB.scopeId}/users/${this.modelB.id}`,
       );
   });
 
@@ -128,7 +128,7 @@ module('Integration | Component | link-list-panel/index', function (hooks) {
       .dom('li.link-list-item:nth-child(2) > a')
       .hasAttribute(
         'href',
-        `/scopes/${this.modelB.scopeId}/users/${this.modelB.id}`
+        `/scopes/${this.modelB.scopeId}/users/${this.modelB.id}`,
       );
     assert
       .dom('li.link-list-item:nth-child(3) > a')

--- a/ui/admin/tests/integration/components/session-recording/player-test.js
+++ b/ui/admin/tests/integration/components/session-recording/player-test.js
@@ -38,7 +38,7 @@ module('Integration | Component | session-recording/player', function (hooks) {
 
     assert.dom('.session-recording-player-header').hasText('Back to channels');
     const result = await waitUntil(() =>
-      find('.ap-player').textContent.includes('yarn test')
+      find('.ap-player').textContent.includes('yarn test'),
     );
     assert.true(result);
   });

--- a/ui/admin/tests/integration/components/worker-diagram/dual-filter/hcp/index-test.js
+++ b/ui/admin/tests/integration/components/worker-diagram/dual-filter/hcp/index-test.js
@@ -25,7 +25,7 @@ module(
 
     test('it renders the correct diagram when egress and ingress filter is false', async function (assert) {
       await render(
-        hbs`<WorkerDiagram::DualFilter::Hcp @egressWorkerFilterEnabled={{false}} @ingressWorkerFilterEnabled={{false}} />`
+        hbs`<WorkerDiagram::DualFilter::Hcp @egressWorkerFilterEnabled={{false}} @ingressWorkerFilterEnabled={{false}} />`,
       );
 
       assert.dom('[data-test-dual-filter-hcp-egress-off-ingress-off]').exists();
@@ -33,7 +33,7 @@ module(
 
     test('it renders the correct diagram when egress filter is true and ingress filter is false', async function (assert) {
       await render(
-        hbs`<WorkerDiagram::DualFilter::Hcp @egressWorkerFilterEnabled={{true}} @ingressWorkerFilterEnabled={{false}} />`
+        hbs`<WorkerDiagram::DualFilter::Hcp @egressWorkerFilterEnabled={{true}} @ingressWorkerFilterEnabled={{false}} />`,
       );
 
       assert.dom('[data-test-dual-filter-hcp-egress-on-ingress-off]').exists();
@@ -41,7 +41,7 @@ module(
 
     test('it renders the correct diagram when egress filter is false and ingress filter is true', async function (assert) {
       await render(
-        hbs`<WorkerDiagram::DualFilter::Hcp @egressWorkerFilterEnabled={{false}} @ingressWorkerFilterEnabled={{true}} />`
+        hbs`<WorkerDiagram::DualFilter::Hcp @egressWorkerFilterEnabled={{false}} @ingressWorkerFilterEnabled={{true}} />`,
       );
 
       assert.dom('[data-test-dual-filter-hcp-egress-off-ingress-on]').exists();
@@ -49,10 +49,10 @@ module(
 
     test('it renders the correct diagram when egress and ingress filter is true', async function (assert) {
       await render(
-        hbs`<WorkerDiagram::DualFilter::Hcp @egressWorkerFilterEnabled={{true}} @ingressWorkerFilterEnabled={{true}} />`
+        hbs`<WorkerDiagram::DualFilter::Hcp @egressWorkerFilterEnabled={{true}} @ingressWorkerFilterEnabled={{true}} />`,
       );
 
       assert.dom('[data-test-dual-filter-hcp-egress-on-ingress-on]').exists();
     });
-  }
+  },
 );

--- a/ui/admin/tests/integration/components/worker-diagram/dual-filter/index-test.js
+++ b/ui/admin/tests/integration/components/worker-diagram/dual-filter/index-test.js
@@ -25,7 +25,7 @@ module(
 
     test('it renders the correct diagram when egress and ingress filter is false', async function (assert) {
       await render(
-        hbs`<WorkerDiagram::DualFilter @egressWorkerFilterEnabled={{false}} @ingressWorkerFilterEnabled={{false}} />`
+        hbs`<WorkerDiagram::DualFilter @egressWorkerFilterEnabled={{false}} @ingressWorkerFilterEnabled={{false}} />`,
       );
 
       assert.dom('[data-test-dual-filter-egress-off-ingress-off]').exists();
@@ -33,7 +33,7 @@ module(
 
     test('it renders the correct diagram when egress filter is true and ingress filter is false', async function (assert) {
       await render(
-        hbs`<WorkerDiagram::DualFilter @egressWorkerFilterEnabled={{true}} @ingressWorkerFilterEnabled={{false}} />`
+        hbs`<WorkerDiagram::DualFilter @egressWorkerFilterEnabled={{true}} @ingressWorkerFilterEnabled={{false}} />`,
       );
 
       assert.dom('[data-test-dual-filter-egress-on-ingress-off]').exists();
@@ -41,7 +41,7 @@ module(
 
     test('it renders the correct diagram when egress filter is false and ingress filter is true', async function (assert) {
       await render(
-        hbs`<WorkerDiagram::DualFilter @egressWorkerFilterEnabled={{false}} @ingressWorkerFilterEnabled={{true}} />`
+        hbs`<WorkerDiagram::DualFilter @egressWorkerFilterEnabled={{false}} @ingressWorkerFilterEnabled={{true}} />`,
       );
 
       assert.dom('[data-test-dual-filter-egress-off-ingress-on]').exists();
@@ -49,10 +49,10 @@ module(
 
     test('it renders the correct diagram when egress and ingress filter is true', async function (assert) {
       await render(
-        hbs`<WorkerDiagram::DualFilter @egressWorkerFilterEnabled={{true}} @ingressWorkerFilterEnabled={{true}} />`
+        hbs`<WorkerDiagram::DualFilter @egressWorkerFilterEnabled={{true}} @ingressWorkerFilterEnabled={{true}} />`,
       );
 
       assert.dom('[data-test-dual-filter-egress-on-ingress-on]').exists();
     });
-  }
+  },
 );

--- a/ui/admin/tests/integration/components/worker-diagram/single-filter/index-test.js
+++ b/ui/admin/tests/integration/components/worker-diagram/single-filter/index-test.js
@@ -18,7 +18,7 @@ module(
     test('it renders the correct diagram when egress filter is false', async function (assert) {
       assert.expect(2);
       await render(
-        hbs`<WorkerDiagram::SingleFilter @egressWorkerFilterEnabled={{false}} />`
+        hbs`<WorkerDiagram::SingleFilter @egressWorkerFilterEnabled={{false}} />`,
       );
 
       assert.dom('[data-test-single-filter-egress-off]').isVisible();
@@ -28,11 +28,11 @@ module(
     test('it renders the correct diagram when egress filter is true', async function (assert) {
       assert.expect(2);
       await render(
-        hbs`<WorkerDiagram::SingleFilter @egressWorkerFilterEnabled={{true}} />`
+        hbs`<WorkerDiagram::SingleFilter @egressWorkerFilterEnabled={{true}} />`,
       );
 
       assert.dom('[data-test-single-filter-egress-on]').isVisible();
       assert.dom('[data-test-single-filter-egress-off]').doesNotExist();
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/abilities/channel-recording-test.js
+++ b/ui/admin/tests/unit/abilities/channel-recording-test.js
@@ -43,7 +43,7 @@ module('Unit | Abilities | channel-recording', function (hooks) {
 
     assert.true(canService.can('play channel-recording', asciicastChannel));
     assert.false(
-      canService.can('play channel-recording', noneAsciicastChannel)
+      canService.can('play channel-recording', noneAsciicastChannel),
     );
   });
 
@@ -51,10 +51,10 @@ module('Unit | Abilities | channel-recording', function (hooks) {
     assert.expect(2);
 
     assert.true(
-      canService.can('viewOnly channel-recording', noneAsciicastChannel)
+      canService.can('viewOnly channel-recording', noneAsciicastChannel),
     );
     assert.false(
-      canService.can('viewOnly channel-recording', asciicastChannel)
+      canService.can('viewOnly channel-recording', asciicastChannel),
     );
   });
 });

--- a/ui/admin/tests/unit/abilities/collection-test.js
+++ b/ui/admin/tests/unit/abilities/collection-test.js
@@ -16,7 +16,7 @@ module('Unit | Abilities | model', function (hooks) {
       authorized_collection_actions: { foobars: [] },
     };
     assert.notOk(
-      service.can('navigate model', model, { collection: 'foobars' })
+      service.can('navigate model', model, { collection: 'foobars' }),
     );
     model.authorized_collection_actions.foobars = ['list'];
     assert.ok(service.can('navigate model', model, { collection: 'foobars' }));

--- a/ui/admin/tests/unit/abilities/session-recording-test.js
+++ b/ui/admin/tests/unit/abilities/session-recording-test.js
@@ -30,21 +30,24 @@ module('Unit | Abilities | session-recording', function (hooks) {
       {
         authorized_actions: ['read'],
         type: TYPE_SESSION_RECORDING_SSH,
-      }
+      },
     );
     const recordingWithoutAuthorizedAction = store.createRecord(
       'session-recording',
       {
         authorized_actions: [],
         type: TYPE_SESSION_RECORDING_SSH,
-      }
+      },
     );
 
     assert.true(
-      canService.can('read session-recording', recordingWithAuthorizedAction)
+      canService.can('read session-recording', recordingWithAuthorizedAction),
     );
     assert.false(
-      canService.can('read session-recording', recordingWithoutAuthorizedAction)
+      canService.can(
+        'read session-recording',
+        recordingWithoutAuthorizedAction,
+      ),
     );
   });
 
@@ -56,21 +59,24 @@ module('Unit | Abilities | session-recording', function (hooks) {
       {
         authorized_actions: ['read'],
         type: TYPE_SESSION_RECORDING_SSH,
-      }
+      },
     );
     const recordingWithoutAuthorizedAction = store.createRecord(
       'session-recording',
       {
         authorized_actions: [],
         type: TYPE_SESSION_RECORDING_SSH,
-      }
+      },
     );
 
     assert.false(
-      canService.can('read session-recording', recordingWithAuthorizedAction)
+      canService.can('read session-recording', recordingWithAuthorizedAction),
     );
     assert.false(
-      canService.can('read session-recording', recordingWithoutAuthorizedAction)
+      canService.can(
+        'read session-recording',
+        recordingWithoutAuthorizedAction,
+      ),
     );
   });
 
@@ -93,12 +99,12 @@ module('Unit | Abilities | session-recording', function (hooks) {
     assert.true(
       canService.can('list scope', scopeModelWithAuthorizedAction, {
         collection: 'session-recordings',
-      })
+      }),
     );
     assert.false(
       canService.can('list scope', scopeModelWithoutAuthorizedAction, {
         collection: 'session-recordings',
-      })
+      }),
     );
   });
 
@@ -121,12 +127,12 @@ module('Unit | Abilities | session-recording', function (hooks) {
     assert.true(
       canService.can('list scope', scopeModelWithAuthorizedAction, {
         collection: 'session-recordings',
-      })
+      }),
     );
     assert.false(
       canService.can('list scope', scopeModelWithoutAuthorizedAction, {
         collection: 'session-recordings',
-      })
+      }),
     );
   });
 
@@ -149,12 +155,12 @@ module('Unit | Abilities | session-recording', function (hooks) {
     assert.true(
       canService.can('navigate scope', scopeModelWithAuthorizedAction, {
         collection: 'session-recordings',
-      })
+      }),
     );
     assert.false(
       canService.can('navigate scope', scopeModelWithoutAuthorizedAction, {
         collection: 'session-recordings',
-      })
+      }),
     );
   });
 
@@ -175,12 +181,12 @@ module('Unit | Abilities | session-recording', function (hooks) {
     assert.false(
       canService.can('navigate scope', scopeModelWithAuthorizedAction, {
         collection: 'session-recordings',
-      })
+      }),
     );
     assert.false(
       canService.can('navigate scope', scopeModelWithoutAuthorizedAction, {
         collection: 'session-recordings',
-      })
+      }),
     );
   });
 });

--- a/ui/admin/tests/unit/abilities/storage-bucket-test.js
+++ b/ui/admin/tests/unit/abilities/storage-bucket-test.js
@@ -89,7 +89,7 @@ module('Unit | Abilities | storage-bucket', function (hooks) {
     assert.true(
       canService.can('list scope', scopeModel, {
         collection: 'storage-buckets',
-      })
+      }),
     );
   });
 
@@ -107,7 +107,7 @@ module('Unit | Abilities | storage-bucket', function (hooks) {
     assert.false(
       canService.can('list scope', scopeModel, {
         collection: 'storage-buckets',
-      })
+      }),
     );
   });
 
@@ -125,7 +125,7 @@ module('Unit | Abilities | storage-bucket', function (hooks) {
     assert.true(
       canService.can('list scope', scopeModel, {
         collection: 'storage-buckets',
-      })
+      }),
     );
   });
 
@@ -143,7 +143,7 @@ module('Unit | Abilities | storage-bucket', function (hooks) {
     assert.true(
       canService.can('create scope', scopeModel, {
         collection: 'storage-buckets',
-      })
+      }),
     );
   });
 
@@ -161,7 +161,7 @@ module('Unit | Abilities | storage-bucket', function (hooks) {
     assert.true(
       canService.can('create scope', scopeModel, {
         collection: 'storage-buckets',
-      })
+      }),
     );
   });
 
@@ -179,7 +179,7 @@ module('Unit | Abilities | storage-bucket', function (hooks) {
     assert.true(
       canService.can('create scope', scopeModel, {
         collection: 'storage-buckets',
-      })
+      }),
     );
   });
 
@@ -197,7 +197,7 @@ module('Unit | Abilities | storage-bucket', function (hooks) {
     assert.false(
       canService.can('create scope', scopeModel, {
         collection: 'storage-buckets',
-      })
+      }),
     );
   });
 
@@ -215,7 +215,7 @@ module('Unit | Abilities | storage-bucket', function (hooks) {
     assert.true(
       canService.can('navigate scope', scopeModel, {
         collection: 'storage-buckets',
-      })
+      }),
     );
   });
 
@@ -231,7 +231,7 @@ module('Unit | Abilities | storage-bucket', function (hooks) {
     assert.false(
       canService.can('navigate scope', scopeModel, {
         collection: 'storage-buckets',
-      })
+      }),
     );
   });
 });

--- a/ui/admin/tests/unit/abilities/user-test.js
+++ b/ui/admin/tests/unit/abilities/user-test.js
@@ -40,7 +40,7 @@ module('Unit | Abilities | user', function (hooks) {
     assert.true(
       canService.can('addAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
   });
 
@@ -50,13 +50,13 @@ module('Unit | Abilities | user', function (hooks) {
     assert.true(
       canService.can('addAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = TYPE_AUTH_METHOD_PASSWORD;
     assert.true(
       canService.can('addAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
   });
 
@@ -66,7 +66,7 @@ module('Unit | Abilities | user', function (hooks) {
     assert.false(
       canService.can('addAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
   });
 
@@ -77,7 +77,7 @@ module('Unit | Abilities | user', function (hooks) {
     assert.true(
       canService.can('removeAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
   });
 
@@ -87,7 +87,7 @@ module('Unit | Abilities | user', function (hooks) {
     assert.false(
       canService.can('removeAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
   });
 
@@ -97,13 +97,13 @@ module('Unit | Abilities | user', function (hooks) {
     assert.true(
       canService.can('removeAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
     instances.account.type = TYPE_AUTH_METHOD_PASSWORD;
     assert.true(
       canService.can('removeAccount user', instances.user, {
         account: instances.account,
-      })
+      }),
     );
   });
 });

--- a/ui/admin/tests/unit/controllers/scopes/scope/auth-methods/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/auth-methods/index-test.js
@@ -12,7 +12,7 @@ module('Unit | Controller | scopes/scope/auth-methods/index', function (hooks) {
   // TODO: Replace this with your real tests.
   test('it exists', function (assert) {
     let controller = this.owner.lookup(
-      'controller:scopes/scope/auth-methods/index'
+      'controller:scopes/scope/auth-methods/index',
     );
     assert.ok(controller);
   });

--- a/ui/admin/tests/unit/controllers/scopes/scope/auth-methods/new-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/auth-methods/new-test.js
@@ -11,7 +11,7 @@ module('Unit | Controller | scopes/scope/auth-methods/new', function (hooks) {
 
   test('it exists', function (assert) {
     let controller = this.owner.lookup(
-      'controller:scopes/scope/auth-methods/new'
+      'controller:scopes/scope/auth-methods/new',
     );
     assert.ok(controller);
   });

--- a/ui/admin/tests/unit/controllers/scopes/scope/authenticate/method/oidc-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/authenticate/method/oidc-test.js
@@ -14,9 +14,9 @@ module(
     // TODO: Replace this with your real tests.
     test('it exists', function (assert) {
       let controller = this.owner.lookup(
-        'controller:scopes/scope/authenticate/method/oidc'
+        'controller:scopes/scope/authenticate/method/oidc',
       );
       assert.ok(controller);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/new-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/new-test.js
@@ -14,9 +14,9 @@ module(
     // TODO: Replace this with your real tests.
     test('it exists', function (assert) {
       let controller = this.owner.lookup(
-        'controller:scopes/scope/credential-stores/credential-store/credential-libraries/new'
+        'controller:scopes/scope/credential-stores/credential-store/credential-libraries/new',
       );
       assert.ok(controller);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/new-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/new-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let controller = this.owner.lookup(
-        'controller:scopes/scope/credential-stores/credential-store/credentials/new'
+        'controller:scopes/scope/credential-stores/credential-store/credentials/new',
       );
       assert.ok(controller);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/new-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/new-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let controller = this.owner.lookup(
-        'controller:scopes/scope/credential-stores/new'
+        'controller:scopes/scope/credential-stores/new',
       );
       assert.ok(controller);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/groups/group/add-members-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/groups/group/add-members-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let controller = this.owner.lookup(
-        'controller:scopes/scope/groups/group/add-members'
+        'controller:scopes/scope/groups/group/add-members',
       );
       assert.ok(controller);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/host-catalogs/new-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/host-catalogs/new-test.js
@@ -12,7 +12,7 @@ module('Unit | Controller | scopes/scope/host-catalogs/new', function (hooks) {
   // TODO: Replace this with your real tests.
   test('it exists', function (assert) {
     let controller = this.owner.lookup(
-      'controller:scopes/scope/host-catalogs/new'
+      'controller:scopes/scope/host-catalogs/new',
     );
     assert.ok(controller);
   });

--- a/ui/admin/tests/unit/controllers/scopes/scope/roles/role/add-principals-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/roles/role/add-principals-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let controller = this.owner.lookup(
-        'controller:scopes/scope/roles/role/add-principals'
+        'controller:scopes/scope/roles/role/add-principals',
       );
       assert.ok(controller);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let controller = this.owner.lookup(
-        'controller:scopes/scope/session-recordings/index'
+        'controller:scopes/scope/session-recordings/index',
       );
       assert.ok(controller);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index-test.js
@@ -19,7 +19,7 @@ module(
     test('isSessionInprogressWithNoConnections returns true if session has started with no connections', function (assert) {
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup(
-        'controller:scopes/scope/session-recordings/session-recording/channels-by-connection/index'
+        'controller:scopes/scope/session-recordings/session-recording/channels-by-connection/index',
       );
 
       const sessionRecording = store.createRecord('session-recording', {
@@ -34,7 +34,7 @@ module(
     test('isSessionInprogressWithNoConnections returns false if session has started and has connections', function (assert) {
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup(
-        'controller:scopes/scope/session-recordings/session-recording/channels-by-connection/index'
+        'controller:scopes/scope/session-recordings/session-recording/channels-by-connection/index',
       );
 
       const sessionRecording = store.createRecord('session-recording', {
@@ -49,7 +49,7 @@ module(
     test('isSessionInprogressWithNoConnections returns false if session is complete and has connections', function (assert) {
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup(
-        'controller:scopes/scope/session-recordings/session-recording/channels-by-connection/index'
+        'controller:scopes/scope/session-recordings/session-recording/channels-by-connection/index',
       );
 
       const sessionRecording = store.createRecord('session-recording', {
@@ -64,7 +64,7 @@ module(
     test('isSessionUnknownWithNoConnections returns true if session is unknown with no connections', function (assert) {
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup(
-        'controller:scopes/scope/session-recordings/session-recording/channels-by-connection/index'
+        'controller:scopes/scope/session-recordings/session-recording/channels-by-connection/index',
       );
 
       const sessionRecording = store.createRecord('session-recording', {
@@ -79,7 +79,7 @@ module(
     test('isSessionUnknownWithNoConnections returns false if session is unknown and has connections', function (assert) {
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup(
-        'controller:scopes/scope/session-recordings/session-recording/channels-by-connection/index'
+        'controller:scopes/scope/session-recordings/session-recording/channels-by-connection/index',
       );
 
       const sessionRecording = store.createRecord('session-recording', {
@@ -94,7 +94,7 @@ module(
     test('isSessionUnknownWithNoConnections returns false if session is complete and has connections', function (assert) {
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup(
-        'controller:scopes/scope/session-recordings/session-recording/channels-by-connection/index'
+        'controller:scopes/scope/session-recordings/session-recording/channels-by-connection/index',
       );
 
       const sessionRecording = store.createRecord('session-recording', {
@@ -105,5 +105,5 @@ module(
 
       assert.false(controller.isSessionUnknownWithNoConnections);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/targets/target/add-brokered-credential-sources-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/targets/target/add-brokered-credential-sources-test.js
@@ -13,7 +13,7 @@ module(
 
     test('it exists', function (assert) {
       const controller = this.owner.lookup(
-        'controller:scopes/scope/targets/target/add-brokered-credential-sources'
+        'controller:scopes/scope/targets/target/add-brokered-credential-sources',
       );
       assert.ok(controller);
     });
@@ -21,7 +21,7 @@ module(
     test('hasAvailableBrokeredCredentialSources returns true if target has available credentials', function (assert) {
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup(
-        'controller:scopes/scope/targets/target/add-brokered-credential-sources'
+        'controller:scopes/scope/targets/target/add-brokered-credential-sources',
       );
 
       const target = store.createRecord('target', {
@@ -39,7 +39,7 @@ module(
     test('hasAvailableBrokeredCredentialSources returns false if target has no available credentials', function (assert) {
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup(
-        'controller:scopes/scope/targets/target/add-brokered-credential-sources'
+        'controller:scopes/scope/targets/target/add-brokered-credential-sources',
       );
 
       const target = store.createRecord('target', {
@@ -53,5 +53,5 @@ module(
 
       assert.false(controller.hasAvailableBrokeredCredentialSources);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/targets/target/add-injected-application-credential-sources-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/targets/target/add-injected-application-credential-sources-test.js
@@ -13,7 +13,7 @@ module(
 
     test('it exists', function (assert) {
       const controller = this.owner.lookup(
-        'controller:scopes/scope/targets/target/add-injected-application-credential-sources'
+        'controller:scopes/scope/targets/target/add-injected-application-credential-sources',
       );
       assert.ok(controller);
     });
@@ -21,7 +21,7 @@ module(
     test('hasAvailableInjectedApplicationCredentialSources returns true if target has available credentials', function (assert) {
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup(
-        'controller:scopes/scope/targets/target/add-injected-application-credential-sources'
+        'controller:scopes/scope/targets/target/add-injected-application-credential-sources',
       );
 
       const target = store.createRecord('target', {
@@ -39,7 +39,7 @@ module(
     test('hasAvailableInjectedApplicationCredentialSources returns false if target has no available credentials', function (assert) {
       const store = this.owner.lookup('service:store');
       const controller = this.owner.lookup(
-        'controller:scopes/scope/targets/target/add-injected-application-credential-sources'
+        'controller:scopes/scope/targets/target/add-injected-application-credential-sources',
       );
 
       const target = store.createRecord('target', {
@@ -53,5 +53,5 @@ module(
 
       assert.false(controller.hasAvailableInjectedApplicationCredentialSources);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/auth-methods/auth-method'
+        'route:scopes/scope/auth-methods/auth-method',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/accounts-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/accounts-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/auth-methods/auth-method/accounts'
+        'route:scopes/scope/auth-methods/auth-method/accounts',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/accounts/account-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/accounts/account-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/auth-methods/auth-method/accounts/account'
+        'route:scopes/scope/auth-methods/auth-method/accounts/account',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/accounts/account/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/accounts/account/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/auth-methods/auth-method/accounts/account/index'
+        'route:scopes/scope/auth-methods/auth-method/accounts/account/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/accounts/account/set-password-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/accounts/account/set-password-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/auth-methods/auth-method/accounts/account/set-password'
+        'route:scopes/scope/auth-methods/auth-method/accounts/account/set-password',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/accounts/new-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/accounts/new-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/auth-methods/auth-method/accounts/new'
+        'route:scopes/scope/auth-methods/auth-method/accounts/new',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/auth-methods/auth-method/index'
+        'route:scopes/scope/auth-methods/auth-method/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/managed-groups-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/managed-groups-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/auth-methods/auth-method/managed-groups'
+        'route:scopes/scope/auth-methods/auth-method/managed-groups',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/managed-groups/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/managed-groups/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/auth-methods/auth-method/managed-groups/index'
+        'route:scopes/scope/auth-methods/auth-method/managed-groups/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/auth-methods/auth-method/managed-groups/managed-group'
+        'route:scopes/scope/auth-methods/auth-method/managed-groups/managed-group',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/auth-methods/auth-method/managed-groups/managed-group/index'
+        'route:scopes/scope/auth-methods/auth-method/managed-groups/managed-group/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group/members-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group/members-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/auth-methods/auth-method/managed-groups/managed-group/members'
+        'route:scopes/scope/auth-methods/auth-method/managed-groups/managed-group/members',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/managed-groups/new-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/auth-methods/auth-method/managed-groups/new-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/auth-methods/auth-method/managed-groups/new'
+        'route:scopes/scope/auth-methods/auth-method/managed-groups/new',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/authenticate/method/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/authenticate/method/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/authenticate/method/index'
+        'route:scopes/scope/authenticate/method/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/authenticate/method/oidc'
+        'route:scopes/scope/authenticate/method/oidc',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/credential-stores/credential-store'
+        'route:scopes/scope/credential-stores/credential-store',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/credential-libraries-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/credential-libraries-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/credential-stores/credential-store/credential-libraries'
+        'route:scopes/scope/credential-stores/credential-store/credential-libraries',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/credential-stores/credential-store/credential-libraries/credential-library'
+        'route:scopes/scope/credential-stores/credential-store/credential-libraries/credential-library',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index'
+        'route:scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/credential-libraries/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/credential-libraries/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/credential-stores/credential-store/credential-libraries/index'
+        'route:scopes/scope/credential-stores/credential-store/credential-libraries/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/credential-libraries/new-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/credential-libraries/new-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/credential-stores/credential-store/credential-libraries/new'
+        'route:scopes/scope/credential-stores/credential-store/credential-libraries/new',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/credentials-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/credentials-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/credential-stores/credential-store/credentials'
+        'route:scopes/scope/credential-stores/credential-store/credentials',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/credential-stores/credential-store/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/credential-stores/credential-store/index'
+        'route:scopes/scope/credential-stores/credential-store/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/groups/group/add-members-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/groups/group/add-members-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/groups/group/add-members'
+        'route:scopes/scope/groups/group/add-members',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog'
+        'route:scopes/scope/host-catalogs/host-catalog',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/host-sets'
+        'route:scopes/scope/host-catalogs/host-catalog/host-sets',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set'
+        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/add-hosts-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/add-hosts-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/add-hosts'
+        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/add-hosts',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/create-and-add-host-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/create-and-add-host-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/create-and-add-host'
+        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/create-and-add-host',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts'
+        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host'
+        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host/index'
+        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/index'
+        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/index'
+        'route:scopes/scope/host-catalogs/host-catalog/host-sets/host-set/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/host-sets/index'
+        'route:scopes/scope/host-catalogs/host-catalog/host-sets/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/new-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/host-sets/new-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/host-sets/new'
+        'route:scopes/scope/host-catalogs/host-catalog/host-sets/new',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/hosts-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/hosts-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/hosts'
+        'route:scopes/scope/host-catalogs/host-catalog/hosts',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/hosts/host-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/hosts/host-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/hosts/host'
+        'route:scopes/scope/host-catalogs/host-catalog/hosts/host',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/hosts/host/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/hosts/host/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/hosts/host/index'
+        'route:scopes/scope/host-catalogs/host-catalog/hosts/host/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/hosts/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/hosts/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/hosts/index'
+        'route:scopes/scope/host-catalogs/host-catalog/hosts/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/hosts/new-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/hosts/new-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/hosts/new'
+        'route:scopes/scope/host-catalogs/host-catalog/hosts/new',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/host-catalogs/host-catalog/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/host-catalogs/host-catalog/index'
+        'route:scopes/scope/host-catalogs/host-catalog/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/roles/role/add-principals-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/roles/role/add-principals-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/roles/role/add-principals'
+        'route:scopes/scope/roles/role/add-principals',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/session-recordings/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/session-recordings/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/session-recordings/index'
+        'route:scopes/scope/session-recordings/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/session-recordings/session-recording-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/session-recordings/session-recording-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/session-recordings/session-recording'
+        'route:scopes/scope/session-recordings/session-recording',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/session-recordings/session-recording/channels-by-connection-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/session-recordings/session-recording/channels-by-connection-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/session-recordings/session-recording/channels-by-connection'
+        'route:scopes/scope/session-recordings/session-recording/channels-by-connection',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/session-recordings/session-recording/channels-by-connection/channel'
+        'route:scopes/scope/session-recordings/session-recording/channels-by-connection/channel',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index'
+        'route:scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/session-recordings/session-recording/channels-by-connection/index'
+        'route:scopes/scope/session-recordings/session-recording/channels-by-connection/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/session-recordings/session-recording/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/session-recordings/session-recording/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/session-recordings/session-recording/index'
+        'route:scopes/scope/session-recordings/session-recording/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/storage-buckets/storage-bucket-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/storage-buckets/storage-bucket-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/storage-buckets/storage-bucket'
+        'route:scopes/scope/storage-buckets/storage-bucket',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/storage-buckets/storage-bucket/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/storage-buckets/storage-bucket/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/storage-buckets/storage-bucket/index'
+        'route:scopes/scope/storage-buckets/storage-bucket/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/targets/target/add-credential-sources-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/targets/target/add-credential-sources-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/targets/target/add-brokered-credential-sources'
+        'route:scopes/scope/targets/target/add-brokered-credential-sources',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/targets/target/add-host-sources-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/targets/target/add-host-sources-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/targets/target/add-host-sources'
+        'route:scopes/scope/targets/target/add-host-sources',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/targets/target/credential-sources-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/targets/target/credential-sources-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/targets/target/brokered-credential-sources'
+        'route:scopes/scope/targets/target/brokered-credential-sources',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/targets/target/enable-session-recording/create-storage-bucket-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/targets/target/enable-session-recording/create-storage-bucket-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/targets/target/enable-session-recording/create-storage-bucket'
+        'route:scopes/scope/targets/target/enable-session-recording/create-storage-bucket',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/targets/target/enable-session-recording/index-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/targets/target/enable-session-recording/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/targets/target/enable-session-recording/index'
+        'route:scopes/scope/targets/target/enable-session-recording/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/routes/scopes/scope/targets/target/host-sources-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/targets/target/host-sources-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/targets/target/host-sources'
+        'route:scopes/scope/targets/target/host-sources',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/admin/tests/unit/services/window-manager-test.js
+++ b/ui/admin/tests/unit/services/window-manager-test.js
@@ -22,7 +22,7 @@ module('Unit | Service | window-manager', function (hooks) {
         open(url) {
           assert.strictEqual(url, fakeURL);
         }
-      }
+      },
     );
     const service = this.owner.lookup('service:window-manager');
     service.open(fakeURL);
@@ -43,7 +43,7 @@ module('Unit | Service | window-manager', function (hooks) {
             },
           };
         }
-      }
+      },
     );
     const service = this.owner.lookup('service:window-manager');
     for (let i = 0; i < instanceCount; i++) {

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -97,7 +97,7 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
 
     this.router.transitionTo(
       'scopes.scope.projects.sessions.session',
-      session_id
+      session_id,
     );
   }
 }

--- a/ui/desktop/app/initializers/cluster-url.js
+++ b/ui/desktop/app/initializers/cluster-url.js
@@ -21,7 +21,7 @@ export function initialize(registry) {
         const clusterUrl = getOwner(this).lookup('service:clusterUrl');
         return clusterUrl.updateClusterUrl().then(
           () => originalBeforeModel.apply(this, arguments),
-          () => originalBeforeModel.apply(this, arguments)
+          () => originalBeforeModel.apply(this, arguments),
         );
       };
     },

--- a/ui/desktop/app/routes/application.js
+++ b/ui/desktop/app/routes/application.js
@@ -45,7 +45,7 @@ export default class ApplicationRoute extends Route {
     controller.set('hasMacOSChrome', await this.ipc.invoke('hasMacOSChrome'));
     controller.set(
       'showWindowActions',
-      await this.ipc.invoke('showWindowActions')
+      await this.ipc.invoke('showWindowActions'),
     );
   }
 

--- a/ui/desktop/app/routes/cluster-url.js
+++ b/ui/desktop/app/routes/cluster-url.js
@@ -71,7 +71,7 @@ export default class ClusterUrlRoute extends Route {
     } catch (e) {
       // If scopes do not load, we assume this is not a Boundary API
       const errorMessage = this.intl.t(
-        'errors.cluster-url-verification-failed.description'
+        'errors.cluster-url-verification-failed.description',
       );
       this.flashMessages.danger(errorMessage, {
         noticationType: 'error',

--- a/ui/desktop/app/routes/scopes/index.js
+++ b/ui/desktop/app/routes/scopes/index.js
@@ -24,7 +24,7 @@ export default class ScopesIndexRoute extends Route {
   redirect() {
     const authenticatedScopeID = get(
       this.session,
-      'data.authenticated.scope.id'
+      'data.authenticated.scope.id',
     );
     if (authenticatedScopeID) {
       this.router.replaceWith('scopes.scope', authenticatedScopeID);

--- a/ui/desktop/app/routes/scopes/scope/authenticate/index.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate/index.js
@@ -24,7 +24,7 @@ export default class ScopesScopeAuthenticateIndexRoute extends Route {
     if (firstAuthMethod) {
       this.router.replaceWith(
         'scopes.scope.authenticate.method',
-        firstAuthMethod
+        firstAuthMethod,
       );
     }
   }

--- a/ui/desktop/app/routes/scopes/scope/authenticate/method.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate/method.js
@@ -75,7 +75,7 @@ export default class ScopesScopeAuthenticateMethodRoute extends Route {
           authenticatorName,
           creds,
           requestCookies,
-          { scope, authMethod }
+          { scope, authMethod },
         );
         this.router.transitionTo('index');
         break;

--- a/ui/desktop/app/routes/scopes/scope/projects.js
+++ b/ui/desktop/app/routes/scopes/scope/projects.js
@@ -45,7 +45,7 @@ export default class ScopesScopeProjectsRoute extends Route {
     const projects = this.resourceFilterStore.queryBy(
       'scope',
       { type: 'project' },
-      { recursive: true, scope_id }
+      { recursive: true, scope_id },
     );
     return projects;
   }

--- a/ui/desktop/app/routes/scopes/scope/projects/sessions/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions/index.js
@@ -53,7 +53,7 @@ export default class ScopesScopeProjectsSessionsIndexRoute extends Route {
     let sessions = await this.resourceFilterStore.queryBy(
       'session',
       { user_id: this.session.data.authenticated.user_id },
-      queryOptions
+      queryOptions,
     );
 
     // If project filters are selected, filter sessions by the selected projects

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
@@ -41,8 +41,8 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
       try {
         const hostSets = await Promise.all(
           target.host_sources.map(({ host_source_id }) =>
-            this.store.findRecord('host-set', host_source_id)
-          )
+            this.store.findRecord('host-set', host_source_id),
+          ),
         );
 
         // Extract host ids from all host sets
@@ -53,8 +53,8 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
 
         hosts = await Promise.all(
           [...uniqueHostIds].map((hostId) =>
-            this.store.findRecord('host', hostId)
-          )
+            this.store.findRecord('host', hostId),
+          ),
         );
       } catch (error) {
         // no operation
@@ -86,7 +86,7 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
     if (this.isConnectionError) {
       /* eslint-disable-next-line ember/no-controller-access-in-routes */
       const controller = this.controllerFor(
-        'scopes.scope.projects.targets.target'
+        'scopes.scope.projects.targets.target',
       );
       controller.set('isConnecting', false);
       this.isConnectionError = false;
@@ -104,7 +104,7 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
   async connect(target, host) {
     /* eslint-disable-next-line ember/no-controller-access-in-routes */
     const parentController = this.controllerFor(
-      'scopes.scope.projects.targets.index'
+      'scopes.scope.projects.targets.index',
     );
     try {
       await parentController.connect(target, host);
@@ -135,7 +135,7 @@ export default class ScopesScopeProjectsTargetsTargetRoute extends Route {
     if (this.isConnectionError) {
       /* eslint-disable-next-line ember/no-controller-access-in-routes */
       const controller = this.controllerFor(
-        'scopes.scope.projects.targets.target'
+        'scopes.scope.projects.targets.target',
       );
       controller.set('isConnecting', false);
       this.isConnectionError = false;

--- a/ui/desktop/app/services/cluster-url.js
+++ b/ui/desktop/app/services/cluster-url.js
@@ -65,7 +65,7 @@ export default class ClusterUrlService extends Service {
     const originalHost = this.adapter.host;
     assert(
       `setClusterUrl expects a string, you passed ${clusterUrl}`,
-      typeof clusterUrl === 'string'
+      typeof clusterUrl === 'string',
     );
     try {
       // Trim whitespaces and silently drop trailing slashes if present.

--- a/ui/desktop/app/services/ipc.js
+++ b/ui/desktop/app/services/ipc.js
@@ -80,7 +80,7 @@ export class IPCRequest {
         payload: this.payload,
       },
       origin,
-      [this.#channel.port2]
+      [this.#channel.port2],
     );
   }
 

--- a/ui/desktop/electron-app/src/helpers/app-updater.js
+++ b/ui/desktop/electron-app/src/helpers/app-updater.js
@@ -166,7 +166,7 @@ module.exports = {
       // Support hosted url and file paths
       displayDownloadPrompt(
         latestVersion,
-        location.match(/^http/i) ? location : `file://${location}`
+        location.match(/^http/i) ? location : `file://${location}`,
       );
       return;
     }

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -89,7 +89,7 @@ const createWindow = (partition, closeWindowCB) => {
       '..',
       'assets',
       'app-icons',
-      'icon.png'
+      'icon.png',
     );
 
   const browserWindow = new BrowserWindow(browserWindowOptions);
@@ -109,10 +109,10 @@ const createWindow = (partition, closeWindowCB) => {
 
   browserWindow.webContents.on('crashed', () => {
     console.log(
-      'Your Ember app (or other code) in the main window has crashed.'
+      'Your Ember app (or other code) in the main window has crashed.',
     );
     console.log(
-      'This is a serious issue that needs to be handled and/or debugged.'
+      'This is a serious issue that needs to be handled and/or debugged.',
     );
   });
 
@@ -136,7 +136,7 @@ const createWindow = (partition, closeWindowCB) => {
 
   browserWindow.on('unresponsive', () => {
     console.log(
-      'Your Ember app (or other code) has made the window unresponsive.'
+      'Your Ember app (or other code) has made the window unresponsive.',
     );
   });
 
@@ -269,7 +269,7 @@ app.on('before-quit', (event) => {
 process.on('uncaughtException', (err) => {
   console.log('An exception in the main thread was not handled.');
   console.log(
-    'This is a serious issue that needs to be handled and/or debugged.'
+    'This is a serious issue that needs to be handled and/or debugged.',
   );
   console.log(`Exception: ${err}`);
 });

--- a/ui/desktop/electron-app/src/ipc/ipc-handler.js
+++ b/ui/desktop/electron-app/src/ipc/ipc-handler.js
@@ -14,7 +14,7 @@ const log = (method, request = '', response = '', type = 'log') => {
     console[type](
       `[ipc] ${method}(${requestString}): `,
       type === 'error' ? 'ERROR' : '',
-      response
+      response,
     );
   }
 };

--- a/ui/desktop/electron-app/src/models/session.js
+++ b/ui/desktop/electron-app/src/models/session.js
@@ -61,7 +61,7 @@ class Session {
         this.#process = spawnedSession.childProcess;
         this.#id = this.#proxyDetails.session_id;
         return this.#proxyDetails;
-      }
+      },
     );
   }
 

--- a/ui/desktop/tests/acceptance/application-test.js
+++ b/ui/desktop/tests/acceptance/application-test.js
@@ -61,7 +61,7 @@ module('Acceptance | index', function (hooks) {
     await visit(urls.clusterUrl);
     assert.ok(
       find('.rose-header.header-cushion'),
-      'Adds header padding around native window actions'
+      'Adds header padding around native window actions',
     );
   });
 
@@ -71,7 +71,7 @@ module('Acceptance | index', function (hooks) {
     await visit(urls.clusterUrl);
     assert.notOk(
       find('.rose-header.header-cushion'),
-      'Does not add header padding around native window actions'
+      'Does not add header padding around native window actions',
     );
   });
 });

--- a/ui/desktop/tests/acceptance/authentication-test.js
+++ b/ui/desktop/tests/acceptance/authentication-test.js
@@ -104,7 +104,7 @@ module('Acceptance | authentication', function (hooks) {
     instances.target = this.server.create(
       'target',
       { scope: instances.scopes.project },
-      'withAssociations'
+      'withAssociations',
     );
     instances.session = this.server.create(
       'session',
@@ -114,7 +114,7 @@ module('Acceptance | authentication', function (hooks) {
         status: 'active',
         user: instances.user,
       },
-      'withAssociations'
+      'withAssociations',
     );
 
     urls.scopes.global = `/scopes/${instances.scopes.global.id}`;
@@ -192,9 +192,9 @@ module('Acceptance | authentication', function (hooks) {
     await click('.rose-header-utilities .rose-dropdown summary');
     assert.strictEqual(
       find(
-        '.rose-header-utilities .rose-dropdown-content button'
+        '.rose-header-utilities .rose-dropdown-content button',
       ).textContent.trim(),
-      'Sign Out'
+      'Sign Out',
     );
     await click('.rose-header-utilities .rose-dropdown-content button');
     assert.notOk(currentSession().isAuthenticated);
@@ -211,7 +211,7 @@ module('Acceptance | authentication', function (hooks) {
     await visit(urls.sessions);
     assert.ok(
       currentSession().isAuthenticated,
-      'Session begins authenticated, before encountering 401'
+      'Session begins authenticated, before encountering 401',
     );
     assert.ok(currentURL(), urls.targets);
     this.server.get('/sessions', () => new Response(401));
@@ -219,7 +219,7 @@ module('Acceptance | authentication', function (hooks) {
     await visit(urls.sessions);
     assert.notOk(
       currentSession().isAuthenticated,
-      'Session is unauthenticated, after encountering 401'
+      'Session is unauthenticated, after encountering 401',
     );
   });
 
@@ -250,7 +250,7 @@ module('Acceptance | authentication', function (hooks) {
     await click('[name="theme"][value="system-default-theme"]');
     assert.strictEqual(
       currentSession().get('data.theme'),
-      'system-default-theme'
+      'system-default-theme',
     );
     assert.notOk(getRootElement().classList.contains('rose-theme-light'));
     assert.notOk(getRootElement().classList.contains('rose-theme-dark'));

--- a/ui/desktop/tests/acceptance/cluster-url-test.js
+++ b/ui/desktop/tests/acceptance/cluster-url-test.js
@@ -87,12 +87,12 @@ module('Acceptance | clusterUrl', function (hooks) {
     instances.hostCatalog = this.server.create(
       'host-catalog',
       { scope: instances.scopes.project },
-      'withChildren'
+      'withChildren',
     );
     instances.target = this.server.create(
       'target',
       { scope: instances.scopes.project },
-      'withAssociations'
+      'withAssociations',
     );
 
     urls.scopes.global = `/scopes/${instances.scopes.global.id}`;

--- a/ui/desktop/tests/acceptance/projects-test.js
+++ b/ui/desktop/tests/acceptance/projects-test.js
@@ -82,12 +82,12 @@ module('Acceptance | projects', function (hooks) {
     instances.hostCatalog = this.server.create(
       'host-catalog',
       { scope: instances.scopes.project },
-      'withChildren'
+      'withChildren',
     );
     instances.target = this.server.create(
       'target',
       { scope: instances.scopes.project },
-      'withAssociations'
+      'withAssociations',
     );
 
     urls.scopes.global = `/scopes/${instances.scopes.global.id}`;

--- a/ui/desktop/tests/acceptance/projects/sessions/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/index-test.js
@@ -95,7 +95,7 @@ module('Acceptance | projects | sessions', function (hooks) {
     instances.target = this.server.create(
       'target',
       { scope: instances.scopes.project },
-      'withAssociations'
+      'withAssociations',
     );
     instances.session = this.server.create(
       'session',
@@ -105,7 +105,7 @@ module('Acceptance | projects | sessions', function (hooks) {
         status: STATUS_SESSION_ACTIVE,
         user: instances.user,
       },
-      'withAssociations'
+      'withAssociations',
     );
 
     urls.scopes.global = `/scopes/${instances.scopes.global.id}`;
@@ -184,7 +184,7 @@ module('Acceptance | projects | sessions', function (hooks) {
 
     assert
       .dom(
-        'tbody tr:first-child td:first-child [data-test-session-detail-link]'
+        'tbody tr:first-child td:first-child [data-test-session-detail-link]',
       )
       .isVisible();
   });
@@ -197,7 +197,7 @@ module('Acceptance | projects | sessions', function (hooks) {
 
     assert
       .dom(
-        'tbody tr:first-child td:first-child [data-test-session-detail-link]'
+        'tbody tr:first-child td:first-child [data-test-session-detail-link]',
       )
       .isVisible();
   });
@@ -210,7 +210,7 @@ module('Acceptance | projects | sessions', function (hooks) {
 
     assert
       .dom(
-        'tbody tr:first-child td:first-child [data-test-session-detail-link]'
+        'tbody tr:first-child td:first-child [data-test-session-detail-link]',
       )
       .isVisible();
   });
@@ -223,7 +223,7 @@ module('Acceptance | projects | sessions', function (hooks) {
 
     assert
       .dom(
-        'tbody tr:first-child td:first-child [data-test-session-detail-link]'
+        'tbody tr:first-child td:first-child [data-test-session-detail-link]',
       )
       .isVisible();
   });
@@ -236,7 +236,7 @@ module('Acceptance | projects | sessions', function (hooks) {
 
     assert
       .dom(
-        'tbody tr:first-child td:first-child [data-test-session-detail-link]'
+        'tbody tr:first-child td:first-child [data-test-session-detail-link]',
       )
       .doesNotExist();
     assert
@@ -253,7 +253,7 @@ module('Acceptance | projects | sessions', function (hooks) {
 
     assert
       .dom(
-        'tbody tr:first-child td:first-child [data-test-session-detail-link]'
+        'tbody tr:first-child td:first-child [data-test-session-detail-link]',
       )
       .doesNotExist();
     assert

--- a/ui/desktop/tests/acceptance/projects/sessions/session-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/session-test.js
@@ -94,7 +94,7 @@ module('Acceptance | projects | sessions | session', function (hooks) {
     instances.target = this.server.create(
       'target',
       { scope: instances.scopes.project, address: 'localhost' },
-      'withAssociations'
+      'withAssociations',
     );
     instances.session = this.server.create(
       'session',
@@ -104,7 +104,7 @@ module('Acceptance | projects | sessions | session', function (hooks) {
         status: STATUS_SESSION_ACTIVE,
         user: instances.user,
       },
-      'withAssociations'
+      'withAssociations',
     );
 
     urls.scopes.global = `/scopes/${instances.scopes.global.id}`;

--- a/ui/desktop/tests/acceptance/projects/targets/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/index-test.js
@@ -105,7 +105,7 @@ module('Acceptance | projects | targets', function (hooks) {
     instances.hostCatalog = this.server.create(
       'host-catalog',
       { scope: instances.scopes.project },
-      'withChildren'
+      'withChildren',
     );
     instances.target = this.server.create('target', {
       scope: instances.scopes.project,
@@ -117,7 +117,7 @@ module('Acceptance | projects | targets', function (hooks) {
         scope: instances.scopes.project,
         status: 'active',
       },
-      'withAssociations'
+      'withAssociations',
     );
 
     // Generate route URLs for resources
@@ -205,7 +205,7 @@ module('Acceptance | projects | targets', function (hooks) {
     await click(`[href="${urls.targets}"]`);
 
     assert.true(
-      instances.target.authorized_actions.includes('authorize-session')
+      instances.target.authorized_actions.includes('authorize-session'),
     );
     assert
       .dom(`[data-test-targets-connect-button="${instances.target.id}"]`)
@@ -216,14 +216,14 @@ module('Acceptance | projects | targets', function (hooks) {
     assert.expect(2);
     instances.target.authorized_actions =
       instances.target.authorized_actions.filter(
-        (item) => item !== 'authorize-session'
+        (item) => item !== 'authorize-session',
       );
     await visit(urls.projects);
 
     await click(`[href="${urls.targets}"]`);
 
     assert.false(
-      instances.target.authorized_actions.includes('authorize-session')
+      instances.target.authorized_actions.includes('authorize-session'),
     );
     assert
       .dom(`[data-test-targets-connect-button="${instances.target.id}"]`)
@@ -264,7 +264,7 @@ module('Acceptance | projects | targets', function (hooks) {
 
     assert.strictEqual(
       currentURL(),
-      `${urls.projects}/sessions/${instances.session.id}`
+      `${urls.projects}/sessions/${instances.session.id}`,
     );
     assert.dom(APP_STATE_TITLE).hasText('Connected');
   });

--- a/ui/desktop/tests/acceptance/projects/targets/target-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/target-test.js
@@ -89,7 +89,7 @@ module('Acceptance | projects | targets | target', function (hooks) {
     instances.hostCatalog = this.server.create(
       'host-catalog',
       { scope: instances.scopes.project },
-      'withChildren'
+      'withChildren',
     );
     instances.target = this.server.create('target', {
       scope: instances.scopes.project,
@@ -98,12 +98,12 @@ module('Acceptance | projects | targets | target', function (hooks) {
     instances.targetWithOneHost = this.server.create(
       'target',
       { scope: instances.scopes.project },
-      'withOneHost'
+      'withOneHost',
     );
     instances.targetWithTwoHosts = this.server.create(
       'target',
       { scope: instances.scopes.project },
-      'withTwoHosts'
+      'withTwoHosts',
     );
     instances.session = this.server.create(
       'session',
@@ -111,7 +111,7 @@ module('Acceptance | projects | targets | target', function (hooks) {
         scope: instances.scopes.project,
         status: 'active',
       },
-      'withAssociations'
+      'withAssociations',
     );
 
     // Generate route URLs for resources

--- a/ui/desktop/tests/acceptance/scopes-test.js
+++ b/ui/desktop/tests/acceptance/scopes-test.js
@@ -99,12 +99,12 @@ module('Acceptance | scopes', function (hooks) {
     instances.hostCatalog = this.server.create(
       'host-catalog',
       { scope: instances.scopes.project },
-      'withChildren'
+      'withChildren',
     );
     instances.target = this.server.create(
       'target',
       { scope: instances.scopes.project, address: 'localhost' },
-      'withAssociations'
+      'withAssociations',
     );
 
     instances.session = this.server.create(
@@ -113,7 +113,7 @@ module('Acceptance | scopes', function (hooks) {
         scope: instances.scopes.project,
         status: 'active',
       },
-      'withAssociations'
+      'withAssociations',
     );
 
     urls.scopes.global = `/scopes/${instances.scopes.global.id}`;
@@ -255,7 +255,7 @@ module('Acceptance | scopes', function (hooks) {
 
     assert.ok(
       find('.rose-message-title').textContent.trim(),
-      'No Targets Available'
+      'No Targets Available',
     );
   });
 
@@ -279,7 +279,7 @@ module('Acceptance | scopes', function (hooks) {
     assert.strictEqual(
       find('.rose-dialog-footer button').textContent.trim(),
       'Close',
-      'Cannot retry'
+      'Cannot retry',
     );
   });
 });

--- a/ui/desktop/tests/end2end/authentication.spec.js
+++ b/ui/desktop/tests/end2end/authentication.spec.js
@@ -14,7 +14,7 @@ const screenshotsDirectory = 'authentication/';
 // Path where the Boundary Desktop client binary is generated
 const executablePath = helpers.returnExecutablePath(
   process.platform,
-  process.arch
+  process.arch,
 );
 
 // Set login variables
@@ -44,7 +44,7 @@ test.describe('Authentication end to end test suite', async () => {
 
       // Override local storage cluster URL
       await boundaryWindow.evaluate(() =>
-        window.localStorage.setItem('desktop:clusterUrl', null)
+        window.localStorage.setItem('desktop:clusterUrl', null),
       );
 
       // Perform login
@@ -52,14 +52,14 @@ test.describe('Authentication end to end test suite', async () => {
         boundaryWindow,
         clusterUrlValue,
         loginUsername,
-        loginPassword
+        loginPassword,
       );
 
       // Take screenshot
       await boundaryWindow.screenshot({
         path: helpers.generateScreenshotPath(
           screenshotsDirectory,
-          'fillUserPassword'
+          'fillUserPassword',
         ),
         fullPage: true,
       });
@@ -77,7 +77,7 @@ test.describe('Authentication end to end test suite', async () => {
       await boundaryWindow.screenshot({
         path: helpers.generateScreenshotPath(
           screenshotsDirectory,
-          'afterLogin'
+          'afterLogin',
         ),
         fullPage: true,
       });
@@ -93,7 +93,7 @@ test.describe('Authentication end to end test suite', async () => {
       await boundaryWindow.screenshot({
         path: helpers.generateScreenshotPath(
           screenshotsDirectory,
-          'userDropdown'
+          'userDropdown',
         ),
         fullPage: true,
       });
@@ -112,7 +112,7 @@ test.describe('Authentication end to end test suite', async () => {
       await boundaryWindow.screenshot({
         path: helpers.generateScreenshotPath(
           screenshotsDirectory,
-          'afterLogout'
+          'afterLogout',
         ),
         fullPage: true,
       });
@@ -122,28 +122,28 @@ test.describe('Authentication end to end test suite', async () => {
       const boundaryWindow = await electronApp.firstWindow(); // The window that contains the app.
       // Override local storage cluster URL
       await boundaryWindow.evaluate(() =>
-        window.localStorage.setItem('desktop:clusterUrl', null)
+        window.localStorage.setItem('desktop:clusterUrl', null),
       );
       // Perform login
       await helpers.login(
         boundaryWindow,
         clusterUrlValue,
         loginUsername,
-        '123456789'
+        '123456789',
       );
 
       // Wait for the notification
       await boundaryWindow.waitForSelector('.rose-notification-body');
       // Expect the notification to alert authentication has failed.
       expect(
-        await boundaryWindow.innerText('div.rose-notification-body')
+        await boundaryWindow.innerText('div.rose-notification-body'),
       ).toEqual('Authentication Failed');
 
       // Take screenshot
       await boundaryWindow.screenshot({
         path: helpers.generateScreenshotPath(
           screenshotsDirectory,
-          'notificationFailed'
+          'notificationFailed',
         ),
         fullPage: true,
       });
@@ -165,7 +165,7 @@ test.describe('Authentication end to end test suite', async () => {
 
       // Override local storage cluster URL
       await boundaryWindow.evaluate(() =>
-        window.localStorage.setItem('desktop:clusterUrl', null)
+        window.localStorage.setItem('desktop:clusterUrl', null),
       );
       const clusterUrlValue = 'http://localhost:9200';
 

--- a/ui/desktop/tests/end2end/targets.spec.js
+++ b/ui/desktop/tests/end2end/targets.spec.js
@@ -14,7 +14,7 @@ const screenshotsDirectory = 'targets/';
 // Path where the Boundary Desktop client binary is generated
 const executablePath = helpers.returnExecutablePath(
   process.platform,
-  process.arch
+  process.arch,
 );
 
 // Set login variables
@@ -43,7 +43,7 @@ test.describe('Targets end to end test suite', async () => {
 
     // Override local storage cluster URL
     await boundaryWindow.evaluate(() =>
-      window.localStorage.setItem('desktop:clusterURL', null)
+      window.localStorage.setItem('desktop:clusterURL', null),
     );
 
     // Perform the login
@@ -51,7 +51,7 @@ test.describe('Targets end to end test suite', async () => {
       boundaryWindow,
       clusterUrlValue,
       loginUsername,
-      loginPassword
+      loginPassword,
     );
 
     // Check we are in Targets
@@ -63,7 +63,7 @@ test.describe('Targets end to end test suite', async () => {
     await boundaryWindow.waitForSelector('table.rose-table');
     await helpers.click(
       boundaryWindow,
-      'table.rose-table >> tbody >> tr >> nth=0 >> button >> text=Connect'
+      'table.rose-table >> tbody >> tr >> nth=0 >> button >> text=Connect',
     );
 
     // The target popup opens
@@ -72,7 +72,7 @@ test.describe('Targets end to end test suite', async () => {
     await boundaryWindow.screenshot({
       path: helpers.generateScreenshotPath(
         screenshotsDirectory,
-        'targetConnectionDetails'
+        'targetConnectionDetails',
       ),
       fullPage: true,
     });
@@ -80,24 +80,24 @@ test.describe('Targets end to end test suite', async () => {
     // TODO: read clipboard value. Running into issues reading clipboard, so will take a shortcut for now
     await helpers.click(
       boundaryWindow,
-      'section.dialog-detail >> div.rose-dialog-body >> button'
+      'section.dialog-detail >> div.rose-dialog-body >> button',
     );
     // Temporary: persist proxy from target
     const persistedProxy = await boundaryWindow.innerText(
-      'section.dialog-detail >> div.rose-dialog-body >> span.copyable-content'
+      'section.dialog-detail >> div.rose-dialog-body >> span.copyable-content',
     );
 
     // Click close popup
     await helpers.click(
       boundaryWindow,
-      'section.dialog-detail >> footer >> button'
+      'section.dialog-detail >> footer >> button',
     );
 
     // On left nav menu, click Sessions
     await boundaryWindow.waitForSelector('section.rose-layout-global >> aside');
     await helpers.click(
       boundaryWindow,
-      'section.rose-layout-global >> aside >> nav >> a >> text=Sessions'
+      'section.rose-layout-global >> aside >> nav >> a >> text=Sessions',
     );
 
     // Take screenshot
@@ -108,14 +108,14 @@ test.describe('Targets end to end test suite', async () => {
 
     // Check the right session has status pending.
     await boundaryWindow.waitForSelector(
-      'main >> div.rose-layout-page-body >> table.rose-table'
+      'main >> div.rose-layout-page-body >> table.rose-table',
     );
     // Select Proxy
     const currentProxy = await boundaryWindow.innerText(
-      'div.rose-layout-page-body >> table >> tbody >> tr >> nth=0 >> td >> nth=1 >> .copyable-content'
+      'div.rose-layout-page-body >> table >> tbody >> tr >> nth=0 >> td >> nth=1 >> .copyable-content',
     );
     const currentStatus = await boundaryWindow.innerText(
-      'div.rose-layout-page-body >> table >> tbody >> tr >> nth=0 >> td >> nth=3 >> .hds-badge'
+      'div.rose-layout-page-body >> table >> tbody >> tr >> nth=0 >> td >> nth=3 >> .hds-badge',
     );
 
     expect(await persistedProxy).toEqual(await currentProxy);

--- a/ui/desktop/tests/end2end/test-helpers.js
+++ b/ui/desktop/tests/end2end/test-helpers.js
@@ -17,7 +17,7 @@ exports.generateScreenshotPath = (screenshotTestDirectory, fileName) => {
   const screenshotsRootPath = path.join(__dirname, 'screenshots');
   const screenshotPath = path.join(
     screenshotsRootPath,
-    screenshotTestDirectory
+    screenshotTestDirectory,
   );
   return path.join(screenshotPath, fileName).concat(screenshotFormat);
 };

--- a/ui/desktop/tests/integration/components/branded-card-test.js
+++ b/ui/desktop/tests/integration/components/branded-card-test.js
@@ -26,7 +26,7 @@ module('Integration | Component | branded-card', function (hooks) {
     assert.strictEqual(find('.branded-card-title').textContent.trim(), 'title');
     assert.strictEqual(
       find('.branded-card-description').textContent.trim(),
-      'description'
+      'description',
     );
   });
 });

--- a/ui/desktop/tests/integration/components/card-test.js
+++ b/ui/desktop/tests/integration/components/card-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | card', function (hooks) {
     assert.ok(find('.card-header .rose-icon'));
     assert.strictEqual(
       this.element.textContent.trim(),
-      'This is a heading test'
+      'This is a heading test',
     );
   });
 });

--- a/ui/desktop/tests/integration/components/proxy-url-test.js
+++ b/ui/desktop/tests/integration/components/proxy-url-test.js
@@ -25,7 +25,7 @@ module('Integration | Component | session/proxy-url', function (hooks) {
           @proxyPort={{this.proxyPort}}
           @isSSHTarget={{false}}
         />
-      `
+      `,
     );
 
     assert.dom('.copy-address').hasText(this.proxyAddress);
@@ -44,7 +44,7 @@ module('Integration | Component | session/proxy-url', function (hooks) {
           @proxyPort={{this.proxyPort}}
           @isSSHTarget={{false}}
         />
-      `
+      `,
     );
     await click('.proxy-url-container .hds-dropdown-toggle-button');
     await click('[data-test-ssh-option]');
@@ -67,7 +67,7 @@ module('Integration | Component | session/proxy-url', function (hooks) {
           @proxyPort={{this.proxyPort}}
           @isSSHTarget={{false}}
         />
-      `
+      `,
     );
 
     assert.dom('.copy-address').hasText(this.proxyAddress);
@@ -86,7 +86,7 @@ module('Integration | Component | session/proxy-url', function (hooks) {
           @proxyPort={{this.proxyPort}}
           @isSSHTarget={{true}}
         />
-      `
+      `,
     );
 
     assert.dom('.copy-ssh-command').isVisible();

--- a/ui/desktop/tests/integration/helpers/raw-json-test.js
+++ b/ui/desktop/tests/integration/helpers/raw-json-test.js
@@ -18,7 +18,7 @@ module('Integration | Helper | raw-json', function (hooks) {
     this.set('inputValue', { key: 'value', nestedKey: { key: 'value' } });
     assert.strictEqual(
       this.element.textContent.trim(),
-      `{\n  "key": "value",\n  "nestedKey": {\n    "key": "value"\n  }\n}`
+      `{\n  "key": "value",\n  "nestedKey": {\n    "key": "value"\n  }\n}`,
     );
   });
 });

--- a/ui/desktop/tests/unit/abilities/collection-test.js
+++ b/ui/desktop/tests/unit/abilities/collection-test.js
@@ -16,7 +16,7 @@ module('Unit | Abilities | model', function (hooks) {
       authorized_collection_actions: { foobars: [] },
     };
     assert.notOk(
-      service.can('navigate model', model, { collection: 'foobars' })
+      service.can('navigate model', model, { collection: 'foobars' }),
     );
     model.authorized_collection_actions.foobars = ['list'];
     assert.ok(service.can('navigate model', model, { collection: 'foobars' }));

--- a/ui/desktop/tests/unit/controllers/scopes/scope/authenticate/method/oidc-test.js
+++ b/ui/desktop/tests/unit/controllers/scopes/scope/authenticate/method/oidc-test.js
@@ -14,9 +14,9 @@ module(
     // TODO: Replace this with your real tests.
     test('it exists', function (assert) {
       let controller = this.owner.lookup(
-        'controller:scopes/scope/authenticate/method/oidc'
+        'controller:scopes/scope/authenticate/method/oidc',
       );
       assert.ok(controller);
     });
-  }
+  },
 );

--- a/ui/desktop/tests/unit/controllers/scopes/scope/projects/sessions/index-test.js
+++ b/ui/desktop/tests/unit/controllers/scopes/scope/projects/sessions/index-test.js
@@ -14,9 +14,9 @@ module(
     // TODO: Replace this with your real tests.
     test('it exists', function (assert) {
       let controller = this.owner.lookup(
-        'controller:scopes/scope/projects/sessions/index'
+        'controller:scopes/scope/projects/sessions/index',
       );
       assert.ok(controller);
     });
-  }
+  },
 );

--- a/ui/desktop/tests/unit/controllers/scopes/scope/projects/targets/target-test.js
+++ b/ui/desktop/tests/unit/controllers/scopes/scope/projects/targets/target-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let controller = this.owner.lookup(
-        'controller:scopes/scope/projects/targets/target'
+        'controller:scopes/scope/projects/targets/target',
       );
       assert.ok(controller);
     });
-  }
+  },
 );

--- a/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/index-test.js
+++ b/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/authenticate/method/index'
+        'route:scopes/scope/authenticate/method/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
+++ b/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/authenticate/method/oidc'
+        'route:scopes/scope/authenticate/method/oidc',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/desktop/tests/unit/routes/scopes/scope/projects/sessions/session-test.js
+++ b/ui/desktop/tests/unit/routes/scopes/scope/projects/sessions/session-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/projects/sessions/session'
+        'route:scopes/scope/projects/sessions/session',
       );
       assert.ok(route);
     });
-  }
+  },
 );

--- a/ui/desktop/tests/unit/routes/scopes/scope/projects/targets/target/index-test.js
+++ b/ui/desktop/tests/unit/routes/scopes/scope/projects/targets/target/index-test.js
@@ -13,9 +13,9 @@ module(
 
     test('it exists', function (assert) {
       let route = this.owner.lookup(
-        'route:scopes/scope/projects/targets/target/index'
+        'route:scopes/scope/projects/targets/target/index',
       );
       assert.ok(route);
     });
-  }
+  },
 );


### PR DESCRIPTION
## Description
Re-run prettier across our entire codebase. There was a [breaking change](https://prettier.io/blog/2023/07/05/3.0.0.html#change-the-default-value-for-trailingcomma-to-all-11479httpsgithubcomprettierprettierpull11479-by-fiskerhttpsgithubcomfisker-13143httpsgithubcomprettierprettierpull13143-by-sosukesuzukihttpsgithubcomsosukesuzuki) when upgrading prettier which now sets trailing commas in function calls by default as well. This seems like a good stylistic change keeps us with prettier defaults.

The auth addon surprisingly had no changes.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
