### PR TITLE
Fix credential library mocks

### DIFF
--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -632,7 +632,26 @@ function routes() {
       { queryParams: { credential_store_id: credentialStoreId } },
     ) => credentialLibraries.where({ credentialStoreId }),
   );
-  this.get('/credential-libraries/:id');
+  this.get(
+    '/credential-libraries/:id',
+    function ({ credentialLibraries }, { params: { id } }) {
+      const library = credentialLibraries.find(id);
+      // BE API only updates these fields if there's an update mask, otherwise they remain unmodified
+      // but we don't need this flow in our mocks, so we are deleting fields with null value
+      const { credentialMappingOverrides } = library;
+      if (
+        credentialMappingOverrides &&
+        Object.keys(credentialMappingOverrides).length
+      ) {
+        Object.keys(credentialMappingOverrides).forEach((key) => {
+          if (credentialMappingOverrides[key] === null) {
+            delete credentialMappingOverrides[key];
+          }
+        });
+      }
+      return library;
+    },
+  );
   this.post(
     '/credential-libraries',
     function ({ credentialStores, credentialLibraries }) {

--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -639,10 +639,7 @@ function routes() {
       // BE API only updates these fields if there's an update mask, otherwise they remain unmodified
       // but we don't need this flow in our mocks, so we are deleting fields with null value
       const { credentialMappingOverrides } = library;
-      if (
-        credentialMappingOverrides &&
-        Object.keys(credentialMappingOverrides).length
-      ) {
+      if (Object.keys(credentialMappingOverrides || {}).length) {
         Object.keys(credentialMappingOverrides).forEach((key) => {
           if (credentialMappingOverrides[key] === null) {
             delete credentialMappingOverrides[key];

--- a/ui/admin/tests/acceptance/credential-library/update-test.js
+++ b/ui/admin/tests/acceptance/credential-library/update-test.js
@@ -133,8 +133,6 @@ module('Acceptance | credential-libraries | update', function (hooks) {
     assert.strictEqual(credentialLibrary.attributes.path, 'path');
     assert.deepEqual(credentialLibrary.credentialMappingOverrides, {
       private_key_attribute: 'key',
-      private_key_passphrase_attribute: null,
-      username_attribute: null,
     });
   });
 


### PR DESCRIPTION
## Description

This PR fixes the mock data when a vault credential library is updated with mapping_overrides

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

## How to Test

<!-- Add steps to test this change. Include any other necessary relevant links -->
1. go to credential-library->vault
2. edit an existing vault credential library and include mapping override attributes
3. click save
4. the form should reflect only the attributes you added in the above steps 
<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
