### PR TITLE
feat: 🎸 Add initial logging for desktop client

### DIFF
--- a/addons/api/.eslintrc.js
+++ b/addons/api/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
   env: {
     browser: true,
   },
+  globals: { __electronLog: 'true' },
   rules: {
     'ember/no-get': 'off',
     'ember/no-get-with-default': 'off',

--- a/addons/api/addon/handlers/client-daemon-handler.js
+++ b/addons/api/addon/handlers/client-daemon-handler.js
@@ -134,8 +134,9 @@ export default class ClientDaemonHandler {
                 'searchClientDaemon',
                 remainingQuery,
               );
-            } catch {
+            } catch (err) {
               // If it fails again just fall back to fetching controller data
+              __electronLog?.info('Failed to add token to client daemon', err);
             }
           }
 

--- a/ui/desktop/.eslintrc.js
+++ b/ui/desktop/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
   env: {
     browser: true,
   },
+  globals: { __electronLog: 'true' },
   rules: {
     'ember/no-get': 'off',
     'ember/no-get-with-default': 'off',

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "electron-devtools-installer": "^3.2.0",
     "electron-is-dev": "^2.0.0",
+    "electron-log": "^5.1.2",
     "electron-squirrel-startup": "^1.0.0",
     "node-html-parser": "^5.3.3",
     "node-pty": "^1.0.0",

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -21,6 +21,7 @@ const {
   shell,
 } = require('electron');
 require('./ipc/handlers.js');
+const log = require('electron-log/main');
 
 const { generateCSPHeader } = require('./config/content-security-policy.js');
 const runtimeSettings = require('./services/runtime-settings.js');
@@ -53,6 +54,11 @@ protocol.registerSchemesAsPrivileged([
 // This is to correctly set the process.env.PATH as electron does not
 // correctly inherit the path variable in production
 fixPath();
+
+// Setup logger
+log.initialize();
+log.transports.file.format =
+  '[{y}-{m}-{d} {h}:{i}:{s}.{ms}{z}] [{level}] {text}';
 
 const createWindow = (partition, closeWindowCB) => {
   /**

--- a/ui/desktop/electron-app/src/services/client-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/client-daemon-manager.js
@@ -41,7 +41,7 @@ class ClientDaemonManager {
    * @returns {Promise<void>}
    */
   async start() {
-    const startDaemonCommand = ['daemon', 'start'];
+    const startDaemonCommand = ['daemon', 'start', '-log-level=debug'];
     // We use spawn here because we want to check the stderr for specific logs
     const { stderr } = await spawn(startDaemonCommand);
 

--- a/ui/desktop/electron-app/src/services/client-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/client-daemon-manager.js
@@ -96,11 +96,12 @@ class ClientDaemonManager {
 
   async search(requestData) {
     const start = Date.now();
+
     if (isWindows()) {
       const result = await searchCliCommand(requestData);
 
       const end = Date.now();
-      const { auth_token_id, ...logRequestData } = requestData;
+      const { auth_token_id, token, ...logRequestData } = requestData;
       log.info(`Search request took ${end - start} ms`, logRequestData);
 
       return result;
@@ -181,6 +182,7 @@ const searchCliCommand = (requestData) => {
   }
 
   parsedResponse = jsonify(stderr);
+  log.info(`Search Request Failed`, parsedResponse);
   return Promise.reject({
     statusCode: parsedResponse?.status_code,
     ...parsedResponse?.api_error,

--- a/ui/desktop/electron-app/src/utils/jsonify.js
+++ b/ui/desktop/electron-app/src/utils/jsonify.js
@@ -3,12 +3,15 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+const log = require('electron-log/main');
+
 // Convert to json
 const jsonify = (data) => {
   if (typeof data !== 'string') data = JSON.stringify(data);
   try {
     return JSON.parse(data);
   } catch (e) {
+    log.info('Error parsing JSON', e);
     // Ignore parse errors
   }
 };

--- a/ui/desktop/electron-app/yarn.lock
+++ b/ui/desktop/electron-app/yarn.lock
@@ -1217,6 +1217,11 @@ electron-is-dev@^2.0.0:
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-2.0.0.tgz#833487a069b8dad21425c67a19847d9064ab19bd"
   integrity sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA==
 
+electron-log@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-5.1.2.tgz#fb40ad7f4ae694dd0e4c02c662d1a65c03e1243e"
+  integrity sha512-Cpg4hAZ27yM9wzE77c4TvgzxzavZ+dVltCczParXN+Vb3jocojCSAuSMCVOI9fhFuuOR+iuu3tZLX1cu0y0kgQ==
+
 electron-squirrel-startup@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/electron-squirrel-startup/-/electron-squirrel-startup-1.0.0.tgz#19b4e55933fa0ef8f556784b9c660f772546a0b8"


### PR DESCRIPTION
## Description
Added initial logging for desktop client.
Example log statements:
```
[2024-04-10 19:24:27.664-04:00] [info]  Search request took 220 ms { query: '', force_refresh: true, resource: 'targets' }
[2024-04-10 19:27:45.446-04:00] [info]  Search request took 219 ms { force_refresh: true, query: '', resource: 'targets' }
[2024-04-10 19:27:45.841-04:00] [info]  Search request took 31 ms {
  query: '(user_id = "u_1234567890") and (status = "active" or status = "pending")',
  force_refresh: true,
  resource: 'sessions'
}
[2024-04-10 19:27:46.079-04:00] [info]  Search request took 204 ms { query: '', force_refresh: true, resource: 'targets' }
```

## How to Test
Run desktop client for a bit and check the desktop logs.
On mac it's at `~/Library/Logs/Boundary/main.log`
