### PR TITLE
feat: 🎸 Do not stop client daemon if it was already started

### DIFF
--- a/ui/desktop/electron-app/src/services/client-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/client-daemon-manager.js
@@ -10,6 +10,7 @@ const runtimeSettings = require('./runtime-settings');
 
 class ClientDaemonManager {
   #socketPath;
+  #isClientDaemonAlreadyRunning = true;
 
   get socketPath() {
     return this.#socketPath;
@@ -33,14 +34,14 @@ class ClientDaemonManager {
    * @returns {Promise<void>}
    */
   async start() {
-    // TODO: Finalize how often the daemon should be refreshing
-    const startDaemonCommand = [
-      'daemon',
-      'start',
-      '-refresh-interval-seconds',
-      '10',
-    ];
-    await spawn(startDaemonCommand);
+    const startDaemonCommand = ['daemon', 'start'];
+    const { stderr } = await spawn(startDaemonCommand);
+
+    // If we get a null/undefined, err on safe side and don't stop daemon when
+    // we close the desktop client
+    if (stderr && !stderr.includes('The daemon is already running')) {
+      this.#isClientDaemonAlreadyRunning = false;
+    }
     this.status();
   }
 
@@ -48,6 +49,10 @@ class ClientDaemonManager {
    * Stops the daemon.
    */
   stop() {
+    if (this.#isClientDaemonAlreadyRunning) {
+      return;
+    }
+
     const stopDaemonCommand = ['daemon', 'stop'];
     spawnSync(stopDaemonCommand);
   }


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-11932

## Description
This PR is to handle the scenario where the client daemon was already running when the desktop client is started. We don't want to stop the client daemon if we the desktop client wasn't the one to start up the client daemon.

## How to Test
Start the daemon before running the DC and then close the desktop client. Confirm that the daemon is still running. Likewise, if the daemon wasn't started beforehand, confirm that the daemon is stopped once the DC is closed.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
