### PR TITLE
refactor: 💡 Migrate `credentials-list` to `Hds::Table`

### DIFF
--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/index.hbs
@@ -28,18 +28,18 @@
   <page.body>
     {{#if @model}}
 
-      <Rose::Table as |table|>
-        <table.header as |header|>
-          <header.row as |row|>
-            <row.headerCell>{{t 'form.name.label'}}</row.headerCell>
-            <row.headerCell>{{t 'form.type.label'}}</row.headerCell>
-            <row.headerCell>{{t 'form.id.label'}}</row.headerCell>
-          </header.row>
-        </table.header>
-        <table.body as |body|>
+      <Hds::Table>
+        <:head as |H|>
+          <H.Tr>
+            <H.Th>{{t 'form.name.label'}}</H.Th>
+            <H.Th>{{t 'form.type.label'}}</H.Th>
+            <H.Th>{{t 'form.id.label'}}</H.Th>
+          </H.Tr>
+        </:head>
+        <:body as |B|>
           {{#each @model as |credential|}}
-            <body.row as |row|>
-              <row.headerCell>
+            <B.Tr>
+              <B.Td>
                 {{#if (can 'read credential' credential)}}
                   <LinkTo
                     @route='scopes.scope.credential-stores.credential-store.credentials.credential'
@@ -48,26 +48,27 @@
                     {{credential.displayName}}
                   </LinkTo>
                 {{else}}
-                  {{credential.displayName}}
+                  <Hds::Text::Body @tag='p'>
+                    {{credential.displayName}}
+                  </Hds::Text::Body>
                 {{/if}}
-                <p>{{credential.description}}</p>
-              </row.headerCell>
-              <row.cell>
+                <Hds::Text::Body @tag='p'>
+                  {{credential.description}}
+                </Hds::Text::Body>
+              </B.Td>
+              <B.Td>
                 <CredSourceTypeBadge @model={{credential}} />
-              </row.cell>
-              <row.cell>
-                <Copyable
-                  @text={{credential.id}}
-                  @buttonText={{t 'actions.copy-to-clipboard'}}
-                  @acknowledgeText={{t 'states.copied'}}
-                >
-                  <code>{{credential.id}}</code>
-                </Copyable>
-              </row.cell>
-            </body.row>
+              </B.Td>
+              <B.Td>
+                <Hds::Copy::Snippet
+                  @color='secondary'
+                  @textToCopy={{credential.id}}
+                />
+              </B.Td>
+            </B.Tr>
           {{/each}}
-        </table.body>
-      </Rose::Table>
+        </:body>
+      </Hds::Table>
 
     {{else}}
 

--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/index.hbs
@@ -28,45 +28,44 @@
   <page.body>
     {{#if @model}}
 
-      <Hds::Table>
-        <:head as |H|>
-          <H.Tr>
-            <H.Th>{{t 'form.name.label'}}</H.Th>
-            <H.Th>{{t 'form.type.label'}}</H.Th>
-            <H.Th>{{t 'form.id.label'}}</H.Th>
-          </H.Tr>
-        </:head>
+      <Hds::Table
+        @model={{@model}}
+        @columns={{array
+          (hash label=(t 'form.name.label'))
+          (hash label=(t 'form.type.label'))
+          (hash label=(t 'form.id.label'))
+        }}
+        @valign='middle'
+      >
         <:body as |B|>
-          {{#each @model as |credential|}}
-            <B.Tr>
-              <B.Td>
-                {{#if (can 'read credential' credential)}}
-                  <LinkTo
-                    @route='scopes.scope.credential-stores.credential-store.credentials.credential'
-                    @model={{credential.id}}
-                  >
-                    {{credential.displayName}}
-                  </LinkTo>
-                {{else}}
-                  <Hds::Text::Body @tag='p'>
-                    {{credential.displayName}}
-                  </Hds::Text::Body>
-                {{/if}}
+          <B.Tr>
+            <B.Td>
+              {{#if (can 'read credential' B.data)}}
+                <LinkTo
+                  @route='scopes.scope.credential-stores.credential-store.credentials.credential'
+                  @model={{B.data.id}}
+                >
+                  {{B.data.displayName}}
+                </LinkTo>
+              {{else}}
                 <Hds::Text::Body @tag='p'>
-                  {{credential.description}}
+                  {{B.data.displayName}}
                 </Hds::Text::Body>
-              </B.Td>
-              <B.Td>
-                <CredSourceTypeBadge @model={{credential}} />
-              </B.Td>
-              <B.Td>
-                <Hds::Copy::Snippet
-                  @color='secondary'
-                  @textToCopy={{credential.id}}
-                />
-              </B.Td>
-            </B.Tr>
-          {{/each}}
+              {{/if}}
+              <Hds::Text::Body @tag='p'>
+                {{B.data.description}}
+              </Hds::Text::Body>
+            </B.Td>
+            <B.Td>
+              <CredSourceTypeBadge @model={{B.data}} />
+            </B.Td>
+            <B.Td>
+              <Hds::Copy::Snippet
+                @color='secondary'
+                @textToCopy={{B.data.id}}
+              />
+            </B.Td>
+          </B.Tr>
         </:body>
       </Hds::Table>
 

--- a/ui/admin/tests/acceptance/credential-store/credentials/list-test.js
+++ b/ui/admin/tests/acceptance/credential-store/credentials/list-test.js
@@ -81,7 +81,7 @@ module('Acceptance | credential-stores | credentials | list', function (hooks) {
     await click(`[href="${urls.credentials}"]`);
     assert.strictEqual(currentURL(), urls.credentials);
     assert
-      .dom('.rose-table-body .rose-table-row')
+      .dom('tbody tr')
       .isVisible({ count: this.server.schema.credentials.all().models.length });
   });
 


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-11725

## Description
- Migrate `credentials-list` to `Hds::Table`
- Migrated `Copyable` components to `Hds::Copy::Snippet` component
- Migrated `p` and unwrapped elements with `Hds::Text` component

## Note
- Could not use the `.data` key to access `@model` for credentials because the model is being returned as a `Proxy(Array)`

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
### Before: 
---
<img width="1691" alt="Screenshot 2023-12-21 at 10 36 35" src="https://github.com/hashicorp/boundary-ui/assets/24277002/607ebd15-e945-4644-b79e-4c3cf6984e2d">

### After:
--- 
<img width="1691" alt="Screenshot 2023-12-21 at 10 39 28" src="https://github.com/hashicorp/boundary-ui/assets/24277002/ebcb372a-5a75-4214-b069-d3512b54b6de">

## How to Test
- [ ] Click on Vercel link for Admin UI or pull down PR and run it locally using `yarn start`
- [ ] Click on any "Orgs" card created by mirage
- [ ] Click on any "Projects" card created by mirage and "Host Catalogs" will appear in the sidebar navigation.
- [ ] Click on "Credential Stores" in the sidebar navigation.
- [ ] Click on a credential store with a `static` type.
- [ ] Click on "Credentials" tab and view list.
- [ ] Ensure clicking on a `credential` will take you to details page view of credential.
- [ ] Ensure clicking on `copy` icon will copy the id of  `credential`

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](https://boundary-ui-git-icu-11725-admin-ui-use-hds-tab-e7a4c8-hashicorp.vercel.app/)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
~~- [ ] I have added JSON response output for API changes~~
~~- [ ] I have added steps to reproduce and test for bug fixes in the description~~
~~- [ ] I have commented on my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
