### PR TITLE
Fix an afterModel check to avoid reloading

### DIFF
--- a/ui/admin/app/routes/scopes/scope/storage-buckets/new.js
+++ b/ui/admin/app/routes/scopes/scope/storage-buckets/new.js
@@ -83,18 +83,20 @@ export default class ScopesScopeStorageBucketsNewRoute extends Route {
   }
 
   async afterModel() {
-    let scopes;
-    const orgScopes = (
-      await this.store.query('scope', {
-        scope_id: 'global',
-        query: { filters: { scope_id: [{ equals: 'global' }] } },
-      })
-    ).map((scope) => ({ model: scope }));
-    scopes = [
-      { model: this.store.peekRecord('scope', 'global') },
-      ...orgScopes,
-    ];
-    this.scopes = scopes;
+    if (!this.scopes) {
+      let scopes;
+      const orgScopes = (
+        await this.store.query('scope', {
+          scope_id: 'global',
+          query: { filters: { scope_id: [{ equals: 'global' }] } },
+        })
+      ).map((scope) => ({ model: scope }));
+      scopes = [
+        { model: this.store.peekRecord('scope', 'global') },
+        ...orgScopes,
+      ];
+      this.scopes = scopes;
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

Fix and afterModel check to avoid page reloading everytime queryParam gets updated.

## How to Test

- Go to storage bucket creation form and change Providers, the page should NOT refres anymore.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
