### PR TITLE
test(e2e): Admin UI test fixes

### DIFF
--- a/ui/admin/tests/e2e/playwright.config.js
+++ b/ui/admin/tests/e2e/playwright.config.js
@@ -10,7 +10,7 @@ const { devices } = require('@playwright/test');
 const config = {
   globalSetup: require.resolve('./global-setup'),
   outputDir: './artifacts/test-failures',
-  timeout: 60000, // Each test is given 60s to complete
+  timeout: 90000, // Each test is given 90s to complete
   workers: 1, // Tests need to be run in serial, otherwise there may be conflicts when using the CLI
   use: {
     baseURL: process.env.BOUNDARY_ADDR,

--- a/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
@@ -11,6 +11,7 @@ const { checkEnv, authenticatedState } = require('../helpers/general');
 const {
   authenticateBoundaryCli,
   checkBoundaryCli,
+  deleteOrgCli,
 } = require('../helpers/boundary-cli');
 const { checkVaultCli } = require('../helpers/vault-cli');
 const {


### PR DESCRIPTION
This PR addresses 2 issues in the Admin UI test suite
- The timeout for each test was bumped from 60s to 90s. It was observed that one of the tests (deleting resources) was sometimes taking longer than the current timeout and failing.
- Adds a missing import to a test