### PR TITLE
feat: 🎸 allow session recording deletion

### DIFF
--- a/addons/api/addon/abilities/session-recording.js
+++ b/addons/api/addon/abilities/session-recording.js
@@ -21,6 +21,14 @@ export default class SessionRecordingAbility extends ModelAbility {
     return !this.model.isUnknown && super.canRead;
   }
 
+  /**
+   * Only "known" session recording types may be deleted.
+   * @type {boolean}
+   */
+  get canDelete() {
+    return !this.model.isUnknown && super.canDelete;
+  }
+
   get canDownload() {
     return this.hasAuthorizedAction('download');
   }

--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -798,6 +798,8 @@ function routes() {
     },
   );
 
+  this.del('/session-recordings/:id');
+
   /* Uncomment the following line and the Response import above
    * Then change the response code to simulate error responses.
    * this.get('/scopes', () => new Response(505));

--- a/addons/api/mirage/factories/session-recording.js
+++ b/addons/api/mirage/factories/session-recording.js
@@ -60,6 +60,7 @@ export default factory.extend({
       'read',
       'download',
       'reapply-storage-policy',
+      'delete',
     ],
 
   withNonExistingUserAndTarget: trait({

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -949,6 +949,7 @@ policy:
     apply: Apply the storage policy to this scope and its children
     new: Add a new storage policy
     update: Re-apply storage policy
+    delete_recording: Delete recording
   questions:
     detach: Are you sure you want to detach this storage policy?
   messages:

--- a/ui/admin/app/abilities/session-recording.js
+++ b/ui/admin/app/abilities/session-recording.js
@@ -29,4 +29,14 @@ export default class OverrideSessionRecordingAbility extends SessionRecordingAbi
       ? this.hasAuthorizedAction('reapply-storage-policy')
       : false;
   }
+
+  /**
+   * This override ensures that session recordings may be deleted only if the
+   * session-recording feature flag is enabled.
+   */
+  get canDelete() {
+    return this.features.isEnabled('ssh-session-recording')
+      ? super.canDelete
+      : false;
+  }
 }

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection.js
@@ -7,6 +7,8 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { notifySuccess, notifyError } from 'core/decorators/notify';
+import { loading } from 'ember-loading';
+import { confirm } from 'core/decorators/confirm';
 
 export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConnectionRoute extends Route {
   // =services
@@ -69,5 +71,20 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
       this.router.refresh();
       throw new Error(e);
     }
+  }
+
+  /**
+   * Deletes the session recording
+   * @param {SessionRecording} recording
+   */
+  @action
+  @loading
+  @confirm('questions.delete-confirm')
+  @notifyError(({ message }) => message, { catch: true })
+  @notifySuccess('notifications.delete-success')
+  async delete(recording) {
+    await recording.destroyRecord();
+    await this.router.replaceWith('scopes.scope.session-recordings');
+    this.router.refresh();
   }
 }

--- a/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
@@ -16,7 +16,7 @@
     {{#if
       (can 'reapplyStoragePolicy session-recording' @model.sessionRecording)
     }}
-      <Hds::Dropdown data-test-manage-dropdown as |dd|>
+      <Hds::Dropdown as |dd|>
         <dd.ToggleButton @text={{t 'actions.manage'}} @color='secondary' />
 
         <dd.Interactive
@@ -26,6 +26,16 @@
             (route-action 'reapplyStoragepolicy' @model.sessionRecording)
           }}
         />
