### PR TITLE
refactor: 💡 remove route-action usage from credential-stores

### DIFF
--- a/ui/admin/app/components/credential-stores/credential-store/actions/index.hbs
+++ b/ui/admin/app/components/credential-stores/credential-store/actions/index.hbs
@@ -30,7 +30,7 @@
     <dropdown.button
       @style='danger'
       @disabled={{@model.canSave}}
-      {{on 'click' (route-action 'delete' @model)}}
+      {{on 'click' @delete}}
     >
       {{t 'resources.credential-store.actions.delete'}}
     </dropdown.button>

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index.js
@@ -1,0 +1,8 @@
+import Controller, { inject as controller } from '@ember/controller';
+
+export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrariesCredentialLibraryIndexController extends Controller {
+  @controller(
+    'scopes/scope/credential-stores/credential-store/credential-libraries/index',
+  )
+  credentialLibraries;
+}

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/index.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/index.js
@@ -1,0 +1,99 @@
+import Controller, { inject as controller } from '@ember/controller';
+import { action } from '@ember/object';
+import { loading } from 'ember-loading';
+import { confirm } from 'core/decorators/confirm';
+import { notifySuccess, notifyError } from 'core/decorators/notify';
+import { inject as service } from '@ember/service';
+
+export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrariesIndexController extends Controller {
+  @controller('scopes/scope/credential-stores/index') credentialStores;
+
+  // =services
+
+  @service can;
+  @service router;
+
+  // =actions
+
+  /**
+   * Rollback changes on a credential library.
+   * @param {CredentialLibraryModel} credentialLibrary
+   */
+  @action
+  async cancel(credentialLibrary) {
+    const { isNew } = credentialLibrary;
+    credentialLibrary.rollbackAttributes();
+    if (isNew)
+      await this.router.transitionTo(
+        'scopes.scope.credential-stores.credential-store.credential-libraries',
+      );
+  }
+
+  /**
+   * Handle save of a credential library
+   * @param {CredentialLibraryModel} credentialLibrary
+   */
+  @action
+  @loading
+  @notifyError(({ message }) => message)
+  @notifySuccess(({ isNew }) =>
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
+  )
+  async save(credentialLibrary) {
+    await credentialLibrary.save();
+    if (this.can.can('read model', credentialLibrary)) {
+      await this.router.transitionTo(
+        'scopes.scope.credential-stores.credential-store.credential-libraries.credential-library',
+        credentialLibrary,
+      );
+    } else {
+      await this.router.transitionTo(
+        'scopes.scope.credential-stores.credential-store.credential-libraries',
+      );
+    }
+    await this.router.refresh();
+  }
+
+  /**
+   * Handle delete of a credential library
+   * @param {CredentialLibraryModel} credentialLibrary
+   */
+  @action
+  @loading
+  @confirm('questions.delete-confirm')
+  @notifyError(({ message }) => message, { catch: true })
+  @notifySuccess('notifications.delete-success')
+  async delete(credentialLibrary) {
+    await credentialLibrary.destroyRecord();
+    await this.router.replaceWith(
+      'scopes.scope.credential-stores.credential-store.credential-libraries',
+    );
+    await this.router.refresh();
+  }
+
+  /**
+   * Copies the contents of array fields in order to force the instance
+   * into a dirty state.  This ensures that `model.rollbackAttributes()` reverts
+   * to the original expected array.
+   *
+   * The deep copy implemented here is required to ensure that both the
+   * array itself and its members are all new.
+   *
+   * @param {credentialLibraryModel} credentialLibrary
+   */
+  @action
+  edit(credentialLibrary) {
+    const { critical_options, extensions } = credentialLibrary;
+    credentialLibrary.critical_options = structuredClone(critical_options);
+    credentialLibrary.extensions = structuredClone(extensions);
+  }
+
+  /**
+   * Update type of credential library
+   * @param {string} type
+   */
+  @action
+  async changeType(type) {
+    await this.router.replaceWith({ queryParams: { type } });
+  }
+}

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/new.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/new.js
@@ -11,8 +11,6 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
   )
   credentialLibraries;
 
