### PR TITLE
refactor: 💡 add -addr flag to add-token command

### DIFF
--- a/ui/desktop/electron-app/src/services/client-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/client-daemon-manager.js
@@ -119,7 +119,6 @@ const addTokenCliCommand = (token) => {
   ];
   const sanitizedToken = sanitizer.base62EscapeAndValidate(token);
 
-  // TODO: Is setting an env var for the address the only way? I'm surprised to not see an -addr flag
   const { stdout, stderr } = spawnSync(addTokenCommand, {
     BOUNDARY_TOKEN: sanitizedToken,
   });

--- a/ui/desktop/electron-app/src/services/client-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/client-daemon-manager.js
@@ -112,6 +112,7 @@ const addTokenCliCommand = (token) => {
   const addTokenCommand = [
     'daemon',
     'add-token',
+    `-addr=${runtimeSettings.clusterUrl}`,
     '-format=json',
     '-token=env://BOUNDARY_TOKEN',
     '-keyring-type=none',
@@ -121,7 +122,6 @@ const addTokenCliCommand = (token) => {
   // TODO: Is setting an env var for the address the only way? I'm surprised to not see an -addr flag
   const { stdout, stderr } = spawnSync(addTokenCommand, {
     BOUNDARY_TOKEN: sanitizedToken,
-    BOUNDARY_ADDR: runtimeSettings.clusterUrl,
   });
   let parsedResponse = jsonify(stdout);
 


### PR DESCRIPTION
## Description

This [PR](https://github.com/hashicorp/boundary/pull/4312) added the `-addr` flag to the `boundary daemon add-token` command which allows us to pass it in via a flag and not set it as an env variable.

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

## How to Test


## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
