### PR TITLE
feat: 🎸 mirage support and initial route for aliases

### DIFF
--- a/addons/api/addon/generated/models/alias.js
+++ b/addons/api/addon/generated/models/alias.js
@@ -50,6 +50,7 @@ export default class GeneratedAliasModel extends BaseModel {
   destination_id;
 
   @attr('object', {
+    isNestedAttribute: true,
     description:
       'This contains a host_id which is the id of the host that the session will be authorized for.',
   })

--- a/addons/api/addon/generated/models/alias.js
+++ b/addons/api/addon/generated/models/alias.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import BaseModel from '../../models/base';
+import { attr } from '@ember-data/model';
+
+/**
+ * Alias contains all fields related to an Alias resource
+ */
+export default class GeneratedAliasModel extends BaseModel {
+  // =attributes
+
+  @attr('string', {
+    description: 'The type of the resource, to help differentiate schemas',
+  })
+  type;
+
+  @attr('string', {
+    description: 'Optional name for identification purposes.',
+  })
+  name;
+
+  @attr('string', {
+    description: 'Optional user-set description for identification purposes.',
+  })
+  description;
+
+  @attr('date', {
+    description: 'The time this resource was created\nOutput only.',
+    readOnly: true,
+  })
+  created_time;
+
+  @attr('date', {
+    description: 'The time this resource was last updated\nOutput only.',
+    readOnly: true,
+  })
+  updated_time;
+
+  @attr('number', {
+    description: 'Current version number of this resource.',
+  })
+  version;
+
+  @attr('string', {
+    description: 'This is the id of the resource that this Alias points to.',
+  })
+  destination_id;
+
+  @attr('object', {
+    description:
+      'This contains a host_id which is the id of the host that the session will be authorized for.',
+  })
+  authorize_session_arguments;
+}

--- a/addons/api/addon/models/alias.js
+++ b/addons/api/addon/models/alias.js
@@ -5,5 +5,6 @@
 
 import GeneratedAliasModel from '../generated/models/alias';
 
-export const TYPE_ALIAS = 'target';
+export const TYPE_ALIAS_TARGET = 'target';
+export const TYPES_ALIAS = Object.freeze([TYPE_ALIAS_TARGET]);
 export default class AliasModel extends GeneratedAliasModel {}

--- a/addons/api/addon/models/alias.js
+++ b/addons/api/addon/models/alias.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import GeneratedAliasModel from '../generated/models/alias';
+
+export const TYPE_ALIAS = 'target';
+export default class AliasModel extends GeneratedAliasModel {}

--- a/addons/api/app/models/alias.js
+++ b/addons/api/app/models/alias.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export { default } from 'api/models/alias';

--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -753,6 +753,22 @@ function routes() {
     return policies.create(attrs);
   });
 
