### PR TITLE
fix: 🐛 fix transition aborted error on storage bucket creation

### DIFF
--- a/ui/admin/app/routes/scopes/scope/storage-buckets/storage-bucket.js
+++ b/ui/admin/app/routes/scopes/scope/storage-buckets/storage-bucket.js
@@ -33,7 +33,7 @@ export default class ScopesScopeStorageBucketsStorageBucketRoute extends Route {
    */
   redirect(storageBucket) {
     const scope = this.modelFor('scopes.scope');
-    if (storageBucket.scopeID !== scope.id) {
+    if (!scope.isGlobal && storageBucket.scopeID !== scope.id) {
       this.router.replaceWith(
         'scopes.scope.storage-buckets.storage-bucket',
         storageBucket.scopeID,

--- a/ui/admin/tests/acceptance/storage-buckets/create-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/create-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
+import { visit, currentURL, click, fillIn, select } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -31,6 +31,8 @@ module('Acceptance | storage-buckets | create', function (hooks) {
   const ROLE_ARN_SELECTOR = '[name="role_arn"]';
   const ACCESS_KEY_SELECTOR = '[name="access_key_id"]';
   const SECRET_KEY_SELECTOR = '[name="secret_access_key"]';
+  const SCOPE_SELECTOR = '[name=scope]';
+
   const instances = {
     scopes: {
       global: null,
@@ -90,7 +92,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
 
     await click(`[href="${urls.newStorageBucket}"]`);
     await fillIn(NAME_FIELD_SELECTOR, NAME_FIELD_TEXT);
-    await click(`[value="${instances.scopes.org.scope.id}"]`);
+    await select(SCOPE_SELECTOR, instances.scopes.org.id);
 
     assert.dom(BUCKET_NAME_FIELD_SELECTOR).isNotDisabled();
     assert.dom(BUCKET_PREFIX_FIELD_SELECTOR).isNotDisabled();
@@ -102,8 +104,9 @@ module('Acceptance | storage-buckets | create', function (hooks) {
       name: NAME_FIELD_TEXT,
     });
 
+    assert.dom(ALERT_TEXT_SELECTOR).hasText('Saved successfully.');
     assert.strictEqual(storageBucket.name, NAME_FIELD_TEXT);
-    assert.strictEqual(storageBucket.scopeId, instances.scopes.org.scope.id);
+    assert.strictEqual(storageBucket.scopeId, instances.scopes.org.id);
     assert.strictEqual(getStorageBucketCount(), storageBucketCount + 1);
   });
 


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12402
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12404
## Description

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):


https://github.com/hashicorp/boundary-ui/assets/107949262/68597391-900e-4d25-b409-7f5b943d6ac5



## How to Test

<!-- Add steps to test this change. Include any other necessary relevant links -->
1. Run `boundary dev` on the latest ent binary
2. Create a storage bucket with an org scope successfully.

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- [X] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