-  // =services
-
   // =attributes
   queryParams = ['type'];
 }

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/new.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/new.js
@@ -3,9 +3,14 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Controller from '@ember/controller';
+import Controller, { inject as controller } from '@ember/controller';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrariesNewController extends Controller {
+  @controller(
+    'scopes/scope/credential-stores/credential-store/credential-libraries/index',
+  )
+  credentialLibraries;
+
   // =services
 
   // =attributes

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credentials/credential/index.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credentials/credential/index.js
@@ -1,0 +1,8 @@
+import Controller, { inject as controller } from '@ember/controller';
+
+export default class ScopesScopeCredentialStoresCredentialStoreCredentialsCredentialIndexController extends Controller {
+  @controller(
+    'scopes/scope/credential-stores/credential-store/credentials/index',
+  )
+  credentials;
+}

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credentials/index.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credentials/index.js
@@ -1,0 +1,81 @@
+import Controller, { inject as controller } from '@ember/controller';
+import { action } from '@ember/object';
+import { loading } from 'ember-loading';
+import { confirm } from 'core/decorators/confirm';
+import { notifySuccess, notifyError } from 'core/decorators/notify';
+import { inject as service } from '@ember/service';
+
+export default class ScopesScopeCredentialStoresCredentialStoreCredentialsIndexController extends Controller {
+  @controller('scopes/scope/credential-stores/index') credentialStores;
+
+  // =services
+
+  @service can;
+  @service router;
+
+  // =actions
+
+  /**
+   * Rollback changes on a credential.
+   * @param {CredentialModel} credential
+   */
+  @action
+  async cancel(credential) {
+    const { isNew } = credential;
+    credential.rollbackAttributes();
+    if (isNew)
+      await this.router.transitionTo(
+        'scopes.scope.credential-stores.credential-store.credentials',
+      );
+  }
+
+  /**
+   * Handle save of a credential
+   * @param {CredentialModel} credential
+   */
+  @action
+  @loading
+  @notifyError(({ message }) => message)
+  @notifySuccess(({ isNew }) =>
+    isNew ? 'notifications.create-success' : 'notifications.save-success',
+  )
+  async save(credential) {
+    await credential.save();
+    if (this.can.can('read credential', credential)) {
+      await this.router.transitionTo(
+        'scopes.scope.credential-stores.credential-store.credentials.credential',
+        credential,
+      );
+    } else {
+      await this.router.transitionTo(
+        'scopes.scope.credential-stores.credential-store.credentials',
+      );
+    }
+    await this.router.refresh();
+  }
+  /**
+   * Handle delete of a credential
+   * @param {Credential} credential
+   */
+  @action
+  @loading
+  @confirm('questions.delete-confirm')
+  @notifyError(({ message }) => message, { catch: true })
+  @notifySuccess('notifications.delete-success')
+  async delete(credential) {
+    await credential.destroyRecord();
+    await this.router.replaceWith(
+      'scopes.scope.credential-stores.credential-store.credentials',
+    );
+    await this.router.refresh();
+  }
+
+  /**
+   * Update type of credential
+   * @param {string} type
+   */
+  @action
+  async changeType(type) {
+    await this.router.replaceWith({ queryParams: { type } });
+  }
+}

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credentials/new.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credentials/new.js
@@ -11,8 +11,6 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialsNewCon
   )
   credentials;
 
