### PR TITLE
fix: Update LDAP address example

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -84,7 +84,7 @@ auth-method:
   form:
     urls:
       label: Server address (URL and port)
-      help: 'The domain name or IP address of the LDAP server. (Example: ldap.example.com:389)'
+      help: 'The domain name or IP address of the LDAP server. (Example: ldaps://ldap.example.com:636)'
     certificates:
       label: Certificates
       help: PEM encoded x509 certificates in ASN.1 DER form that can be used as trust anchors when connecting to an LDAP provider.


### PR DESCRIPTION
## Description

This PR updates the example text for an LDAP server address. This was noted by a Solutions Engineer.
- The field does require a scheme (i.e. `ldap://`)
- `ldaps://` was selected since most production environments will use SSL
- `636` is the default port for `ldaps://`

## Screenshots (if appropriate):

_BEFORE_
![image](https://github.com/hashicorp/boundary-ui/assets/2474253/615d8603-542a-4833-98a5-1b51fcb6188e)

_AFTER_
![Screenshot 2024-04-24 at 12 09 57 PM](https://github.com/hashicorp/boundary-ui/assets/2474253/fa6d3086-8bee-4bd0-9922-b3aa64be67f7)

## How to Test
- [x] Verify text changes appear in UI

:technologist: [Admin preview](https://boundary-ui-git-moduli-update-ldap-example-hashicorp.vercel.app)

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] ~I have added JSON response output for API changes~
- [ ] ~I have added steps to reproduce and test for bug fixes in the description~
- [ ] ~I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
