### PR TITLE
test(admin/e2e): Update tests to account for changes in 0.14.3

### DIFF
--- a/ui/admin/tests/e2e/global-setup.js
+++ b/ui/admin/tests/e2e/global-setup.js
@@ -23,7 +23,7 @@ module.exports = async () => {
     .getByLabel('Login Name')
     .fill(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
   await page
-    .getByLabel('Password')
+    .getByLabel('Password', { exact: true })
     .fill(process.env.E2E_PASSWORD_ADMIN_PASSWORD);
   await page.getByRole('button', { name: 'Sign In' }).click();
   await page.getByRole('navigation', { name: 'General' }).waitFor();

--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -27,9 +27,7 @@ exports.createNewOrg = async (page) => {
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
-    page
-      .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: orgName }),
+    page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(orgName),
   ).toBeVisible();
 
   return orgName;
@@ -57,7 +55,7 @@ exports.createNewProject = async (page) => {
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: projectName }),
+      .getByText(projectName),
   ).toBeVisible();
 
   return projectName;
@@ -85,7 +83,7 @@ exports.createNewHostCatalog = async (page) => {
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: hostCatalogName }),
+      .getByText(hostCatalogName),
   ).toBeVisible();
 
   return hostCatalogName;
@@ -110,7 +108,7 @@ exports.createNewHostSet = async (page) => {
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: hostSetName }),
+      .getByText(hostSetName),
   ).toBeVisible();
 
   return hostSetName;
@@ -159,9 +157,7 @@ exports.createNewTarget = async (page) => {
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
-    page
-      .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: targetName }),
+    page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(targetName),
   ).toBeVisible();
 
   return targetName;
@@ -189,9 +185,7 @@ exports.createNewTargetWithAddress = async (page) => {
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
-    page
-      .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: targetName }),
+    page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(targetName),
   ).toBeVisible();
 
   return targetName;
@@ -339,7 +333,7 @@ exports.createNewPasswordAuthMethod = async (page, authMethodName) => {
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: authMethodName }),
+      .getByText(authMethodName),
   ).toBeVisible();
 };
 
@@ -387,7 +381,7 @@ exports.addAccountToAuthMethod = async (page, accountName, login, password) => {
   await expect(
     page
       .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: accountName }),
+      .getByText(accountName),
   ).toBeVisible();
 };
 
@@ -428,9 +422,7 @@ exports.createNewUser = async (page, userName) => {
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
-    page
-      .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: userName }),
+    page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(userName),
   ).toBeVisible();
 };
 
@@ -476,9 +468,7 @@ exports.createNewGroup = async (page, groupName) => {
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
-    page
-      .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: groupName }),
+    page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(groupName),
   ).toBeVisible();
 };
 
@@ -520,9 +510,7 @@ exports.createNewRole = async (page, roleName) => {
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
-    page
-      .getByRole('navigation', { name: 'breadcrumbs' })
-      .getByRole('link', { name: roleName }),
+    page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(roleName),
   ).toBeVisible();
 };
 

