### PR TITLE
refactor: 💡 add global settings link

### DIFF
--- a/addons/api/mirage/factories/scope.js
+++ b/addons/api/mirage/factories/scope.js
@@ -11,15 +11,20 @@ import generateId from '../helpers/id';
 export default factory.extend({
   type: 'global',
 
-  authorized_actions: () =>
-    permissions.authorizedActionsFor('scope') || [
-      'no-op',
-      'read',
-      'update',
-      'delete',
-      'attach-storage-policy',
-      'detach-storage-policy',
-    ],
+  authorized_actions() {
+    const authorizedActions = ['no-op', 'read', 'update'];
+
+    // Storage policies can only be attatched to global and org scopes.
+    if (this.type === 'global' || this.type === 'org') {
+      authorizedActions.push('attach-storage-policy', 'detach-storage-policy');
+    }
+
+    if (this.type === 'org' || this.type === 'project') {
+      authorizedActions.push('delete');
+    }
+
+    return permissions.authorizedActionsFor('scope') || authorizedActions;
+  },
 
   authorized_collection_actions() {
     const collectionActions = {

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -326,6 +326,12 @@ session:
     address-port: Address & port
     ssh: SSH
   shell: Shell
+global:
+  title: Global
+  description: The global scope is the outermost scope. There is always a single global scope and it cannot be deleted.
+  messages:
+    settings:
+      title: Global Settings
 org:
   title: Org
   title_plural: Orgs

--- a/ui/admin/app/components/form/scope/index.hbs
+++ b/ui/admin/app/components/form/scope/index.hbs
@@ -51,7 +51,7 @@
     {{/if}}
   </Hds::Form::Textarea::Field>
 
-  {{#if (can 'save model' @model)}}
+  {{#if (and (can 'save model' @model) (not @model.isGlobal))}}
     <form.actions
       @enableEditText={{t 'actions.edit-form'}}
       @submitText={{t 'actions.save'}}

--- a/ui/admin/app/templates/scopes/scope.hbs
+++ b/ui/admin/app/templates/scopes/scope.hbs
@@ -199,6 +199,16 @@
         {{/unless}}
       </Rose::Nav::Sidebar>
 
+      {{#if (and @model.isGlobal (feature-flag 'ssh-session-recording'))}}
+        {{#if this.session.data.authenticated.isGlobal}}
+          <Rose::Nav::Sidebar @title={{t 'titles.settings'}} as |nav|>
+            <nav.link @route='scopes.scope.edit'>
+              {{t 'resources.global.messages.settings.title'}}
+            </nav.link>
+          </Rose::Nav::Sidebar>
+        {{/if}}
+      {{/if}}
+
       {{#if @model.isOrg}}
         {{#if this.session.data.authenticated.isGlobal}}
           <Rose::Nav::Sidebar @title={{t 'titles.settings'}} as |nav|>

--- a/ui/admin/app/templates/scopes/scope/edit.hbs
+++ b/ui/admin/app/templates/scopes/scope/edit.hbs
@@ -3,6 +3,16 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
+{{#if @model.isGlobal}}
+  {{page-title (t 'resources.global.title')}}
+  <Breadcrumbs::Item
+    @text={{t 'resources.global.title'}}
+    @icon='globe'
+    @route='scopes.scope.edit'
+    @model={{@model.id}}
+  />
+{{/if}}
+
 <Rose::Layout::Page as |page|>
 
   <page.breadcrumbs>
@@ -10,6 +20,13 @@
   </page.breadcrumbs>
 
   <page.header>
+    {{#if @model.isGlobal}}
+      <h2>
+        {{t 'resources.global.title'}}
+        {{! TODO: Add doc link }}
+      </h2>
+      <p>{{t 'resources.global.description'}}</p>
+    {{/if}}
     {{#if @model.isOrg}}
       <h2>
         {{t 'resources.org.title'}}

--- a/ui/admin/tests/acceptance/scopes/read-test.js
+++ b/ui/admin/tests/acceptance/scopes/read-test.js
@@ -19,6 +19,13 @@ module('Acceptance | scopes | read', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
+  let features;
+
+  const FORM_SELECTOR = 'main .rose-form';
+  const FORM_ACTIONS_SELECTOR = '.rose-form-actions';
+  const DELETE_DROPDOWN_SELECTOR =
+    '.rose-layout-page-actions .rose-dropdown-button-danger';
+
   const instances = {
     scopes: {
       global: null,
@@ -26,6 +33,8 @@ module('Acceptance | scopes | read', function (hooks) {
     },
   };
   const urls = {
+    globalScope: null,
+    globalScopeEdit: null,
     orgScope: null,
     orgScopeEdit: null,
   };
@@ -38,8 +47,11 @@ module('Acceptance | scopes | read', function (hooks) {
       scope: { id: 'global', type: 'global' },
     });
     // Generate route URLs for resources
+    urls.globalScope = `/scopes/global`;
+    urls.globalScopeEdit = `/scopes/global/edit`;
     urls.orgScope = `/scopes/${instances.scopes.org.id}/scopes`;
     urls.orgScopeEdit = `/scopes/${instances.scopes.org.id}/edit`;
+    features = this.owner.lookup('service:features');
     authenticateSession({ isGlobal: true });
   });
 
@@ -51,7 +63,23 @@ module('Acceptance | scopes | read', function (hooks) {
     await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.orgScopeEdit);
-    assert.dom('main .rose-form').exists();
+    assert.dom(FORM_SELECTOR).exists();
+    assert.dom(FORM_ACTIONS_SELECTOR).exists();
+    assert.dom(DELETE_DROPDOWN_SELECTOR).exists();
+  });
+
+  test('visiting global scope edit', async function (assert) {
+    features.enable('ssh-session-recording');
+    await visit(urls.globalScope);
+    await a11yAudit();
+
+    await click(`[href="${urls.globalScopeEdit}"]`);
+    await a11yAudit();
+
+    assert.strictEqual(currentURL(), urls.globalScopeEdit);
+    assert.dom(FORM_SELECTOR).exists();
+    assert.dom(FORM_ACTIONS_SELECTOR).doesNotExist();
+    assert.dom(DELETE_DROPDOWN_SELECTOR).doesNotExist();
   });
 
   test('visiting org scope edit without read permission results in no form displayed', async function (assert) {
@@ -64,6 +92,6 @@ module('Acceptance | scopes | read', function (hooks) {
 
     await click(`[href="${urls.orgScopeEdit}"]`);
     assert.strictEqual(currentURL(), urls.orgScopeEdit);
-    assert.dom('main .rose-form').doesNotExist();
+    assert.dom(FORM_SELECTOR).doesNotExist();
   });
 });


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12257

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-12257)

## Description
NOTE: Design feedback is still needed on this change.
Add a "Global Settings" nav link with readonly fields so that users can navigate and attach a storage policy.

## Screenshots (if appropriate):


https://github.com/hashicorp/boundary-ui/assets/107949262/ae004372-c3a3-4b46-a4c4-b65c6d27949f


## How to Test
1. Checkout this branch
2. Make sure "Global Settings" link is visible and all fields are readonly.
3. Make sure a storage policy can be attached.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
