### PR TITLE
test(e2e): Update credential library form behavior

### DIFF
--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -150,7 +150,7 @@ exports.createStaticCredentialStore = async (page) => {
     .getByRole('link', { name: 'Credential Stores' })
     .click();
   await page.getByRole('link', { name: 'New', exact: true }).click();
-  await page.getByLabel('Name', { exact: true }).fill(credentialStoreName);
+  await page.getByLabel('Name (Optional)').fill(credentialStoreName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('group', { name: 'Type' }).getByLabel('Static').click();
   await page.getByRole('button', { name: 'Save' }).click();
@@ -181,11 +181,11 @@ exports.createVaultCredentialStore = async (page, vaultAddr, clientToken) => {
     .getByRole('link', { name: 'Credential Stores' })
     .click();
   await page.getByRole('link', { name: 'New', exact: true }).click();
-  await page.getByLabel('Name', { exact: true }).fill(credentialStoreName);
+  await page.getByLabel('Name (Optional)').fill(credentialStoreName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('group', { name: 'Type' }).getByLabel('Vault').click();
-  await page.getByLabel('Address', { exact: true }).fill(vaultAddr);
-  await page.getByLabel('Token', { exact: true }).fill(clientToken);
+  await page.getByLabel('Address').fill(vaultAddr);
+  await page.getByLabel('Token').fill(clientToken);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
     page.getByRole('alert').getByText('Success', { exact: true }),
@@ -211,7 +211,7 @@ exports.createStaticCredentialKeyPair = async (page, username, keyPath) => {
   const credentialName = 'Credential ' + nanoid();
   await page.getByRole('link', { name: 'Credentials', exact: true }).click();
   await page.getByRole('link', { name: 'New', exact: true }).click();
-  await page.getByLabel('Name', { exact: true }).fill(credentialName);
+  await page.getByLabel('Name (Optional)').fill(credentialName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page
     .getByRole('group', { name: 'Type' })
@@ -221,7 +221,7 @@ exports.createStaticCredentialKeyPair = async (page, username, keyPath) => {
   const keyData = await readFile(keyPath, {
     encoding: 'utf-8',
   });
-  await page.getByLabel('SSH Private Key', { exact: true }).fill(keyData);
+  await page.getByLabel('SSH Private Key').fill(keyData);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(
     page.getByRole('alert').getByText('Success', { exact: true }),
@@ -725,7 +725,7 @@ exports.createPasswordAccount = async (page, login, password) => {
     .getByRole('article')
     .getByRole('link', { name: 'Create Account', exact: true })
     .click();
-  await page.getByLabel('Name', { exact: true }).fill(accountName);
+  await page.getByLabel('Name (Optional)').fill(accountName);
   await page.getByLabel('Login Name').fill(login);
   await page.getByLabel('Password', { exact: true }).fill(password);
   await page.getByRole('button', { name: 'Save' }).click();

--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -294,19 +294,16 @@ exports.createVaultSshCertificateCredentialLibrary = async (
   await page.getByRole('link', { name: 'Credential Libraries' }).click();
   await page.getByRole('link', { name: 'New', exact: true }).click();
 
-  // Temporarily putting the Group selection first due to a bug where
-  // Name and Description fields get cleared when the Group is selected
-  await page
-    .getByRole('group', { name: 'Type' })
-    .getByLabel('SSH Certificates')
-    .click();
-
   await page
     .getByLabel('Name (Optional)', { exact: true })
     .fill(credentialLibraryName);
   await page
     .getByLabel('Description (Optional)')
     .fill('This is an automated test');
+  await page
+    .getByRole('group', { name: 'Type' })
+    .getByLabel('SSH Certificates')
+    .click();
   await page.getByLabel('Vault Path').fill(vaultPath);
   await page.getByLabel('Username').fill(username);
   await page.getByLabel('Key Type').selectOption('ecdsa');

--- a/ui/admin/tests/e2e/tests/credential-store-static.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static.spec.js
@@ -99,7 +99,7 @@ test('Static Credential Store (Username & Password) @ce @aws @docker', async ({
   const credentialName = 'Credential ' + nanoid();
   await page.getByRole('link', { name: 'Credentials', exact: true }).click();
   await page.getByRole('link', { name: 'New', exact: true }).click();
-  await page.getByLabel('Name', { exact: true }).fill(credentialName);
+  await page.getByLabel('Name (Optional)').fill(credentialName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page
     .getByRole('group', { name: 'Type' })
@@ -155,7 +155,7 @@ test('Static Credential Store (JSON) @ce @aws @docker', async ({ page }) => {
   const credentialName = 'Credential ' + nanoid();
   await page.getByRole('link', { name: 'Credentials', exact: true }).click();
   await page.getByRole('link', { name: 'New', exact: true }).click();
-  await page.getByLabel('Name', { exact: true }).fill(credentialName);
+  await page.getByLabel('Name (Optional)').fill(credentialName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('group', { name: 'Type' }).getByLabel('JSON').click();
   await page.getByText('{}').click();

--- a/ui/admin/tests/e2e/tests/dynamic-host-catalog.spec.js
+++ b/ui/admin/tests/e2e/tests/dynamic-host-catalog.spec.js
@@ -70,7 +70,7 @@ test.describe('AWS', async () => {
     const hostSetName = 'Host Set ' + nanoid();
     await page.getByRole('link', { name: 'Host Sets' }).click();
     await page.getByRole('link', { name: 'New', exact: true }).click();
-    await page.getByLabel('Name').fill(hostSetName);
+    await page.getByLabel('Name (Optional)').fill(hostSetName);
     await page.getByLabel('Description').fill('This is an automated test');
     await page
       .getByRole('group', { name: 'Filter' })


### PR DESCRIPTION
After merging https://github.com/hashicorp/boundary-ui/pull/2169/files, we can update an e2e test that uses the vault credential library form.

This PR also includes some other locator fixes due to some other form changes (using commit `9843310dfbf6fa7710a9e65dba89a8ff7e05fd2a`) 