-  // =services
-
   // =attributes
 
   queryParams = ['type'];

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credentials/new.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credentials/new.js
@@ -3,9 +3,14 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Controller from '@ember/controller';
+import Controller, { inject as controller } from '@ember/controller';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialsNewController extends Controller {
+  @controller(
+    'scopes/scope/credential-stores/credential-store/credentials/index',
+  )
+  credentials;
+
   // =services
 
   // =attributes

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/index.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/index.js
@@ -1,0 +1,5 @@
+import Controller, { inject as controller } from '@ember/controller';
+
+export default class ScopesScopeCredentialStoresCredentialStoreIndexController extends Controller {
+  @controller('scopes/scope/credential-stores/index') credentialStores;
+}

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/index.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/index.js
@@ -1,0 +1,73 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { loading } from 'ember-loading';
+import { confirm } from 'core/decorators/confirm';
+import { notifySuccess, notifyError } from 'core/decorators/notify';
+
+export default class ScopesScopeCredentialStoresIndexController extends Controller {
+  // =services
+
+  @service can;
+  @service router;
+
+  // =actions
+
+  /**
+   * Handle save
+   * @param {CredentialStoreModel} credentialStore
+   */
+  @action
+  @loading
+  @notifyError(({ message }) => message)
+  @notifySuccess('notifications.save-success')
+  async save(credentialStore) {
+    await credentialStore.save();
+    if (this.can.can('read model', credentialStore)) {
+      await this.router.transitionTo(
+        'scopes.scope.credential-stores.credential-store',
+        credentialStore,
+      );
+    } else {
+      await await this.router.transitionTo('scopes.scope.credential-stores');
+    }
+    await this.router.refresh();
+  }
+
+  /**
+   * Rollback changes on credential stores.
+   * @param {CredentialStoreModel} credentialStore
+   */
+  @action
+  async cancel(credentialStore) {
+    const { isNew } = credentialStore;
+    credentialStore.rollbackAttributes();
+    if (isNew) {
+      await this.router.transitionTo('scopes.scope.credential-stores');
+    }
+  }
+
+  /**
+   * Deletes the credential store and redirects to index
+   * @param {CredentialStoreModel} credentialStore
+   */
+  @action
+  @loading
+  @confirm('questions.delete-confirm')
+  @notifyError(({ message }) => message, { catch: true })
+  @notifySuccess('notifications.delete-success')
+  async delete(credentialStore) {
+    await credentialStore.destroyRecord();
+    await this.router.replaceWith('scopes.scope.credential-stores');
+    await this.router.refresh();
+  }
+
+  /**
+   * Update type of credential store
+   * @param {string} type
+   */
+  @action
+  async changeType(type) {
+    await this.router.replaceWith({ queryParams: { type } });
+  }
+}

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/index.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/index.js
@@ -29,7 +29,7 @@ export default class ScopesScopeCredentialStoresIndexController extends Controll
         credentialStore,
       );
     } else {
-      await await this.router.transitionTo('scopes.scope.credential-stores');
+      await this.router.transitionTo('scopes.scope.credential-stores');
     }
     await this.router.refresh();
   }

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/new.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/new.js
@@ -8,8 +8,6 @@ import Controller, { inject as controller } from '@ember/controller';
 export default class ScopesScopeCredentialStoresNewController extends Controller {
   @controller('scopes/scope/credential-stores/index') credentialStores;
 
-  // =services
-
   // =attributes
   queryParams = ['type'];
 }

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/new.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/new.js
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import Controller from '@ember/controller';
+import Controller, { inject as controller } from '@ember/controller';
 
 export default class ScopesScopeCredentialStoresNewController extends Controller {
+  @controller('scopes/scope/credential-stores/index') credentialStores;
+
   // =services
 
   // =attributes

--- a/ui/admin/app/routes/scopes/scope/credential-stores.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores.js
@@ -5,17 +5,12 @@
 
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { action } from '@ember/object';
-import { loading } from 'ember-loading';
-import { confirm } from 'core/decorators/confirm';
-import { notifySuccess, notifyError } from 'core/decorators/notify';
 
 export default class ScopesScopeCredentialStoresRoute extends Route {
   // =services
 
   @service store;
   @service can;
-  @service router;
 
   // =methods
 
@@ -33,50 +28,5 @@ export default class ScopesScopeCredentialStoresRoute extends Route {
     ) {
       return this.store.query('credential-store', { scope_id });
     }
-  }
-
-  // =actions
-
-  /**
-   * Handle save
-   * @param {CredentialStoreModel} credentialStore
-   */
-  @action
-  @loading
-  @notifyError(({ message }) => message)
-  @notifySuccess('notifications.save-success')
-  async save(credentialStore) {
-    await credentialStore.save();
-    await this.router.transitionTo(
-      'scopes.scope.credential-stores.credential-store',
-      credentialStore,
-    );
-    this.refresh();
-  }
-
-  /**
-   * Rollback changes on credential stores.
-   * @param {CredentialStoreModel} credentialStore
-   */
-  @action
-  cancel(credentialStore) {
-    const { isNew } = credentialStore;
-    credentialStore.rollbackAttributes();
-    if (isNew) this.router.transitionTo('scopes.scope.credential-stores');
-  }
-
-  /**
-   * Deletes the credential store and redirects to index
-   * @param {CredentialStoreModel} credentialStore
-   */
-  @action
-  @loading
-  @confirm('questions.delete-confirm')
-  @notifyError(({ message }) => message, { catch: true })
-  @notifySuccess('notifications.delete-success')
-  async delete(credentialStore) {
-    await credentialStore.destroyRecord();
-    await this.router.replaceWith('scopes.scope.credential-stores');
-    this.refresh();
   }
 }

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries.js
@@ -4,10 +4,6 @@
  */
 
 import Route from '@ember/routing/route';
