### PR TITLE
refactor: 💡 Migrate last `form.fieldset` over to use Hds

### DIFF
--- a/ui/admin/app/components/form/credential/json/index.hbs
+++ b/ui/admin/app/components/form/credential/json/index.hbs
@@ -48,32 +48,26 @@
   </Hds::Form::Textarea::Field>
 
   {{#if @model.isNew}}
-    <Hds::Form::Fieldset @layout='horizontal' as |F|>
-      <F.Control>
-        <Hds::Form::RadioCard::Group as |G|>
-          <G.Legend>{{t 'form.type.label'}}</G.Legend>
-          {{#each @types as |credentialType|}}
-            <G.RadioCard
-              @name={{credentialType}}
-              @value={{credentialType}}
-              @checked={{eq credentialType @model.type}}
-              @maxWidth='20rem'
-              {{on 'input' (fn @changeType credentialType)}}
-              as |R|
-            >
-              <R.Label>{{t
-                  (concat 'resources.credential.types.' credentialType)
-                }}
-              </R.Label>
-              <R.Description>{{t
-                  (concat 'resources.credential.help.' credentialType)
-                }}
-              </R.Description>
-            </G.RadioCard>
-          {{/each}}
-        </Hds::Form::RadioCard::Group>
-      </F.Control>
-    </Hds::Form::Fieldset>
+    <Hds::Form::RadioCard::Group as |G|>
+      <G.Legend>{{t 'form.type.label'}}</G.Legend>
+      {{#each @types as |credentialType|}}
+        <G.RadioCard
+          @name={{credentialType}}
+          @value={{credentialType}}
+          @checked={{eq credentialType @model.type}}
+          @maxWidth='20rem'
+          {{on 'input' (fn @changeType credentialType)}}
+          as |R|
+        >
+          <R.Label>{{t (concat 'resources.credential.types.' credentialType)}}
+          </R.Label>
+          <R.Description>{{t
+              (concat 'resources.credential.help.' credentialType)
+            }}
+          </R.Description>
+        </G.RadioCard>
+      {{/each}}
+    </Hds::Form::RadioCard::Group>
 
     <Hds::Form::Fieldset as |F|>
       <F.Legend>{{t 'resources.credential.form.json.label'}}</F.Legend>

--- a/ui/admin/app/components/form/credential/json/index.hbs
+++ b/ui/admin/app/components/form/credential/json/index.hbs
@@ -48,8 +48,8 @@
   </Hds::Form::Textarea::Field>
 
   {{#if @model.isNew}}
-    <form.fieldset>
-      <:body>
+    <Hds::Form::Fieldset @layout='horizontal' as |F|>
+      <F.Control>
         <Hds::Form::RadioCard::Group as |G|>
           <G.Legend>{{t 'form.type.label'}}</G.Legend>
           {{#each @types as |credentialType|}}
@@ -63,27 +63,29 @@
             >
               <R.Label>{{t
                   (concat 'resources.credential.types.' credentialType)
-                }}</R.Label>
+                }}
+              </R.Label>
               <R.Description>{{t
                   (concat 'resources.credential.help.' credentialType)
-                }}</R.Description>
+                }}
+              </R.Description>
             </G.RadioCard>
           {{/each}}
         </Hds::Form::RadioCard::Group>
-      </:body>
-    </form.fieldset>
+      </F.Control>
+    </Hds::Form::Fieldset>
 
-    <form.fieldset>
-      <:title>{{t 'resources.credential.form.json.label'}}</:title>
-      <:description>{{t 'resources.credential.form.json.help'}}</:description>
-      <:body>
+    <Hds::Form::Fieldset as |F|>
+      <F.Legend>{{t 'resources.credential.form.json.label'}}</F.Legend>
+      <F.HelperText>{{t 'resources.credential.form.json.help'}}</F.HelperText>
+      <F.Control>
         <Form::Field::JsonSecret
           @value={{@model.json_object}}
           @onInput={{fn (mut @model.json_object)}}
           @showEditButton={{false}}
         />
-      </:body>
-    </form.fieldset>
+      </F.Control>
+    </Hds::Form::Fieldset>
   {{else}}
     <InfoField
       @value={{t (concat 'resources.credential.types.' @model.type)}}
@@ -94,18 +96,18 @@
       </F.HelperText>
     </InfoField>
 
-    <form.fieldset>
-      <:title>{{t 'resources.credential.form.json.label'}}</:title>
-      <:description>{{t 'resources.credential.form.json.help'}}</:description>
-      <:body>
+    <Hds::Form::Fieldset as |F|>
+      <F.Legend>{{t 'resources.credential.form.json.label'}}</F.Legend>
+      <F.HelperText>{{t 'resources.credential.form.json.help'}}</F.HelperText>
+      <F.Control>
         <Form::Field::JsonSecret
           @disabled={{form.disabled}}
           @value={{@model.json_object}}
           @onInput={{fn (mut @model.json_object)}}
           @showEditButton={{true}}
         />
-      </:body>
-    </form.fieldset>
+      </F.Control>
+    </Hds::Form::Fieldset>
   {{/if}}
 
   {{#if (can 'save model' @model)}}


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-9427

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-9427)

## Description
- Migrate last `form.fieldset` for `json` type over to use `Hds::FormFieldset`

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
### Before:
---
<img width="1489" alt="Screenshot 2024-02-12 at 12 55 20" src="https://github.com/hashicorp/boundary-ui/assets/24277002/7abb1063-7202-4726-ad59-2310b4130064">

### After:
---
<img width="1489" alt="Screenshot 2024-02-12 at 12 56 52" src="https://github.com/hashicorp/boundary-ui/assets/24277002/a0ee2f77-f31b-420a-a06d-3dc67c26ea60">


## How to Test
- Click on Vercel link for Admin UI or pull down PR and run it locally using yarn start
- Click on "Credential Stores" in sidebar navigation.
- Click on a "static" store from the list.
- Use the "Manage" dropdown on view to create a new "credential"
- Click on the "JSON" card and ensure that the secret field exists and is functional.
- Click on the "credentials" tab on the single static store view and click on your newly created JSON credential to view details.

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
~~- [ ] I have added JSON response output for API changes~~
~~- [ ] I have added steps to reproduce and test for bug fixes in the description~~
~~- [ ] I have commented on my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
