### PR TITLE
Fix scope field validation on storage buckets

### DIFF
--- a/ui/admin/app/components/form/storage-bucket/aws/index.hbs
+++ b/ui/admin/app/components/form/storage-bucket/aws/index.hbs
@@ -52,6 +52,7 @@
     <Hds::Form::Select::Field
       name='scope'
       @isRequired={{true}}
+      @isInvalid={{@model.errors.scope_id}}
       @width='100%'
       disabled={{form.disabled}}
       {{on 'change' @updateScope}}
@@ -82,6 +83,13 @@
           </option>
         {{/each}}
       </F.Options>
+      {{#if @model.errors.scope_id}}
+        <F.Error as |E|>
+          {{#each @model.errors.scope_id as |error|}}
+            <E.Message>{{error.message}}</E.Message>
+          {{/each}}
+        </F.Error>
+      {{/if}}
     </Hds::Form::Select::Field>
   {{else}}
     <InfoField

--- a/ui/admin/app/components/form/storage-bucket/minio/index.hbs
+++ b/ui/admin/app/components/form/storage-bucket/minio/index.hbs
@@ -52,6 +52,7 @@
     <Hds::Form::Select::Field
       name='scope'
       @isRequired={{true}}
+      @isInvalid={{@model.errors.scope_id}}
       @width='100%'
       disabled={{form.disabled}}
       {{on 'change' @updateScope}}
@@ -82,6 +83,13 @@
           </option>
         {{/each}}
       </F.Options>
+      {{#if @model.errors.scope_id}}
+        <F.Error as |E|>
+          {{#each @model.errors.scope_id as |error|}}
+            <E.Message>{{error.message}}</E.Message>
+          {{/each}}
+        </F.Error>
+      {{/if}}
     </Hds::Form::Select::Field>
   {{else}}
     <InfoField


### PR DESCRIPTION
## Description

Add field validation for scope within Storage bucket creation. Storage buckets did not have implemented field validation for Scope select.

## Screenshots:

### Before:
![Screenshot 2024-04-19 at 11 00 28 AM](https://github.com/hashicorp/boundary-ui/assets/9775006/f90a6024-d388-4440-ab4b-f7165a451029)


### After:
![Screenshot 2024-04-19 at 10 58 21 AM](https://github.com/hashicorp/boundary-ui/assets/9775006/a5067c31-4e1d-4ceb-a81d-780f678bbfdb)


## How to Test
- Using a Boundary instance + MinIO try to create a storage bucket without filling any field in the form.
- You should see Scope field showing required field error.

## Checklist:

- [x] I have added before and after screenshots for UI changes
- ~~[ ] I have added JSON response output for API changes~~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~~[ ] I have commented on my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new warnings
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
