### PR TITLE
refactor: 💡 add template helper for checking filters

### DIFF
--- a/addons/core/addon/helpers/has-search-or-filter-selections.js
+++ b/addons/core/addon/helpers/has-search-or-filter-selections.js
@@ -5,17 +5,22 @@ import { assert } from '@ember/debug';
 export default class extends Helper {
   /**
    * Returns true if the controller for the specified route
-   * has a value set for any field name passed into the helper.
+   * has a value set for any search or filter field.
    * @param {string} routeName
-   * @param {string[]} names - names of controller fields
    * @return {boolean}
    */
-  compute([routePath, ...names]) {
+  compute([routePath]) {
     const controller = getOwner(this).lookup(`controller:${routePath}`);
     assert(`Controller for route path ${routePath} must exist`, controller);
-    for (let i in names) {
-      if (controller[names[i]]) {
-        return true;
+
+    for (const param of controller['queryParams']) {
+      if (param !== 'page' && param !== 'pageSize') {
+        const queryParam =
+          typeof param === 'string' ? param : Object.keys(param)[0];
+        const queryParamValue = controller[queryParam];
+        if (queryParamValue && queryParamValue.length > 0) {
+          return true;
+        }
       }
     }
     return false;

--- a/addons/core/addon/helpers/has-search-or-filter-selections.js
+++ b/addons/core/addon/helpers/has-search-or-filter-selections.js
@@ -1,0 +1,23 @@
+import Helper from '@ember/component/helper';
+import { getOwner } from '@ember/application';
+import { assert } from '@ember/debug';
+
+export default class extends Helper {
+  /**
+   * Returns true if the controller for the specified route
+   * has a value set for any field name passed into the helper.
+   * @param {string} routeName
+   * @param {string[]} names - names of controller fields
+   * @return {boolean}
+   */
+  compute([routePath, ...names]) {
+    const controller = getOwner(this).lookup(`controller:${routePath}`);
+    assert(`Controller for route path ${routePath} must exist`, controller);
+    for (let i in names) {
+      if (controller[names[i]]) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/addons/core/app/helpers/has-search-or-filter-selections.js
+++ b/addons/core/app/helpers/has-search-or-filter-selections.js
@@ -1,0 +1,1 @@
+export { default } from 'core/helpers/has-search-or-filter-selections';

--- a/ui/admin/tests/integration/helpers/has-search-or-filter-selections-test.js
+++ b/ui/admin/tests/integration/helpers/has-search-or-filter-selections-test.js
@@ -1,0 +1,74 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Helper | has-search-or-filter-selections',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders false when given route with no search or filters set', async function (assert) {
+      await render(
+        hbs`{{has-search-or-filter-selections 'scopes/scope/targets/index'}}`,
+      );
+
+      assert.dom(this.element).hasText('false');
+    });
+
+    test('it renders true when given route with search set', async function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/targets/index',
+      );
+      controller.search = 'test';
+
+      await render(
+        hbs`{{has-search-or-filter-selections 'scopes/scope/targets/index'}}`,
+      );
+
+      assert.dom(this.element).hasText('true');
+    });
+
+    test('it renders true when given route with a filter set', async function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/targets/index',
+      );
+      controller.availableSessions = ['yes'];
+
+      await render(
+        hbs`{{has-search-or-filter-selections 'scopes/scope/targets/index'}}`,
+      );
+
+      assert.dom(this.element).hasText('true');
+    });
+
+    test('it renders true when given route with search and a filter set', async function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/targets/index',
+      );
+      controller.search = 'test';
+      controller.availableSessions = ['yes'];
+
+      await render(
+        hbs`{{has-search-or-filter-selections 'scopes/scope/targets/index'}}`,
+      );
+
+      assert.dom(this.element).hasText('true');
+    });
+
+    test('it renders true when given route with search and all filters set', async function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/targets/index',
+      );
+      controller.search = 'test';
+      controller.availableSessions = ['yes'];
+      controller.types = ['ssh'];
+
+      await render(
+        hbs`{{has-search-or-filter-selections 'scopes/scope/targets/index'}}`,
+      );
+
+      assert.dom(this.element).hasText('true');
+    });
+  },
+);


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12153

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-12153)

## Description
Adds one template helper for pages that use search/filtering. Removes the need for getters that merely check query params. If we notice more patterns along the line, then we can add more helpers or alter this helper.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