+  // Alias
+  this.get(
+    '/aliases',
+    ({ aliases }, { queryParams: { scope_id: scopeId } }) => {
+      return aliases.where({ scopeId });
+    },
+  );
+  this.get('/aliases/:id');
+  this.del('/aliases/:id');
+  this.patch('/aliases/:id');
+  this.post('/aliases', function ({ aliases }) {
+    const attrs = this.normalizedRequestAttrs();
+
+    return aliases.create(attrs);
+  });
+
   // session recordings
   this.get(
     '/session-recordings',

--- a/addons/api/mirage/factories/alias.js
+++ b/addons/api/mirage/factories/alias.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import factory from '../generated/factories/alias';
+import permissions from '../helpers/permissions';
+import generateId from '../helpers/id';
+
+export default factory.extend({
+  id: () => generateId('alt_'),
+
+  authorized_actions: () =>
+    permissions.authorizedActionsFor('alias') || [
+      'no-op',
+      'read',
+      'update',
+      'delete',
+    ],
+});

--- a/addons/api/mirage/factories/alias.js
+++ b/addons/api/mirage/factories/alias.js
@@ -7,9 +7,11 @@ import factory from '../generated/factories/alias';
 import permissions from '../helpers/permissions';
 import generateId from '../helpers/id';
 
+const destinationIDs = ['', generateId('t_')];
+
 export default factory.extend({
   id: () => generateId('alt_'),
-
+  destination_id: (i) => destinationIDs[i % destinationIDs.length],
   authorized_actions: () =>
     permissions.authorizedActionsFor('alias') || [
       'no-op',

--- a/addons/api/mirage/factories/scope.js
+++ b/addons/api/mirage/factories/scope.js
@@ -33,13 +33,13 @@ export default factory.extend({
       roles: ['create', 'list'],
     };
 
-    // Worker permissions only available on the global scope
+    // Resources that are available only on the global scope
     if (this.type === 'global') {
       collectionActions.workers = ['create:worker-led', 'list'];
       collectionActions.aliases = ['create', 'list'];
     }
 
-    // Session recording resources are only available on global or org scope
+    // Resources that are only available on the global or the org scope
     if (this.type === 'global' || this.type === 'org') {
       collectionActions['storage-buckets'] = ['create', 'list'];
       collectionActions['session-recordings'] = ['list'];

--- a/addons/api/mirage/factories/scope.js
+++ b/addons/api/mirage/factories/scope.js
@@ -36,6 +36,7 @@ export default factory.extend({
     // Worker permissions only available on the global scope
     if (this.type === 'global') {
       collectionActions.workers = ['create:worker-led', 'list'];
+      collectionActions.aliases = ['create', 'list'];
     }
 
     // Session recording resources are only available on global or org scope

--- a/addons/api/mirage/generated/factories/alias.js
+++ b/addons/api/mirage/generated/factories/alias.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { Factory } from 'miragejs';
+import { faker } from '@faker-js/faker';
+
+/**
+ * GeneratedAliasModelFactory
+ */
+export default Factory.extend({
+  name: () => faker.word.words(),
+  type: 'target',
+  value: () => faker.word.words(),
+  description: () => faker.word.words(),
+  created_time: () => faker.date.recent(),
+  updated_time: () => faker.date.recent(),
+  version: () => faker.number.int(),
+});

--- a/addons/api/mirage/generated/factories/alias.js
+++ b/addons/api/mirage/generated/factories/alias.js
@@ -5,13 +5,14 @@
 
 import { Factory } from 'miragejs';
 import { faker } from '@faker-js/faker';
+import { TYPE_ALIAS_TARGET } from 'api/models/alias';
 
 /**
  * GeneratedAliasModelFactory
  */
 export default Factory.extend({
   name: () => faker.word.words(),
-  type: 'target',
+  type: TYPE_ALIAS_TARGET,
   value: () => faker.word.words(),
   description: () => faker.word.words(),
   created_time: () => faker.date.recent(),

--- a/addons/api/mirage/models/alias.js
+++ b/addons/api/mirage/models/alias.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { belongsTo } from 'miragejs';
+import Model from './base';
+
+export default Model.extend({
+  scope: belongsTo(),
+});

--- a/addons/api/mirage/scenarios/default.js
+++ b/addons/api/mirage/scenarios/default.js
@@ -108,6 +108,9 @@ export default function (server) {
   server.createList('policy', 3, { scope: globalScope });
   server.createList('policy', 3, { scope: orgScope });
 
+  // Aliases
+  server.createList('alias', 3, { scope: globalScope });
+
   // Other resources
   server.schema.scopes.where({ type: 'project' }).models.forEach((scope) => {
     server.createList('host-catalog', 8, { scope }, 'withChildren');

--- a/addons/api/tests/unit/models/alias-test.js
+++ b/addons/api/tests/unit/models/alias-test.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | alias', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('alias', {});
+    assert.ok(model);
+  });
+});

--- a/ui/admin/app/router.js
+++ b/ui/admin/app/router.js
@@ -95,6 +95,11 @@ Router.map(function () {
         this.route('new');
       });
 
+      this.route('aliases', function () {
+        this.route('new');
+        this.route('alias', { path: ':alias_id' }, function () {});
+      });
+
       this.route('host-catalogs', function () {
         this.route('new');
         this.route('host-catalog', { path: ':host_catalog_id' }, function () {

--- a/ui/admin/app/routes/scopes/scope/aliases.js
+++ b/ui/admin/app/routes/scopes/scope/aliases.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class ScopesScopeAliasesRoute extends Route {
+  // =services
+
+  @service store;
+  @service session;
+  @service can;
+  @service router;
+
+  // =methods
+
+  /**
+   * If arriving here unauthenticated, redirect to index for further processing.
+   */
+  beforeModel() {
+    if (!this.session.isAuthenticated) this.router.transitionTo('index');
+  }
+
+  /**
+   * Load all aliases in current scope
+   * @return {Promise<[AliasModel]>}
+   */
+  async model() {
+    const scope = this.modelFor('scopes.scope');
+    const { id: scope_id } = scope;
+
+    if (
+      this.can.can('list model', scope, {
+        collection: 'aliases',
+      })
+    ) {
+      return this.store.query('alias', { scope_id });
+    }
+  }
+}


### PR DESCRIPTION
 Jira - https://hashicorp.atlassian.net/browse/ICU-12932, https://hashicorp.atlassian.net/browse/ICU-12934

## Description

This PR adds an initial list route and mirage support for alias resources. 

## Screenshots (if appropriate):
 
![Untitled](https://github.com/hashicorp/boundary-ui/assets/15043878/2779e526-8467-483f-a0e5-3cd69b2978bf)

## How to Test

- Using mirage, go to /scopes/global/aliases and look at the dev console to see the generated mirage data

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- [x] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
