### PR TITLE
feat: 🎸 Add pagination component to targets

### DIFF
--- a/addons/api/addon-test-support/handlers/client-daemon-search.js
+++ b/addons/api/addon-test-support/handlers/client-daemon-search.js
@@ -1,0 +1,62 @@
+import sinon from 'sinon';
+
+/**
+ * This test helper can be used to help setup your sinon stubs in your tests.
+ * Must be called after setupMirage.
+ *
+ * ```js
+ * import setupStubs from 'api/test-support/handlers/client-daemon-search';
+ *
+ * module('Acceptance | my test', function(hooks) {
+ *  setupApplicationTest(hooks);
+ *  setupMirage(hooks);
+ *  setupStubs(hooks);
+ *
+ *   // add your actual tests here
+ * });
+ * ```
+ *
+ * This will setup a stub for the IPC service and include helper methods to
+ * help setup what the client daemon search command returns.
+ *
+ * @module Test Helpers
+ * @public
+ */
+export default function setupStubs(hooks) {
+  hooks.beforeEach(function () {
+    const ipcService = this.owner.lookup('service:ipc');
+    this.ipcStub = sinon.stub(ipcService, 'invoke');
+
+    /**
+     * We aim to still use mirage data when stubbing out the client daemon
+     * search. However, the handler expects the search data to be raw JSON from
+     * the API which will get serialized. We add back the scope object for it to
+     * get correctly normalized and other fields such as "attributes" from the
+     * API will already be hoisted and will not be re-normalized from mirage data.
+     *
+     * This convenience method can take in multiple types,
+     * e.g. this.stubClientDaemonSearch('targets', 'sessions').
+     * This will have sinon stub out each call so the first call to search will
+     * provide all the models from the first parameter you specify,
+     * the second call will provide all the models from the second argument, etc.
+     * @param types
+     */
+    this.stubClientDaemonSearch = (...types) => {
+      types.forEach((type, i) => {
+        this.ipcStub
+          .withArgs('searchClientDaemon')
+          .onCall(i)
+          .returns({
+            [type]: this.server.db[type].map((model) => ({
+              ...model,
+              scope: this.server.db.scopes.find(model.scopeId),
+            })),
+          });
+      });
+    };
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+}

--- a/addons/rose/addon/components/rose/pagination/index.hbs
+++ b/addons/rose/addon/components/rose/pagination/index.hbs
@@ -1,0 +1,7 @@
+<Hds::Pagination::Numbered
+  @totalItems={{@totalItems}}
+  @currentPage={{@currentPage}}
+  @currentPageSize={{@currentPageSize}}
+  @route={{this.router.currentRouteName}}
+  @queryFunction={{this.paginationQueryParams}}
+/>

--- a/addons/rose/addon/components/rose/pagination/index.js
+++ b/addons/rose/addon/components/rose/pagination/index.js
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class RosePaginationComponent extends Component {
+  @service router;
+
+  /**
+   * Returns the query params needed for the pagination component.
+   * @returns {function(number, number): {pageSize: number, page: number}}
+   */
+  get paginationQueryParams() {
+    return (page, pageSize) => {
+      return {
+        page,
+        pageSize,
+      };
+    };
+  }
+}

--- a/addons/rose/app/components/rose/pagination.js
+++ b/addons/rose/app/components/rose/pagination.js
@@ -1,0 +1,1 @@
+export { default } from 'rose/components/rose/pagination';

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -21,9 +21,11 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
 
   // =attributes
 
-  queryParams = ['search'];
+  queryParams = ['search', 'page', 'pageSize'];
 
   @tracked search;
+  @tracked page = 1;
+  @tracked pageSize = 10;
   @tracked searchItems = ['Project 1', 'Project 2', 'Project 3'];
 
   // =methods
@@ -135,5 +137,6 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
   handleSearchInput(event) {
     const { value } = event.target;
     this.search = value;
+    this.page = 1;
   }
 }

--- a/ui/desktop/app/routes/scopes/scope/projects/sessions.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions.js
@@ -53,7 +53,7 @@ export default class ScopesScopeProjectsSessionsRoute extends Route {
       this.router.currentRoute.name ===
       'scopes.scope.projects.sessions.session.index'
     ) {
-      await this.router.replaceWith('scopes.scope.projects.targets');
+      this.router.replaceWith('scopes.scope.projects.targets');
     }
   }
 

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
@@ -23,6 +23,12 @@ export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
       refreshModel: true,
       replace: true,
     },
+    page: {
+      refreshModel: true,
+    },
+    pageSize: {
+      refreshModel: true,
+    },
   };
 
   // =methods
@@ -39,10 +45,15 @@ export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
    *
    * @returns {Promise<{totalItems: number, targets: [TargetModel]}>}
    */
