### PR TITLE
refact(e2e): Convert to match "create" helper convention

### DIFF
--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -713,14 +713,16 @@ exports.makeAuthMethodPrimary = async (page) => {
 };
 
 /**
- * Uses the UI to create new Account. Assumes you have selected the desired Auth Method
+ * Uses the UI to create new password Account. Assumes you have selected the desired Auth Method
  * which the account will be created for.
  * @param {Page} page Playwright page object
- * @param {string} accountName Name of new account
  * @param {string} login Login of new account
  * @param {string} password Password of new account
+ * @returns Name of the account
  */
-exports.addAccountToAuthMethod = async (page, accountName, login, password) => {
+exports.createPasswordAccount = async (page, login, password) => {
+  const accountName = 'Account ' + nanoid();
+
   await page.getByRole('link', { name: 'Accounts' }).click();
   await page
     .getByRole('article')
@@ -739,6 +741,8 @@ exports.addAccountToAuthMethod = async (page, accountName, login, password) => {
       .getByRole('navigation', { name: 'breadcrumbs' })
       .getByText(accountName),
   ).toBeVisible();
+
+  return accountName;
 };
 
 /**

--- a/ui/admin/tests/e2e/tests/auth-method-password.spec.js
+++ b/ui/admin/tests/e2e/tests/auth-method-password.spec.js
@@ -15,7 +15,7 @@ const {
 const {
   createOrg,
   createPasswordAuthMethod,
-  addAccountToAuthMethod,
+  createPasswordAccount,
   setPasswordToAccount,
   createUser,
   addAccountToUser,
@@ -44,12 +44,7 @@ test('Verify new auth-method can be created and assigned to users @ce @ent @aws 
     const orgs = JSON.parse(execSync('boundary scopes list -format json'));
     org = orgs.items.filter((obj) => obj.name == orgName)[0];
     await createPasswordAuthMethod(page);
-    await addAccountToAuthMethod(
-      page,
-      'UI Test Account',
-      'test-user',
-      'password',
-    );
+    await createPasswordAccount(page, 'test-user', 'password');
     await setPasswordToAccount(page, 'password2');
     await makeAuthMethodPrimary(page);
     await createUser(page);


### PR DESCRIPTION
This PR updates a "create" helper method in the Admin UI e2e test suite to follow the convention established in this PR: https://github.com/hashicorp/boundary-ui/pull/2191