### PR TITLE
fix: 🐛 remove client daemon params and pass remaining params

### DIFF
--- a/addons/api/addon/handlers/client-daemon-handler.js
+++ b/addons/api/addon/handlers/client-daemon-handler.js
@@ -41,11 +41,13 @@ const paginateResults = (array, page, pageSize) => {
 
 const fetchControllerData = async (context, next) => {
   const { data } = context.request;
-  const { query } = data;
-  const { recursive, scope_id, page, pageSize } = query;
+  const { query: originalQuery } = data;
+  // remove client daemon specific query params
+  // eslint-disable-next-line no-unused-vars
+  const { query, page, pageSize, ...remainingQuery } = originalQuery;
 
   // If we get an error or client daemon is unavailable, fall back to calling the API
-  context.request.data.query = { recursive, scope_id };
+  context.request.data.query = remainingQuery;
   const results = await next(context.request);
   const models = results.content.toArray();
 


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12301

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-12301)

## Description

When queries are being passed to the controller, we were sending through `scope_id` and `recursive` but realized that there is also a `filter` query param that should be getting passed to the controller as well. Now we will remove client daemon related params and sending the `remainingQuery` to the controller. See attached images below that show the `type` filter that was not being applied to the `v1/scopes` request to fetch all projects under a specific org scope.

To test this, start a `boundary dev` instance and start the desktop client. Verify in the network request that one of the `v1/scopes` requests has `filter: ("/item/type" == "project")` as one of the query params.

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
Before:
<img width="472" alt="Screenshot 2024-01-19 at 11 27 42 AM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/1eda8a7c-8bb8-4137-89ef-c6a82b346bad">
After:
<img width="472" alt="Screenshot 2024-01-19 at 11 27 21 AM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/7a350413-cb29-4e72-921d-d62d74a345e3">

## How to Test


## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [x] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
