### PR TITLE
feat: 🎸 Implement time-remaining helper into desktop UI

### DIFF
--- a/addons/api/mirage/scenarios/ipc.js
+++ b/addons/api/mirage/scenarios/ipc.js
@@ -57,6 +57,7 @@ export default function initializeMockIPC(server, config) {
         userId: 'authenticateduser',
         type,
         created_time: new Date().toISOString(),
+        expiration_time: faker.date.soon(),
       });
       const decoded = {
         key1: 'value 1',

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -60,7 +60,8 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
 
     // Associate the connection details with the session
     let session;
-    const { session_id, address, port, credentials } = connectionDetails;
+    const { session_id, address, port, credentials, expiration_time } =
+      connectionDetails;
     try {
       session = await this.store.findRecord('session', session_id);
     } catch (error) {
@@ -76,9 +77,11 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
             proxy_address: address,
             proxy_port: port,
             target_id: target.id,
+            expiration_time,
           },
         ],
       });
+
       session = this.store.peekRecord('session', session_id);
     }
 

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -60,8 +60,13 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
 
     // Associate the connection details with the session
     let session;
-    const { session_id, address, port, credentials, expiration_time } =
-      connectionDetails;
+    const {
+      session_id,
+      address,
+      port,
+      credentials,
+      expiration_time: expiration,
+    } = connectionDetails;
     try {
       session = await this.store.findRecord('session', session_id);
     } catch (error) {
@@ -77,7 +82,7 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
             proxy_address: address,
             proxy_port: port,
             target_id: target.id,
-            expiration_time,
+            expiration_time: expiration,
           },
         ],
       });

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -60,13 +60,8 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
 
     // Associate the connection details with the session
     let session;
-    const {
-      session_id,
-      address,
-      port,
-      credentials,
-      expiration: expiration_time,
-    } = connectionDetails;
+    const { session_id, address, port, credentials, expiration } =
+      connectionDetails;
     try {
       session = await this.store.findRecord('session', session_id);
     } catch (error) {

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -65,7 +65,7 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
       address,
       port,
       credentials,
-      expiration_time: expiration,
+      expiration: expiration_time,
     } = connectionDetails;
     try {
       session = await this.store.findRecord('session', session_id);

--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -505,14 +505,7 @@ $chevron-down: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%231
 .session-details-info {
   display: flex;
   align-items: center;
-
-  > * {
-    margin-right: 1rem;
-  }
-
-  .hds-badge {
-    margin-left: 1rem;
-  }
+  gap: 1rem;
 }
 
 .target-details-header {

--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -502,15 +502,16 @@ $chevron-down: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%231
   }
 }
 
-.session-details-header {
-  &,
-  h1 {
-    display: flex;
-    align-items: center;
+.session-details-info {
+  display: flex;
+  align-items: center;
 
-    > * {
-      margin-right: 1rem;
-    }
+  > * {
+    margin-right: 1rem;
+  }
+
+  .hds-badge {
+    margin-left: 1rem;
   }
 }
 

--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -502,7 +502,18 @@ $chevron-down: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%231
   }
 }
 
