### PR TITLE
test(e2e): Fixes for 0.16.0

### DIFF
--- a/ui/admin/tests/e2e/helpers/boundary-cli.js
+++ b/ui/admin/tests/e2e/helpers/boundary-cli.js
@@ -626,7 +626,7 @@ exports.waitForSessionRecordingCli = async (storageBucketId) => {
   do {
     i = i + 1;
     const sessionRecordings = JSON.parse(
-      execSync('boundary session-recordings list -format json'),
+      execSync('boundary session-recordings list --recursive -format json'),
     );
     filteredSessionRecording = sessionRecordings.items.filter(
       (obj) =>

--- a/ui/admin/tests/e2e/tests/credential-store-static.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static.spec.js
@@ -16,14 +16,10 @@ const {
 const {
   createOrg,
   createProject,
-  createHostCatalog,
-  createHostSet,
-  createHostInHostSet,
-  createTarget,
+  createTargetWithAddress,
   createStaticCredentialStore,
   createStaticCredentialKeyPair,
   addBrokeredCredentialsToTarget,
-  addHostSourceToTarget,
 } = require('../helpers/boundary-ui');
 
 test.use({ storageState: authenticatedState });
@@ -48,11 +44,11 @@ test.beforeEach(async ({ page }) => {
 
   orgName = await createOrg(page);
   projectName = await createProject(page);
-  await createHostCatalog(page);
-  const hostSetName = await createHostSet(page);
-  await createHostInHostSet(page, process.env.E2E_TARGET_ADDRESS);
-  targetName = await createTarget(page, process.env.E2E_TARGET_PORT);
-  await addHostSourceToTarget(page, hostSetName);
+  targetName = await createTargetWithAddress(
+    page,
+    process.env.E2E_TARGET_ADDRESS,
+    process.env.E2E_TARGET_PORT,
+  );
   await createStaticCredentialStore(page);
 });
 

--- a/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
@@ -18,11 +18,7 @@ const {
   createOrg,
   createProject,
   createVaultCredentialStore,
-  createHostCatalog,
-  createHostSet,
-  createHostInHostSet,
-  createTarget,
-  addHostSourceToTarget,
+  createTargetWithAddress,
   addBrokeredCredentialsToTarget,
 } = require('../helpers/boundary-ui');
 const { readFile } = require('fs/promises');
@@ -103,11 +99,11 @@ test('Vault Credential Store (User & Key Pair) @ce @aws @docker', async ({
     );
     const project = projects.items.filter((obj) => obj.name == projectName)[0];
 
-    await createHostCatalog(page);
-    const hostSetName = await createHostSet(page);
-    await createHostInHostSet(page, process.env.E2E_TARGET_ADDRESS);
-    const targetName = await createTarget(page, process.env.E2E_TARGET_PORT);
-    await addHostSourceToTarget(page, hostSetName);
+    const targetName = await createTargetWithAddress(
+      page,
+      process.env.E2E_TARGET_ADDRESS,
+      process.env.E2E_TARGET_PORT,
+    );
     const targets = JSON.parse(
       execSync(`boundary targets list -format json -scope-id ${project.id}`),
     );

--- a/ui/admin/tests/e2e/tests/session-recording-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/session-recording-ent.spec.js
@@ -79,6 +79,7 @@ test('Verify session recording can be deleted @ent @aws', async ({ page }) => {
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
     const storageBucketName = await createStorageBucket(
       page,
+      orgName,
       process.env.E2E_AWS_BUCKET_NAME,
       process.env.E2E_AWS_REGION,
       process.env.E2E_AWS_ACCESS_KEY_ID,
@@ -86,7 +87,7 @@ test('Verify session recording can be deleted @ent @aws', async ({ page }) => {
       `"${process.env.E2E_WORKER_TAG_EGRESS}" in "/tags/type"`,
     );
     const storageBuckets = JSON.parse(
-      execSync('boundary storage-buckets list -format json'),
+      execSync('boundary storage-buckets list --recursive -format json'),
     );
     storageBucket = storageBuckets.items.filter(
       (obj) => obj.name == storageBucketName,
@@ -94,8 +95,8 @@ test('Verify session recording can be deleted @ent @aws', async ({ page }) => {
 
     // Create target
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
-    await page.getByRole('link', { name: orgId }).click();
-    await page.getByRole('link', { name: projectId }).click();
+    await page.getByRole('link', { name: orgName }).click();
+    await page.getByRole('link', { name: projectName }).click();
     const targetName = await createSshTargetWithAddressAndWorkerFilterEnt(
       page,
       process.env.E2E_TARGET_ADDRESS,
@@ -118,7 +119,7 @@ test('Verify session recording can be deleted @ent @aws', async ({ page }) => {
 
     // Create storage policy in org scope: keep session recordings forever
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
-    await page.getByRole('link', { name: orgId }).click();
+    await page.getByRole('link', { name: orgName }).click();
     const policyName = await createStoragePolicy(page);
     await attachStoragePolicy(page, policyName);
 
@@ -135,7 +136,7 @@ test('Verify session recording can be deleted @ent @aws', async ({ page }) => {
     await expect(
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();
-    await page.getByRole('button', { name: 'Dismiss' }).click();
+    await page.getByRole('button', { name: 'Dismiss', exact: true }).click();
     await waitForSessionRecordingCli(storageBucket.id);
 
     // Play back session recording
@@ -182,7 +183,7 @@ test('Verify session recording can be deleted @ent @aws', async ({ page }) => {
       (obj) => obj.name == policyName,
     )[0];
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
-    await page.getByRole('link', { name: orgId }).click();
+    await page.getByRole('link', { name: orgName }).click();
     await page
       .getByRole('link', { name: 'Storage Policies', exact: true })
       .click();


### PR DESCRIPTION
This PR makes some adjustments to the Admin UI e2e test suite based on changes for 0.16.0.
- The "New Storage Bucket" page no longer defaults to a `global` scope, so we now have to specify a scope. The test now creates the bucket within the created org scope, and the respective changes 
- Multiple tests were modified to create a target with an address associated with it to reduce the number of actions needed. We still have one test that creates a target and associated a host source to it.
- The Sessions page no longer shows the Refresh button in its empty state. Needed to modify the logic of `waitForSessionToBeVisible` accordingly
- Some link locators were modified (removed a `.getByRole('article')`)