### PR TITLE
refactor: 💡 Use a native class for the client daemon handler

### DIFF
--- a/ui/desktop/app/services/store.js
+++ b/ui/desktop/app/services/store.js
@@ -1,21 +1,17 @@
 import Store, { CacheHandler } from '@ember-data/store';
 import RequestManager from '@ember-data/request';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
-import { inject as service } from '@ember/service';
 import ClientDaemonHandler from 'api/handlers/client-daemon-handler';
 
 export default class extends Store {
-  @service ipc;
-  @service session;
-
   requestManager = new RequestManager();
 
   constructor(args) {
     super(args);
 
-    ClientDaemonHandler.request = ClientDaemonHandler.request.bind(this);
+    const clientDaemonHandler = new ClientDaemonHandler(this);
 
-    this.requestManager.use([ClientDaemonHandler, LegacyNetworkHandler]);
+    this.requestManager.use([clientDaemonHandler, LegacyNetworkHandler]);
     this.requestManager.useCache(CacheHandler);
   }
 }

--- a/ui/desktop/tests/acceptance/authentication-test.js
+++ b/ui/desktop/tests/acceptance/authentication-test.js
@@ -22,7 +22,6 @@ import {
   invalidateSession,
 } from 'ember-simple-auth/test-support';
 import WindowMockIPC from '../helpers/window-mock-ipc';
-import Store from 'api/services/store';
 
 module('Acceptance | authentication', function (hooks) {
   setupApplicationTest(hooks);
@@ -129,9 +128,6 @@ module('Acceptance | authentication', function (hooks) {
     // Mock the postMessage interface used by IPC.
     this.owner.register('service:browser/window', WindowMockIPC);
     setDefaultClusterUrl(this);
-
-    // Use the original store so we don't try and hit the client daemon
-    this.owner.register('service:store', Store);
   });
 
   test('visiting index while unauthenticated redirects to global authenticate method', async function (assert) {

--- a/ui/desktop/tests/acceptance/cluster-url-test.js
+++ b/ui/desktop/tests/acceptance/cluster-url-test.js
@@ -13,7 +13,6 @@ import { invalidateSession } from 'ember-simple-auth/test-support';
 import { setupBrowserFakes } from 'ember-browser-services/test-support';
 import WindowMockIPC from '../helpers/window-mock-ipc';
 import config from '../../config/environment';
-import Store from 'api/services/store';
 
 module('Acceptance | clusterUrl', function (hooks) {
   setupApplicationTest(hooks);
@@ -101,9 +100,6 @@ module('Acceptance | clusterUrl', function (hooks) {
     urls.authenticate.methods.global = `${urls.authenticate.global}/${instances.authMethods.global.id}`;
     urls.projects = `${urls.scopes.global}/projects`;
     urls.targets = `${urls.projects}/targets`;
-
-    // Use the original store so we don't try and hit the client daemon
-    this.owner.register('service:store', Store);
   });
 
   hooks.afterEach(function () {

--- a/ui/desktop/tests/acceptance/projects/sessions/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/index-test.js
@@ -22,7 +22,6 @@ import {
   STATUS_SESSION_CANCELING,
   STATUS_SESSION_TERMINATED,
 } from 'api/models/session';
-import Store from 'api/services/store';
 
 module('Acceptance | projects | sessions', function (hooks) {
   setupApplicationTest(hooks);
@@ -123,9 +122,6 @@ module('Acceptance | projects | sessions', function (hooks) {
 
     const ipcService = this.owner.lookup('service:ipc');
     stubs.ipcService = sinon.stub(ipcService, 'invoke');
-
-    // Use the original store so we don't try and hit the client daemon
-    this.owner.register('service:store', Store);
   });
 
   hooks.afterEach(function () {

--- a/ui/desktop/tests/acceptance/projects/sessions/session-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/session-test.js
@@ -15,7 +15,6 @@ import { authenticateSession } from 'ember-simple-auth/test-support';
 import sinon from 'sinon';
 import WindowMockIPC from '../../../helpers/window-mock-ipc';
 import { STATUS_SESSION_ACTIVE } from 'api/models/session';
-import Store from 'api/services/store';
 
 module('Acceptance | projects | sessions | session', function (hooks) {
   setupApplicationTest(hooks);
@@ -122,9 +121,6 @@ module('Acceptance | projects | sessions | session', function (hooks) {
 
     const ipcService = this.owner.lookup('service:ipc');
     stubs.ipcService = sinon.stub(ipcService, 'invoke');
-
-    // Use the original store so we don't try and hit the client daemon
-    this.owner.register('service:store', Store);
   });
 
   hooks.afterEach(function () {

--- a/ui/desktop/tests/acceptance/projects/targets/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/index-test.js
@@ -21,9 +21,8 @@ import {
   invalidateSession,
   currentSession,
 } from 'ember-simple-auth/test-support';
-import Store from 'api/services/store';
 
-module('Acceptance | projects | targets', function (hooks) {
+module('Acceptance | projects | targets | index', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -140,9 +139,6 @@ module('Acceptance | projects | targets', function (hooks) {
 
     const ipcService = this.owner.lookup('service:ipc');
     stubs.ipcService = sinon.stub(ipcService, 'invoke');
-
-    // Use the original store so we don't try and hit the client daemon
-    this.owner.register('service:store', Store);
   });
 
   hooks.afterEach(function () {

--- a/ui/desktop/tests/acceptance/projects/targets/target-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/target-test.js
@@ -10,7 +10,6 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import sinon from 'sinon';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import WindowMockIPC from '../../../helpers/window-mock-ipc';
-import Store from 'api/services/store';
 
 module('Acceptance | projects | targets | target', function (hooks) {
   setupApplicationTest(hooks);
@@ -132,9 +131,6 @@ module('Acceptance | projects | targets | target', function (hooks) {
 
     const ipcService = this.owner.lookup('service:ipc');
     stubs.ipcService = sinon.stub(ipcService, 'invoke');
-
-    // Use the original store so we don't try and hit the client daemon
-    this.owner.register('service:store', Store);
   });
 
   hooks.afterEach(function () {

--- a/ui/desktop/tests/acceptance/scopes-test.js
+++ b/ui/desktop/tests/acceptance/scopes-test.js
@@ -16,7 +16,6 @@ import {
   invalidateSession,
 } from 'ember-simple-auth/test-support';
 import WindowMockIPC from '../helpers/window-mock-ipc';
-import Store from 'api/services/store';
 
 module('Acceptance | scopes', function (hooks) {
   setupApplicationTest(hooks);
@@ -137,9 +136,6 @@ module('Acceptance | scopes', function (hooks) {
 
     const ipcService = this.owner.lookup('service:ipc');
     stubs.ipcService = sinon.stub(ipcService, 'invoke');
-
-    // Use the original store so we don't try and hit the client daemon
-    this.owner.register('service:store', Store);
   });
 
   hooks.afterEach(function () {


### PR DESCRIPTION
## Description
This refactors the client daemon handler to be a native class instead of just a simple function that is bound with the store's context. It turns out the handlers can take any object that just has a `request` function on it. This enables us to move the services to the class and have the directly injected with ember aware of their usage.

This fixes the issue where tests would error out when we try to use any service from within the handler (e.g. the IPC invoke methods) even when we try to mock the service out. This enables us to be able to properly mock out the client daemon searching. 

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
