### PR TITLE
fix: 🐛 required & optional labels in oidc auth-methods form

### DIFF
--- a/ui/admin/app/components/form/auth-method/oidc/index.hbs
+++ b/ui/admin/app/components/form/auth-method/oidc/index.hbs
@@ -97,8 +97,8 @@
   <Hds::Form::TextInput::Field
     name='client_id'
     @value={{@model.client_id}}
+    @isRequired={{true}}
     @isInvalid={{@model.errors.client_id}}
-    @isOptional={{true}}
     disabled={{form.disabled}}
     {{on 'input' (set-from-event @model 'client_id')}}
     as |F|
@@ -117,8 +117,8 @@
   <Hds::Form::TextInput::Field
     name='client_secret'
     @value={{@model.client_secret}}
+    @isRequired={{true}}
     @isInvalid={{@model.errors.client_secret}}
-    @isOptional={{true}}
     disabled={{form.disabled}}
     @hasVisibilityToggle={{false}}
     @type='password'
@@ -147,7 +147,11 @@
   {{/unless}}
 
   {{! Signing Algorithms }}
-  <Form::Field::ListWrapper @layout='horizontal' @disabled={{form.disabled}}>
+  <Form::Field::ListWrapper
+    @layout='horizontal'
+    @isOptional={{true}}
+    @disabled={{form.disabled}}
+  >
     <:fieldset as |F|>
       <F.Legend>
         {{t 'form.signing_algorithms.label'}}
@@ -412,6 +416,7 @@
   <Hds::Form::TextInput::Field
     name='max_age'
     @value={{@model.max_age}}
+    @isOptional={{true}}
     @isInvalid={{@model.errors.max_age}}
     disabled={{form.disabled}}
     {{on 'input' (set-from-event @model 'max_age')}}
@@ -431,6 +436,7 @@
   <Hds::Form::TextInput::Field
     name='api_url_prefix'
     @value={{@model.api_url_prefix}}
+    @isRequired={{true}}
     @isInvalid={{@model.errors.api_url_prefix}}
     disabled={{form.disabled}}
     {{on 'input' (set-from-event @model 'api_url_prefix')}}


### PR DESCRIPTION
## Description
Update required fields with "Required" label
<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

![image](https://github.com/hashicorp/boundary-ui/assets/107949262/fae57701-e0f9-4ca2-b605-77b10b6c5afd)

## How to Test

<!-- Add steps to test this change. Include any other necessary relevant links -->
1. run boundary dev instance
2. save oidc auth method without inputting anything to see required fields.
<!--
Replace PATH_TO_FEATURE with Vercel link
-->

:technologist: [Admin preview](PATH_TO_FEATURE)

:desktop_computer: [Desktop preview](PATH_TO_FEATURE)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [X] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
