### PR TITLE
feat: 🎸 remove Type of Worker from worker details page

### DIFF
--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -58,8 +58,6 @@ worker_last_seen:
   help: Last time the worker reported status.
 worker_address:
   help: URL and port for this worker.
-worker_type:
-  help: Type of worker
 host_set:
   label: Host Set
 grant_scope:

--- a/ui/admin/app/components/form/worker/index.hbs
+++ b/ui/admin/app/components/form/worker/index.hbs
@@ -12,15 +12,6 @@
 >
 
   <form.input
-    @name='type'
-    @value={{@model.type}}
-    @label={{t 'form.type.label'}}
-    @helperText={{t 'form.worker_type.help'}}
-    @disabled={{true}}
-    readonly={{true}}
-  />
-
-  <form.input
     @name='name'
     @type='name'
     @value={{@model.name}}


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12409

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-12409)

## Description

remove Type of Worker from worker details page

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
Before:
<img width="711" alt="Screenshot 2024-02-06 at 1 16 31 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/82d40c0e-198e-458e-8a3a-0a9a096c7ec5">

After:
<img width="711" alt="Screenshot 2024-02-06 at 1 16 12 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/438a9471-80d4-4ddc-8704-8502fd48e665">


## How to Test

Click on the Admin preview and navigate to the workers tab and click into a worker. There should be no `Type of Worker` field.

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](https://boundary-ui-git-icu-12409-remove-field-worker-f592c8-hashicorp.vercel.app/scopes/global/workers/w_rx3btr6y2a)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] ~I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] ~I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
