### PR TITLE
Icu 12137 add additional session sorting and add default filters

### DIFF
--- a/addons/core/addon/components/filter-tags/index.js
+++ b/addons/core/addon/components/filter-tags/index.js
@@ -11,9 +11,10 @@ export default class FilterTagsIndexComponent extends Component {
   // =attributes
 
   get filters() {
-    return Object.entries(this.args.filters).flatMap(([key, value]) => {
+    const { allFilters, selectedFilters } = this.args.filters;
+    return Object.entries(allFilters).flatMap(([key, value]) => {
       assert(`Tags must be an array for key ${key}`, Array.isArray(value));
-      const paramsSet = new Set(this.getCurrentQueryParams(key));
+      const paramsSet = new Set(selectedFilters[key]);
       const filters = value.filter((item) => paramsSet.has(item.id));
 
       return filters.map((item) => ({
@@ -26,24 +27,13 @@ export default class FilterTagsIndexComponent extends Component {
 
   // =methods
 
-  getCurrentQueryParams(key) {
-    let queryParamValue;
-    try {
-      queryParamValue = JSON.parse(this.router.currentRoute.queryParams[key]);
-    } catch {
-      // We should never get an error as we are always asserting the queryParam to an array
-      queryParamValue = [];
-    }
-    return queryParamValue;
-  }
-
   /**
    * Clears a single filter from queryParams for current route
    * @param {object} tag
    */
   @action
   removeFilter(tag) {
-    const queryParamValue = this.getCurrentQueryParams(tag.type);
+    const queryParamValue = this.args.filters.selectedFilters[tag.type];
 
     const queryParams = {
       [tag.type]: queryParamValue.filter((item) => item !== tag.id),
@@ -57,10 +47,13 @@ export default class FilterTagsIndexComponent extends Component {
    */
   @action
   clearAllFilters() {
-    const queryParams = Object.keys(this.args.filters).reduce((params, key) => {
-      params[key] = [];
-      return params;
-    }, {});
+    const queryParams = Object.keys(this.args.filters.allFilters).reduce(
+      (params, key) => {
+        params[key] = [];
+        return params;
+      },
+      {},
+    );
 
     this.router.replaceWith({ queryParams });
   }

--- a/addons/core/tests/integration/components/filter-tags/index-test.js
+++ b/addons/core/tests/integration/components/filter-tags/index-test.js
@@ -3,25 +3,16 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import sinon from 'sinon';
 
 module('Integration | Component | filter-tags/index', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   test('it renders', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    sinon.stub(router, 'currentRoute').value({
-      queryParams: {
-        scopes: JSON.stringify(['1']),
-      },
+    this.set('filter', {
+      allFilters: { scopes: [{ id: '1', name: 'Project 1' }] },
+      selectedFilters: { scopes: ['1'] },
     });
-
-    this.set('filter', { scopes: [{ id: '1', name: 'Project 1' }] });
     await render(hbs`<FilterTags @filters={{this.filter}} />`);
 
     assert.dom('.hds-tag__text').hasText('Project 1');

--- a/ui/desktop/app/controllers/scopes/scope/projects/sessions/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/sessions/index.js
@@ -26,7 +26,7 @@ export default class ScopesScopeProjectsSessionsIndexController extends Controll
   ];
 
   @tracked targets = [];
-  @tracked status = [];
+  @tracked status = ['active', 'pending', 'canceling'];
   @tracked scopes = [];
   @tracked page = 1;
   @tracked pageSize = 10;
@@ -34,11 +34,17 @@ export default class ScopesScopeProjectsSessionsIndexController extends Controll
   // =methods
 
   /**
-   * A list of sessions sorted by created time
+   * A list of sessions sorted by created time then sorted by availability
    * @type {[SessionModel]}
    */
   get sortedSessions() {
-    return orderBy(this.model.sessions, 'created_time', 'desc');
+    const sortedSessions = orderBy(this.model.sessions, 'created_time', 'desc');
+    return [
+      // then move active sessions to the top
+      ...sortedSessions.filter((session) => session.isAvailable),
+      // and all others to the end
+      ...sortedSessions.filter((session) => !session.isAvailable),
+    ];
   }
 
   /**
@@ -84,9 +90,16 @@ export default class ScopesScopeProjectsSessionsIndexController extends Controll
    */
   get filters() {
     return {
-      targets: this.availableTargets,
-      status: this.sessionStatusOptions,
-      scopes: this.availableScopes,
+      allFilters: {
+        targets: this.availableTargets,
+        status: this.sessionStatusOptions,
+        scopes: this.availableScopes,
+      },
+      selectedFilters: {
+        targets: this.targets,
+        status: this.status,
+        scopes: this.scopes,
+      },
     };
   }
 

--- a/ui/desktop/app/controllers/scopes/scope/projects/sessions/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/sessions/index.js
@@ -38,13 +38,11 @@ export default class ScopesScopeProjectsSessionsIndexController extends Controll
    * @type {[SessionModel]}
    */
   get sortedSessions() {
-    const sortedSessions = orderBy(this.model.sessions, 'created_time', 'desc');
-    return [
-      // then move active sessions to the top
-      ...sortedSessions.filter((session) => session.isAvailable),
-      // and all others to the end
-      ...sortedSessions.filter((session) => !session.isAvailable),
-    ];
+    return orderBy(
+      this.model.sessions,
+      ['isAvailable', 'created_time'],
+      ['desc', 'desc'],
+    );
   }
 
   /**

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -141,9 +141,16 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
    */
   get filters() {
     return {
-      scopes: this.availableScopes,
-      availableSessions: this.availableSessionOptions,
-      types: this.targetTypeOptions,
+      allFilters: {
+        scopes: this.availableScopes,
+        availableSessions: this.availableSessionOptions,
+        types: this.targetTypeOptions,
+      },
+      selectedFilters: {
+        scopes: this.scopes,
+        availableSessions: this.availableSessions,
+        types: this.types,
+      },
     };
   }
 


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-12137)

## Description
Default queryParam values are [pruned](https://github.com/emberjs/ember.js/blob/v5.5.0/packages/%40ember/routing/router.ts#L1032) when a transition from one route to another is made. Therefore, the RouteInfo object for the current route doesn't show the existing default queryParams. In order to work around not being able to access default query param values through the router service, we pass in the filters as an object named `selectedFilters`.

## Screenshots (if appropriate):

https://github.com/hashicorp/boundary-ui/assets/107949262/cc3cefb8-e243-47b2-869d-c3440481846d


## How to Test
1. Use llb-pagination-2 be branch and start boundary dev
2. Copy newly made binary into ui/desktop/electron-app/cli
3. Checkout this branch and run ENABLE_MIRAGE=false BYPASS_CLI_SETUP=true yarn start:desktop
4. Make sure filter tags are displayed as expected.


## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
