### PR TITLE
fix: 🐛 modal bubbling up when user has not updated model

### DIFF
--- a/ui/admin/app/components/header-nav/index.hbs
+++ b/ui/admin/app/components/header-nav/index.hbs
@@ -4,7 +4,11 @@
 }}
 
 <Rose::Dropdown
-  @text={{this.scope.org.displayName}}
+  @text={{if
+    this.scope.org.isGlobal
+    (t 'titles.global')
+    this.scope.org.displayName
+  }}
   @icon={{if
     this.scope.org.isGlobal
     'flight-icons/svg/globe-16'

--- a/ui/admin/app/routes/scopes/scope.js
+++ b/ui/admin/app/routes/scopes/scope.js
@@ -33,17 +33,13 @@ export default class ScopesScopeRoute extends Route {
    * @param {string} params.scope_id
    * @return {Promise{ScopeModel}}
    */
-  model({ scope_id: id }) {
+  async model({ scope_id: id }) {
     // Since only global and org scopes are authenticatable, we can infer type
     // from ID because global has a fixed ID.
     const type = id === 'global' ? 'global' : 'org';
     return this.store.findRecord('scope', id).catch(() => {
       const maybeExistingScope = this.store.peekRecord('scope', id);
       const scopeOptions = { id, type };
-      /* istanbul ignore else */
-      if (type === 'global') {
-        scopeOptions.name = this.intl.t('titles.global');
-      }
       return (
         maybeExistingScope || this.store.createRecord('scope', scopeOptions)
       );


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-13106

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-13106)

## Description

<!-- Add a brief description of changes here -->
Fixes the "Discard unsaved changes?" modal from popping up when the user made no changes to the model. Bug was seen in the global settings page when trying to navigate away.

## Screenshots (if appropriate):
Before:

https://github.com/hashicorp/boundary-ui/assets/107949262/ac34d865-f60c-4959-946a-8e0b8283b3c7


After:

https://github.com/hashicorp/boundary-ui/assets/107949262/f9ad6e4b-c007-4ca8-8d91-dfbd226bd2e9


## How to Test

<!-- Add steps to test this change. Include any other necessary relevant links -->
1. start boundary dev instance.
2. login in
3. navigate to "Global settings"
4. Attempt to navigate to a different route, and validate that "Discard unsaved changes?" modal does not pop up.
( look at slack thread in jira ticket for additional details if necessary )
<!--
Replace PATH_TO_FEATURE with Vercel link
-->


## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [X] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