-import { action } from '@ember/object';
-import { loading } from 'ember-loading';
-import { confirm } from 'core/decorators/confirm';
-import { notifySuccess, notifyError } from 'core/decorators/notify';
 import { inject as service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrariesRoute extends Route {
@@ -15,7 +11,6 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
 
   @service store;
   @service can;
-  @service router;
 
   // =methods
 
@@ -35,63 +30,5 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
     ) {
       return this.store.query('credential-library', { credential_store_id });
     }
-  }
-
-  // =actions
-
-  /**
-   * Rollback changes on a credential library.
-   * @param {CredentialLibraryModel} credentialLibrary
-   */
-  @action
-  cancel(credentialLibrary) {
-    const { isNew } = credentialLibrary;
-    credentialLibrary.rollbackAttributes();
-    if (isNew)
-      this.router.transitionTo(
-        'scopes.scope.credential-stores.credential-store.credential-libraries',
-      );
-  }
-
-  /**
-   * Handle save of a credential library
-   * @param {CredentialLibraryModel} credentialLibrary
-   */
-  @action
-  @loading
-  @notifyError(({ message }) => message)
-  @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success',
-  )
-  async save(credentialLibrary) {
-    await credentialLibrary.save();
-    if (this.can.can('read model', credentialLibrary)) {
-      await this.router.transitionTo(
-        'scopes.scope.credential-stores.credential-store.credential-libraries.credential-library',
-        credentialLibrary,
-      );
-    } else {
-      await this.router.transitionTo(
-        'scopes.scope.credential-stores.credential-store.credential-libraries',
-      );
-    }
-    this.refresh();
-  }
-
-  /**
-   * Handle delete of a credential library
-   * @param {CredentialLibraryModel} credentialLibrary
-   */
-  @action
-  @loading
-  @confirm('questions.delete-confirm')
-  @notifyError(({ message }) => message, { catch: true })
-  @notifySuccess('notifications.delete-success')
-  async deleteCredentialLibrary(credentialLibrary) {
-    await credentialLibrary.destroyRecord();
-    await this.router.replaceWith(
-      'scopes.scope.credential-stores.credential-store.credential-libraries',
-    );
-    this.refresh();
   }
 }

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library.js
@@ -5,13 +5,11 @@
 
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { action } from '@ember/object';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrariesCredentialLibraryRoute extends Route {
   // =services
 
   @service store;
-  @service can;
   @service router;
 
   // =methods
@@ -44,22 +42,5 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
         credentialLibrary.id,
       );
     }
-  }
-
-  /**
-   * Copies the contents of array fields in order to force the instance
-   * into a dirty state.  This ensures that `model.rollbackAttributes()` reverts
-   * to the original expected array.
-   *
-   * The deep copy implemented here is required to ensure that both the
-   * array itself and its members are all new.
-   *
-   * @param {credentialLibraryModel} credentialLibrary
-   */
-  @action
-  edit(credentialLibrary) {
-    const { critical_options, extensions } = credentialLibrary;
-    credentialLibrary.critical_options = structuredClone(critical_options);
-    credentialLibrary.extensions = structuredClone(extensions);
   }
 }

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/new.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/new.js
@@ -4,7 +4,6 @@
  */
 
 import Route from '@ember/routing/route';
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { TYPE_CREDENTIAL_LIBRARY_VAULT_GENERIC } from 'api/models/credential-library';
 
@@ -63,14 +62,5 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrari
       type,
       credential_store_id,
     });
-  }
-
-  /**
-   * Update type of credential library
-   * @param {string} type
-   */
-  @action
-  changeType(type) {
-    this.router.replaceWith({ queryParams: { type } });
   }
 }

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials.js
@@ -11,7 +11,6 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialsRoute 
 
   @service store;
   @service can;
-  @service router;
 
   // =methods
 

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials.js
@@ -4,10 +4,6 @@
  */
 
 import Route from '@ember/routing/route';
