### PR TITLE
refactor: 💡 only show scopes with auth methods at authenticate

### DIFF
--- a/ui/admin/app/routes/scopes/scope/authenticate.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate.js
@@ -5,7 +5,6 @@
 
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { hash } from 'rsvp';
 
 export default class ScopesScopeAuthenticateRoute extends Route {
   // =services
@@ -13,6 +12,7 @@ export default class ScopesScopeAuthenticateRoute extends Route {
   @service session;
   @service router;
   @service resourceFilterStore;
+
   // =methods
 
   beforeModel() {
@@ -27,16 +27,7 @@ export default class ScopesScopeAuthenticateRoute extends Route {
    */
   async model() {
     const { id: scope_id } = this.modelFor('scopes.scope');
-    // Fetch auth methods for the current scope
-    const authMethods = await this.resourceFilterStore.queryBy(
-      'auth-method',
-      {
-        authorized_actions: [{ contains: 'authenticate' }],
-      },
-      {
-        scope_id,
-      },
-    );
+
     // Preload all authenticatable auth methods into the store
     const authMethodsForAllScopes = await this.resourceFilterStore.queryBy(
       'auth-method',
@@ -48,22 +39,25 @@ export default class ScopesScopeAuthenticateRoute extends Route {
         recursive: true,
       },
     );
-    // Fetch org scopes
-    // and filter out any that have no auth methods
-    const scopes = this.modelFor('scopes').filter(
-      ({ id: scope_id, isOrg }) =>
-        isOrg &&
-        authMethodsForAllScopes.filter((i) => i.scopeID === scope_id).length,
+
+    const scopeIDs = new Set(
+      authMethodsForAllScopes.map((authMethod) => authMethod.scopeID),
     );
-    return hash({
+
+    // Fetch org scopes and filter out any that have no auth methods
+    const scopes = this.modelFor('scopes').filter(({ id: scope_id }) =>
+      scopeIDs.has(scope_id),
+    );
+
+    // Filter out auth methods that are not for the current scope
+    const authMethods = authMethodsForAllScopes.filter(
+      (authMethod) => authMethod.scopeID === scope_id,
+    );
+
+    return {
       scope: this.modelFor('scopes.scope'),
       scopes,
       authMethods,
-      // for integration testing:
-      // authMethods: A([{
-      //   id: 'am_1234567890',
-      //   type: 'password'
-      // }])
-    });
+    };
   }
 }

--- a/ui/admin/app/templates/scopes/scope/authenticate.hbs
+++ b/ui/admin/app/templates/scopes/scope/authenticate.hbs
@@ -61,6 +61,19 @@
           {{#if @model.authMethods}}
             {{outlet}}
           {{/if}}
+          {{#unless @model.authMethods}}
+            <Rose::Layout::Centered>
+              <Rose::Message
+                @title={{t 'resources.auth-method.messages.none.title'}}
+                @icon='flight-icons/svg/alert-circle-16'
+                as |message|
+              >
+                <message.description>
+                  {{t 'resources.auth-method.messages.none.description'}}
+                </message.description>
+              </Rose::Message>
+            </Rose::Layout::Centered>
+          {{/unless}}
         </:body>
       </Rose::Frame>
     </page.body>

--- a/ui/admin/tests/acceptance/authentication-test.js
+++ b/ui/admin/tests/acceptance/authentication-test.js
@@ -76,6 +76,15 @@ module('Acceptance | authentication', function (hooks) {
       },
       'withChildren',
     );
+    // create an emtpy org with no auth methods
+    this.server.create(
+      'scope',
+      {
+        type: 'org',
+        scope: { id: globalScope.id, type: globalScope.type },
+      },
+      'withChildren',
+    );
     scope = { id: orgScope.id, type: orgScope.type };
     globalAuthMethod = this.server.create('auth-method', {
       scope: globalScope,
@@ -366,4 +375,12 @@ module('Acceptance | authentication', function (hooks) {
   });
 
   // TODO:  test OIDC retry and cancel
+
+  test('org scopes with no auth methods are not visible in dropdown', async function (assert) {
+    await visit(authMethodGlobalAuthenticateURL);
+
+    await click('.rose-dropdown-trigger');
+
+    assert.dom('.rose-dropdown-content a').exists({ count: 2 });
+  });
 });

--- a/ui/desktop/app/routes/scopes/scope/authenticate.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate.js
@@ -5,7 +5,6 @@
 
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { hash } from 'rsvp';
 
 export default class ScopesScopeAuthenticateRoute extends Route {
   // =services
@@ -43,21 +42,22 @@ export default class ScopesScopeAuthenticateRoute extends Route {
         recursive: true,
       },
     );
-    const scopeIDs = new Set(authMethodsForAllScopes.map((i) => i.scopeID));
-    // Fetch org scopes
-    // and filter out any that have no auth methods
+    const scopeIDs = new Set(
+      authMethodsForAllScopes.map((authMethod) => authMethod.scopeID),
+    );
+    // Fetch org scopes and filter out any that have no auth methods
     const scopes = this.modelFor('scopes').filter(({ id: scope_id }) =>
       scopeIDs.has(scope_id),
     );
     const authMethods = authMethodsForAllScopes.filter(
-      (i) => i.scopeID === scope_id,
+      (authMethod) => authMethod.scopeID === scope_id,
     );
 
-    return hash({
+    return {
       scope: this.modelFor('scopes.scope'),
       scopes,
       authMethods,
-    });
+    };
   }
 
   redirect() {

--- a/ui/desktop/app/routes/scopes/scope/authenticate.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate.js
@@ -42,13 +42,17 @@ export default class ScopesScopeAuthenticateRoute extends Route {
         recursive: true,
       },
     );
+
     const scopeIDs = new Set(
       authMethodsForAllScopes.map((authMethod) => authMethod.scopeID),
     );
+
     // Fetch org scopes and filter out any that have no auth methods
     const scopes = this.modelFor('scopes').filter(({ id: scope_id }) =>
       scopeIDs.has(scope_id),
     );
+
+    // Filter out auth methods that are not for the current scope
     const authMethods = authMethodsForAllScopes.filter(
       (authMethod) => authMethod.scopeID === scope_id,
     );

--- a/ui/desktop/app/templates/scopes/scope/authenticate.hbs
+++ b/ui/desktop/app/templates/scopes/scope/authenticate.hbs
@@ -57,19 +57,5 @@
       </p>
 
     {{/if}}
-    {{#unless @model.authMethods}}
-      <Rose::Layout::Centered>
-        <Rose::Message
-          @title={{t 'resources.auth-method.messages.none.title'}}
-          @icon='flight-icons/svg/alert-circle-16'
-          as |message|
-        >
-          <message.description>
-            {{t 'resources.auth-method.messages.none.description'}}
-          </message.description>
-        </Rose::Message>
-      </Rose::Layout::Centered>
-    {{/unless}}
-
   </BrandedCard>
 </main>

--- a/ui/desktop/app/templates/scopes/scope/authenticate.hbs
+++ b/ui/desktop/app/templates/scopes/scope/authenticate.hbs
@@ -57,5 +57,18 @@
       </p>
 
     {{/if}}
+    {{#unless @model.authMethods}}
+      <Rose::Layout::Centered>
+        <Rose::Message
+          @title={{t 'resources.auth-method.messages.none.title'}}
+          @icon='flight-icons/svg/alert-circle-16'
+          as |message|
+        >
+          <message.description>
+            {{t 'resources.auth-method.messages.none.description'}}
+          </message.description>
+        </Rose::Message>
+      </Rose::Layout::Centered>
+    {{/unless}}
   </BrandedCard>
 </main>

--- a/ui/desktop/tests/acceptance/authentication-test.js
+++ b/ui/desktop/tests/acceptance/authentication-test.js
@@ -31,6 +31,7 @@ module('Acceptance | authentication', function (hooks) {
     scopes: {
       global: null,
       org: null,
+      emptyOrg: null,
       project: null,
     },
     authMethods: {
@@ -92,6 +93,10 @@ module('Acceptance | authentication', function (hooks) {
     stubs.project = { id: instances.scopes.project.id, type: 'project' };
 
     // create other resources
+    instances.scopes.emptyOrg = this.server.create('scope', {
+      type: 'org',
+      scope: stubs.global,
+    });
     instances.authMethods.global = this.server.create('auth-method', {
       scope: instances.scopes.global,
       type: 'password',
@@ -245,5 +250,13 @@ module('Acceptance | authentication', function (hooks) {
     );
     assert.notOk(getRootElement().classList.contains('rose-theme-light'));
     assert.notOk(getRootElement().classList.contains('rose-theme-dark'));
+  });
+
+  test('org scopes with no auth methods are not visible in dropdown', async function (assert) {
+    await visit(urls.authenticate.methods.global);
+
+    await click('.rose-dropdown-trigger');
+
+    assert.dom('.rose-dropdown-content a').exists({ count: 2 });
   });
 });

--- a/ui/desktop/tests/acceptance/authentication-test.js
+++ b/ui/desktop/tests/acceptance/authentication-test.js
@@ -138,15 +138,6 @@ module('Acceptance | authentication', function (hooks) {
     assert.strictEqual(currentURL(), urls.authenticate.methods.global);
   });
 
-  test('visiting authenticate route when there no methods shows a message', async function (assert) {
-    assert.expect(2);
-    instances.authMethods.global.destroy();
-    await visit(urls.authenticate.global);
-    await a11yAudit();
-    assert.strictEqual(currentURL(), urls.authenticate.global);
-    assert.ok(find('.rose-message'));
-  });
-
   test('visiting authenticate route without clusterUrl redirects to clusterUrl index', async function (assert) {
     assert.expect(1);
     this.owner.lookup('service:clusterUrl').rendererClusterUrl = null;


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-2355

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-2355)

## Description

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
Before:
<img width="630" alt="Screenshot 2024-02-05 at 2 25 24 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/9534e818-0b34-41d7-a9f7-784a22c36965">

After:
<img width="630" alt="Screenshot 2024-02-05 at 2 25 02 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/86d37a1c-7aa8-46ad-8e55-a53e13a70203">

## How to Test
Start a `boundary dev` instance and start the desktop client with the cluster URL pointing to `http://localhost:9200`. The only scope you should see in the dropdown is `Global` as the generated org will have no auth methods by default.


## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] ~I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
