### PR TITLE
refactor: 💡 Migrate `workers-tags` over to use `Hds::Table`

### DIFF
--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -57,57 +57,63 @@
           'resources.worker.form.worker_tags.help'
         }}</F.HelperText>
       <F.Control>
-        <Rose::Table @style='condensed' as |table|>
-          <table.body as |body|>
-            {{#each this.workerTags as |tag index|}}
-              <body.row as |row|>
-                <row.cell>
-                  <form.input @type='text' @value={{tag.key}} />
-                </row.cell>
-                <row.cell>
-                  <form.input @type='text' @value={{tag.value}} />
-                </row.cell>
-                <row.cell @shrink={{true}}>
-                  <Rose::Button
-                    @style='warning'
-                    @iconOnly='flight-icons/svg/trash-16'
-                    title={{t 'actions.remove'}}
-                    {{on 'click' (fn this.removeWorkerTagByIndex index)}}
-                  >
-                    {{t 'actions.remove'}}
-                  </Rose::Button>
-                </row.cell>
-              </body.row>
+        <Hds::Table class='list-wrapper-field' name='workers_tags'>
+          <:body as |B|>
+            {{#each this.workerTags as |tag i|}}
+              <B.Tr>
+                <B.Td>
+                  <Hds::Form::TextInput::Base
+                    @value={{tag.key}}
+                    @type='text'
+                    {{on 'input' (set-from-event tag 'key')}}
+                  />
+                </B.Td>
+                <B.Td>
+                  <Hds::Form::TextInput::Base
+                    @value={{tag.value}}
+                    @type='text'
+                    {{on 'input' (set-from-event tag 'value')}}
+                  />
+                </B.Td>
+                <B.Td>
+                  <Hds::Button
+                    @text={{t 'actions.remove'}}
+                    @color='critical'
+                    @icon='trash'
+                    @isIconOnly={{true}}
+                    {{on 'click' (fn this.removeWorkerTagByIndex i)}}
+                  />
+                </B.Td>
+              </B.Tr>
             {{/each}}
-
-            <body.row as |row|>
-              <row.cell>
-                <form.input
-                  @type='text'
+            <B.Tr>
+              <B.Td>
+                <Hds::Form::TextInput::Base
                   @value={{this.newWorkerKey}}
-                  placeholder='Key'
-                />
-              </row.cell>
-              <row.cell>
-                <form.input
                   @type='text'
-                  @value={{this.newWorkerValue}}
-                  placeholder='Value'
+                  placeholder='Key'
+                  {{on 'input' (set-from-event this 'newWorkerKey')}}
                 />
-              </row.cell>
-              <row.cell @shrink={{true}}>
-                <Rose::Button
-                  @style='secondary'
-                  title={{t 'actions.add'}}
-                  @disabled={{not this.newWorkerKey}}
+              </B.Td>
+              <B.Td>
+                <Hds::Form::TextInput::Base
+                  @value={{this.newWorkerValue}}
+                  @type='text'
+                  placeholder='Value'
+                  {{on 'input' (set-from-event this 'newWorkerValue')}}
+                />
+              </B.Td>
+              <B.Td>
+                <Hds::Button
+                  @text={{t 'actions.add'}}
+                  @color='secondary'
+                  disabled={{not this.newWorkerKey}}
                   {{on 'click' this.addWorkerTag}}
-                >
-                  {{t 'actions.add'}}
-                </Rose::Button>
-              </row.cell>
-            </body.row>
-          </table.body>
-        </Rose::Table>
+                />
+              </B.Td>
+            </B.Tr>
+          </:body>
+        </Hds::Table>
       </F.Control>
     </Hds::Form::Fieldset>
 

--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -50,72 +50,30 @@
         placeholder='10.0.0.1, 10.0.0.2, 10.0.0.3'
       />
     {{/if}}
+    <Form::Field::ListWrapper
+      @layout='horizontal'
+      @isOptional={{true}}
+      @disabled={{form.disabled}}
+    >
+      <:fieldset as |F|>
+        <F.Legend>{{t 'resources.worker.form.worker_tags.label'}}</F.Legend>
+        <F.HelperText>
+          {{t 'resources.worker.form.worker_tags.help'}}
+        </F.HelperText>
+      </:fieldset>
 
-    <Hds::Form::Fieldset as |F|>
-      <F.Legend>{{t 'resources.worker.form.worker_tags.label'}}</F.Legend>
-      <F.HelperText>{{t
-          'resources.worker.form.worker_tags.help'
-        }}</F.HelperText>
-      <F.Control>
-        <Hds::Table class='list-wrapper-field' name='workers_tags'>
-          <:body as |B|>
-            {{#each this.workerTags as |tag i|}}
-              <B.Tr>
-                <B.Td>
-                  <Hds::Form::TextInput::Base
-                    @value={{tag.key}}
-                    @type='text'
-                    {{on 'input' (set-from-event tag 'key')}}
-                  />
-                </B.Td>
-                <B.Td>
-                  <Hds::Form::TextInput::Base
-                    @value={{tag.value}}
-                    @type='text'
-                    {{on 'input' (set-from-event tag 'value')}}
-                  />
-                </B.Td>
-                <B.Td>
-                  <Hds::Button
-                    @text={{t 'actions.remove'}}
-                    @color='critical'
-                    @icon='trash'
-                    @isIconOnly={{true}}
-                    {{on 'click' (fn this.removeWorkerTagByIndex i)}}
-                  />
-                </B.Td>
-              </B.Tr>
-            {{/each}}
-            <B.Tr>
-              <B.Td>
-                <Hds::Form::TextInput::Base
-                  @value={{this.newWorkerKey}}
-                  @type='text'
-                  placeholder='Key'
-                  {{on 'input' (set-from-event this 'newWorkerKey')}}
-                />
-              </B.Td>
-              <B.Td>
-                <Hds::Form::TextInput::Base
-                  @value={{this.newWorkerValue}}
-                  @type='text'
-                  placeholder='Value'
-                  {{on 'input' (set-from-event this 'newWorkerValue')}}
-                />
-              </B.Td>
-              <B.Td>
-                <Hds::Button
-                  @text={{t 'actions.add'}}
-                  @color='secondary'
-                  disabled={{not this.newWorkerKey}}
-                  {{on 'click' this.addWorkerTag}}
-                />
-              </B.Td>
-            </B.Tr>
-          </:body>
-        </Hds::Table>
-      </F.Control>
-    </Hds::Form::Fieldset>
+      <:field as |F|>
+        <F.KeyValue
+          @name='worker_tags'
+          @options={{this.workerTags}}
+          @disabled={{form.disabled}}
+          @removeOptionByIndex={{this.removeWorkerTagByIndex}}
+          @addOption={{this.addWorkerTag}}
+          @newOptionKey={{this.newWorkerTagKey}}
+          @newOptionValue={{this.newWorkerTagValue}}
+        />
+      </:field>
+    </Form::Field::ListWrapper>
 
     {{#if (feature-flag 'ssh-session-recording')}}
       <Hds::Form::Fieldset as |F|>

--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -50,11 +50,7 @@
         placeholder='10.0.0.1, 10.0.0.2, 10.0.0.3'
       />
     {{/if}}
-    <Form::Field::ListWrapper
-      @layout='horizontal'
-      @isOptional={{true}}
-      @disabled={{form.disabled}}
-    >
+    <Form::Field::ListWrapper @layout='horizontal' @disabled={{form.disabled}}>
       <:fieldset as |F|>
         <F.Legend>{{t 'resources.worker.form.worker_tags.label'}}</F.Legend>
         <F.HelperText>
@@ -67,10 +63,8 @@
           @name='worker_tags'
           @options={{this.workerTags}}
           @disabled={{form.disabled}}
-          @removeOptionByIndex={{this.removeWorkerTagByIndex}}
           @addOption={{this.addWorkerTag}}
-          @newOptionKey={{this.newWorkerTagKey}}
-          @newOptionValue={{this.newWorkerTagValue}}
+          @removeOptionByIndex={{this.removeWorkerTagByIndex}}
         />
       </:field>
     </Form::Field::ListWrapper>

--- a/ui/admin/app/components/form/worker/create-worker-led/index.js
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.js
@@ -14,7 +14,6 @@ class Tag {
   @tracked value;
 
   constructor(key, value) {
-    console.log(key, value);
     this.key = key;
     this.value = value;
   }

--- a/ui/admin/app/components/form/worker/create-worker-led/index.js
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.js
@@ -189,8 +189,10 @@ unzip *.zip ;\\
   }
 
   @action
-  addWorkerTag() {
-    this.workerTags.pushObject(new Tag(this.newWorkerKey, this.newWorkerValue));
+  addWorkerTag(e) {
+    this.workerTags.pushObject(
+      new Tag((this.newWorkerKey = e.key), (this.newWorkerValue = e.value)),
+    );
     this.newWorkerKey = '';
     this.newWorkerValue = '';
   }

--- a/ui/admin/app/components/form/worker/create-worker-led/index.js
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.js
@@ -14,6 +14,7 @@ class Tag {
   @tracked value;
 
   constructor(key, value) {
+    console.log(key, value);
     this.key = key;
     this.value = value;
   }
@@ -31,8 +32,6 @@ export default class FormWorkerCreateWorkerLedComponent extends Component {
   @tracked configFilePath;
   @tracked initialUpstreams;
   @tracked workerTags = A([]);
-  @tracked newWorkerKey;
-  @tracked newWorkerValue;
   @tracked enableRecordingStoragePath = false;
   @tracked recording_storage_path = '';
 
@@ -190,11 +189,7 @@ unzip *.zip ;\\
 
   @action
   addWorkerTag(e) {
-    this.workerTags.pushObject(
-      new Tag((this.newWorkerKey = e.key), (this.newWorkerValue = e.value)),
-    );
-    this.newWorkerKey = '';
-    this.newWorkerValue = '';
+    this.workerTags.pushObject(new Tag(e.key, e.value));
   }
 
   @action


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-11722

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER)

## Description
- Migrate `workers-tags` in `worker-create` form to use  `Form::Field::ListWrapper` instead of `Rose::Table`
- Now that we are using the `Form::Field::ListWrapper` we can pass the `worker_tags` object directly into the options for table, which tracks the `newOptionKey` and `newOptionValue`.  We removed the tracked properties for `newKeyWorker` and `newValueWorker`
- Refactored the `addWorkerTag` method .
- 
<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
### Before 
--- 
<img width="1690" alt="Screenshot 2024-01-03 at 15 41 23" src="https://github.com/hashicorp/boundary-ui/assets/24277002/2c442c28-fe44-4211-a747-6e1a5311fc9d">

### After
---
<img width="1690" alt="Screenshot 2024-01-03 at 15 38 37" src="https://github.com/hashicorp/boundary-ui/assets/24277002/25f5ce63-7f5b-4f50-bab7-0ba9c6dc55d9">

### Tested against Boundary v0.14.0 Ent binary

https://github.com/hashicorp/boundary-ui/assets/24277002/32d4b39e-4c9e-4c9d-b578-277c1d26d604



## How to Test basic UI flow
- Click on Vercel link for Admin UI or pull down PR and run it locally using `yarn start`
- Click on "Workers" in the sidebar navigation.
- Click on the "New" button
- Add anything to the required fields, add worker tags and add text to the `worker auth registration request`
- Ensure that the text added to `key` and `value` for workers tags is getting translated into the copy code editor
- Ensure that you are able to add additional key-value pairs as well as edit and delete previously aded.
- Click done
- Click on previously created worker from list and ensure that those worker tags are present.

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
~~- [ ] I have added JSON response output for API changes~~
~~- [ ] I have added steps to reproduce and test for bug fixes in the description~~
~~- [ ] I have commented on my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
