### PR TITLE
feat: 🎸 Add warning when upgrading to 2.0 for desktop client

### DIFF
--- a/ui/desktop/electron-app/src/helpers/app-updater.js
+++ b/ui/desktop/electron-app/src/helpers/app-updater.js
@@ -107,17 +107,25 @@ const displayInfoPrompt = () => {
 /**
  * Show update available prompt
  */
-const displayDownloadPrompt = (version, url) => {
+const displayDownloadPrompt = (latestVersion, url) => {
+  let detail = 'A new version is available for download.';
+
   const dialogOpts = {
     type: 'info',
     buttons: ['Download', 'Later'],
     icon: null,
-    detail: 'A new version is available for download',
+    detail,
   };
+
+  // If the user's current version is less than 2.0.0, show a warning that upgrading might not be compatible
+  if (semver.lt(currentVersion, '2.0.0')) {
+    dialogOpts.detail += `\n\nThis is a major version upgrade which could be incompatible with your current controller version.`;
+    dialogOpts.type = 'warning';
+  }
 
   dialog.showMessageBox(dialogOpts).then((returnValue) => {
     if (returnValue.response === 0) {
-      downloadAndInstallUpdate(version, url);
+      downloadAndInstallUpdate(latestVersion, url);
     }
   });
 };

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -260,8 +260,6 @@ app.on('before-quit', (event) => {
 });
 
 app.on('quit', () => {
-  // TODO: Should we check if the desktop client started the daemon?
-  //  If not, we probably shouldn't stop the daemon
   clientDaemonManager.stop();
 });
 


### PR DESCRIPTION
## Description
Added a warning when upgrading to the newest version since it's a breaking change. 

## Screenshots (if appropriate):
<img width="1277" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/5783847/e08e0c83-ed99-47a2-8320-2922a6451793">

## How to Test
Build the normal desktop client and it should prompt to upgrade with the warning. 

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
