### PR TITLE
fix: 🐛 Fix HDS labels and helpers in host sets

### DIFF
--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -168,7 +168,7 @@ ip_addresses:
   help: Read-only public and private IP addresses given by the plugin host catalog provider
 sync-interval:
   label: Sync Interval
-  help: Optional. Number of seconds between the time Boundary syncs hosts in this set.
+  help: Number of seconds between the time Boundary syncs hosts in this set.
 tags:
   label: Tags
 secret-editor:

--- a/ui/admin/app/components/form/host-set/aws/index.hbs
+++ b/ui/admin/app/components/form/host-set/aws/index.hbs
@@ -97,7 +97,11 @@
     </:field>
   </Form::Field::ListWrapper>
 
-  <Form::Field::ListWrapper @layout='horizontal' @disabled={{form.disabled}}>
+  <Form::Field::ListWrapper
+    @layout='horizontal'
+    @isOptional={{true}}
+    @disabled={{form.disabled}}
+  >
     <:fieldset as |F|>
       <F.Legend>
         {{t 'resources.host-set.form.filter.label'}}
@@ -127,6 +131,7 @@
     name='sync_interval_seconds'
     @value={{@model.sync_interval_seconds}}
     @isInvalid={{@model.errors.sync_interval_seconds}}
+    @isOptional={{true}}
     disabled={{form.disabled}}
     {{on 'input' (set-from-event @model 'sync_interval_seconds')}}
     as |F|

--- a/ui/admin/app/components/form/host-set/aws/index.hbs
+++ b/ui/admin/app/components/form/host-set/aws/index.hbs
@@ -131,9 +131,9 @@
     {{on 'input' (set-from-event @model 'sync_interval_seconds')}}
     as |F|
   >
-    <F.Label>{{t 'form.name.label'}}</F.Label>
+    <F.Label>{{t 'form.sync-interval.label'}}</F.Label>
     <F.HelperText>
-      {{t 'form.name.help'}}
+      {{t 'form.sync-interval.help'}}
       <Hds::Link::Inline @href={{doc-url 'host-set.sync-interval-seconds'}}>
         {{t 'actions.learn-more'}}
       </Hds::Link::Inline>

--- a/ui/admin/app/components/form/host-set/azure/index.hbs
+++ b/ui/admin/app/components/form/host-set/azure/index.hbs
@@ -127,9 +127,9 @@
     {{on 'input' (set-from-event @model 'sync_interval_seconds')}}
     as |F|
   >
-    <F.Label>{{t 'form.name.label'}}</F.Label>
+    <F.Label>{{t 'form.sync-interval.label'}}</F.Label>
     <F.HelperText>
-      {{t 'form.name.help'}}
+      {{t 'form.sync-interval.help'}}
       <Hds::Link::Inline @href={{doc-url 'host-set.sync-interval-seconds'}}>
         {{t 'actions.learn-more'}}
       </Hds::Link::Inline>

--- a/ui/admin/app/components/form/host-set/azure/index.hbs
+++ b/ui/admin/app/components/form/host-set/azure/index.hbs
@@ -123,6 +123,7 @@
     name='sync_interval_seconds'
     @value={{@model.sync_interval_seconds}}
     @isInvalid={{@model.errors.sync_interval_seconds}}
+    @isOptional={{true}}
     disabled={{form.disabled}}
     {{on 'input' (set-from-event @model 'sync_interval_seconds')}}
     as |F|


### PR DESCRIPTION
## Description
The sync interval field was mistakenly changed in https://github.com/hashicorp/boundary-ui/pull/2147. This changes the label and helper text back.

## Screenshots (if appropriate):
Before:
<img width="1574" alt="Screenshot 2024-04-22 at 7 41 16 PM" src="https://github.com/hashicorp/boundary-ui/assets/5783847/3f4ead31-a300-487f-9895-47de1f33c0d2">


After:
<img width="1523" alt="Screenshot 2024-04-22 at 7 58 25 PM" src="https://github.com/hashicorp/boundary-ui/assets/5783847/6bd075e5-a845-44b5-a679-5b4126dd621f">


## How to Test
Go to the AWS and azure host sets and confirm the field is correct.

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
