### PR TITLE
fix: 🐛 Add back scope_id as part of request query parameter

### DIFF
--- a/ui/admin/app/routes/scopes/scope/targets/target/add-host-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/add-host-sources.js
@@ -34,6 +34,7 @@ export default class ScopesScopeTargetsTargetAddHostSourcesRoute extends Route {
     const target = this.modelFor('scopes.scope.targets.target');
     const { id: scope_id } = this.modelFor('scopes.scope');
     const hostCatalogs = await this.store.query('host-catalog', {
+      scope_id,
       query: { filters: { scope_id: [{ equals: scope_id }] } },
     });
     await all(


### PR DESCRIPTION
## Description
Accidentally removed the scope ID query param when refactoring the call to use indexed DB.

## How to Test
Add a host set from a target and it shouldn't error out.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
