### PR TITLE
chore: 🤖 replace `Rose::CodeEditor` with `Hds::CodeBlock` on new worker page

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -917,7 +917,7 @@ worker:
         title: 1. Configure your new worker
         create_directory: Create a configuration file in a new directory on your server
         create_config: 'Open the file with a text editor, such as Vi. Paste the following configuration into the worker config file:'
-        save_config: Save the configuration in your `pki-worker.hcl` file.
+        save_config: Save the configuration in your <code>pki-worker.hcl</code> file.
       2:
         title: 2. Install & start Boundary on your server
         run_command: 'Run this command on your server to install Boundary:'

--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -108,41 +108,53 @@
       </Hds::Form::Fieldset>
     {{/if}}
 
-    <Rose::CodeEditor @codeValue={{this.createConfigText}} as |c|>
-      <c.toolbar>
-        <:action>
-          <span>{{t 'resources.worker.form.steps.1.create_directory'}}</span>
-        </:action>
-      </c.toolbar>
-      <c.fieldEditor class='rose-autosize' @options={{this.shellCodeEditor}} />
-    </Rose::CodeEditor>
+    <Hds::Text::Body @tag='p'>
+      {{t 'resources.worker.form.steps.1.create_directory'}}
+    </Hds::Text::Body>
 
-    <Rose::CodeEditor @codeValue={{this.workerConfigText}} as |c|>
-      <c.toolbar>
-        <:action>
-          <span>{{t 'resources.worker.form.steps.1.create_config'}}</span>
-        </:action>
-      </c.toolbar>
-      <c.fieldEditor class='rose-autosize' @options={{this.hclCodeEditor}} />
-    </Rose::CodeEditor>
-    <p>{{t 'resources.worker.form.steps.1.save_config'}}</p>
+    <Hds::CodeBlock
+      @language='bash'
+      @value={{this.createConfigText}}
+      @hasCopyButton={{true}}
+      @hasLineNumbers={{false}}
+    />
+
+    <Hds::Text::Body @tag='p'>
+      {{t 'resources.worker.form.steps.1.create_config'}}
+    </Hds::Text::Body>
+
+    <Hds::CodeBlock
+      @language='hcl'
+      @value={{this.workerConfigText}}
+      @hasCopyButton={{true}}
+      @hasLineNumbers={{false}}
+    />
+
+    <Hds::Text::Body @tag='p'>
+      {{t 'resources.worker.form.steps.1.save_config' htmlSafe=true}}
+    </Hds::Text::Body>
   </div>
 
   <h3>{{t 'resources.worker.form.steps.2.title'}}</h3>
   <div class='worker-create-section'>
-    <Rose::CodeEditor @codeValue={{this.installBoundaryText}} as |c|>
-      <c.toolbar>
-        <:action>
-          <span>{{t 'resources.worker.form.steps.2.run_command'}}</span>
-        </:action>
-      </c.toolbar>
-      <c.fieldEditor class='rose-autosize' @options={{this.shellCodeEditor}} />
-    </Rose::CodeEditor>
-    <span>{{t 'resources.worker.form.steps.2.copy_registration_request'}}</span>
-    <code>{{t
-        'resources.worker.form.steps.3.worker_auth_registration_request.label'
-      }}
-    </code>
+
+    <Hds::Text::Body @tag='p'>
+      {{t 'resources.worker.form.steps.2.run_command'}}
+    </Hds::Text::Body>
+
+    <Hds::CodeBlock
+      @language='bash'
+      @value={{this.installBoundaryText}}
+      @hasCopyButton={{true}}
+      @hasLineNumbers={{false}}
+    />
+
+    <Hds::Text::Body @tag='p'>
+      {{t 'resources.worker.form.steps.2.copy_registration_request'}}
+      <code>{{t
+          'resources.worker.form.steps.3.worker_auth_registration_request.label'
+        }}</code>.
+    </Hds::Text::Body>
   </div>
 
   <h3>{{t 'resources.worker.form.steps.3.title'}}</h3>

--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -108,9 +108,9 @@
       </Hds::Form::Fieldset>
     {{/if}}
 
-    <Hds::Text::Body @tag='p'>
+    <p>
       {{t 'resources.worker.form.steps.1.create_directory'}}
-    </Hds::Text::Body>
+    </p>
 
     <Hds::CodeBlock
       @language='bash'
@@ -119,9 +119,9 @@
       @hasLineNumbers={{false}}
     />
 
-    <Hds::Text::Body @tag='p'>
+    <p>
       {{t 'resources.worker.form.steps.1.create_config'}}
