### PR TITLE
Icu 12557 refresh not working as intended on windows

### DIFF
--- a/ui/desktop/electron-app/src/services/client-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/client-daemon-manager.js
@@ -150,7 +150,7 @@ const searchCliCommand = (requestData) => {
     searchCommand.push(`-filter=${requestData.filter}`);
   }
   if (requestData.force_refresh) {
-    searchCommand.push(`-force-refresh`);
+    searchCommand.push(`-force-refresh=true`);
   }
   const sanitizedToken = sanitizer.base62EscapeAndValidate(requestData.token);
 

--- a/ui/desktop/electron-app/src/services/client-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/client-daemon-manager.js
@@ -149,6 +149,9 @@ const searchCliCommand = (requestData) => {
   if (requestData.filter) {
     searchCommand.push(`-filter=${requestData.filter}`);
   }
+  if (requestData.force_refresh) {
+    searchCommand.push(`-force-refresh`);
+  }
   const sanitizedToken = sanitizer.base62EscapeAndValidate(requestData.token);
 
   const { stdout, stderr } = spawnSync(searchCommand, {


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-12557)

## Description
Fix for this issue: https://github.com/hashicorp/boundary-ui/issues/2130
<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

Before: 
![image](https://github.com/hashicorp/boundary-ui/assets/107949262/aa6f3d75-fb9d-4528-a4bb-9b49644a4f51)

After (tested in native windows env not in utm):

https://github.com/hashicorp/boundary-ui/assets/107949262/f22c6eec-54e6-46f7-aa8e-787275651962


## How to Test
Ideally test in windows env, if not pull this change and remove isWindows() check.
1. start boundary 0.15.0 instance
2. run cmd `BYPASS_CLI_SETUP=true ENABLE_MIRAGE=false yarn start:desktop`
3. check that sessions appear immediately after connecting.
