### PR TITLE
refactor: 💡 add active sessions column to targets table

### DIFF
--- a/ui/admin/app/templates/scopes/scope/sessions/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/sessions/index.hbs
@@ -89,7 +89,7 @@
           @valign='middle'
         >
           <:body as |B|>
-            <B.Tr>
+            <B.Tr data-test-sessions-table-row={{B.data.id}}>
               <B.Td>
                 <Hds::Copy::Snippet
                   data-test-session={{B.data.id}}

--- a/ui/admin/app/templates/scopes/scope/targets/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/targets/index.hbs
@@ -73,7 +73,7 @@
         >
           <:body as |B|>
             {{#if (feature-flag 'ssh-target')}}
-              <B.Tr>
+              <B.Tr data-test-targets-table-row={{B.data.id}}>
                 <B.Td>
                   {{#if (can 'read model' B.data)}}
                     <LinkTo
@@ -113,7 +113,7 @@
               </B.Tr>
             {{else}}
               {{#if B.data.isTCP}}
-                <B.Tr>
+                <B.Tr data-test-targets-table-row={{B.data.id}}>
                   <B.Td>
                     {{#if (can 'read model' B.data)}}
                       <LinkTo

--- a/ui/admin/app/templates/scopes/scope/targets/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/targets/index.hbs
@@ -64,6 +64,7 @@
           @columns={{array
             (hash label=(t 'form.name.label'))
             (hash label=(t 'form.type.label'))
+            (hash label=(t 'resources.target.titles.active-sessions'))
             (hash label=(t 'form.id.label'))
           }}
           @model={{@model.targets}}
@@ -90,6 +91,16 @@
                   {{#if B.data.type}}
                     <Hds::Badge
                       @text={{t (concat 'resources.target.types.' B.data.type)}}
+                    />
+                  {{/if}}
+                </B.Td>
+                <B.Td>
+                  {{#if B.data.isActive}}
+                    <Hds::Link::Standalone
+                      @text={{t 'actions.yes'}}
+                      @route='scopes.scope.sessions.index'
+                      @query={{hash targets=(array B.data.id)}}
+                      @icon='info'
                     />
                   {{/if}}
                 </B.Td>
@@ -122,6 +133,16 @@
                         @text={{t
                           (concat 'resources.target.types.' B.data.type)
                         }}
+                      />
+                    {{/if}}
+                  </B.Td>
+                  <B.Td>
+                    {{#if B.data.isActive}}
+                      <Hds::Link::Standalone
+                        @text={{t 'actions.yes'}}
+                        @route='scopes.scope.sessions.index'
+                        @query={{hash targets=(array B.data.id)}}
+                        @icon='info'
                       />
                     {{/if}}
                   </B.Td>


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-13085

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-13085)

## Description
Add active sessions column to targets table. The link should take user to sessions list view with appropriate target pre selected.

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

https://github.com/hashicorp/boundary-ui/assets/107949262/f52b01b4-c9a7-4e73-8fc3-a7587fd7af7a


## How to Test

<!-- Add steps to test this change. Include any other necessary relevant links -->
1. start boundary dev env
2. create a session
3. login to admin ui -> navigate to targets
4. validate that the active sessions column is correctly populated
5. validate that correct target is pre selected when user clicks "Yes" link in active sessions column
<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)


## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