+        {{#if (eq @model.sessionRecording.state 'available')}}
+          {{#if (can 'delete session-recording' @model.sessionRecording)}}
+            <dd.Separator />
+            <dd.Interactive
+              @color='critical'
+              @text={{t 'resources.policy.actions.delete_recording'}}
+              {{on 'click' (route-action 'delete' @model.sessionRecording)}}
+            />
+          {{/if}}
+        {{/if}}
       </Hds::Dropdown>
     {{/if}}
   </page.actions>

--- a/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
@@ -17,7 +17,11 @@ module(
     setupMirage(hooks);
 
     let featuresService;
+    let getRecordingCount;
 
+    const DELETE_DROPDOWN_SELECTOR =
+      '.hds-dropdown-list-item--color-critical [type="button"]';
+    const DROPDOWN_SELECTOR = '.hds-dropdown-toggle-button';
     // Instances
     const instances = {
       scopes: {
@@ -43,8 +47,14 @@ module(
         type: 'org',
         scope: { id: 'global', type: 'global' },
       });
+      instances.scopes.targetModel = this.server.create('target', {
+        scope: instances.scopes.global,
+      });
       instances.sessionRecording = this.server.create('session-recording', {
         scope: instances.scopes.global,
+        create_time_values: {
+          target: instances.scopes.targetModel.attrs,
+        },
       });
       instances.connectionRecording = this.server.create(
         'connection-recording',
@@ -59,6 +69,9 @@ module(
       urls.sessionRecordings = `${urls.globalScope}/session-recordings`;
       urls.sessionRecording = `${urls.sessionRecordings}/${instances.sessionRecording.id}/channels-by-connection`;
       urls.channelRecording = `${urls.sessionRecording}/${instances.channelRecording.id}`;
+      getRecordingCount = () =>
+        this.server.schema.sessionRecordings.all().models.length;
+
       featuresService = this.owner.lookup('service:features');
       authenticateSession({});
     });
@@ -157,16 +170,34 @@ module(
         );
       await visit(urls.sessionRecording);
 
-      assert.dom('[data-test-manage-dropdown]').doesNotExist();
+      assert.dom(DROPDOWN_SELECTOR).doesNotExist();
     });
 
-    test('user can view manage dropdown with proper authorization', async function (assert) {
+    test('user can delete a recording with proper authorization', async function (assert) {
+      // Visit channel
+      const count = getRecordingCount();
+      featuresService.enable('ssh-session-recording');
+      assert.true(
+        instances.sessionRecording.authorized_actions.includes('delete'),
+      );
+      await visit(urls.sessionRecording);
+      await click(DROPDOWN_SELECTOR);
+
+      await click(DELETE_DROPDOWN_SELECTOR);
+      assert.strictEqual(currentURL(), urls.sessionRecordings);
+
+      assert.strictEqual(getRecordingCount(), count - 1);
+    });
+
+    test('user cannot delete a recording without proper authorization', async function (assert) {
       // Visit channel
       featuresService.enable('ssh-session-recording');
-
+      instances.sessionRecording.authorized_actions =
+        instances.sessionRecording.authorized_actions.filter(
+          (item) => item !== 'delete',
+        );
       await visit(urls.sessionRecording);
-
-      assert.dom('[data-test-manage-dropdown]').isVisible();
+      assert.dom(DELETE_DROPDOWN_SELECTOR).doesNotExist();
     });
 
     test('both retain until and delete after can be seen with proper authorization', async function (assert) {

--- a/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
@@ -173,6 +173,15 @@ module(
       assert.dom(DROPDOWN_SELECTOR).doesNotExist();
     });
 
+    test('user can view manage dropdown with proper authorization', async function (assert) {
+      // Visit channel
+      featuresService.enable('ssh-session-recording');
+
+      await visit(urls.sessionRecording);
+
+      assert.dom(DROPDOWN_SELECTOR).isVisible();
+    });
+
     test('user can delete a recording with proper authorization', async function (assert) {
       // Visit channel
       const count = getRecordingCount();


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12549

https://hashicorp.atlassian.net/browse/ICU-12550

## Description

add recording deletion support in the UI 

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

https://github.com/hashicorp/boundary-ui/assets/15043878/af90155c-e5f2-4a00-8f6b-78794befd0b3


on recording state, we don't allow deletion
![1](https://github.com/hashicorp/boundary-ui/assets/15043878/69e908cd-6e0e-4866-9739-56bd662a7bee)


## How to Test
1. use ent binary, create some recordings using desktop 
2. you should be able to see `delete` option when the recording state is `available`, otherwise it should not be visible
3. when you click on delete, the resource gets destroyed and redirected to the list page


<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
