### PR TITLE
refactor: 💡 Refactor workers list to use `Hds::Table`

### DIFF
--- a/addons/rose/app/styles/rose/components/toolbar/_toolbar.scss
+++ b/addons/rose/app/styles/rose/components/toolbar/_toolbar.scss
@@ -12,7 +12,6 @@ $xxxxs: sizing.rems(xxxxs); // 1
 
 .rose-toolbar {
   display: flex;
-  background-color: var(--ui-gray-subtler-6);
   padding: $xxs + $xxxxs;
 
   .rose-toolbar-primary,

--- a/ui/admin/app/templates/scopes/scope/workers/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/index.hbs
@@ -90,67 +90,61 @@
 
       </Rose::Toolbar>
 
-      <Rose::Table as |table|>
-        <table.header as |header|>
-          <header.row as |row|>
-            <row.headerCell>{{t 'resources.worker.title'}}</row.headerCell>
-            <row.headerCell>{{t 'form.id.label'}}</row.headerCell>
-            <row.headerCell>{{t
-                'resources.worker.table.session_count'
-              }}</row.headerCell>
-            <row.headerCell>{{t
-                'resources.worker.table.release_version'
-              }}</row.headerCell>
-            <row.headerCell>{{t
-                'resources.worker.table.ip_address'
-              }}</row.headerCell>
-          </header.row>
-        </table.header>
-        <table.body as |body|>
-          {{#each @model as |worker|}}
-            <body.row as |row|>
-              <row.headerCell>
-                {{#if (and (can 'read worker' worker) worker.isPki)}}
-                  <LinkTo
-                    @route='scopes.scope.workers.worker'
-                    @model={{worker.id}}
-                  >
-                    {{worker.displayName}}
-                  </LinkTo>
-                {{else}}
-                  {{worker.displayName}}
-                {{/if}}
-                {{#if worker.description}}
-                  <p>{{worker.description}}</p>
-                {{/if}}
-                {{#if worker.tagCount}}
-                  <div>
-                    <Hds::Badge
-                      @icon='tag'
-                      @text={{t
-                        'resources.worker.table.tag_count'
-                        tagCount=worker.tagCount
-                      }}
-                    />
-                  </div>
-                {{/if}}
-              </row.headerCell>
-              <row.cell>
-                <Copyable
-                  @text={{worker.id}}
-                  @buttonText={{t 'actions.copy-to-clipboard'}}
-                  @acknowledgeText={{t 'states.copied'}}
+      <Hds::Table
+        @model={{@model}}
+        @columns={{array
+          (hash label=(t 'resources.worker.title'))
+          (hash label=(t 'form.tags.label'))
+          (hash label=(t 'resources.session.title_plural'))
+          (hash label=(t 'resources.worker.table.release_version'))
+          (hash label=(t 'resources.worker.table.ip_address'))
+          (hash label=(t 'form.id.label'))
+        }}
+        @density='short'
+      >
+        <:body as |B|>
+          <B.Tr>
+            <B.Td>
+              {{#if (and (can 'read worker' B.data) B.data.isPki)}}
+                <LinkTo
+                  @route='scopes.scope.workers.worker'
+                  @model={{B.data.id}}
                 >
-                  <code>{{worker.id}}</code>
-                </Copyable>
-              </row.cell>
-              <row.cell>{{worker.active_connection_count}}</row.cell>
-              <row.cell>{{worker.release_version}}</row.cell>
-              <row.cell>{{worker.address}} </row.cell>
-            </body.row>
-          {{/each}}
-        </table.body>
-      </Rose::Table>
+                  {{B.data.displayName}}
+                </LinkTo>
+              {{else}}
+                {{B.data.displayName}}
+              {{/if}}
+              {{#if B.data.description}}
+                <p>{{B.data.description}}</p>
+              {{/if}}
+            </B.Td>
+            <B.Td>
+              {{#if B.data.tagCount}}
+                <Hds::Badge
+                  @icon='tag'
+                  @text={{t
+                    'resources.worker.table.tag_count'
+                    tagCount=B.data.tagCount
+                  }}
+                />
+              {{/if}}
+            </B.Td>
+            <B.Td>{{B.data.active_connection_count}}</B.Td>
+            <B.Td>{{B.data.release_version}}</B.Td>
+            <B.Td>{{B.data.address}} </B.Td>
+            <B.Td>
+              <Copyable
+                @text={{B.data.id}}
+                @buttonText={{t 'actions.copy-to-clipboard'}}
+                @acknowledgeText={{t 'states.copied'}}
+              >
+                <code>{{B.data.id}}</code>
+              </Copyable>
+            </B.Td>
+          </B.Tr>
+        </:body>
+      </Hds::Table>
     {{else}}
       <Rose::Layout::Centered>
         <Rose::Message

--- a/ui/admin/tests/acceptance/workers/read-test.js
+++ b/ui/admin/tests/acceptance/workers/read-test.js
@@ -74,7 +74,7 @@ module('Acceptance | workers | read', function (hooks) {
     await click(`[href="${urls.workers}"]`);
 
     assert
-      .dom('main tbody .rose-table-header-cell:nth-child(1) a')
+      .dom('.hds-table__tbody .hds-table__tr:nth-child(1) a')
       .isNotVisible();
   });
 
@@ -84,7 +84,7 @@ module('Acceptance | workers | read', function (hooks) {
 
     await click(`[href="${urls.workers}"]`);
 
-    assert.dom('main tbody .rose-table-header-cell:nth-child(1) a').isVisible();
+    assert.dom('.hds-table__tbody .hds-table__tr:nth-child(1) a').isVisible();
   });
 
   test('users can navigate to worker and incorrect url autocorrects', async function (assert) {


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-11734

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER)

## Description
- Refactor workers list to use `Hds::Table` instead of `Rose::Table`.
- Moved `tags` into their own cell
- Removed background-color form `Rose::Toolbar` instead of adding additional custom margin to `Hds::Table`.  Referenced in the thread below
- Rearranged location of header and data for `workers.id` to the end of the table

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
### Before
---
<img width="1925" alt="Screenshot 2023-12-08 at 14 23 56" src="https://github.com/hashicorp/boundary-ui/assets/24277002/51f133ec-5d8f-4849-b63e-70b3bb665cfb">

### After
---
<img width="1692" alt="Screenshot 2023-12-11 at 11 02 21" src="https://github.com/hashicorp/boundary-ui/assets/24277002/69246c68-59ad-4f41-8e04-153cbde3ac3a">

## How to Test
- [ ] Start up Admin UI with `yarn start`
- [ ] Click on "Workers" resource in the left sidebar navigation.

<!--
Replace PATH_TO_FEATURE with Vercel link
-->
:technologist: [Admin preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
~~- [ ] I have added JSON response output for API changes~~
- [x] I have added steps to reproduce and test for bug fixes in the description
~~- [ ] I have commented on my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
