### PR TITLE
fix: 🐛 place modal outside table

### DIFF
--- a/ui/admin/app/templates/scopes/scope/aliases/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/aliases/index.hbs
@@ -2,6 +2,7 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
+
 <Rose::Layout::Page as |page|>
   <page.breadcrumbs>
     <Breadcrumbs::Container />
@@ -25,6 +26,7 @@
     {{/if}}
   </page.actions>
   <page.body>
+
     {{#if @model}}
       <Hds::Table
         @model={{@model}}
@@ -119,63 +121,6 @@
                         @color='critical'
                         {{on 'click' (fn this.toggleModal B.data.alias)}}
                       />
-                      {{#if this.showModal}}
-                        <Hds::Modal
-                          class='alias-deletion-modal'
-                          @color='warning'
-                          @onClose={{this.toggleModal}}
-                          as |M|
-                        >
-                          <M.Header @icon='alert-triangle'>
-                            {{t 'questions.delete-confirm'}}
-                          </M.Header>
-
-                          <M.Body>
-
-                            <p
-                              class='hds-typography-body-300 hds-foreground-primary'
-                            >
-                              {{#if this.hasDestinationId}}
-                                {{t 'resources.alias.messages.clear-or-delete'}}
-                              {{else}}
-                                {{t 'resources.alias.messages.delete'}}
-                              {{/if}}
-                            </p>
-
-                          </M.Body>
-
-                          <M.Footer>
-                            <Hds::ButtonSet>
-                              <Hds::Button
-                                type='button'
-                                @text={{t 'actions.delete'}}
-                                {{on
-                                  'click'
-                                  (fn this.deleteAlias this.selectedAlias)
-                                }}
-                              />
-                              {{#if this.hasDestinationId}}
-                                <Hds::Button
-                                  type='button'
-                                  @text={{t 'actions.clear'}}
-                                  @color='secondary'
-                                  {{on
-                                    'click'
-                                    (fn this.clearAlias this.selectedAlias)
-                                  }}
-                                />
-                              {{/if}}
-                              <Hds::Button
-                                type='button'
-                                @text={{t 'actions.cancel'}}
-                                @color='secondary'
-                                {{on 'click' this.toggleModal}}
-                              />
-                            </Hds::ButtonSet>
-
-                          </M.Footer>
-                        </Hds::Modal>
-                      {{/if}}
                     {{/if}}
                   </Hds::Dropdown>
 
@@ -216,6 +161,55 @@
           {{/if}}
         </Rose::Message>
       </Rose::Layout::Centered>
+    {{/if}}
+    {{#if this.showModal}}
+      <Hds::Modal
+        class='alias-deletion-modal'
+        @color='warning'
+        @onClose={{this.toggleModal}}
+        as |M|
+      >
+        <M.Header @icon='alert-triangle'>
+          {{t 'questions.delete-confirm'}}
+        </M.Header>
+
+        <M.Body>
+
+          <p class='hds-typography-body-300 hds-foreground-primary'>
+            {{#if this.hasDestinationId}}
+              {{t 'resources.alias.messages.clear-or-delete'}}
+            {{else}}
+              {{t 'resources.alias.messages.delete'}}
+            {{/if}}
+          </p>
+
+        </M.Body>
+
+        <M.Footer>
+          <Hds::ButtonSet>
+            <Hds::Button
+              type='button'
+              @text={{t 'actions.delete'}}
+              {{on 'click' (fn this.deleteAlias this.selectedAlias)}}
+            />
+            {{#if this.hasDestinationId}}
+              <Hds::Button
+                type='button'
+                @text={{t 'actions.clear'}}
+                @color='secondary'
+                {{on 'click' (fn this.clearAlias this.selectedAlias)}}
+              />
+            {{/if}}
+            <Hds::Button
+              type='button'
+              @text={{t 'actions.cancel'}}
+              @color='secondary'
+              {{on 'click' this.toggleModal}}
+            />
+          </Hds::ButtonSet>
+
+        </M.Footer>
+      </Hds::Modal>
     {{/if}}
   </page.body>
 </Rose::Layout::Page>


### PR DESCRIPTION

## Description

This Pr fixes the `oveflow:hidden` issue that happens even after the modal is closed. 

## Screenshots (if appropriate):

## How to Test

1. click on the aliases modal by clicking on the `delete` button and interact with the modal
2. you should be able to scroll the page, and when you check the `body` element, you should not see `overflow:hidden`

<!-- Add steps to test this change. Include any other necessary relevant links -->

<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x ] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works
