### PR TITLE
fix: 🐛 remove recursive param from list scopes endpoint

### DIFF
--- a/ui/desktop/app/routes/scopes.js
+++ b/ui/desktop/app/routes/scopes.js
@@ -23,7 +23,6 @@ export default class ScopesRoute extends Route {
     try {
       const scopesCheck = await adapter.query(this.store, scopeSchema, {
         page_size: 1,
-        recursive: true,
       });
       // we use the response_type to determine if pagination is supported
       // and this will still pass even if there are no scopes returned


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12543

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-12543)

## Description

A user has configured their boundary cluster to not allow listing all scopes when not authenticated. When checking to see if the controller is a supported version for the desktop client, we were using the `recursive: true` queryParam which was causing the API to return a `500` response which causes the desktop client to assume the controller is unsupported. Simply removing the `recursive: true` queryParam and only list the `global` scope, we remove that issue and properly determine if the controller is supported.

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

## How to Test

Follow steps mentioned [here](https://github.com/hashicorp/boundary-ui/issues/2192#issuecomment-2014765882). 

<!-- Add steps to test this change. Include any other necessary relevant links -->


## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] ~I have added JSON response output for API changes~
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] ~I have commented on my code, particularly in hard-to-understand areas~
- [ ] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