-.session-details-header,
+.session-details-header {
+  &,
+  h1 {
+    display: flex;
+    align-items: center;
+
+    > * {
+      margin-right: 1rem;
+    }
+  }
+}
+
 .target-details-header {
   display: flex;
   align-items: center;

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/session.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/session.hbs
@@ -8,10 +8,16 @@
 <Rose::Layout::Page as |page|>
 
   <page.header>
-    <h1 class='session-details-header'>
-      <Hds::IconTile @color='boundary' @icon='terminal' />
-      {{@model.displayName}}
-    </h1>
+    <div class='session-details-header'>
+      <h1>
+        <Hds::IconTile @color='boundary' @icon='terminal' />
+        {{@model.displayName}}
+      </h1>
+      <Hds::Badge
+        @text={{time-remaining @model.expiration_time}}
+        @icon='loading'
+      />
+    </div>
   </page.header>
 
   <page.actions>

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/session.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/session.hbs
@@ -10,7 +10,7 @@
   <page.header>
     <h1 class='session-details-info'>
       <Hds::IconTile @color='boundary' @icon='terminal' />
-      {{@model.displayName}}
+      <span>{{@model.displayName}}</span>
       <Hds::Badge
         @text={{time-remaining @model.expiration_time}}
         @icon='loading'

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/session.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/session.hbs
@@ -8,14 +8,16 @@
 <Rose::Layout::Page as |page|>
 
   <page.header>
-    <h1 class='session-details-info'>
+    <span class='session-details-info'>
       <Hds::IconTile @color='boundary' @icon='terminal' />
-      <span>{{@model.displayName}}</span>
+      <Hds::Text::Display @tag='h1' @size='500'>
+        {{@model.displayName}}
+      </Hds::Text::Display>
       <Hds::Badge
         @text={{time-remaining @model.expiration_time}}
         @icon='loading'
       />
-    </h1>
+    </span>
   </page.header>
 
   <page.actions>

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/session.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/session.hbs
@@ -8,16 +8,14 @@
 <Rose::Layout::Page as |page|>
 
   <page.header>
-    <div class='session-details-header'>
-      <h1>
-        <Hds::IconTile @color='boundary' @icon='terminal' />
-        {{@model.displayName}}
-      </h1>
+    <h1 class='session-details-info'>
+      <Hds::IconTile @color='boundary' @icon='terminal' />
+      {{@model.displayName}}
       <Hds::Badge
         @text={{time-remaining @model.expiration_time}}
         @icon='loading'
       />
-    </div>
+    </h1>
   </page.header>
 
   <page.actions>

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/session.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/session.hbs
@@ -7,17 +7,15 @@
 
 <Rose::Layout::Page as |page|>
 
-  <page.header>
-    <span class='session-details-info'>
-      <Hds::IconTile @color='boundary' @icon='terminal' />
-      <Hds::Text::Display @tag='h1' @size='500'>
-        {{@model.displayName}}
-      </Hds::Text::Display>
-      <Hds::Badge
-        @text={{time-remaining @model.expiration_time}}
-        @icon='loading'
-      />
-    </span>
+  <page.header class='session-details-info'>
+    <Hds::IconTile @color='boundary' @icon='terminal' />
+    <Hds::Text::Display @tag='h1' @size='500'>
+      {{@model.displayName}}
+    </Hds::Text::Display>
+    <Hds::Badge
+      @text={{time-remaining @model.expiration_time}}
+      @icon='loading'
+    />
   </page.header>
 
   <page.actions>

--- a/ui/desktop/tests/acceptance/projects/sessions/session-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/session-test.js
@@ -191,7 +191,7 @@ module('Acceptance | projects | sessions | session', function (hooks) {
       address: 'a_123',
       port: 'p_123',
       protocol: 'tcp',
-      expiration_time: '2022-02-05T09:55:39.216Z',
+      expiration: '2022-02-05T09:55:39.216Z',
     });
 
     await visit(urls.target);

--- a/ui/desktop/tests/acceptance/projects/sessions/session-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/session-test.js
@@ -191,11 +191,11 @@ module('Acceptance | projects | sessions | session', function (hooks) {
       address: 'a_123',
       port: 'p_123',
       protocol: 'tcp',
+      expiration_time: '2022-02-05T09:55:39.216Z',
     });
 
     await visit(urls.target);
     await click(TARGET_CONNECT_BUTTON);
-
     assert.strictEqual(currentURL(), urls.session);
   });
 


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-10487

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-10487)

## Description
- Implement `time-remainig` helper to display duration of a session for desktop app.
-  Moved the header elements into a `div` to enforce current styling for items.
- 

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
https://github.com/hashicorp/boundary-ui/assets/24277002/78ca5ffd-f8a9-4ee3-8177-e98852662d3e

## How to Test
---
#### PreCondition for user with all session permissions
- [ ] Spin up a Boundary dev instance and start the desktop application using `ENABLE_MIRAGE=false yarn start:desktop`
- [ ] Default permissions that come with default binary dev instance will allow list, read capabilities of a session and if you open developer console and look at network tab on the desktop app there will be no `403 forbidden`  responses
---
#### Testing user with all session permissions
- [ ] Click on "Targets" in the sidebar navigation and click "Connect" on any of generated targets from the Boundary dev instance targets.
- [ ] User gets redirected to "session details"  page.
- [ ] Next to the ID of the session in the header, you should see the time-remaining helper counting down
- [ ] After the connect workflow, click back on "Sessions" in the sidebar navigation and click the active session and you should see the time remaining helper, with state of the helper persisting and time is continuously going down. 

---
#### PreCondition for user with list session list permissions
- [ ] Spin up a Boundary dev instance and start the desktop application using `ENABLE_MIRAGE=false yarn start:desktop`
- [ ] Create a user and provide them with grants with the ability to authorize-session and the permission to only list sessions and not read them.
#### Grants used:
- `id=*;type=session;actions=list,cancel:self`
- `id=*;type=target;actions=list,authorize-session`
---

### Testing user with just list permissions
- [ ] Click on "Targets" in the sidebar navigation and click "Connect" on any of generated targets from the Boundary dev instance targets.
- [ ] User gets redirected to "session details"  page.
- [ ] Next to the ID of the session in the header, you should see the time-remaining helper counting down
- [ ] If you clicked on the target with host sources, user should not see the host details on the content sidebar
- [ ] Users with list permissions will still be able to connect to session, but if you open a your dev console their should be a 403 forbidden error response in the network tab of your console.
- [ ] After the connect workflow, click back on "Sessions" in the sidebar navigation and click the active session and you should see the time remaining helper, with state of the helper persisting and time is continuously going down. 

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
~~- [ ] I have added JSON response output for API changes~~
~~- [ ] I have added steps to reproduce and test for bug fixes in the description~~
~~- [ ] I have commented on my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
