### PR TITLE
fix: 🐛 Add error notification if adding token to daemon fails

### DIFF
--- a/ui/desktop/app/routes/application.js
+++ b/ui/desktop/app/routes/application.js
@@ -8,6 +8,7 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
 import { getOwner } from '@ember/application';
+import { notifyError } from 'core/decorators/notify';
 
 export default class ApplicationRoute extends Route {
   // =services
@@ -29,6 +30,7 @@ export default class ApplicationRoute extends Route {
    * reported by the main process.  If they differ, update the main process
    * clusterUrl so that the renderer's CSP can be rewritten to allow requests.
    */
+  @notifyError(({ message }) => message, { catch: true })
   async beforeModel() {
     this.intl.setLocale(['en-us']);
     await this.session.setup();
@@ -39,7 +41,7 @@ export default class ApplicationRoute extends Route {
     // Add token to client daemon after a successful authentication restoration
     if (this.session.isAuthenticated) {
       const sessionData = this.session.data?.authenticated;
-      this.ipc.invoke('addTokenToClientDaemon', {
+      await this.ipc.invoke('addTokenToClientDaemon', {
         tokenId: sessionData?.id,
         token: sessionData?.token,
       });

--- a/ui/desktop/app/services/session.js
+++ b/ui/desktop/app/services/session.js
@@ -5,6 +5,7 @@
 
 import { inject as service } from '@ember/service';
 import BaseSessionService from 'ember-simple-auth/services/session';
+import { notifyError } from 'core/decorators/notify';
 
 export default class SessionService extends BaseSessionService {
   @service ipc;
@@ -13,12 +14,13 @@ export default class SessionService extends BaseSessionService {
    * Extend ember simple auth's handleAuthentication method
    * so we can hook in and add the user's token to the client daemon
    */
-  handleAuthentication() {
+  @notifyError(({ message }) => message, { catch: true })
+  async handleAuthentication() {
     super.handleAuthentication(...arguments);
 
     if (this.session.isAuthenticated) {
       const sessionData = this.data?.authenticated;
-      this.ipc.invoke('addTokenToClientDaemon', {
+      await this.ipc.invoke('addTokenToClientDaemon', {
         tokenId: sessionData?.id,
         token: sessionData?.token,
       });


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12488

## Description
We currently don't display any errors or any indication that something has gone wrong if adding a token fails. This change adds a popup toast to at least display the error backend gives. Also need to confirm the error we get back from CLI on windows is correct.

## Screenshots (if appropriate):
https://github.com/hashicorp/boundary-ui/assets/5783847/d0f3f122-61fd-4038-a150-615782f3771e



## How to Test
Start up a new instance of desktop client. Create a new user that doesn't have read permissions to tokens. Login to this user and we should get an error notification.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
