### PR TITLE
refactor: 💡 Migrate `credential-libraries-list` to `Hds::Table`

### DIFF
--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credential-libraries/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credential-libraries/index.hbs
@@ -28,54 +28,50 @@
   <page.body>
     {{#if @model}}
 
-      <Rose::Table as |table|>
-        <table.header as |header|>
-          <header.row as |row|>
-            <row.headerCell>{{t 'form.name.label'}}</row.headerCell>
-            <row.headerCell>{{t 'form.type.label'}}</row.headerCell>
-            <row.headerCell>{{t 'form.id.label'}}</row.headerCell>
-          </header.row>
-        </table.header>
-        <table.body as |body|>
-          {{#each @model as |credentialLibrary|}}
-            <body.row as |row|>
-              <row.headerCell>
-                {{#if (can 'read credential-library' credentialLibrary)}}
-                  <LinkTo
-                    @route='scopes.scope.credential-stores.credential-store.credential-libraries.credential-library'
-                    @model={{credentialLibrary.id}}
-                  >
-                    {{credentialLibrary.displayName}}
-                  </LinkTo>
-                {{else}}
-                  {{credentialLibrary.displayName}}
-                {{/if}}
-                <p>{{credentialLibrary.description}}</p>
-              </row.headerCell>
-              <row.cell>
-                <Hds::Badge
-                  @text={{t
-                    (concat
-                      'resources.credential-library.types.'
-                      credentialLibrary.type
-                    )
-                  }}
-                />
-              </row.cell>
-              <row.cell>
-                <Copyable
-                  @text={{credentialLibrary.id}}
-                  @buttonText={{t 'actions.copy-to-clipboard'}}
-                  @acknowledgeText={{t 'states.copied'}}
+      <Hds::Table
+        @model={{@model}}
+        @columns={{array
+          (hash label=(t 'form.name.label'))
+          (hash label=(t 'form.type.label'))
+          (hash label=(t 'form.id.label'))
+        }}
+        @valign='middle'
+      >
+        <:body as |B|>
+          <B.Tr>
+            <B.Td>
+              {{#if (can 'read credential-library' B.data)}}
+                <LinkTo
+                  @route='scopes.scope.credential-stores.credential-store.credential-libraries.credential-library'
+                  @model={{B.data.id}}
                 >
-                  <code>{{credentialLibrary.id}}</code>
-                </Copyable>
-              </row.cell>
-            </body.row>
-          {{/each}}
-        </table.body>
-      </Rose::Table>
-
+                  {{B.data.displayName}}
+                </LinkTo>
+              {{else}}
+                <Hds::Text::Body @tag='p'>
+                  {{B.data.displayName}}
+                </Hds::Text::Body>
+              {{/if}}
+              <Hds::Text::Body @tag='p'>
+                {{B.data.description}}
+              </Hds::Text::Body>
+            </B.Td>
+            <B.Td>
+              <Hds::Badge
+                @text={{t
+                  (concat 'resources.credential-library.types.' B.data.type)
+                }}
+              />
+            </B.Td>
+            <B.Td>
+              <Hds::Copy::Snippet
+                @textToCopy={{B.data.id}}
+                @color='secondary'
+              />
+            </B.Td>
+          </B.Tr>
+        </:body>
+      </Hds::Table>
     {{else}}
 
       <Rose::Layout::Centered>

--- a/ui/admin/tests/acceptance/credential-library/read-test.js
+++ b/ui/admin/tests/acceptance/credential-library/read-test.js
@@ -68,7 +68,7 @@ module('Acceptance | credential-libraries | read', function (hooks) {
 
   test('can navigate to resource', async function (assert) {
     await visit(urls.credentialLibraries);
-    await click('main tbody .rose-table-header-cell a');
+    await click('.hds-table .hds-table__tbody .hds-table__tr a');
     await a11yAudit();
     assert.strictEqual(currentURL(), urls.credentialLibrary);
   });


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-11724

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER)

## Description
- Migrate `credential-libraries-list` to `Hds::Table` instead of `Rose::Table`
- Migrated Copyable components to Hds::Copy::Snippet component
- Migrated p and unwrapped elements with Hds::Text component

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
### Before:
--- 
<img width="1691" alt="Screenshot 2024-01-02 at 10 43 28" src="https://github.com/hashicorp/boundary-ui/assets/24277002/7d54dded-75c9-42ee-bd05-70e5f8d290f5">

### After:
--- 
<img width="1691" alt="Screenshot 2024-01-02 at 10 49 51" src="https://github.com/hashicorp/boundary-ui/assets/24277002/7ce89148-a57e-4462-81c0-93293635a94b">

## How to Test
- Click on Vercel link for Admin UI or pull down PR and run it locally using `yarn start`
- Click on any "Orgs" card created by mirage
- Click on any "Projects" card created by mirage and "Host Catalogs" will appear in the sidebar navigation.
- Click on "Credential Stores" in the sidebar navigation.
- Click on any credential store from list.
- Navigate to "Credential Libraries" via tab and view list.
- Ensure clicking on a `credential library` will take you to details page view of credential.
- Ensure clicking on `copy` icon in list will copy the id of  `credential`

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](https://boundary-ui-git-icu-11724-admin-ui-use-hds-tab-d3814b-hashicorp.vercel.app/)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
~~- [ ] I have added JSON response output for API changes~~
~~- [ ] I have added steps to reproduce and test for bug fixes in the description~~
~~- [ ] I have commented on my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