-import { action } from '@ember/object';
-import { loading } from 'ember-loading';
-import { confirm } from 'core/decorators/confirm';
-import { notifySuccess, notifyError } from 'core/decorators/notify';
 import { inject as service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialsRoute extends Route {
@@ -35,62 +31,5 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialsRoute 
     ) {
       return this.store.query('credential', { credential_store_id });
     }
-  }
-
-  // =actions
-
-  /**
-   * Rollback changes on a credential.
-   * @param {CredentialModel} credential
-   */
-  @action
-  cancel(credential) {
-    const { isNew } = credential;
-    credential.rollbackAttributes();
-    if (isNew)
-      this.router.transitionTo(
-        'scopes.scope.credential-stores.credential-store.credentials',
-      );
-  }
-
-  /**
-   * Handle save of a credential
-   * @param {CredentialModel} credential
-   */
-  @action
-  @loading
-  @notifyError(({ message }) => message)
-  @notifySuccess(({ isNew }) =>
-    isNew ? 'notifications.create-success' : 'notifications.save-success',
-  )
-  async save(credential) {
-    await credential.save();
-    if (this.can.can('read model', credential)) {
-      await this.router.transitionTo(
-        'scopes.scope.credential-stores.credential-store.credentials.credential',
-        credential,
-      );
-    } else {
-      await this.router.transitionTo(
-        'scopes.scope.credential-stores.credential-store.credentials',
-      );
-    }
-    this.refresh();
-  }
-  /**
-   * Handle delete of a credential
-   * @param {Credential} credential
-   */
-  @action
-  @loading
-  @confirm('questions.delete-confirm')
-  @notifyError(({ message }) => message, { catch: true })
-  @notifySuccess('notifications.delete-success')
-  async deleteCredential(credential) {
-    await credential.destroyRecord();
-    await this.router.replaceWith(
-      'scopes.scope.credential-stores.credential-store.credentials',
-    );
-    this.refresh();
   }
 }

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials/new.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials/new.js
@@ -4,7 +4,6 @@
  */
 
 import Route from '@ember/routing/route';
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialsNewRoute extends Route {
@@ -76,14 +75,5 @@ export default class ScopesScopeCredentialStoresCredentialStoreCredentialsNewRou
       description,
       ...typeSpecificAttrs,
     });
-  }
-
-  /**
-   * Update type of credential
-   * @param {string} type
-   */
-  @action
-  changeType(type) {
-    this.router.replaceWith({ queryParams: { type } });
   }
 }

--- a/ui/admin/app/routes/scopes/scope/credential-stores/new.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/new.js
@@ -4,7 +4,6 @@
  */
 
 import Route from '@ember/routing/route';
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresNewRoute extends Route {
@@ -62,14 +61,5 @@ export default class ScopesScopeCredentialStoresNewRoute extends Route {
     });
     record.scopeModel = scopeModel;
     return record;
-  }
-
-  /**
-   * Update type of credential store
-   * @param {string} type
-   */
-  @action
-  changeType(type) {
-    this.router.replaceWith({ queryParams: { type } });
   }
 }

--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index.hbs
@@ -38,7 +38,7 @@
         <dropdown.button
           @style='danger'
           @disabled={{@model.canSave}}
-          {{on 'click' (route-action 'deleteCredentialLibrary' @model)}}
+          {{on 'click' (fn this.credentialLibraries.delete @model)}}
         >
           {{t 'resources.credential-library.actions.delete'}}
         </dropdown.button>
@@ -49,9 +49,9 @@
   <page.body>
     <Form::CredentialLibrary
       @model={{@model}}
-      @edit={{route-action 'edit' @model}}
-      @submit={{route-action 'save' @model}}
-      @cancel={{route-action 'cancel' @model}}
+      @edit={{fn this.credentialLibraries.edit @model}}
+      @submit={{fn this.credentialLibraries.save @model}}
+      @cancel={{fn this.credentialLibraries.cancel @model}}
     />
   </page.body>
 </Rose::Layout::Page>

--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credential-libraries/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credential-libraries/index.hbs
@@ -22,6 +22,7 @@
   <page.actions>
     <CredentialStores::CredentialStore::Actions
       @model={{this.credentialStore}}
+      @delete={{fn this.credentialStores.delete this.credentialStore}}
     />
   </page.actions>
 

--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credential-libraries/new.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credential-libraries/new.hbs
@@ -26,9 +26,9 @@
   <page.body>
     <Form::CredentialLibrary
       @model={{@model}}
