### PR TITLE
chore: 🤖 Fix breaking change in labeler when upgrading to v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,22 +2,29 @@
 # SPDX-License-Identifier: MPL-2.0
 
 addons:
-  - addons/**/*
+  - changed-files:
+    - any-glob-to-any-file: "addons/**/*"
 
 api-addon:
-  - addons/api/**/*
+  - changed-files:
+    - any-glob-to-any-file: "addons/api/**/*"
 
 auth-addon:
-  - addons/auth/**/*
+  - changed-files:
+    - any-glob-to-any-file: "addons/auth/**/*"
 
 styles-addon:
-  - addons/rose/**/*
+  - changed-files:
+    - any-glob-to-any-file: "addons/rose/**/*"
 
 ui:
-  - ui/**/*
+  - changed-files:
+    - any-glob-to-any-file: "ui/**/*"
 
 admin:
-  - ui/admin/**/*
+  - changed-files:
+    - any-glob-to-any-file: "ui/admin/**/*"
 
 desktop:
-  - ui/desktop/**/*
+  - changed-files:
+    - any-glob-to-any-file: "ui/desktop/**/*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,13 +1,11 @@
 name: "Pull Request Labeler"
 on:
-#  TODO: Switch back to pull_request_target, this is just to test
-- pull_request
+- pull_request_target
 
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,11 +1,13 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+#  TODO: Switch back to pull_request_target, this is just to test
+- pull_request
 
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description
The github [labeler](https://github.com/actions/labeler) broke when upgrading to v5 from the [automated](https://github.com/hashicorp/boundary-ui/pull/2065) workflow pin upgrade.

The check for labeler in this PR will still fail as it's using the workflow and config file from `main`

