### PR TITLE
refactor: 💡 add include_terminated param to sessions query

### DIFF
--- a/ui/admin/app/routes/scopes/scope/sessions/index.js
+++ b/ui/admin/app/routes/scopes/scope/sessions/index.js
@@ -67,6 +67,7 @@ export default class ScopesScopeSessionsIndexRoute extends Route {
     });
 
     const queryOptions = {
+      include_terminated: true,
       query: { search, filters },
       page,
       pageSize,
@@ -102,6 +103,7 @@ export default class ScopesScopeSessionsIndexRoute extends Route {
    */
   async getAllSessions(scope_id) {
     const allSessionsQuery = {
+      include_terminated: true,
       query: { filters: { scope_id: [{ equals: scope_id }] } },
     };
     this.allSessions = await this.store.query('session', allSessionsQuery, {


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-13130

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-13130)

## Description

Add `include_terminated` param to sessions query in Admin UI. In desktop we don't need this as the client daemon is handling it for us. I did not include this param in the targets list route as we only care about active and pending sessions in that route. 

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
Here you can see when refreshed (or searched), the session that is now terminated is returned.
<img width="804" alt="Screenshot 2024-04-04 at 5 21 24 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/262a5784-dded-4b64-bafd-e194890f4787">

## How to Test

Connect to a target via the cli or desktop client. In the Admin UI visit the sessions list route to view the active or pending session. Cancel the session, then refresh the data in Admin UI and you should see the status change to canceling. After a few minutes the status will change to `terminated`. Refresh the sessions list again and you should see the status change again in Admin UI.

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->


## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [x] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] ~I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