-  async model({ search = '' }) {
+  async model({ search, page, pageSize }) {
     // TODO: Filter targets by scope we're in manually
     // const { id: scope_id } = this.modelFor('scopes.scope');
-    const queryOptions = { query: { search } };
+
+    const queryOptions = {
+      query: { search },
+      page,
+      pageSize,
+    };
 
     let targets = await this.store.query('target', queryOptions);
     const totalItems = targets.meta?.totalItems;

--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -692,16 +692,20 @@ $chevron-down: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%231
 }
 
 // Search & Filtering
-.targets {
+.search-filtering {
   .hds-application-state {
-    padding-top: 3rem;
+    margin-top: 3rem;
   }
 
-  .target-search-filtering {
-    padding-bottom: 1rem;
+  .hds-segmented-group {
+    margin-bottom: 1rem;
 
     .hds-dropdown-toggle-button__text {
       white-space: nowrap;
     }
+  }
+
+  .hds-table {
+    margin-bottom: 1rem;
   }
 }

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
@@ -13,47 +13,45 @@
     <p>{{t 'resources.target.description'}}</p>
   </page.header>
 
-  <page.body class='targets'>
+  <page.body class='search-filtering'>
     {{#if (or @model.targets this.search)}}
-      <div class='target-search-filtering'>
-        <Hds::SegmentedGroup as |S|>
-          <S.TextInput
-            @type='search'
-            placeholder={{t 'actions.search'}}
-            aria-label={{t 'actions.search'}}
-            {{on 'input' this.handleSearchInput}}
+      <Hds::SegmentedGroup as |S|>
+        <S.TextInput
+          @type='search'
+          placeholder={{t 'actions.search'}}
+          aria-label={{t 'actions.search'}}
+          {{on 'input' this.handleSearchInput}}
+        />
+        <S.Dropdown as |DD|>
+          <DD.ToggleButton
+            @color='secondary'
+            @text={{t 'resources.scope.title'}}
           />
-          <S.Dropdown as |DD|>
-            <DD.ToggleButton
-              @color='secondary'
-              @text={{t 'resources.scope.title'}}
+          <DD.Header @hasDivider={{true}}>
+            <Hds::Form::TextInput::Base
+              @type='search'
+              placeholder={{t 'actions.narrow-results'}}
+              aria-label={{t 'actions.narrow-results'}}
+              data-test-search
             />
-            <DD.Header @hasDivider={{true}}>
-              <Hds::Form::TextInput::Base
-                @type='search'
-                placeholder={{t 'actions.narrow-results'}}
-                aria-label={{t 'actions.narrow-results'}}
-                data-test-search
-              />
-            </DD.Header>
-            {{#each this.searchItems as |item|}}
-              <DD.Checkbox @value={{item}} data-test-checkbox={{item}}>
-                {{item}}
-              </DD.Checkbox>
-            {{/each}}
-          </S.Dropdown>
-          <S.Dropdown as |DD|>
-            <DD.ToggleButton @color='secondary' @text='Active session' />
-            <DD.Checkbox>{{t 'actions.yes'}}</DD.Checkbox>
-            <DD.Checkbox>{{t 'actions.no'}}</DD.Checkbox>
-          </S.Dropdown>
-          <S.Dropdown as |DD|>
-            <DD.ToggleButton @color='secondary' @text='Type' @count='2' />
-            <DD.Checkbox>{{t 'resources.target.types.tcp'}}</DD.Checkbox>
-            <DD.Checkbox>{{t 'resources.target.types.ssh'}}</DD.Checkbox>
-          </S.Dropdown>
-        </Hds::SegmentedGroup>
-      </div>
+          </DD.Header>
+          {{#each this.searchItems as |item|}}
+            <DD.Checkbox @value={{item}} data-test-checkbox={{item}}>
+              {{item}}
+            </DD.Checkbox>
+          {{/each}}
+        </S.Dropdown>
+        <S.Dropdown as |DD|>
+          <DD.ToggleButton @color='secondary' @text='Active session' />
+          <DD.Checkbox>{{t 'actions.yes'}}</DD.Checkbox>
+          <DD.Checkbox>{{t 'actions.no'}}</DD.Checkbox>
+        </S.Dropdown>
+        <S.Dropdown as |DD|>
+          <DD.ToggleButton @color='secondary' @text='Type' @count='2' />
+          <DD.Checkbox>{{t 'resources.target.types.tcp'}}</DD.Checkbox>
+          <DD.Checkbox>{{t 'resources.target.types.ssh'}}</DD.Checkbox>
+        </S.Dropdown>
+      </Hds::SegmentedGroup>
       {{#if @model.targets}}
         <Hds::Table
           @model={{@model.targets}}
@@ -139,6 +137,12 @@
             </B.Tr>
           </:body>
         </Hds::Table>
+        <Rose::Pagination
+          @totalItems={{@model.totalItems}}
+          @currentPage={{this.page}}
+          @currentPageSize={{this.pageSize}}
+        />
+
       {{/if}}
       {{#if this.noResults}}
         <Hds::ApplicationState data-test-no-target-results as |A|>

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -146,7 +146,7 @@ handle('searchClientDaemon', async (request) =>
  * Check to see if the client daemon is running. We use the presence of a
  * socket path as a proxy for whether the daemon is running.
  */
-handle('isClientDaemonRunning', async (request) =>
+handle('isClientDaemonRunning', async () =>
   Boolean(clientDaemonManager.socketPath),
 );
 


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-11905

## Description
This adds the pagination component for targets in the desktop client. I created a thin wrapper around the HDS pagination so for the `paginationQueryParams` as it should be the same for every usage we have.

Still working on having a test harness for our client daemon now.
<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

https://github.com/hashicorp/boundary-ui/assets/5783847/6749bb35-097b-4716-a938-811ad36dcf20



## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
