### PR TITLE
fix: 🐛 delete and retain_until should be readonly and Scope level policies

### DIFF
--- a/addons/api/addon/generated/models/session-recording.js
+++ b/addons/api/addon/generated/models/session-recording.js
@@ -112,12 +112,14 @@ export default class GeneratedSessionRecordingModel extends BaseModel {
 
   @attr('date', {
     description: 'The time until a session recording is required to be stored.',
+    readOnly: true,
   })
   retain_until;
 
   @attr('date', {
     description:
       'The time a session recording is scheduled to be automatically deleted.',
+    readOnly: true,
   })
   delete_after;
 }

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -950,7 +950,6 @@ policy:
   messages:
     detach: Successfully detached
     reapply: Successfully reapplied
-    later: The policy will be reapplied after the recording has completed
     none:
       title: No storage policies yet
       description: A Storage Policy defines how long Session Recordings must be kept and when they should be deleted. We recommend checking your data retention policies for compliance requirements.

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -950,6 +950,7 @@ policy:
   messages:
     detach: Successfully detached
     reapply: Successfully reapplied
+    later: The policy will be reapplied after the recording has completed
     none:
       title: No storage policies yet
       description: A Storage Policy defines how long Session Recordings must be kept and when they should be deleted. We recommend checking your data retention policies for compliance requirements.

