### PR TITLE
fix: 🐛 Fix error when deleting auth method

### DIFF
--- a/ui/admin/app/controllers/scopes/scope/auth-methods/index.js
+++ b/ui/admin/app/controllers/scopes/scope/auth-methods/index.js
@@ -142,11 +142,11 @@ export default class ScopesScopeAuthMethodsIndexController extends Controller {
   @notifyError(({ message }) => message, { catch: true })
   @notifySuccess('notifications.delete-success')
   async delete(authMethod) {
+    const scopeID = authMethod.scopeID;
     await authMethod.destroyRecord();
     // Reload the scope, since this is where the primary_auth_method_id is
     // stored.  An auth method deletion could affect this field.
-    const scope = this.store.peekRecord('scope', authMethod.scopeID);
-    await scope.reload();
+    await this.store.findRecord('scope', scopeID, { reload: true });
     this.router.replaceWith('scopes.scope.auth-methods');
     await this.router.refresh();
   }


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-13624

## Description
There was an issue with deleting an auth method where we tried to access a model field after deleting it. Weirdly enough ember only throws the error when we make the auth method primary and then removing it as primary.

## Screenshots (if appropriate):
![image](https://github.com/hashicorp/boundary-ui/assets/5783847/daec62bb-1547-4699-b69f-238a0a519066)

## How to Test
* Create a password auth method in an org
* Mark it as primary
* Remove it as primary
* Delete it
* Should not error 

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
