### PR TITLE
fix: 🐛 update id to ids for target onboarding creation

### DIFF
--- a/addons/api/mirage/factories/role.js
+++ b/addons/api/mirage/factories/role.js
@@ -21,8 +21,8 @@ export default factory.extend({
     ],
   // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
   grant_strings: () => [
-    'id=*;action=*',
-    'id=*;type=host-catalog;actions=create,read',
+    'ids=*;action=*',
+    'ids=*;type=host-catalog;actions=create,read',
   ],
 
   id: () => generateId('r_'),

--- a/ui/admin/app/routes/onboarding.js
+++ b/ui/admin/app/routes/onboarding.js
@@ -135,7 +135,7 @@ export default class OnboardingRoute extends Route {
       await role.save();
       await role.saveGrantStrings([
         `type=target;actions=list`,
-        `id=${target.id};actions=authorize-session`,
+        `ids=${target.id};actions=authorize-session`,
       ]);
     } catch (error) {
       // Redirect to targets that belong to scope

--- a/ui/admin/tests/acceptance/roles/grants-test.js
+++ b/ui/admin/tests/acceptance/roles/grants-test.js
@@ -97,7 +97,7 @@ module('Acceptance | roles | grants', function (hooks) {
         const attrs = JSON.parse(requestBody);
         assert.strictEqual(
           attrs.grant_strings[0],
-          'id=123,action=delete',
+          'ids=123,action=delete',
           'A grant is updated',
         );
         const id = idMethod.split(':')[0];
@@ -105,17 +105,17 @@ module('Acceptance | roles | grants', function (hooks) {
       },
     );
     await visit(urls.grants);
-    await fillIn(`${grantsForm} [name="grant"]`, 'id=123,action=delete');
+    await fillIn(`${grantsForm} [name="grant"]`, 'ids=123,action=delete');
     await click('.rose-form-actions [type="submit"]:not(:disabled)');
   });
 
   test('cancel a grant update', async function (assert) {
     await visit(urls.grants);
-    await fillIn(`${grantsForm} [name="grant"]`, 'id=123,action=delete');
+    await fillIn(`${grantsForm} [name="grant"]`, 'ids=123,action=delete');
     await click('.rose-form-actions button:not([type="submit"])');
     assert.notEqual(
       find(`${grantsForm} [name="grant"]`).value,
-      'id=123,action=delete',
+      'ids=123,action=delete',
     );
   });
 
@@ -137,7 +137,7 @@ module('Acceptance | roles | grants', function (hooks) {
       findAll(`${grantsForm} [name="grant"]`).length,
       grantsCount,
     );
-    await fillIn(`${grantsForm} [name="grant"]`, 'id=123,action=delete');
+    await fillIn(`${grantsForm} [name="grant"]`, 'ids=123,action=delete');
     await click('.rose-form-actions [type="submit"]:not(:disabled)');
     assert.ok(find('[role="alert"]'));
   });
@@ -158,14 +158,14 @@ module('Acceptance | roles | grants', function (hooks) {
       },
     );
     await visit(urls.grants);
-    await fillIn(`${newGrantForm} [name="grant"]`, 'id=123,action=delete');
+    await fillIn(`${newGrantForm} [name="grant"]`, 'ids=123,action=delete');
     await click(`${newGrantForm} [type="submit"]:not(:disabled)`);
     await click('.rose-form-actions [type="submit"]:not(:disabled)');
   });
 
   test('cancel a grant creation', async function (assert) {
     await visit(urls.grants);
-    await fillIn(`${newGrantForm} [name="grant"]`, 'id=123,action=delete');
+    await fillIn(`${newGrantForm} [name="grant"]`, 'ids=123,action=delete');
     await click(`${newGrantForm} [type="submit"]:not(:disabled)`);
     await click('.rose-form-actions button:not([type="submit"])');
     assert.notOk(find(`${newGrantForm} [name="grant"]`).value);
@@ -189,7 +189,7 @@ module('Acceptance | roles | grants', function (hooks) {
       findAll(`${grantsForm} [name="grant"]`).length,
       grantsCount,
     );
-    await fillIn(`${newGrantForm} [name="grant"]`, 'id=123,action=delete');
+    await fillIn(`${newGrantForm} [name="grant"]`, 'ids=123,action=delete');
     await click(`${newGrantForm} [type="submit"]:not(:disabled)`);
     await click('.rose-form-actions [type="submit"]:not(:disabled)');
     assert.ok(find('[role="alert"]'));


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12412

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-12412)

## Description

update id to ids for target onboarding creation

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

https://github.com/hashicorp/boundary-ui/assets/29386339/12edefca-e0ee-4300-9e32-83b96dfca553

## How to Test
Start a `boundary dev` instance and delete the org scope; this will remove all resources. Navigate back to the global scope and you will enter the onboarding workflow. Enter the target address and port, click Save followed by Done and a target will be created for you. Navigate back to that project level and view the `SecOps` org role named `test_target_role`. View the grants on that role and it should now say `ids=ttcp_xxx`.


## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] ~I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] ~I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
