### PR TITLE
fix: 🐛 Fix returning mirage data from client daemon mock

### DIFF
--- a/addons/api/addon-test-support/handlers/client-daemon-search.js
+++ b/addons/api/addon-test-support/handlers/client-daemon-search.js
@@ -47,10 +47,16 @@ export default function setupStubs(hooks) {
           .withArgs('searchClientDaemon')
           .onCall(i)
           .returns({
-            [type]: this.server.db[type].map((model) => ({
-              ...model,
-              scope: this.server.db.scopes.find(model.scopeId),
-            })),
+            [type]: this.server.schema[type]?.all().models.map((model) => {
+              // Use internal serializer to serialize the model correctly
+              // according to our mirage serializers
+              const modelData =
+                this.server.serializerOrRegistry.serialize(model);
+
+              // Serialize the data properly to standard JSON as that is what
+              // we're expecting from the client daemon response
+              return JSON.parse(JSON.stringify(modelData));
+            }),
           });
       });
     };


### PR DESCRIPTION
## Description
This PR fixes two issues in tests:

1. We weren't properly serializing the data (using our mirage serializers to rename some properties to snake case and serializing the scope object)
2. We were returning the data raw which includes any JS objects such as date objects. We need to return this data as standard JSON so our ember data can properly normalize the data it receives. 
