### PR TITLE
fix: 🐛 add parentScope.id to refresh action for sessions

### DIFF
--- a/ui/admin/app/routes/scopes/scope/sessions/index.js
+++ b/ui/admin/app/routes/scopes/scope/sessions/index.js
@@ -165,10 +165,10 @@ export default class ScopesScopeSessionsIndexRoute extends Route {
    */
   @action
   async refreshAll() {
-    const { id: scope_id } = this.modelFor('scopes.scope');
+    const { id: scope_id, scope: parentScope } = this.modelFor('scopes.scope');
 
     await this.getAllSessions(scope_id);
-    await this.getAssociatedUsers();
+    await this.getAssociatedUsers(parentScope.id);
     await this.getAssociatedTargets(scope_id);
 
     return super.refresh(...arguments);

--- a/ui/admin/app/routes/scopes/scope/sessions/index.js
+++ b/ui/admin/app/routes/scopes/scope/sessions/index.js
@@ -49,7 +49,7 @@ export default class ScopesScopeSessionsIndexRoute extends Route {
    * @return {Promise{[{sessions: [SessionModel], allSessions: [SessionModel], associatedUsers: [UserModel], associatedTargets: [TargetModel], totalItems: number}]}}
    */
   async model({ search, users, targets, status, page, pageSize }) {
-    const { id: scope_id, scope: parentScope } = this.modelFor('scopes.scope');
+    const { id: scope_id } = this.modelFor('scopes.scope');
     const filters = {
       scope_id: [{ equals: scope_id }],
       status: [],
@@ -80,10 +80,10 @@ export default class ScopesScopeSessionsIndexRoute extends Route {
       await this.getAllSessions(scope_id);
     }
     if (!this.associatedUsers) {
-      await this.getAssociatedUsers(parentScope.id);
+      await this.getAssociatedUsers();
     }
     if (!this.associatedTargets) {
-      await this.getAssociatedTargets(scope_id);
+      await this.getAssociatedTargets();
     }
 
     return {
@@ -113,17 +113,14 @@ export default class ScopesScopeSessionsIndexRoute extends Route {
    * Get all the users but only load them once when entering the route.
    * @returns {Promise<void>}
    */
-  async getAssociatedUsers(parentScopeId) {
+  async getAssociatedUsers() {
     const uniqueSessionUserIds = new Set(
       this.allSessions
         .filter((session) => session.user_id)
         .map((session) => session.user_id),
     );
-    // Users can belong to the global scope or the org scope
-    // the project is under so we need to query for both.
     const filters = {
       id: { values: [] },
-      scope_id: [{ equals: 'global' }, { equals: parentScopeId }],
     };
     uniqueSessionUserIds.forEach((userId) => {
       filters.id.values.push({ equals: userId });
@@ -136,16 +133,15 @@ export default class ScopesScopeSessionsIndexRoute extends Route {
 
   /**
    * Get all the targets but only load them once when entering the route.
-   * @param scope_id
    * @returns {Promise<void>}
    */
-  async getAssociatedTargets(scope_id) {
+  async getAssociatedTargets() {
     const uniqueSessionTargetIds = new Set(
       this.allSessions
         .filter((session) => session.target_id)
         .map((session) => session.target_id),
     );
-    const filters = { id: { values: [] }, scope_id: [{ equals: scope_id }] };
+    const filters = { id: { values: [] } };
     uniqueSessionTargetIds.forEach((targetId) => {
       filters.id.values.push({ equals: targetId });
     });
@@ -165,11 +161,11 @@ export default class ScopesScopeSessionsIndexRoute extends Route {
    */
   @action
   async refreshAll() {
-    const { id: scope_id, scope: parentScope } = this.modelFor('scopes.scope');
+    const { id: scope_id } = this.modelFor('scopes.scope');
 
     await this.getAllSessions(scope_id);
-    await this.getAssociatedUsers(parentScope.id);
-    await this.getAssociatedTargets(scope_id);
+    await this.getAssociatedUsers();
+    await this.getAssociatedTargets();
 
     return super.refresh(...arguments);
   }


### PR DESCRIPTION
## Description

Add `parentScope.id` to `this.getAssociatedUsers` in the `refreshAll` action

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

## How to Test

Start `boundary dev` and connect to a few targets to create sessions. In the Admin UI, navigate to the sessions list view and click the refresh button. This should trigger 4 more network requests for sessions (x2), users, and targets.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
