### PR TITLE
fix: 🐛 breadcrumbs on scopes route not showing since model moved

### DIFF
--- a/ui/admin/app/routes/scopes/scope/scopes.js
+++ b/ui/admin/app/routes/scopes/scope/scopes.js
@@ -25,4 +25,10 @@ export default class ScopesScopeScopesRoute extends Route {
   beforeModel() {
     if (!this.session.isAuthenticated) this.router.transitionTo('index');
   }
+
+  setupController(controller) {
+    const currentScope = this.modelFor('scopes.scope');
+    super.setupController(...arguments);
+    controller.setProperties({ currentScope });
+  }
 }

--- a/ui/admin/app/templates/scopes/scope/scopes.hbs
+++ b/ui/admin/app/templates/scopes/scope/scopes.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: MPL-2.0
 }}
 
-{{#if @model.currentScope.isGlobal}}
+{{#if this.currentScope.isGlobal}}
   {{page-title (t 'resources.org.title_plural')}}
   <Breadcrumbs::Item
     @text={{t 'resources.org.title_plural'}}
@@ -13,13 +13,13 @@
   />
 {{/if}}
 
-{{#if @model.currentScope.isOrg}}
+{{#if this.currentScope.isOrg}}
   {{page-title (t 'resources.project.title_plural')}}
   <Breadcrumbs::Item
     @text={{t 'resources.project.title_plural'}}
     @icon='grid'
     @route='scopes.scope.scopes'
-    @model={{@model.currentScope.id}}
+    @model={{this.currentScope.id}}
   />
 {{/if}}
 


### PR DESCRIPTION
## Description
Fix bug causing breadcrumbs on scopes route to not show.

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
BEFORE: 
![image](https://github.com/hashicorp/boundary-ui/assets/107949262/2736c0d8-22da-40d6-adb6-48cf35ac4448)

AFTER:
![image](https://github.com/hashicorp/boundary-ui/assets/107949262/b0e26e8e-b8c9-4d9c-a621-87121bc913df)

## How to Test

<!-- Add steps to test this change. Include any other necessary relevant links -->
1. open admin-ui
2. navigate to scopes.scope.scopes routes and make sure that breadcrumbs are appearing correctly
<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](https://boundary-ui-git-fix-scopes-breadcrumb-not-showing-hashicorp.vercel.app/scopes/global/scopes)


## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [X] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