-      @submit={{route-action 'save' @model}}
-      @cancel={{route-action 'cancel' @model}}
-      @changeType={{route-action 'changeType'}}
+      @submit={{fn this.credentialLibraries.save @model}}
+      @cancel={{fn this.credentialLibraries.cancel @model}}
+      @changeType={{this.credentialLibraries.changeType}}
     />
   </page.body>
 </Rose::Layout::Page>

--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/credential/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/credential/index.hbs
@@ -38,7 +38,7 @@
         <dropdown.button
           @style='danger'
           @disabled={{@model.canSave}}
-          {{on 'click' (route-action 'deleteCredential' @model)}}
+          {{on 'click' (fn this.credentials.delete @model)}}
         >
           {{t 'resources.credential.actions.delete'}}
         </dropdown.button>
@@ -49,8 +49,8 @@
   <page.body>
     <Form::Credential
       @model={{@model}}
-      @submit={{route-action 'save' @model}}
-      @cancel={{route-action 'cancel' @model}}
+      @submit={{fn this.credentials.save @model}}
+      @cancel={{fn this.credentials.cancel @model}}
     />
   </page.body>
 </Rose::Layout::Page>

--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/index.hbs
@@ -22,6 +22,7 @@
   <page.actions>
     <CredentialStores::CredentialStore::Actions
       @model={{this.credentialStore}}
+      @delete={{fn this.credentialStores.delete this.credentialStore}}
     />
   </page.actions>
 

--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/new.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/credentials/new.hbs
@@ -26,9 +26,9 @@
   <page.body>
     <Form::Credential
       @model={{@model}}
-      @submit={{route-action 'save' @model}}
-      @cancel={{route-action 'cancel' @model}}
-      @changeType={{route-action 'changeType'}}
+      @submit={{fn this.credentials.save @model}}
+      @cancel={{fn this.credentials.cancel @model}}
+      @changeType={{this.credentials.changeType}}
     />
   </page.body>
 </Rose::Layout::Page>

--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/index.hbs
@@ -18,14 +18,17 @@
   </page.navigation>
 
   <page.actions>
-    <CredentialStores::CredentialStore::Actions @model={{@model}} />
+    <CredentialStores::CredentialStore::Actions
+      @model={{@model}}
+      @delete={{fn this.credentialStores.delete @model}}
+    />
   </page.actions>
 
   <page.body>
     <Form::CredentialStore
       @model={{@model}}
-      @submit={{route-action 'save' @model}}
-      @cancel={{route-action 'cancel' @model}}
+      @submit={{fn this.credentialStores.save @model}}
+      @cancel={{fn this.credentialStores.cancel @model}}
     />
   </page.body>
 </Rose::Layout::Page>

--- a/ui/admin/app/templates/scopes/scope/credential-stores/new.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/new.hbs
@@ -25,9 +25,9 @@
   <page.body>
     <Form::CredentialStore
       @model={{@model}}
-      @submit={{route-action 'save' @model}}
-      @cancel={{route-action 'cancel' @model}}
-      @changeType={{route-action 'changeType'}}
+      @submit={{fn this.credentialStores.save @model}}
+      @cancel={{fn this.credentialStores.cancel @model}}
+      @changeType={{this.credentialStores.changeType}}
     />
   </page.body>
 

