### PR TITLE
fix: 🐛 show change cluster url when no auth methods

### DIFF
--- a/ui/desktop/app/templates/scopes/scope/authenticate.hbs
+++ b/ui/desktop/app/templates/scopes/scope/authenticate.hbs
@@ -46,22 +46,13 @@
 
     {{#if @model.authMethods}}
       {{outlet}}
-
-      <p class='change-origin'>
-        {{t 'cluster-url.connected-to'}}:
-        <code>{{this.clusterUrl}}</code>
-        <br />
-        <LinkTo @route='cluster-url'>
-          {{t 'actions.change-cluster-url'}}
-        </LinkTo>
-      </p>
-
     {{/if}}
     {{#unless @model.authMethods}}
       <Rose::Layout::Centered>
         <Rose::Message
           @title={{t 'resources.auth-method.messages.none.title'}}
           @icon='flight-icons/svg/alert-circle-16'
+          data-test-no-auth-methods
           as |message|
         >
           <message.description>
@@ -70,5 +61,13 @@
         </Rose::Message>
       </Rose::Layout::Centered>
     {{/unless}}
+    <p class='change-origin'>
+      {{t 'cluster-url.connected-to'}}:
+      <code>{{this.clusterUrl}}</code>
+      <br />
+      <LinkTo @route='cluster-url'>
+        {{t 'actions.change-cluster-url'}}
+      </LinkTo>
+    </p>
   </BrandedCard>
 </main>

--- a/ui/desktop/tests/acceptance/authentication-test.js
+++ b/ui/desktop/tests/acceptance/authentication-test.js
@@ -259,4 +259,12 @@ module('Acceptance | authentication', function (hooks) {
 
     assert.dom('.rose-dropdown-content a').exists({ count: 2 });
   });
+
+  test('change cluster url is visible when no auth methods are available', async function (assert) {
+    this.server.get('/auth-methods', () => new Response(200));
+    await visit(urls.authenticate.methods.global);
+
+    assert.dom('[data-test-no-auth-methods]').includesText('No Auth Methods');
+    assert.dom('.change-origin').exists();
+  });
 });


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-13133

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-13133)

## Description

While this should never happen, if the permissions are misconfigured the user will see no auth methods available to sign in with. If this happens, the "Change cluster URL" action will not be displayed either. It has now been updated to show up no matter what to give the user a way out of this error state without having to shutdown the desktop client.

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
Before:
<img width="770" alt="Screenshot 2024-03-22 at 12 03 57 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/32c5b6b4-1b91-4d1c-9f27-6aa518fe4c5a">
After:
<img width="770" alt="Screenshot 2024-03-22 at 5 25 30 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/2fa474e2-1062-4754-addc-f4e02814efc8">


## How to Test

Start up `boundary dev` and modify the `Login Grants` Role at the global scope. Delete the auth-method grant: `ids=*;type=auth-method;actions=list,authenticate`. Now start the desktop using `ENABLE_MIRAGE=false BYPASS_CLI_SETUP=true yarn start:desktop` and after you enter the cluster URL you should see the "no auth methods" message AND the change cluster URL action.

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] ~I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] ~I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
