### PR TITLE
fix: 🐛 Add support for not equals in MQL expression parsing

### DIFF
--- a/addons/api/addon/utils/mqlQuery.js
+++ b/addons/api/addon/utils/mqlQuery.js
@@ -45,6 +45,8 @@ export function generateMQLFilterExpression(filterObj) {
               return lt(key, value);
             case 'lte':
               return lte(key, value);
+            case 'notEquals':
+              return notEquals(key, value);
             default:
               return equals(key, value);
           }
@@ -104,6 +106,9 @@ const sanitize = (input) => input?.replace(/(["\\])/g, '\\$1');
 // Comparison Operators
 const equals = (key, value) =>
   !isEmpty(value) ? `${key} = "${sanitize(value)}"` : null;
+
+const notEquals = (key, value) =>
+  !isEmpty(value) ? `${key} != "${sanitize(value)}"` : null;
 
 const contains = (key, value) =>
   !isEmpty(value) ? `${key} % "${sanitize(value)}"` : null;


### PR DESCRIPTION
## Description
Forgot to add support for not equals as part of our MQL filter expressions.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
