### PR TITLE
refact(e2e): Move env outside of helper methods

### DIFF
--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -118,15 +118,16 @@ exports.createNewHostSet = async (page) => {
 /**
  * Uses the UI to create a new host in a host set. Assumes you have just created a new host set.
  * @param {Page} page Playwright page object
+ * @param {string} address Address of the host
  * @returns Name of the host
  */
-exports.createNewHostInHostSet = async (page) => {
+exports.createNewHostInHostSet = async (page, address) => {
   const hostName = 'Host ' + nanoid();
   await page.getByText('Manage').click();
   await page.getByRole('link', { name: 'Create and Add Host' }).click();
   await page.getByLabel('Name').fill(hostName);
   await page.getByLabel('Description').fill('This is an automated test');
-  await page.getByLabel('Address').fill(process.env.E2E_TARGET_ADDRESS);
+  await page.getByLabel('Address').fill(address);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
     page.getByRole('alert').getByText('Success', { exact: true }),
@@ -169,10 +170,11 @@ exports.createStaticCredentialStore = async (page) => {
 /**
  * Uses the UI to create a vault credential store. Assumes you have selected the desired project.
  * @param {Page} page Playwright page object
+ * @param {string} vaultAddr address of the vault server
  * @param {string} clientToken vault token to connect to boundary
  * @returns Name of the credential store
  */
-exports.createVaultCredentialStore = async (page, clientToken) => {
+exports.createVaultCredentialStore = async (page, vaultAddr, clientToken) => {
   const credentialStoreName = 'Credential Store ' + nanoid();
   await page
     .getByRole('navigation', { name: 'Resources' })
@@ -182,9 +184,7 @@ exports.createVaultCredentialStore = async (page, clientToken) => {
   await page.getByLabel('Name', { exact: true }).fill(credentialStoreName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('group', { name: 'Type' }).getByLabel('Vault').click();
-  await page
-    .getByLabel('Address', { exact: true })
-    .fill(process.env.E2E_VAULT_ADDR);
+  await page.getByLabel('Address', { exact: true }).fill(vaultAddr);
   await page.getByLabel('Token', { exact: true }).fill(clientToken);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
@@ -203,9 +203,11 @@ exports.createVaultCredentialStore = async (page, clientToken) => {
 /**
  * Uses the UI to create a static key pair credential . Assumes you have selected the desired project.
  * @param {Page} page Playwright page object
+ * @param {string} username username for the credential
+ * @param {string} keyPath path to the private key
  * @returns Name of the credential
  */
-exports.createStaticCredentialKeyPair = async (page) => {
+exports.createStaticCredentialKeyPair = async (page, username, keyPath) => {
   const credentialName = 'Credential ' + nanoid();
   await page.getByRole('link', { name: 'Credentials', exact: true }).click();
   await page.getByRole('link', { name: 'New', exact: true }).click();
@@ -215,10 +217,8 @@ exports.createStaticCredentialKeyPair = async (page) => {
     .getByRole('group', { name: 'Type' })
     .getByLabel('Username & Key Pair')
     .click();
-  await page
-    .getByLabel('Username', { exact: true })
-    .fill(process.env.E2E_SSH_USER);
-  const keyData = await readFile(process.env.E2E_SSH_KEY_PATH, {
+  await page.getByLabel('Username', { exact: true }).fill(username);
+  const keyData = await readFile(keyPath, {
     encoding: 'utf-8',
   });
   await page.getByLabel('SSH Private Key', { exact: true }).fill(keyData);
@@ -281,11 +281,13 @@ exports.createVaultGenericCredentialLibrary = async (
  * the desired credential store.
  * @param {Page} page Playwright page object
  * @param {string} vaultPath path to secret in vault
+ * @param {string} username username for the credential
  * @returns Name of the credential library
  */
 exports.createVaultSshCertificateCredentialLibrary = async (
   page,
   vaultPath,
+  username,
 ) => {
   const credentialLibraryName = 'Credential Library ' + nanoid();
 
@@ -306,7 +308,7 @@ exports.createVaultSshCertificateCredentialLibrary = async (
     .getByLabel('Description (Optional)')
     .fill('This is an automated test');
   await page.getByLabel('Vault Path').fill(vaultPath);
-  await page.getByLabel('Username').fill(process.env.E2E_SSH_USER);
+  await page.getByLabel('Username').fill(username);
   await page.getByLabel('Key Type').selectOption('ecdsa');
   await page.getByLabel('Key Bits').fill('521');
 
@@ -331,9 +333,10 @@ exports.createVaultSshCertificateCredentialLibrary = async (
 /**
  * Uses the UI to create a new target. Assumes you have selected the desired project.
  * @param {Page} page Playwright page object
+ * @param {string} port Port of the target
  * @returns Name of the target
  */
-exports.createNewTarget = async (page) => {
+exports.createNewTarget = async (page, port) => {
   const targetName = 'Target ' + nanoid();
   await page
     .getByRole('navigation', { name: 'Resources' })
@@ -342,7 +345,7 @@ exports.createNewTarget = async (page) => {
   await page.getByRole('link', { name: 'New', exact: true }).click();
   await page.getByLabel('Name').fill(targetName);
   await page.getByLabel('Description').fill('This is an automated test');
-  await page.getByLabel('Default Port').fill(process.env.E2E_TARGET_PORT);
+  await page.getByLabel('Default Port').fill(port);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
     page.getByRole('alert').getByText('Success', { exact: true }),
@@ -358,9 +361,11 @@ exports.createNewTarget = async (page) => {
 /**
  * Uses the UI to create a new target with address. Assumes you have selected the desired project.
  * @param {Page} page Playwright page object
+ * @param {string} address Address of the target
+ * @param {string} port Port of the target
  * @returns Name of the target
  */
-exports.createNewTargetWithAddress = async (page) => {
+exports.createNewTargetWithAddress = async (page, address, port) => {
   const targetName = 'Target ' + nanoid();
   await page
     .getByRole('navigation', { name: 'Resources' })
@@ -369,8 +374,8 @@ exports.createNewTargetWithAddress = async (page) => {
   await page.getByRole('link', { name: 'New', exact: true }).click();
   await page.getByLabel('Name').fill(targetName);
   await page.getByLabel('Description').fill('This is an automated test');
-  await page.getByLabel('Target Address').fill(process.env.E2E_TARGET_ADDRESS);
-  await page.getByLabel('Default Port').fill(process.env.E2E_TARGET_PORT);
+  await page.getByLabel('Target Address').fill(address);
+  await page.getByLabel('Default Port').fill(port);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
     page.getByRole('alert').getByText('Success', { exact: true }),
@@ -387,9 +392,11 @@ exports.createNewTargetWithAddress = async (page) => {
  * Uses the UI to create a new TCP target with address in boundary-enterprise
  * Assumes you have selected the desired project.
  * @param {Page} page Playwright page object
+ * @param {string} address Address of the target
+ * @param {string} port Port of the target
  * @returns Name of the target
  */
-exports.createTcpTargetWithAddressEnt = async (page) => {
+exports.createTcpTargetWithAddressEnt = async (page, address, port) => {
   const targetName = 'Target ' + nanoid();
   await page
     .getByRole('navigation', { name: 'Resources' })
@@ -399,8 +406,8 @@ exports.createTcpTargetWithAddressEnt = async (page) => {
   await page.getByLabel('Name').fill(targetName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('group', { name: 'Type' }).getByLabel('TCP').click();
-  await page.getByLabel('Target Address').fill(process.env.E2E_TARGET_ADDRESS);
-  await page.getByLabel('Default Port').fill(process.env.E2E_TARGET_PORT);
+  await page.getByLabel('Target Address').fill(address);
+  await page.getByLabel('Default Port').fill(port);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
     page.getByRole('alert').getByText('Success', { exact: true }),
@@ -417,9 +424,11 @@ exports.createTcpTargetWithAddressEnt = async (page) => {
  * Uses the UI to create a new SSH target with address in boundary-enterprise
  * Assumes you have selected the desired project.
  * @param {Page} page Playwright page object
+ * @param {string} address Address of the target
+ * @param {string} port Port of the target
  * @returns Name of the target
  */
-exports.createSshTargetWithAddressEnt = async (page) => {
+exports.createSshTargetWithAddressEnt = async (page, address, port) => {
   const targetName = 'Target ' + nanoid();
   await page
     .getByRole('navigation', { name: 'Resources' })
@@ -429,8 +438,8 @@ exports.createSshTargetWithAddressEnt = async (page) => {
   await page.getByLabel('Name').fill(targetName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('group', { name: 'Type' }).getByLabel('SSH').click();
-  await page.getByLabel('Target Address').fill(process.env.E2E_TARGET_ADDRESS);
-  await page.getByLabel('Default Port').fill(process.env.E2E_TARGET_PORT);
+  await page.getByLabel('Target Address').fill(address);
+  await page.getByLabel('Default Port').fill(port);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
     page.getByRole('alert').getByText('Success', { exact: true }),
@@ -907,25 +916,32 @@ exports.addGrantsToGroup = async (page, grants) => {
 /**
  * Uses the UI to create a new Storage Bucket. Assumes you have selected the desired scope.
  * @param {Page} page Playwright page object
+ * @param {string} bucketName Name of the Storage Bucket
+ * @param {string} region Region of the Storage Bucket
+ * @param {string} accessKeyId Access Key ID for the Storage Bucket
+ * @param {string} secretAccessKey Secret Access Key for the Storage Bucket
+ * @param {string} workerFilter Worker filter for the Storage Bucket
  * @returns Name of the Storage Bucket
  */
-exports.createStorageBucket = async (page) => {
+exports.createStorageBucket = async (
+  page,
+  bucketName,
+  region,
+  accessKeyId,
+  secretAccessKey,
+  workerFilter,
+) => {
   const storageBucketName = 'Bucket ' + nanoid();
   await page
     .getByRole('link', { name: 'Storage Buckets', exact: true })
     .click();
   await page.getByRole('link', { name: 'New Storage Bucket' }).click();
   await page.getByLabel(new RegExp('Name*')).fill(storageBucketName);
-  await page.getByLabel('Bucket name').fill(process.env.E2E_AWS_BUCKET_NAME);
-  await page.getByLabel('Region').fill(process.env.E2E_AWS_REGION);
-  await page
-    .getByLabel('Access key ID')
-    .fill(process.env.E2E_AWS_ACCESS_KEY_ID);
-  await page
-    .getByLabel('Secret access key')
-    .fill(process.env.E2E_AWS_SECRET_ACCESS_KEY);
-  const workerTag = `"${process.env.E2E_WORKER_TAG_EGRESS}" in "/tags/type"`;
-  await page.getByLabel('Worker filter').fill(workerTag);
+  await page.getByLabel('Bucket name').fill(bucketName);
+  await page.getByLabel('Region').fill(region);
+  await page.getByLabel('Access key ID').fill(accessKeyId);
+  await page.getByLabel('Secret access key').fill(secretAccessKey);
+  await page.getByLabel('Worker filter').fill(workerFilter);
   await page.getByLabel('Disable credential rotation').click();
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(

--- a/ui/admin/tests/e2e/tests/auth-method-ldap.spec.js
+++ b/ui/admin/tests/e2e/tests/auth-method-ldap.spec.js
@@ -43,7 +43,12 @@ test('Set up LDAP auth method @ce @ent @docker', async ({ page }) => {
   try {
     // Create an org
     const orgName = await createNewOrg(page);
-    await authenticateBoundaryCli();
+    await authenticateBoundaryCli(
+      process.env.BOUNDARY_ADDR,
+      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     org = orgs.items.filter((obj) => obj.name == orgName)[0];
 

--- a/ui/admin/tests/e2e/tests/auth-method-password.spec.js
+++ b/ui/admin/tests/e2e/tests/auth-method-password.spec.js
@@ -35,7 +35,12 @@ test('Verify new auth-method can be created and assigned to users @ce @ent @aws 
   let org;
   try {
     const orgName = await createNewOrg(page);
-    await authenticateBoundaryCli();
+    await authenticateBoundaryCli(
+      process.env.BOUNDARY_ADDR,
+      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     org = orgs.items.filter((obj) => obj.name == orgName)[0];
     await createNewPasswordAuthMethod(page, 'UI Test Auth Method');

--- a/ui/admin/tests/e2e/tests/credential-store-static.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static.spec.js
@@ -50,8 +50,8 @@ test.beforeEach(async ({ page }) => {
   projectName = await createNewProject(page);
   await createNewHostCatalog(page);
   const hostSetName = await createNewHostSet(page);
-  await createNewHostInHostSet(page);
-  targetName = await createNewTarget(page);
+  await createNewHostInHostSet(page, process.env.E2E_TARGET_ADDRESS);
+  targetName = await createNewTarget(page, process.env.E2E_TARGET_PORT);
   await addHostSourceToTarget(page, hostSetName);
   await createStaticCredentialStore(page);
 });
@@ -59,7 +59,11 @@ test.beforeEach(async ({ page }) => {
 test('Static Credential Store (User & Key Pair) @ce @aws @docker', async ({
   page,
 }) => {
-  const credentialName = await createStaticCredentialKeyPair(page);
+  const credentialName = await createStaticCredentialKeyPair(
+    page,
+    process.env.E2E_SSH_USER,
+    process.env.E2E_SSH_KEY_PATH,
+  );
   await addBrokeredCredentialsToTarget(page, targetName, credentialName);
 
   await authenticateBoundaryCli();

--- a/ui/admin/tests/e2e/tests/credential-store-static.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static.spec.js
@@ -66,7 +66,12 @@ test('Static Credential Store (User & Key Pair) @ce @aws @docker', async ({
   );
   await addBrokeredCredentialsToTarget(page, targetName, credentialName);
 
-  await authenticateBoundaryCli();
+  await authenticateBoundaryCli(
+    process.env.BOUNDARY_ADDR,
+    process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+    process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+    process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+  );
   const session = await getSessionCli(orgName, projectName, targetName);
   const retrievedUser = session.item.credentials[0].credential.username;
   const retrievedKey = session.item.credentials[0].credential.private_key;
@@ -118,7 +123,12 @@ test('Static Credential Store (Username & Password) @ce @aws @docker', async ({
 
   await addBrokeredCredentialsToTarget(page, targetName, credentialName);
 
-  await authenticateBoundaryCli();
+  await authenticateBoundaryCli(
+    process.env.BOUNDARY_ADDR,
+    process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+    process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+    process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+  );
   const session = await getSessionCli(orgName, projectName, targetName);
   const retrievedUser = session.item.credentials[0].credential.username;
   const retrievedPassword = session.item.credentials[0].credential.password;
@@ -170,7 +180,12 @@ test('Static Credential Store (JSON) @ce @aws @docker', async ({ page }) => {
 
   await addBrokeredCredentialsToTarget(page, targetName, credentialName);
 
-  await authenticateBoundaryCli();
+  await authenticateBoundaryCli(
+    process.env.BOUNDARY_ADDR,
+    process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+    process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+    process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+  );
   const session = await getSessionCli(orgName, projectName, targetName);
   const retrievedUser = session.item.credentials[0].credential.username;
   const retrievedPassword = session.item.credentials[0].credential.password;

--- a/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
@@ -100,15 +100,19 @@ test('Vault Credential Store (User & Key Pair) @ce @aws @docker', async ({
 
     await createNewHostCatalog(page);
     const hostSetName = await createNewHostSet(page);
-    await createNewHostInHostSet(page);
-    const targetName = await createNewTarget(page);
+    await createNewHostInHostSet(page, process.env.E2E_TARGET_ADDRESS);
+    const targetName = await createNewTarget(page, process.env.E2E_TARGET_PORT);
     await addHostSourceToTarget(page, hostSetName);
     const targets = JSON.parse(
       execSync(`boundary targets list -format json -scope-id ${project.id}`),
     );
     const target = targets.items.filter((obj) => obj.name == targetName)[0];
 
-    await createVaultCredentialStore(page, clientToken);
+    await createVaultCredentialStore(
+      page,
+      process.env.E2E_VAULT_ADDR,
+      clientToken,
+    );
 
     const credentialLibraryName = 'Credential Library ' + nanoid();
     await page.getByRole('link', { name: 'Credential Libraries' }).click();

--- a/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
@@ -88,7 +88,12 @@ test('Vault Credential Store (User & Key Pair) @ce @aws @docker', async ({
     const clientToken = vaultToken.auth.client_token;
 
     const orgName = await createNewOrg(page);
-    await authenticateBoundaryCli();
+    await authenticateBoundaryCli(
+      process.env.BOUNDARY_ADDR,
+      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     org = orgs.items.filter((obj) => obj.name == orgName)[0];
 

--- a/ui/admin/tests/e2e/tests/delete-resources-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/delete-resources-ent.spec.js
@@ -61,7 +61,12 @@ test.beforeAll(async () => {
 test.beforeEach(async () => {
   execSync(`vault policy delete ${secretPolicyName}`);
   execSync(`vault policy delete ${boundaryPolicyName}`);
-  await authenticateBoundaryCli();
+  await authenticateBoundaryCli(
+    process.env.BOUNDARY_ADDR,
+    process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+    process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+    process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+  );
 });
 
 test('Verify resources can be deleted (enterprise) @ent @aws', async ({
@@ -91,6 +96,7 @@ test('Verify resources can be deleted (enterprise) @ent @aws', async ({
       await createNewStaticCredentialStoreCli(projectId);
     let vaultCredentialStoreId = await createNewVaultCredentialStoreCli(
       projectId,
+      process.env.E2E_VAULT_ADDR,
       secretPolicyName,
       boundaryPolicyName,
     );

--- a/ui/admin/tests/e2e/tests/delete-resources.spec.js
+++ b/ui/admin/tests/e2e/tests/delete-resources.spec.js
@@ -60,7 +60,12 @@ test.beforeAll(async () => {
 test.beforeEach(async () => {
   execSync(`vault policy delete ${secretPolicyName}`);
   execSync(`vault policy delete ${boundaryPolicyName}`);
-  await authenticateBoundaryCli();
+  await authenticateBoundaryCli(
+    process.env.BOUNDARY_ADDR,
+    process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+    process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+    process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+  );
 });
 
 test('Verify resources can be deleted @ce @aws', async ({ page }) => {
@@ -87,6 +92,7 @@ test('Verify resources can be deleted @ce @aws', async ({ page }) => {
       await createNewStaticCredentialStoreCli(projectId);
     let vaultCredentialStoreId = await createNewVaultCredentialStoreCli(
       projectId,
+      process.env.E2E_VAULT_ADDR,
       secretPolicyName,
       boundaryPolicyName,
     );

--- a/ui/admin/tests/e2e/tests/group-role.spec.js
+++ b/ui/admin/tests/e2e/tests/group-role.spec.js
@@ -34,7 +34,12 @@ test('Verify a new role can be created and associated with a group @ce @ent @aws
   let org;
   try {
     const orgName = await createNewOrg(page);
-    await authenticateBoundaryCli();
+    await authenticateBoundaryCli(
+      process.env.BOUNDARY_ADDR,
+      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     org = orgs.items.filter((obj) => obj.name == orgName)[0];
     const groupName = 'test-group';

--- a/ui/admin/tests/e2e/tests/session-recording-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/session-recording-ent.spec.js
@@ -73,7 +73,14 @@ test('Verify session recording can be deleted @ent @aws', async ({ page }) => {
 
     // Create Storage Bucket
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
-    const storageBucketName = await createStorageBucket(page);
+    const storageBucketName = await createStorageBucket(
+      page,
+      process.env.E2E_AWS_BUCKET_NAME,
+      process.env.E2E_AWS_REGION,
+      process.env.E2E_AWS_ACCESS_KEY_ID,
+      process.env.E2E_AWS_SECRET_ACCESS_KEY,
+      `"${process.env.E2E_WORKER_TAG_EGRESS}" in "/tags/type"`,
+    );
     const storageBuckets = JSON.parse(
       execSync('boundary storage-buckets list -format json'),
     );
@@ -96,7 +103,11 @@ test('Verify session recording can be deleted @ent @aws', async ({ page }) => {
     );
     const target = targets.items.filter((obj) => obj.name == targetName)[0];
     await createStaticCredentialStore(page);
-    const credentialName = await createStaticCredentialKeyPair(page);
+    const credentialName = await createStaticCredentialKeyPair(
+      page,
+      process.env.E2E_SSH_USER,
+      process.env.E2E_SSH_KEY_PATH,
+    );
     await addInjectedCredentialsToTarget(page, targetName, credentialName);
 
     // Enable session recording for Target

--- a/ui/admin/tests/e2e/tests/session-recording-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/session-recording-ent.spec.js
@@ -55,10 +55,14 @@ test('Verify session recording can be deleted @ent @aws', async ({ page }) => {
   let storageBucket;
   let connect;
   try {
-    await authenticateBoundaryCli();
     // Create org
     const orgName = await createNewOrg(page);
-    await authenticateBoundaryCli();
+    await authenticateBoundaryCli(
+      process.env.BOUNDARY_ADDR,
+      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     const org = orgs.items.filter((obj) => obj.name == orgName)[0];
     orgId = org.id;

--- a/ui/admin/tests/e2e/tests/ssh-certificate-injection-vault-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/ssh-certificate-injection-vault-ent.spec.js
@@ -39,6 +39,7 @@ test.beforeAll(async () => {
     'VAULT_TOKEN',
     'E2E_VAULT_ADDR', // Address used by Boundary Server (could be different from VAULT_ADDR depending on network config (i.e. docker network))
     'E2E_TARGET_ADDRESS',
+    'E2E_TARGET_PORT',
     'E2E_SSH_USER',
     'E2E_SSH_CA_KEY',
     'E2E_SSH_CA_KEY_PUBLIC',
@@ -108,18 +109,27 @@ test('SSH Certificate Injection @ent @docker', async ({ page }) => {
     const project = projects.items.filter((obj) => obj.name == projectName)[0];
 
     // Create target
-    const targetName = await createSshTargetWithAddressEnt(page);
+    const targetName = await createSshTargetWithAddressEnt(
+      page,
+      process.env.E2E_TARGET_ADDRESS,
+      process.env.E2E_TARGET_PORT,
+    );
     const targets = JSON.parse(
       execSync('boundary targets list -format json -scope-id ' + project.id),
     );
     const target = targets.items.filter((obj) => obj.name == targetName)[0];
 
     // Create credentials
-    await createVaultCredentialStore(page, clientToken);
+    await createVaultCredentialStore(
+      page,
+      process.env.E2E_VAULT_ADDR,
+      clientToken,
+    );
     const credentialLibraryName =
       await createVaultSshCertificateCredentialLibrary(
         page,
         `${secretsPath}/issue/${secretName}`,
+        process.env.E2E_SSH_USER,
       );
     await addInjectedCredentialsToTarget(
       page,

--- a/ui/admin/tests/e2e/tests/ssh-certificate-injection-vault-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/ssh-certificate-injection-vault-ent.spec.js
@@ -97,7 +97,12 @@ test('SSH Certificate Injection @ent @docker', async ({ page }) => {
 
     // Create org
     const orgName = await createNewOrg(page);
-    await authenticateBoundaryCli();
+    await authenticateBoundaryCli(
+      process.env.BOUNDARY_ADDR,
+      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     org = orgs.items.filter((obj) => obj.name == orgName)[0];
 

--- a/ui/admin/tests/e2e/tests/ssh-credential-injection-vault-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/ssh-credential-injection-vault-ent.spec.js
@@ -101,14 +101,22 @@ test('SSH Credential Injection (Vault User & Key Pair) @ent @docker', async ({
     const project = projects.items.filter((obj) => obj.name == projectName)[0];
 
     // Create target
-    const targetName = await createSshTargetWithAddressEnt(page);
+    const targetName = await createSshTargetWithAddressEnt(
+      page,
+      process.env.E2E_TARGET_ADDRESS,
+      process.env.E2E_TARGET_PORT,
+    );
     const targets = JSON.parse(
       execSync('boundary targets list -format json -scope-id ' + project.id),
     );
     const target = targets.items.filter((obj) => obj.name == targetName)[0];
 
     // Create credentials
-    await createVaultCredentialStore(page, clientToken);
+    await createVaultCredentialStore(
+      page,
+      process.env.E2E_VAULT_ADDR,
+      clientToken,
+    );
     const credentialLibraryName = await createVaultGenericCredentialLibrary(
       page,
       `${secretsPath}/data/${secretName}`,

--- a/ui/admin/tests/e2e/tests/ssh-credential-injection-vault-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/ssh-credential-injection-vault-ent.spec.js
@@ -89,7 +89,12 @@ test('SSH Credential Injection (Vault User & Key Pair) @ent @docker', async ({
 
     // Create org
     const orgName = await createNewOrg(page);
-    await authenticateBoundaryCli();
+    await authenticateBoundaryCli(
+      process.env.BOUNDARY_ADDR,
+      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     org = orgs.items.filter((obj) => obj.name == orgName)[0];
 

--- a/ui/admin/tests/e2e/tests/target-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/target-ent.spec.js
@@ -57,7 +57,11 @@ test('Verify session created for TCP target @ent @aws @docker', async ({
     );
     const project = projects.items.filter((obj) => obj.name == projectName)[0];
 
-    const targetName = await createTcpTargetWithAddressEnt(page);
+    const targetName = await createTcpTargetWithAddressEnt(
+      page,
+      process.env.E2E_TARGET_ADDRESS,
+      process.env.E2E_TARGET_PORT,
+    );
     const targets = JSON.parse(
       execSync('boundary targets list -format json -scope-id ' + project.id),
     );
@@ -99,14 +103,22 @@ test('Verify session created for SSH target @ent @aws @docker', async ({
     );
     const project = projects.items.filter((obj) => obj.name == projectName)[0];
 
-    const targetName = await createSshTargetWithAddressEnt(page);
+    const targetName = await createSshTargetWithAddressEnt(
+      page,
+      process.env.E2E_TARGET_ADDRESS,
+      process.env.E2E_TARGET_PORT,
+    );
     const targets = JSON.parse(
       execSync('boundary targets list -format json -scope-id ' + project.id),
     );
     const target = targets.items.filter((obj) => obj.name == targetName)[0];
 
     await createStaticCredentialStore(page);
-    const credentialName = await createStaticCredentialKeyPair(page);
+    const credentialName = await createStaticCredentialKeyPair(
+      page,
+      process.env.E2E_SSH_USER,
+      process.env.E2E_SSH_KEY_PATH,
+    );
     await addInjectedCredentialsToTarget(page, targetName, credentialName);
 
     connect = await connectSshToTarget(target.id);

--- a/ui/admin/tests/e2e/tests/target-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/target-ent.spec.js
@@ -47,7 +47,12 @@ test('Verify session created for TCP target @ent @aws @docker', async ({
   let connect;
   try {
     const orgName = await createNewOrg(page);
-    await authenticateBoundaryCli();
+    await authenticateBoundaryCli(
+      process.env.BOUNDARY_ADDR,
+      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     org = orgs.items.filter((obj) => obj.name == orgName)[0];
 
@@ -67,7 +72,11 @@ test('Verify session created for TCP target @ent @aws @docker', async ({
     );
     const target = targets.items.filter((obj) => obj.name == targetName)[0];
 
-    connect = await connectToTarget(target.id);
+    connect = await connectToTarget(
+      target.id,
+      process.env.E2E_SSH_USER,
+      process.env.E2E_SSH_KEY_PATH,
+    );
     await waitForSessionToBeVisible(page, targetName);
     await page
       .getByRole('cell', { name: targetName })
@@ -93,7 +102,12 @@ test('Verify session created for SSH target @ent @aws @docker', async ({
   let connect;
   try {
     const orgName = await createNewOrg(page);
-    await authenticateBoundaryCli();
+    await authenticateBoundaryCli(
+      process.env.BOUNDARY_ADDR,
+      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     org = orgs.items.filter((obj) => obj.name == orgName)[0];
 

--- a/ui/admin/tests/e2e/tests/target.spec.js
+++ b/ui/admin/tests/e2e/tests/target.spec.js
@@ -49,8 +49,8 @@ test('Verify session created to target with host, then cancel the session @ce @a
     const projectName = await createNewProject(page);
     await createNewHostCatalog(page);
     const hostSetName = await createNewHostSet(page);
-    await createNewHostInHostSet(page);
-    const targetName = await createNewTarget(page);
+    await createNewHostInHostSet(page, process.env.E2E_TARGET_ADDRESS);
+    const targetName = await createNewTarget(page, process.env.E2E_TARGET_PORT);
     await addHostSourceToTarget(page, hostSetName);
 
     await authenticateBoundaryCli();
@@ -90,7 +90,11 @@ test('Verify session created to target with address, then cancel the session @ce
   try {
     const orgName = await createNewOrg(page);
     const projectName = await createNewProject(page);
-    const targetName = await createNewTargetWithAddress(page);
+    const targetName = await createNewTargetWithAddress(
+      page,
+      process.env.E2E_TARGET_ADDRESS,
+      process.env.E2E_TARGET_PORT,
+    );
 
     await authenticateBoundaryCli();
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
@@ -126,7 +130,11 @@ test('Verify TCP target is updated @ce @aws @docker', async ({ page }) => {
   try {
     orgName = await createNewOrg(page);
     await createNewProject(page);
-    await createNewTargetWithAddress(page);
+    await createNewTargetWithAddress(
+      page,
+      process.env.E2E_TARGET_ADDRESS,
+      process.env.E2E_TARGET_PORT,
+    );
 
     // Update target
     await page.getByRole('button', { name: 'Edit Form' }).click();

--- a/ui/admin/tests/e2e/tests/target.spec.js
+++ b/ui/admin/tests/e2e/tests/target.spec.js
@@ -53,7 +53,12 @@ test('Verify session created to target with host, then cancel the session @ce @a
     const targetName = await createNewTarget(page, process.env.E2E_TARGET_PORT);
     await addHostSourceToTarget(page, hostSetName);
 
-    await authenticateBoundaryCli();
+    await authenticateBoundaryCli(
+      process.env.BOUNDARY_ADDR,
+      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     org = orgs.items.filter((obj) => obj.name == orgName)[0];
     const projects = JSON.parse(
@@ -65,7 +70,11 @@ test('Verify session created to target with host, then cancel the session @ce @a
     );
     const target = targets.items.filter((obj) => obj.name == targetName)[0];
 
-    connect = await connectToTarget(target.id);
+    connect = await connectToTarget(
+      target.id,
+      process.env.E2E_SSH_USER,
+      process.env.E2E_SSH_KEY_PATH,
+    );
     await waitForSessionToBeVisible(page, targetName);
     await page
       .getByRole('cell', { name: targetName })
@@ -96,7 +105,12 @@ test('Verify session created to target with address, then cancel the session @ce
       process.env.E2E_TARGET_PORT,
     );
 
-    await authenticateBoundaryCli();
+    await authenticateBoundaryCli(
+      process.env.BOUNDARY_ADDR,
+      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     org = orgs.items.filter((obj) => obj.name == orgName)[0];
     const projects = JSON.parse(
@@ -108,7 +122,11 @@ test('Verify session created to target with address, then cancel the session @ce
     );
     const target = targets.items.filter((obj) => obj.name == targetName)[0];
 
-    connect = await connectToTarget(target.id);
+    connect = await connectToTarget(
+      target.id,
+      process.env.E2E_SSH_USER,
+      process.env.E2E_SSH_KEY_PATH,
+    );
     await waitForSessionToBeVisible(page, targetName);
     await page
       .getByRole('cell', { name: targetName })
@@ -155,7 +173,12 @@ test('Verify TCP target is updated @ce @aws @docker', async ({ page }) => {
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();
   } finally {
-    await authenticateBoundaryCli();
+    await authenticateBoundaryCli(
+      process.env.BOUNDARY_ADDR,
+      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     const org = orgs.items.filter((obj) => obj.name === orgName)[0];
     await deleteOrgCli(org.id);


### PR DESCRIPTION
This PR does some refactoring in the Admin UI e2e test suite to move any direct use of environment variables outside of helper methods to make it consistent and explicit where they are used within tests.