--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -378,7 +378,7 @@ exports.addAccountToAuthMethod = async (page, accountName, login, password) => {
     .click();
   await page.getByLabel('Name', { exact: true }).fill(accountName);
   await page.getByLabel('Login Name').fill(login);
-  await page.getByLabel('Password').fill(password);
+  await page.getByLabel('Password', { exact: true }).fill(password);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
     page.getByRole('alert').getByText('Success', { exact: true }),
@@ -399,7 +399,7 @@ exports.addAccountToAuthMethod = async (page, accountName, login, password) => {
  */
 exports.setPasswordToAccount = async (page, password) => {
   await page.getByRole('link', { name: 'Set Password' }).click();
-  await page.getByLabel('Password').fill(password);
+  await page.getByLabel(new RegExp('Password*')).fill(password);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
     page.getByRole('alert').getByText('Success', { exact: true }),

--- a/ui/admin/tests/e2e/tests/credential-store-static.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static.spec.js
@@ -67,7 +67,9 @@ test.beforeEach(async ({ page }) => {
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
-    page.getByRole('link', { name: credentialStoreName }),
+    page
+      .getByRole('navigation', { name: 'breadcrumbs' })
+      .getByText(credentialStoreName),
   ).toBeVisible();
 });
 
@@ -93,7 +95,11 @@ test('Static Credential Store (User & Key Pair)', async ({ page }) => {
     page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
-  await expect(page.getByRole('link', { name: credentialName })).toBeVisible();
+  await expect(
+    page
+      .getByRole('navigation', { name: 'breadcrumbs' })
+      .getByText(credentialName),
+  ).toBeVisible();
 
   await addBrokeredCredentialsToTarget(page, targetName, credentialName);
 
@@ -135,7 +141,11 @@ test('Static Credential Store (Username & Password)', async ({ page }) => {
     page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
-  await expect(page.getByRole('link', { name: credentialName })).toBeVisible();
+  await expect(
+    page
+      .getByRole('navigation', { name: 'breadcrumbs' })
+      .getByText(credentialName),
+  ).toBeVisible();
 
   await addBrokeredCredentialsToTarget(page, targetName, credentialName);
 
@@ -183,7 +193,11 @@ test('Static Credential Store (JSON)', async ({ page }) => {
     page.getByRole('alert').getByText('Success', { exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
-  await expect(page.getByRole('link', { name: credentialName })).toBeVisible();
+  await expect(
+    page
+      .getByRole('navigation', { name: 'breadcrumbs' })
+      .getByText(credentialName),
+  ).toBeVisible();
 
   await addBrokeredCredentialsToTarget(page, targetName, credentialName);
 

--- a/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
@@ -107,7 +107,9 @@ test('Vault Credential Store (User & Key Pair)', async ({ page }) => {
   ).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss' }).click();
   await expect(
-    page.getByRole('link', { name: credentialStoreName }),
+    page
+      .getByRole('navigation', { name: 'breadcrumbs' })
+      .getByText(credentialStoreName),
   ).toBeVisible();
 
   const credentialLibraryName = 'Credential Library ' + nanoid();

--- a/ui/admin/tests/e2e/tests/dynamic-host-catalog.spec.js
+++ b/ui/admin/tests/e2e/tests/dynamic-host-catalog.spec.js
@@ -63,14 +63,14 @@ test.describe('AWS', async () => {
     await expect(
       page
         .getByRole('navigation', { name: 'breadcrumbs' })
-        .getByRole('link', { name: hostCatalogName }),
+        .getByText(hostCatalogName),
     ).toBeVisible();
 
     // Create first host set
-    const hostSetName1 = 'Host Set ' + nanoid();
+    const hostSetName = 'Host Set ' + nanoid();
     await page.getByRole('link', { name: 'Host Sets' }).click();
     await page.getByRole('link', { name: 'New', exact: true }).click();
-    await page.getByLabel('Name').fill(hostSetName1);
+    await page.getByLabel('Name').fill(hostSetName);
     await page.getByLabel('Description').fill('This is an automated test');
     await page
       .getByRole('group', { name: 'Filter' })
@@ -88,14 +88,12 @@ test.describe('AWS', async () => {
     await expect(
       page
         .getByRole('navigation', { name: 'breadcrumbs' })
-        .getByRole('link', { name: hostSetName1 }),
+        .getByText(hostSetName),
     ).toBeVisible();
 
     await page.getByRole('link', { name: 'Hosts' }).click();
     await expect(
-      page
-        .getByRole('navigation', { name: 'breadcrumbs' })
-        .getByRole('link', { name: 'Hosts' }),
+      page.getByRole('navigation', { name: 'breadcrumbs' }).getByText('Hosts'),
     ).toBeVisible();
 
     // Check number of hosts in host set
@@ -119,7 +117,7 @@ test.describe('AWS', async () => {
       await page.reload();
       await page
         .getByRole('navigation', { name: 'breadcrumbs' })
-        .getByRole('link', { name: hostSetName1 })
+        .getByText(hostSetName)
         .waitFor();
     } while (i < 5);
 
@@ -147,12 +145,12 @@ test.describe('AWS', async () => {
       await expect(
         page
           .getByRole('navigation', { name: 'breadcrumbs' })
-          .getByRole('link', { name: hostName }),
+          .getByText(hostName),
       ).toBeVisible();
 
       await page
         .getByRole('navigation', { name: 'breadcrumbs' })
-        .getByRole('link', { name: hostSetName1 })
+        .getByText(hostSetName)
         .click();
       await page.getByRole('link', { name: 'Hosts' }).click();
     }

--- a/ui/admin/tests/e2e/tests/login.spec.js
+++ b/ui/admin/tests/e2e/tests/login.spec.js
@@ -13,7 +13,7 @@ test('Log in, log out, and then log back in', async ({ page }) => {
     .getByLabel('Login Name')
     .fill(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
   await page
-    .getByLabel('Password')
+    .getByLabel('Password', { exact: true })
     .fill(process.env.E2E_PASSWORD_ADMIN_PASSWORD);
   await page.getByRole('button', { name: 'Sign In' }).click();
   await expect(page.getByRole('navigation', { name: 'General' })).toBeVisible();
@@ -31,7 +31,7 @@ test('Log in, log out, and then log back in', async ({ page }) => {
     .getByLabel('Login Name')
     .fill(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
   await page
-    .getByLabel('Password')
+    .getByLabel('Password', { exact: true })
     .fill(process.env.E2E_PASSWORD_ADMIN_PASSWORD);
   await page.getByRole('button', { name: 'Sign In' }).click();
   await expect(page.getByRole('navigation', { name: 'General' })).toBeVisible();
@@ -46,7 +46,7 @@ test.describe('Failure Cases', async () => {
     await page
       .getByLabel('Login Name')
       .fill(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
-    await page.getByLabel('Password').fill('badpassword');
+    await page.getByLabel('Password', { exact: true }).fill('badpassword');
     await page.getByRole('button', { name: 'Sign In' }).click();
     await expect(page.getByRole('alert').getByText('Error')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
@@ -67,7 +67,7 @@ test.describe('Failure Cases', async () => {
 
   test('Log in with only password', async ({ page }) => {
     await page
-      .getByLabel('Password')
+      .getByLabel('Password', { exact: true })
       .fill(process.env.E2E_PASSWORD_ADMIN_PASSWORD);
     await page.getByRole('button', { name: 'Sign In' }).click();
     await expect(page.getByRole('alert').getByText('Error')).toBeVisible();


### PR DESCRIPTION
This PR updates some Admin UI e2e tests to account for some changes in 0.14.3

1. The introduction of  the `Show Password` button resulted in a conflict with how we were finding the Password textbox. 
![Screenshot 2023-12-06 at 3 15 13 PM](https://github.com/hashicorp/boundary-ui/assets/2474253/e8979733-1bf9-4c98-bb86-d6aaf2267df0)

2. The breadcrumbs used to be links for all elements, but it seems like the currently active page is no longer a link (In this example, the project name/id is no longer a link)
![Screenshot 2023-12-06 at 3 15 39 PM](https://github.com/hashicorp/boundary-ui/assets/2474253/02ca7bd3-f6ba-471f-bfc1-803cdbdf48a9)
