### PR TITLE
Replace `Rose::CodeEditor` with `Hds::CodeBlock` (HDS-2827)

### DIFF
--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -150,36 +150,40 @@
       </Hds::Form::Fieldset>
     {{/if}}
 
-    <Rose::CodeEditor @codeValue={{this.createConfigText}} as |c|>
-      <c.toolbar>
-        <:action>
-          <span>{{t 'resources.worker.form.steps.1.create_directory'}}</span>
-        </:action>
-      </c.toolbar>
-      <c.fieldEditor class='rose-autosize' @options={{this.shellCodeEditor}} />
-    </Rose::CodeEditor>
+    <Hds::CodeBlock
+      @language="bash"
+      @value={{this.createConfigText}}
+      @hasCopyButton={{true}}
+      @hasLineNumbers={{false}}
+    as |CB|>
+      <CB.Title>
+        {{t 'resources.worker.form.steps.1.create_directory'}}
+      </CB.Title>
+    </Hds::CodeBlock>
 
-    <Rose::CodeEditor @codeValue={{this.workerConfigText}} as |c|>
-      <c.toolbar>
-        <:action>
-          <span>{{t 'resources.worker.form.steps.1.create_config'}}</span>
-        </:action>
-      </c.toolbar>
-      <c.fieldEditor class='rose-autosize' @options={{this.hclCodeEditor}} />
-    </Rose::CodeEditor>
+    <Hds::CodeBlock
+      @language="hcl"
+      @value={{this.workerConfigText}}
+      @hasCopyButton={{true}}
+    as |CB|>
+      <CB.Title>
+        {{t 'resources.worker.form.steps.1.create_config'}}
+      </CB.Title>
+    </Hds::CodeBlock>
     <p>{{t 'resources.worker.form.steps.1.save_config'}}</p>
   </div>
 
   <h3>{{t 'resources.worker.form.steps.2.title'}}</h3>
   <div class='worker-create-section'>
-    <Rose::CodeEditor @codeValue={{this.installBoundaryText}} as |c|>
-      <c.toolbar>
-        <:action>
-          <span>{{t 'resources.worker.form.steps.2.run_command'}}</span>
-        </:action>
-      </c.toolbar>
-      <c.fieldEditor class='rose-autosize' @options={{this.shellCodeEditor}} />
-    </Rose::CodeEditor>
+    <Hds::CodeBlock
+      @language="bash"
+      @value={{this.installBoundaryText}}
+      @hasCopyButton={{true}}
+    as |CB|>
+      <CB.Title>
+        {{t 'resources.worker.form.steps.2.run_command'}}
+      </CB.Title>
+    </Hds::CodeBlock>
     <span>{{t 'resources.worker.form.steps.2.copy_registration_request'}}</span>
     <code>{{t
         'resources.worker.form.steps.3.worker_auth_registration_request.label'


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/HDS-2827)

## Description

If merged, this PR replaces instances of the `Rose::CodeEditor` component with `Hds::CodeBlock`.

## Screenshots (if appropriate):
### BEFORE:
<img width="963" alt="Screenshot 2023-11-30 at 11 25 47 AM" src="https://github.com/hashicorp/boundary-ui/assets/108769823/10d436d0-58e4-4bea-b3f4-feb4aa6bde73">

### AFTER:
<img width="962" alt="Screenshot 2023-11-30 at 11 34 44 AM" src="https://github.com/hashicorp/boundary-ui/assets/108769823/e11f4fa3-a5ae-4dc2-922a-dc390ce55ae8">

<!-- 
## How to Test
Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
