### PR TITLE
fix: 🐛 transition aborted error when deleting group

### DIFF
--- a/ui/admin/app/controllers/scopes/scope/groups/index.js
+++ b/ui/admin/app/controllers/scopes/scope/groups/index.js
@@ -69,7 +69,7 @@ export default class ScopesScopeGroupsIndexController extends Controller {
   @notifySuccess('notifications.delete-success')
   async delete(group) {
     await group.destroyRecord();
-    await this.router.replaceWith('scopes.scope.groups');
+    this.router.replaceWith('scopes.scope.groups');
     await this.router.refresh();
   }
 


### PR DESCRIPTION
## Description

fix: 🐛 transition aborted error when deleting group

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):
Before:
<img width="1076" alt="Screenshot 2024-04-17 at 10 36 34 AM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/417a9b5b-1bb7-4f88-842d-8fb599bc5029">

After:
https://github.com/hashicorp/boundary-ui/assets/29386339/fd3240fd-62a1-49d5-81b8-bf3b41dbc193


## How to Test

Start a boundary instance, create a group, then delete. You should see no errors.

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
