### PR TITLE
fix: 🐛 Fix errors not getting propagated up from client daemon

### DIFF
--- a/ui/desktop/electron-app/src/helpers/request-promise.js
+++ b/ui/desktop/electron-app/src/helpers/request-promise.js
@@ -54,6 +54,15 @@ const unixSocketRequest = (options, reqBody) =>
           parsedResponse = JSON.parse(response);
         }
 
+        // Reject the response if the status code is not in the 2xx range.
+        const { statusCode } = res;
+        if (statusCode < 200 || statusCode >= 400) {
+          reject({
+            statusCode,
+            ...parsedResponse,
+          });
+        }
+
         resolve(parsedResponse);
       } catch (e) {
         reject(e);


### PR DESCRIPTION
## Description
Client daemon errors weren't correctly getting propagated up to the desktop client which meant they were getting interpreted as search results and erroring out.

## How to Test
A quick way is to start the desktop client, then stop the client daemon and restart it. The DC should now be getting `403` responses from the daemon and it shouldn't error out.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
