### PR TITLE
chore: 🤖 translation check and label

### DIFF
--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection.js
@@ -7,7 +7,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { notifySuccess, notifyError } from 'core/decorators/notify';
-import { STATE_SESSION_RECORDING_AVAILABLE } from 'api/models/session-recording';
 
 export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConnectionRoute extends Route {
   // =services
@@ -58,10 +57,10 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
    */
   @action
   @notifyError(({ message }) => message, { catch: true })
-  @notifySuccess(({ state }) =>
-    state === STATE_SESSION_RECORDING_AVAILABLE
-      ? 'resources.policy.messages.reapply'
-      : 'resources.policy.messages.later',
+  @notifySuccess(({ end_time }) =>
+    !end_time
+      ? 'resources.policy.messages.later'
+      : 'resources.policy.messages.reapply',
   )
   async reapplyStoragepolicy(sessionRecording) {
     await sessionRecording.reapplyStoragePolicy();

--- a/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
@@ -252,7 +252,16 @@
                       @model.sessionRecording.retain_until
                     }}
                   >
-                    {{format-date-iso @model.sessionRecording.retain_until}}
+                    {{#if
+                      (eq
+                        (format-date-iso @model.sessionRecording.retain_until)
+                        '9999-12-31T23:23:23.999Z'
+                      )
+                    }}
+                      {{t 'resources.policy.titles.forever'}}
+                    {{else}}
+                      {{format-date-iso @model.sessionRecording.retain_until}}
+                    {{/if}}
                   </time>
                 </list.Item>
               {{/if}}


### PR DESCRIPTION
This PR updates the label on the session recording page when it is a forever retention period and updates the translation check based on end_time instead of state to identify the error states correctly. 


## Description

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
![Untitled](https://github.com/hashicorp/boundary-ui/assets/15043878/2b410f75-ddc2-4fb8-a4c4-d5c47ed41396)
![Untitled 3](https://github.com/hashicorp/boundary-ui/assets/15043878/ef682937-4b12-4782-ba89-3cfa4d6ac0ea)

## How to Test

1. go to a recording using enterprise build  
2. click on reapply at completed/recording/error status, you should see the appropriate translated message on success. 

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
