### PR TITLE
PoC use hds pageHeader

### DIFF
--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -10,6 +10,17 @@
 @import 'rose';
 @import 'notify';
 
+// Overrides to use HDS appHeader. Once we stop relying on rose-layout page
+// for layouting, we can delete these styles.
+.rose-layout-page {
+  display: grid;
+  grid-template-areas:
+    'header header header'
+    'body body body';
+}
+
+// End of Rose override to fit HDS components /////////////
+
 .rose-layout-centered {
   > .rose-layout-page {
     width: sizing.rems(l) * 18;

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
@@ -6,11 +6,15 @@
 <Rose::Layout::Page as |page|>
 
   <page.header>
-    <h2>
-      {{t 'resources.session.title_plural'}}
-      <DocLink @doc='sessions' @iconSize='large' />
-    </h2>
-    <p>{{t 'resources.session.description'}}</p>
+    <Hds::PageHeader as |PH|>
+      <PH.Title>{{t 'resources.session.title_plural'}}</PH.Title>
+      <PH.Description>
+        {{t 'resources.session.description'}}
+        <Hds::Link::Inline @color='secondary' @href={{(doc-url 'sessions')}}>
+          {{t 'actions.learn-more'}}
+        </Hds::Link::Inline>
+      </PH.Description>
+    </Hds::PageHeader>
   </page.header>
 
   <page.body>


### PR DESCRIPTION
## Description

THIS PR WILL NOT BE MERGED it is just for demonstration and discussion purposes.
THIS changes have been checked with @joshuaogle .

Goal of this PR:
- Use `<Hds::PageHeader>` component, [documentation here](https://helios.hashicorp.design/components/page-header), within desktop client.
- Because we're still relying on `rose-layout` for Boundary UI's, we will keep using `<Rose::Layout::Page>` and its childs elements, such as `<page.header>` as containers, but overriding/cleaning up the rose styles of those elements to keep them as pure containers as possible.
- This PR provides an overrid of `rose-layout-age` JUST for desktop client. If we like this approach an decide to use `<Hds::PageHeader>` this override will be deleted from desktop and ported to Rose, as a stage 1 deprecation process. So all the `<page.header>` within our UI's are simple containers to wrap `<Hds::PageHeader>` until we use `appFrame` as base layout.

Next steps (if we like the idea and approach):
- I will create tasks to start using `<Hds::PageHeader>` within desktop.
- I will create tasks to start using `<Hds::PageHeader>` within Admin UI.
- I will create  a task to clean up all the `.rose-layout-page-header` within `rose` and perhaps (TBD) clean up/deprecate `<DocLink>` rose component. It will not be necessary.

## Screenshots:

Before the changes:
![Screenshot 2023-12-08 at 12 01 05 PM](https://github.com/hashicorp/boundary-ui/assets/9775006/d9ae9efb-9692-4647-9de1-f067cfbf7bbe)


After:
![Screenshot 2023-12-08 at 11 58 24 AM](https://github.com/hashicorp/boundary-ui/assets/9775006/170944c7-20a7-48df-9fcc-ab6c35929a3f)
