### PR TITLE
chore: 🤖 move overridable next to select

### DIFF
--- a/ui/admin/app/components/form/policy/policy-selection/index.hbs
+++ b/ui/admin/app/components/form/policy/policy-selection/index.hbs
@@ -10,7 +10,7 @@
       name={{@name}}
       disabled={{or @disabled this.isDeleteDisable}}
       aria-label={{t (concat 'resources.policy.form.' @name '.label')}}
-      @width='80%'
+      @width='70%'
       {{on 'change' this.handlePolicyTypeSelection}}
       as |F|
     >
@@ -28,7 +28,17 @@
       </F.Options>
 
     </Hds::Form::Select::Field>
-
+    {{#if @model.scope.isGlobal}}
+      <Hds::Form::Toggle::Field
+        checked={{this.isOverridable}}
+        disabled={{@disabled}}
+        name={{@customInputName}}
+        {{on 'change' this.handleOverridableToggle}}
+        as |F|
+      >
+        <F.Label>{{t 'resources.policy.form.overridable.label'}}</F.Label>
+      </Hds::Form::Toggle::Field>
+    {{/if}}
   </F.Control>
 </Hds::Form::Fieldset>
 {{#if this.showCustomInput}}
@@ -54,17 +64,7 @@
           />
         </S.Generic>
       </Hds::SegmentedGroup>
-      {{#if @model.scope.isGlobal}}
-        <Hds::Form::Toggle::Field
-          checked={{this.isOverridable}}
-          disabled={{@disabled}}
-          name={{@customInputName}}
-          {{on 'change' this.handleOverridableToggle}}
-          as |F|
-        >
-          <F.Label>{{t 'resources.policy.form.overridable.label'}}</F.Label>
-        </Hds::Form::Toggle::Field>
-      {{/if}}
+
     </F.Control>
 
   </Hds::Form::Field>

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -955,6 +955,12 @@
 // storage policies
 .policy {
   margin-bottom: 0;
+  .hds-form-field--layout-vertical {
+    width: 50%;
+  }
+  .hds-form-group__control-fields-wrapper {
+    flex-direction: row;
+  }
 }
 
 .policy-custom-input {

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -955,9 +955,11 @@
 // storage policies
 .policy {
   margin-bottom: 0;
+
   .hds-form-field--layout-vertical {
     width: 50%;
   }
+
   .hds-form-group__control-fields-wrapper {
     flex-direction: row;
   }


### PR DESCRIPTION
 overridable toggle should be visible for all options in the select list

## Screenshots (if appropriate):

before: 
<img width="1000" alt="Screenshot 2024-01-12 at 2 35 10 PM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/1ed346f2-d3d2-44e3-b531-c15842e1fb70">

after:
<img width="845" alt="Screenshot 2024-01-12 at 2 37 01 PM" src="https://github.com/hashicorp/boundary-ui/assets/15043878/bf4425bf-de1d-46ff-861e-9fd6c1861e37">


## How to Test

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