--- a/ui/admin/tests/acceptance/credential-store/credentials/update-test.js
+++ b/ui/admin/tests/acceptance/credential-store/credentials/update-test.js
@@ -23,6 +23,8 @@ module(
     setupApplicationTest(hooks);
     setupMirage(hooks);
 
+    let featuresService;
+
     const instances = {
       scopes: {
         global: null,
@@ -83,6 +85,8 @@ module(
       urls.usernamePasswordCredential = `${urls.credentials}/${instances.usernamePasswordCredential.id}`;
       urls.usernameKeyPairCredential = `${urls.credentials}/${instances.usernameKeyPairCredential.id}`;
       urls.jsonCredential = `${urls.credentials}/${instances.jsonCredential.id}`;
+
+      featuresService = this.owner.lookup('service:features');
       authenticateSession({});
     });
 
@@ -117,6 +121,7 @@ module(
     });
 
     test('can save changes to existing JSON credential', async function (assert) {
+      featuresService.enable('json-credentials');
       const mockInput = 'random string';
       assert.notEqual(instances.jsonCredential.name, mockInput);
       await visit(urls.jsonCredential);

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'admin/tests/helpers';
+import { setupTest } from 'ember-qunit';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'admin/tests/helpers';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module(
+  'Unit | Controller | scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index',
+  function (hooks) {
+    setupTest(hooks);
+
+    test('it exists', function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/credential-stores/credential-store/credential-libraries/credential-library/index',
+      );
+      assert.ok(controller);
+    });
+  },
+);

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/index-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'admin/tests/helpers';
+import { setupTest } from 'ember-qunit';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/credential-libraries/index',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/index-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module(
+  'Unit | Controller | scopes/scope/credential-stores/credential-store/credential-libraries/index',
+  function (hooks) {
+    setupTest(hooks);
+
+    test('it exists', function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/credential-stores/credential-store/credential-libraries/index',
+      );
+      assert.ok(controller);
+    });
+  },
+);

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/index-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'admin/tests/helpers';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/credential-libraries/index',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/new-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/new-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupTest } from 'admin/tests/helpers';
+import { setupTest } from 'ember-qunit';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/credential-libraries/new',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/new-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/new-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'admin/tests/helpers';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/credential-libraries/new',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/credential/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/credential/index-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'admin/tests/helpers';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/credentials/credential/index',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/credential/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/credential/index-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module(
+  'Unit | Controller | scopes/scope/credential-stores/credential-store/credentials/credential/index',
+  function (hooks) {
+    setupTest(hooks);
+
+    test('it exists', function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/credential-stores/credential-store/credentials/credential/index',
+      );
+      assert.ok(controller);
+    });
+  },
+);

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/credential/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/credential/index-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'admin/tests/helpers';
+import { setupTest } from 'ember-qunit';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/credentials/credential/index',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/index-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'admin/tests/helpers';
+import { setupTest } from 'ember-qunit';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/credentials/index',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/index-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'admin/tests/helpers';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/credentials/index',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/index-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module(
+  'Unit | Controller | scopes/scope/credential-stores/credential-store/credentials/index',
+  function (hooks) {
+    setupTest(hooks);
+
+    test('it exists', function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/credential-stores/credential-store/credentials/index',
+      );
+      assert.ok(controller);
+    });
+  },
+);

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/new-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/new-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'admin/tests/helpers';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/credentials/new',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/new-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/credentials/new-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupTest } from 'admin/tests/helpers';
+import { setupTest } from 'ember-qunit';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/credentials/new',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/index-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'admin/tests/helpers';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/index',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/index-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module(
+  'Unit | Controller | scopes/scope/credential-stores/credential-store/index',
+  function (hooks) {
+    setupTest(hooks);
+
+    test('it exists', function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/credential-stores/credential-store/index',
+      );
+      assert.ok(controller);
+    });
+  },
+);

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/credential-store/index-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'admin/tests/helpers';
+import { setupTest } from 'ember-qunit';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/credential-store/index',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/index-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'admin/tests/helpers';
+import { setupTest } from 'ember-qunit';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/index',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/index-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module(
+  'Unit | Controller | scopes/scope/credential-stores/index',
+  function (hooks) {
+    setupTest(hooks);
+
+    test('it exists', function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/credential-stores/index',
+      );
+      assert.ok(controller);
+    });
+  },
+);

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/index-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'admin/tests/helpers';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/index',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/new-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/new-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupTest } from 'admin/tests/helpers';
+import { setupTest } from 'ember-qunit';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/new',

--- a/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/new-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/credential-stores/new-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'admin/tests/helpers';
 
 module(
   'Unit | Controller | scopes/scope/credential-stores/new',


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12604

## Description

<!-- Add a brief description of changes here -->
Remove route-action usage from credential-stores, credentials, and credential-libraries.

## How to Test

<!-- Add steps to test this change. Include any other necessary relevant links -->
1. Start boundary dev instance
2. Test CRUDL for credential stores
3. Test CRUDL for credentials
4. Test CRUDL for credential-libraries
Note: for vault cred stores you can use steps in [this doc](https://docs.google.com/document/d/1k1NFIu7HpljSM38gwSjADjKsi2tiMJdJqklhKib4WZU/edit) to start the vault server and to create the vault token used in the vault cred store creation form.
<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)


## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