-    </Hds::Text::Body>
+    </p>
 
     <Hds::CodeBlock
       @language='hcl'
@@ -130,17 +130,17 @@
       @hasLineNumbers={{false}}
     />
 
-    <Hds::Text::Body @tag='p'>
+    <p>
       {{t 'resources.worker.form.steps.1.save_config' htmlSafe=true}}
-    </Hds::Text::Body>
+    </p>
   </div>
 
   <h3>{{t 'resources.worker.form.steps.2.title'}}</h3>
   <div class='worker-create-section'>
 
-    <Hds::Text::Body @tag='p'>
+    <p>
       {{t 'resources.worker.form.steps.2.run_command'}}
-    </Hds::Text::Body>
+    </p>
 
     <Hds::CodeBlock
       @language='bash'
@@ -149,12 +149,12 @@
       @hasLineNumbers={{false}}
     />
 
-    <Hds::Text::Body @tag='p'>
+    <p>
       {{t 'resources.worker.form.steps.2.copy_registration_request'}}
       <code>{{t
           'resources.worker.form.steps.3.worker_auth_registration_request.label'
         }}</code>.
-    </Hds::Text::Body>
+    </p>
   </div>
 
   <h3>{{t 'resources.worker.form.steps.3.title'}}</h3>

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -333,11 +333,12 @@
   margin-bottom: sizing.rems(xl);
   padding: sizing.rems(l);
 
-  > div {
+  > div,
+  > p:not(:last-of-type) {
     margin-bottom: sizing.rems(l);
   }
 
-  > code {
+  > p code {
     background-color: var(--ui-gray-subtler-5);
     border: sizing.rems(xxxxs) solid var(--ui-gray-subtler-2);
     color: var(--failure);

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -333,8 +333,7 @@
   margin-bottom: sizing.rems(xl);
   padding: sizing.rems(l);
 
-  > div,
-  > p:not(:last-of-type) {
+  > div {
     margin-bottom: sizing.rems(l);
   }
 

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -339,9 +339,10 @@
   }
 
   > p code {
-    background-color: var(--ui-gray-subtler-5);
-    border: sizing.rems(xxxxs) solid var(--ui-gray-subtler-2);
-    color: var(--failure);
+    background-color: var(--token-color-surface-strong);
+    border-radius: 5px;
+    color: var(--token-color-foreground-primary);
+    padding: sizing.rems(xxxs) sizing.rems(xxs);
   }
 
   .worker-auth-token {


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/HDS-2827)

## Description

Follow-up on https://github.com/hashicorp/boundary-ui/pull/2020#discussion_r1412315581. 

We replace the `Rose::CodeEditor` instances with `Hds::CodeBlock` on the new worker page. In the previous attempt, we discovered an issue where the `Hds::CodeBlock` crashed when the associated content was dynamically updated.

While at it, I updated the inline code style in the instructions for creating a worker. This is only a suggestion, so if you'd like to address it separately I can drop the last commit.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="1512" alt="code-block-worker-before" src="https://github.com/hashicorp/boundary-ui/assets/788096/0b96576b-d0db-4675-9e83-e79092d601dc">


</td><td>

<img width="1512" alt="code-block-worker-after" src="https://github.com/hashicorp/boundary-ui/assets/788096/3cd0f4e0-9688-4e51-8335-858914d38cc1">


</td></tr>
<tr><td>

<img width="1512" alt="Screenshot 2024-02-02 at 11 27 01" src="https://github.com/hashicorp/boundary-ui/assets/788096/4e16b142-89fb-4313-943b-f36309fc564e">


</td><td>

<img width="1512" alt="Screenshot 2024-02-02 at 11 26 13" src="https://github.com/hashicorp/boundary-ui/assets/788096/fc36976c-1c4b-4ee7-9d4f-ef631f8610fa">


</td></tr>

</table>


## How to Test

 - go to `/scopes/global/workers/new`
 - check the instructions are correct and the code block renders as expected
 - provide configuration input (a few examples below) and check the code blocks get updated accordingly
   - change the config file path and check it's reflected in the first instruction code block
   - add worker tags and check they are reflected in the worker config code block
   - provide a local recording storage path and check they are reflected in the worker config code block

![code-block-boundary](https://github.com/hashicorp/boundary-ui/assets/788096/5c9ca3e9-46c6-4a05-8a7d-e3aee03fd28d)


:technologist: [Admin preview](https://boundary-ui-git-hds-code-block-hashicorp.vercel.app/scopes/global/workers/new)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
