### PR TITLE
fix: 🐛 Fix failing tests from rebase onto main

### DIFF
--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -107,7 +107,9 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
     const { session_id, address, port, credentials, expiration } =
       connectionDetails;
     try {
-      session = await this.store.findRecord('session', session_id);
+      session = await this.store.findRecord('session', session_id, {
+        reload: true,
+      });
     } catch (error) {
       /**
        * if the user cannot read or fetch the session we add the important

--- a/ui/desktop/tests/acceptance/projects/targets/target-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/target-test.js
@@ -126,11 +126,10 @@ module('Acceptance | projects | targets | target', function (hooks) {
     this.ipcStub.withArgs('isClientDaemonRunning').returns(true);
     this.stubClientDaemonSearch(
       'targets',
+      'sessions',
+      'sessions',
+      'sessions',
       'targets',
-      'targets',
-      'sessions',
-      'sessions',
-      'sessions',
     );
   });
 


### PR DESCRIPTION
## Description
Some tests starting to fail after rebasing onto main. The root cause of the issue is a recent PR added some calls to get sessions in the targets route which adds them to the store so the following call to retrieve the session is returning cached data from the store (which for some reason didn't have expiration_time).

Some of the stubbed client daemon calls were also not being setup correctly as they were returning target data for session calls. 

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
