### PR TITLE
fix: 🐛 Fix add expiration_time when user has no grants to read

### DIFF
--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -60,7 +60,8 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
 
     // Associate the connection details with the session
     let session;
-    const { session_id, address, port, credentials } = connectionDetails;
+    const { session_id, address, port, credentials, expiration_time } =
+      connectionDetails;
     try {
       session = await this.store.findRecord('session', session_id);
     } catch (error) {
@@ -76,9 +77,11 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
             proxy_address: address,
             proxy_port: port,
             target_id: target.id,
+            expiration_time,
           },
         ],
       });
+
       session = this.store.peekRecord('session', session_id);
     }
 

--- a/ui/desktop/tests/acceptance/projects/sessions/session-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/session-test.js
@@ -191,11 +191,11 @@ module('Acceptance | projects | sessions | session', function (hooks) {
       address: 'a_123',
       port: 'p_123',
       protocol: 'tcp',
+      expiration_time: '2022-02-05T09:55:39.216Z',
     });
 
     await visit(urls.target);
     await click(TARGET_CONNECT_BUTTON);
-
     assert.strictEqual(currentURL(), urls.session);
   });
 


### PR DESCRIPTION
## Description

This fixes the issue mentioned within [this slack thread](https://hashicorp.slack.com/archives/C012GTH1C4E/p1701384535719469?thread_ts=1701372005.384369&cid=C012GTH1C4E).

The test checks that a user with NO permission to read a session, but with permission to connect can establish a connection to the target, then been redirect succesfully to Session detail page. Regardless the permissions, the user expect a minimum information on the session detail page.

Behaviour:
- User clicks connect to a specific target.
- When the user stablish the connection, we read important information of the session and aggregate that to the session store.
- Once the connection is stablished, user gets redirected to the session page.
- Because the user can not read the session, relies only on the important information we aggregate at connection time to redenr the session detail page.

Issue this PR solves:
- The test uses a `stub` but was not returning the `expiration_time`, so the store had `expiration_time: undefined`.
- The process of aggregating session data from the connection was not taking care of `expiration_time`. So in the edge case of a user with no permission to read the session, will never get `expiration_time` on the model.



