### PR TITLE
fix: 🐛 update destination path for autoUpdater workflow

### DIFF
--- a/ui/desktop/electron-app/src/helpers/app-updater.js
+++ b/ui/desktop/electron-app/src/helpers/app-updater.js
@@ -62,10 +62,10 @@ const createAppUpdaterConfig = (url, version, destination) => {
 };
 
 const downloadAndInstallUpdate = async (version, url) => {
-  const destination = path.resolve(__dirname, '..', 'nextVersion');
-  if (!fs.existsSync(destination)) fs.mkdirSync(destination);
-
   try {
+    const destination = path.resolve(process.resourcesPath, 'nextVersion');
+    if (!fs.existsSync(destination)) fs.mkdirSync(destination);
+
     const configPath = createAppUpdaterConfig(url, version, destination);
     autoUpdater.on('update-downloaded', () => {
       const dialogOpts = {


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12878

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-12878)

## Description

Our update process in the desktop client was running into conflicts with our ASAR changes we made for the `1.7.0` release. The autoUpdater workflow was trying to store update specific data in a directory that no longer exist. We changed the destination for the update specific data and the workflow is no longer erroring out. We also moved the destination logic inside the try catch so we can catch the error if one is thrown.

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

## How to Test

To properly test this, you will need a signed build of the desktop client. AutoUpdater will not work without it. Please use a signed artifact from this [build](https://github.com/hashicorp/boundary-ui-releases/actions/runs/8255809808) to test.


## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] ~I have added before and after screenshots for UI changes~
- [ ] ~I have added JSON response output for API changes~
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] ~I have commented on my code, particularly in hard-to-understand areas~
- [ ] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
