### PR TITLE
fix: 🐛 recording storage path not being set

### DIFF
--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -128,6 +128,7 @@
               name='recording_storage_path'
               @value={{this.recording_storage_path}}
               placeholder='/tmp/worker1'
+              {{on 'input' (set-from-event this 'recording_storage_path')}}
               as |F|
             >
               <F.Label>{{t


### PR DESCRIPTION

## Description

<!-- Add a brief description of changes here -->
Fix regression due to [input box refactor](https://github.com/hashicorp/boundary-ui/pull/2151).

## Screenshots (if appropriate):

https://github.com/hashicorp/boundary-ui/assets/107949262/2afd9c57-6856-47f0-a4bb-7c927430b45c


## How to Test

1. Go to Wokers List View
2. Click New
3. Toggle Enable Recording Storage
4. Enter in a value for the storage path & text editor should update with inputed value

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [X] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
