### PR TITLE
refactor: 💡 remove icon from sessions table for session id

### DIFF
--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
@@ -72,12 +72,6 @@
         <B.Tr>
           <B.Td>
             {{#if B.data.isAvailable}}
-              <Hds::Badge
-                @text={{t 'resources.session.title'}}
-                @icon='entry-point'
-                @isIconOnly={{true}}
-                @color='success'
-              />
               <Copyable
                 @text={{B.data.id}}
                 @buttonText={{t 'actions.copy-to-clipboard'}}
@@ -92,11 +86,6 @@
                 </LinkTo>
               </Copyable>
             {{else}}
-              <Hds::Badge
-                @text={{t 'resources.session.title'}}
-                @icon='entry-point'
-                @isIconOnly={{true}}
-              />
               <Copyable
                 @text={{B.data.id}}
                 @buttonText={{t 'actions.copy-to-clipboard'}}


### PR DESCRIPTION
## Description

Update sessions table to match new designs

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
Before:
<img width="1076" alt="Screenshot 2024-01-24 at 1 10 23 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/eda3b33f-d62d-4ab6-930b-a3f8ee88bab2">
After:
<img width="1076" alt="Screenshot 2024-01-24 at 1 09 51 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/e58e8045-f244-48f9-a59e-6353765abf70">

## How to Test

You can use the vercel link to verify that sessions no longer have the `entry-point` icon.

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:desktop_computer: [Desktop preview](https://boundary-ui-desktop-git-update-sessions-table-hashicorp.vercel.app/scopes/global/projects/sessions)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] ~I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] ~I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
