### PR TITLE
fix: 🐛 target cred sources association

### DIFF
--- a/ui/admin/app/routes/scopes/scope/targets/target/add-brokered-credential-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/add-brokered-credential-sources.js
@@ -40,11 +40,11 @@ export default class ScopesScopeTargetsTargetAddBrokeredCredentialSourcesRoute e
     await all(
       credentialStores.map(({ id: credential_store_id, isStatic }) => {
         if (isStatic) {
-          return this.store.query('credential', {
+          this.store.query('credential', {
             credential_store_id,
           });
         } else {
-          return this.store.query('credential-library', {
+          this.store.query('credential-library', {
             credential_store_id,
           });
         }

--- a/ui/admin/app/routes/scopes/scope/targets/target/add-injected-application-credential-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/add-injected-application-credential-sources.js
@@ -40,11 +40,11 @@ export default class ScopesScopeTargetsTargetAddInjectedApplicationCredentialSou
     await all(
       credentialStores.map(({ id: credential_store_id, isStatic }) => {
         if (isStatic) {
-          return this.store.query('credential', {
+          this.store.query('credential', {
             credential_store_id,
           });
         } else {
-          return this.store.query('credential-library', {
+          this.store.query('credential-library', {
             credential_store_id,
           });
         }


### PR DESCRIPTION
https://hashicorp.atlassian.net/browse/ICU-12046
## Description

This PR fixes the error caused when the `add/remove credential sources` process was repeated.

Note: When we `return` within the `await.all`, the peekAll method on L53& L54 adds duplicate stale IDs from the previous iteration with no `type`, causing the error. 

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

## How to Test

Add an injected credential source to a target
Remove the credential source from the target
Repeat 1-2 more times
you should not see any error

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