--- a/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
+++ b/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
@@ -57,7 +57,6 @@ export default class ScopesScopeAddStoragePolicyIndexRoute extends Route {
   @notifyError(({ message }) => message, { catch: true })
   @notifySuccess('notifications.save-success')
   async attachStoragePolicy(scope) {
-    console.log(scope, 'SCOPE');
     const { storage_policy_id } = scope;
     if (storage_policy_id) {
       await scope.attachStoragePolicy(storage_policy_id);

--- a/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
+++ b/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
@@ -22,20 +22,19 @@ export default class ScopesScopeAddStoragePolicyIndexRoute extends Route {
    */
   async afterModel() {
     const { id: scope_id } = this.modelFor('scopes.scope');
-
+    const currentScope = await this.store.query('policy', {
+      scope_id,
+    });
     if (scope_id === 'global') {
-      //Global scope should list both global and org scope policies
-      const globalPolicy = await this.store.query('policy', {
-        scope_id,
-        recursive: true,
-      });
-      this.policyList = globalPolicy;
+      //Global scope should only list policies from its scope
+      this.policyList = currentScope;
     } else {
-      //Org scope should only list policies from its scope
-      const orgPolicy = await this.store.query('policy', {
-        scope_id,
+      //Org scope should list both global and org scope policies
+      const globalScope = await this.store.query('policy', {
+        scope_id: 'global',
       });
-      this.policyList = orgPolicy;
+
+      this.policyList = [...globalScope, ...currentScope];
     }
   }
 

--- a/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
+++ b/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
@@ -22,19 +22,19 @@ export default class ScopesScopeAddStoragePolicyIndexRoute extends Route {
    */
   async afterModel() {
     const { id: scope_id } = this.modelFor('scopes.scope');
-    const currentScope = await this.store.query('policy', {
+    const currentScopePolicies = await this.store.query('policy', {
       scope_id,
     });
     if (scope_id === 'global') {
       // Global scope should only list policies from its scope
-      this.policyList = currentScope;
+      this.policyList = currentScopePolicies;
     } else {
       // Org scope should list both global and org scope policies
-      const globalScope = await this.store.query('policy', {
+      const globalScopePolicies = await this.store.query('policy', {
         scope_id: 'global',
       });
 
-      this.policyList = [...globalScope, ...currentScope];
+      this.policyList = [...globalScopePolicies, ...currentScopePolicies];
     }
   }
 

--- a/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
+++ b/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
@@ -26,7 +26,7 @@ export default class ScopesScopeAddStoragePolicyIndexRoute extends Route {
       scope_id,
     });
     if (scope_id === 'global') {
-      //Global scope should only list policies from its scope
+      // Global scope should only list policies from its scope
       this.policyList = currentScope;
     } else {
       //Org scope should list both global and org scope policies

--- a/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
+++ b/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
@@ -26,7 +26,7 @@ export default class ScopesScopeAddStoragePolicyIndexRoute extends Route {
     if (scope_id === 'global') {
       //Global scope should list both global and org scope policies
       const globalPolicy = await this.store.query('policy', {
-        scope_id: 'global',
+        scope_id,
         recursive: true,
       });
       this.policyList = globalPolicy;

--- a/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
+++ b/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
@@ -25,6 +25,7 @@ export default class ScopesScopeAddStoragePolicyIndexRoute extends Route {
     const currentScopePolicies = await this.store.query('policy', {
       scope_id,
     });
+
     if (scope_id === 'global') {
       // Global scope should only list policies from its scope
       this.policyList = currentScopePolicies;
@@ -56,6 +57,7 @@ export default class ScopesScopeAddStoragePolicyIndexRoute extends Route {
   @notifyError(({ message }) => message, { catch: true })
   @notifySuccess('notifications.save-success')
   async attachStoragePolicy(scope) {
+    console.log(scope, 'SCOPE');
     const { storage_policy_id } = scope;
     if (storage_policy_id) {
       await scope.attachStoragePolicy(storage_policy_id);

--- a/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
+++ b/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
@@ -23,20 +23,18 @@ export default class ScopesScopeAddStoragePolicyIndexRoute extends Route {
   async afterModel() {
     const { id: scope_id } = this.modelFor('scopes.scope');
 
-    //Global scope should list both global and org scope policies
-    const globalPolicy = await this.store.query('policy', {
-      scope_id: 'global',
-      recursive: true,
-    });
-
-    //Org scope should only list policies from its scope
-    const orgPolicy = await this.store.query('policy', {
-      scope_id,
-    });
-
     if (scope_id === 'global') {
+      //Global scope should list both global and org scope policies
+      const globalPolicy = await this.store.query('policy', {
+        scope_id: 'global',
+        recursive: true,
+      });
       this.policyList = globalPolicy;
     } else {
+      //Org scope should only list policies from its scope
+      const orgPolicy = await this.store.query('policy', {
+        scope_id,
+      });
       this.policyList = orgPolicy;
     }
   }

--- a/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
+++ b/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
@@ -29,7 +29,7 @@ export default class ScopesScopeAddStoragePolicyIndexRoute extends Route {
       // Global scope should only list policies from its scope
       this.policyList = currentScope;
     } else {
-      //Org scope should list both global and org scope policies
+      // Org scope should list both global and org scope policies
       const globalScope = await this.store.query('policy', {
         scope_id: 'global',
       });

--- a/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
+++ b/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
@@ -23,12 +23,22 @@ export default class ScopesScopeAddStoragePolicyIndexRoute extends Route {
   async afterModel() {
     const { id: scope_id } = this.modelFor('scopes.scope');
 
-    //fetch policies from current scope
-    const orgScopePolicies = await this.store.query('policy', {
+    //Global scope should list both global and org scope policies
+    const globalPolicy = await this.store.query('policy', {
+      scope_id: 'global',
+      recursive: true,
+    });
+
+    //Org scope should only list policies from its scope
+    const orgPolicy = await this.store.query('policy', {
       scope_id,
     });
 
-    this.policyList = orgScopePolicies;
+    if (scope_id === 'global') {
+      this.policyList = globalPolicy;
+    } else {
+      this.policyList = orgPolicy;
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

This PR fixes a bug where the old value was retained when the field becomes null/zero from the API, this is due to ember-data not updating the old value if the field was removed from the API, so we explicitly set these `readonly` fields to null. For more context - check [this](https://github.com/hashicorp/boundary-ui/blob/3f4beaada88d62a813a45c978e42ae3e10504b9c/addons/api/addon/serializers/application.js#L302)

And also https://hashicorp.atlassian.net/browse/ICU-12323

## Screenshots (if appropriate):



## How to Test

1. run ENT staged binary, 
2. and create a few org and global policies, 
3. you should be able to see both global and org at org setting 
4. only global policies at the global scope

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
