### PR TITLE
Add more options retain

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -949,6 +949,10 @@ policy:
         label: Custom
       do_not_protect:
         label: Do not protect, allow deletion any time
+      hippa:
+        label: HIPPA (6 years)
+      soc:
+        label: SOC 2 (7 years)
     deletion_policy_options:
       do_not_delete:
         label: Do not delete

--- a/ui/admin/app/components/form/policy/index.js
+++ b/ui/admin/app/components/form/policy/index.js
@@ -49,7 +49,6 @@ export default class FormPolicyComponent extends Component {
     const val = Object.keys(RETENTION_POLICY).find(
       (i) => RETENTION_POLICY[i] === this.args.model.retain_for?.days,
     );
-    console.log(val, 'VAL');
     return val;
   }
 

--- a/ui/admin/app/components/form/policy/index.js
+++ b/ui/admin/app/components/form/policy/index.js
@@ -9,6 +9,8 @@ const RETENTION_POLICY = {
   forever: -1,
   custom: 1,
   do_not_protect: 0,
+  soc: 2555,
+  hippa: 2190,
 };
 
 const DELETION_POLICY = { do_not_delete: 0, custom: 1 };
@@ -44,13 +46,11 @@ export default class FormPolicyComponent extends Component {
    * @type {string}
    */
   get selectRetentionPolicyType() {
-    if (this.args.model.retain_for?.days < 0) {
-      return 'forever';
-    } else if (this.args.model.retain_for?.days >= 1) {
-      return 'custom';
-    } else {
-      return 'do_not_protect';
-    }
+    const val = Object.keys(RETENTION_POLICY).find(
+      (i) => RETENTION_POLICY[i] === this.args.model.retain_for?.days,
+    );
+    console.log(val, 'VAL');
+    return val;
   }
 
   /**

--- a/ui/admin/app/components/form/policy/index.js
+++ b/ui/admin/app/components/form/policy/index.js
@@ -49,7 +49,7 @@ export default class FormPolicyComponent extends Component {
     const val = Object.keys(RETENTION_POLICY).find(
       (i) => RETENTION_POLICY[i] === this.args.model.retain_for?.days,
     );
-    return val;
+    return val || 'custom';
   }
 
   /**

--- a/ui/admin/app/components/form/policy/policy-selection/index.js
+++ b/ui/admin/app/components/form/policy/policy-selection/index.js
@@ -25,7 +25,7 @@ export default class FormPolicySelectionComponent extends Component {
    * @type {boolean}
    */
   get isCustomRetentionSelected() {
-    return this.args.model.retain_for?.days > 0;
+    return this.args.model.retain_for?.days === 1;
   }
 
   /**

--- a/ui/admin/app/components/form/policy/policy-selection/index.js
+++ b/ui/admin/app/components/form/policy/policy-selection/index.js
@@ -25,7 +25,9 @@ export default class FormPolicySelectionComponent extends Component {
    * @type {boolean}
    */
   get isCustomRetentionSelected() {
-    return this.args.model.retain_for?.days === 1;
+    //no need to show custom input for the below days
+    const arr = [-1, 0, 2555, 2190];
+    return arr.includes(this.args.model.retain_for?.days) ? false : true;
   }
 
   /**

--- a/ui/admin/app/templates/scopes/scope/policies/policy/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/policies/policy/index.hbs
@@ -9,16 +9,11 @@
   </page.breadcrumbs>
 
   <page.header>
-    <h2>
+    <Hds::Text::Display @tag='h2'>
       {{t 'resources.policy.title'}}
-    </h2>
-    <Copyable
-      @text={{@model.id}}
-      @buttonText={{t 'actions.copy-to-clipboard'}}
-      @acknowledgeText={{t 'states.copied'}}
-    >
-      <Hds::Text::Code>{{@model.id}}</Hds::Text::Code>
-    </Copyable>
+    </Hds::Text::Display>
+
+    <Hds::Copy::Snippet @color='secondary' @textToCopy={{@model.id}} />
   </page.header>
 
   <page.navigation>


### PR DESCRIPTION
this pr adds more options to the retention policy based on this [thread](https://hashicorp.slack.com/archives/C012GTH1C4E/p1705001194264479?thread_ts=1704997089.212949&cid=C012GTH1C4E)

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

<img width="1070" alt="Screenshot 2024-01-12 at 12 26 15 PM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/421dd15e-6838-4323-9e31-737a71b938d0">


## How to Test

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
