### PR TITLE
fix: 🐛 Add refresh button back

### DIFF
--- a/addons/core/addon/styles/addon.scss
+++ b/addons/core/addon/styles/addon.scss
@@ -38,6 +38,26 @@
   .hds-table {
     margin-bottom: 1rem;
   }
+
+  &-toolbar {
+    display: flex;
+
+    // TODO: Remove these copied styles by migrating to HDS for the toolbar refresher component.
+    //  The original styles assumed we were using the old toolbar component under a "rose-toolbar" class.
+    .rose-button-inline-link-action {
+      font-size: 0.8125rem;
+      line-height: 1.8461538462;
+      font-weight: 600;
+      color: var(--stark);
+      display: inline-block;
+      vertical-align: middle;
+      padding: 0.375rem 1rem;
+    }
+
+    > :last-child {
+      margin-left: auto;
+    }
+  }
 }
 
 // Flyout with table

--- a/addons/core/addon/styles/addon.scss
+++ b/addons/core/addon/styles/addon.scss
@@ -39,7 +39,7 @@
     margin-bottom: 1rem;
   }
 
-  &-toolbar {
+  .search-filtering-toolbar {
     display: flex;
 
     // TODO: Remove these copied styles by migrating to HDS for the toolbar refresher component.

--- a/addons/rose/app/styles/rose/components/toolbar/_info.scss
+++ b/addons/rose/app/styles/rose/components/toolbar/_info.scss
@@ -7,19 +7,17 @@
 @use '../../variables/media';
 @use '../../utilities/type';
 
-.rose-toolbar {
-  .rose-toolbar-info {
-    @include type.type(button);
+.rose-toolbar-info {
+  @include type.type(button);
 
-    color: var(--ui-gray);
-    position: relative;
-    display: inline-block;
-    vertical-align: middle;
-    white-space: nowrap;
-    overflow: hidden;
+  color: var(--ui-gray);
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  white-space: nowrap;
+  overflow: hidden;
 
-    $y-padding: sizing.rems(xxs) + sizing.rems(xxxs);
+  $y-padding: sizing.rems(xxs) + sizing.rems(xxxs);
 
-    padding: $y-padding sizing.rems(m) $y-padding sizing.rems(l);
-  }
+  padding: $y-padding sizing.rems(m) $y-padding sizing.rems(l);
 }

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
@@ -5,54 +5,60 @@
 
 {{#if (or @model.sessions @model.allSessions)}}
   {{#if @model.isClientDaemonRunning}}
-    <Hds::SegmentedGroup as |S|>
-      <S.Generic>
-        <Dropdown
-          @name={{t 'resources.target.title'}}
-          @itemOptions={{this.availableTargets}}
-          @checkedItems={{this.targets}}
-          @applyFilter={{fn this.applyFilter 'targets'}}
-          @isSearchable={{true}}
-          @listPosition='bottom-left'
-        />
-      </S.Generic>
-      <S.Generic>
-        <Dropdown
-          @name={{t 'form.status.label'}}
-          @itemOptions={{this.sessionStatusOptions}}
-          @checkedItems={{this.status}}
-          @applyFilter={{fn this.applyFilter 'status'}}
-        />
-      </S.Generic>
-      <S.Generic>
-        <Dropdown
-          @name={{t 'resources.scope.title'}}
-          @itemOptions={{this.availableScopes}}
-          @checkedItems={{this.scopes}}
-          @applyFilter={{fn this.applyFilter 'scopes'}}
-          @isSearchable={{true}}
-          as |FD selectItem itemOptions|
-        >
-          {{#let (group-by itemOptions 'scopeModel') as |orgs|}}
-            {{#each orgs as |org|}}
-              <FD.Generic>
-                <FlightIcon @name='org' />
-                {{org.key.displayName}}
-              </FD.Generic>
-              {{#each org.items as |project|}}
-                <FD.Checkbox
-                  @value={{project.id}}
-                  checked={{includes project.id this.scopes}}
-                  {{on 'change' selectItem}}
-                >
-                  {{project.displayName}}
-                </FD.Checkbox>
+    <div class='search-filtering-toolbar'>
+      <Hds::SegmentedGroup as |S|>
+        <S.Generic>
+          <Dropdown
+            @name={{t 'resources.target.title'}}
+            @itemOptions={{this.availableTargets}}
+            @checkedItems={{this.targets}}
+            @applyFilter={{fn this.applyFilter 'targets'}}
+            @isSearchable={{true}}
+            @listPosition='bottom-left'
+          />
+        </S.Generic>
+        <S.Generic>
+          <Dropdown
+            @name={{t 'form.status.label'}}
+            @itemOptions={{this.sessionStatusOptions}}
+            @checkedItems={{this.status}}
+            @applyFilter={{fn this.applyFilter 'status'}}
+          />
+        </S.Generic>
+        <S.Generic>
+          <Dropdown
+            @name={{t 'resources.scope.title'}}
+            @itemOptions={{this.availableScopes}}
+            @checkedItems={{this.scopes}}
+            @applyFilter={{fn this.applyFilter 'scopes'}}
+            @isSearchable={{true}}
+            as |FD selectItem itemOptions|
+          >
+            {{#let (group-by itemOptions 'scopeModel') as |orgs|}}
+              {{#each orgs as |org|}}
+                <FD.Generic>
+                  <FlightIcon @name='org' />
+                  {{org.key.displayName}}
+                </FD.Generic>
+                {{#each org.items as |project|}}
+                  <FD.Checkbox
+                    @value={{project.id}}
+                    checked={{includes project.id this.scopes}}
+                    {{on 'change' selectItem}}
+                  >
+                    {{project.displayName}}
+                  </FD.Checkbox>
+                {{/each}}
               {{/each}}
-            {{/each}}
-          {{/let}}
-        </Dropdown>
-      </S.Generic>
-    </Hds::SegmentedGroup>
+            {{/let}}
+          </Dropdown>
+        </S.Generic>
+      </Hds::SegmentedGroup>
+      <span>
+        <ToolbarRefresher @onClick={{route-action 'refreshAll'}} />
+      </span>
+    </div>
+
     <FilterTags @filters={{this.filters}} />
   {{/if}}
   {{#if @model.sessions}}

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
@@ -5,60 +5,65 @@
 
 {{#if this.showFilters}}
   {{#if @model.isClientDaemonRunning}}
-    <Hds::SegmentedGroup as |S|>
-      <S.TextInput
-        @value={{this.search}}
-        @type='search'
-        placeholder={{t 'actions.search'}}
-        aria-label={{t 'actions.search'}}
-        {{on 'input' this.handleSearchInput}}
-      />
-      <S.Generic>
-        <Dropdown
-          @name={{t 'resources.target.titles.active-sessions'}}
-          @itemOptions={{this.availableSessionOptions}}
-          @checkedItems={{this.availableSessions}}
-          @applyFilter={{fn this.applyFilter 'availableSessions'}}
+    <div class='search-filtering-toolbar'>
+      <Hds::SegmentedGroup as |S|>
+        <S.TextInput
+          @value={{this.search}}
+          @type='search'
+          placeholder={{t 'actions.search'}}
+          aria-label={{t 'actions.search'}}
+          {{on 'input' this.handleSearchInput}}
         />
-      </S.Generic>
-      <S.Generic>
-        <Dropdown
-          @name={{t 'form.type.label'}}
-          @itemOptions={{this.targetTypeOptions}}
-          @checkedItems={{this.types}}
-          @applyFilter={{fn this.applyFilter 'types'}}
-        />
-      </S.Generic>
-      <S.Generic>
-        <Dropdown
-          @name={{t 'resources.scope.title'}}
-          @itemOptions={{this.availableScopes}}
-          @checkedItems={{this.scopes}}
-          @applyFilter={{fn this.applyFilter 'scopes'}}
-          @isSearchable={{true}}
-          as |FD selectItem itemOptions|
-        >
-          {{#let (group-by itemOptions 'scopeModel') as |orgs|}}
-            {{#each orgs as |org|}}
-              <FD.Generic>
-                <FlightIcon @name='org' />
-                {{org.key.displayName}}
-              </FD.Generic>
-              {{#each org.items as |project|}}
-                <FD.Checkbox
-                  @value={{project.id}}
-                  data-test-checkbox={{project.name}}
-                  checked={{includes project.id this.scopes}}
-                  {{on 'change' selectItem}}
-                >
-                  {{project.displayName}}
-                </FD.Checkbox>
+        <S.Generic>
+          <Dropdown
+            @name={{t 'resources.target.titles.active-sessions'}}
+            @itemOptions={{this.availableSessionOptions}}
+            @checkedItems={{this.availableSessions}}
+            @applyFilter={{fn this.applyFilter 'availableSessions'}}
+          />
+        </S.Generic>
+        <S.Generic>
+          <Dropdown
+            @name={{t 'form.type.label'}}
+            @itemOptions={{this.targetTypeOptions}}
+            @checkedItems={{this.types}}
+            @applyFilter={{fn this.applyFilter 'types'}}
+          />
+        </S.Generic>
+        <S.Generic>
+          <Dropdown
+            @name={{t 'resources.scope.title'}}
+            @itemOptions={{this.availableScopes}}
+            @checkedItems={{this.scopes}}
+            @applyFilter={{fn this.applyFilter 'scopes'}}
+            @isSearchable={{true}}
+            as |FD selectItem itemOptions|
+          >
+            {{#let (group-by itemOptions 'scopeModel') as |orgs|}}
+              {{#each orgs as |org|}}
+                <FD.Generic>
+                  <FlightIcon @name='org' />
+                  {{org.key.displayName}}
+                </FD.Generic>
+                {{#each org.items as |project|}}
+                  <FD.Checkbox
+                    @value={{project.id}}
+                    data-test-checkbox={{project.name}}
+                    checked={{includes project.id this.scopes}}
+                    {{on 'change' selectItem}}
+                  >
+                    {{project.displayName}}
+                  </FD.Checkbox>
+                {{/each}}
               {{/each}}
-            {{/each}}
-          {{/let}}
-        </Dropdown>
-      </S.Generic>
-    </Hds::SegmentedGroup>
+            {{/let}}
+          </Dropdown>
+        </S.Generic>
+      </Hds::SegmentedGroup>
+      <span>
+        <ToolbarRefresher @onClick={{route-action 'refreshAll'}} />
+      </span>
+    </div>
     <FilterTags @filters={{this.filters}} />
   {{/if}}
 

--- a/ui/desktop/tests/acceptance/projects/sessions/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/index-test.js
@@ -373,8 +373,6 @@ module('Acceptance | projects | sessions | index', function (hooks) {
         resource: 'sessions',
         func: () => [instances.session2],
       },
-      'sessions',
-      'targets',
     );
     await visit(urls.globalSessions);
 


### PR DESCRIPTION
## Description
Add refresh back with some optimizations for how we handle retrieving all targets/sessions. I removed the transition check so we don't ever reload all targets or sessions if it's been previously loaded even if we switch between routes to help improve performance a bit. Now that the user can manually refresh, it's not needed and they can force the refresh.

## Screenshots (if appropriate):
<img width="1596" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/5783847/57ce0b2b-d20b-4628-8f99-e812b260dcb2">

## How to Test
Start up the DC and add some scopes and sessions while the DC is running. Manually refresh and they should now be in the table and filters.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
