### PR TITLE
refactor: 💡 remove route-action usage for storage-policies

### DIFF
--- a/ui/admin/app/components/form/scope/add-storage-policy/create.hbs
+++ b/ui/admin/app/components/form/scope/add-storage-policy/create.hbs
@@ -21,8 +21,8 @@
   <page.body>
     <Form::Policy
       @model={{@model}}
-      @submit={{route-action 'save' @model}}
-      @cancel={{route-action 'cancel' @model}}
+      @submit={{fn this.save @model}}
+      @cancel={{fn this.cancel @model}}
     />
   </page.body>
 

--- a/ui/admin/app/controllers/scopes/scope/add-storage-policy/create.js
+++ b/ui/admin/app/controllers/scopes/scope/add-storage-policy/create.js
@@ -1,0 +1,37 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { notifySuccess, notifyError } from 'core/decorators/notify';
+import { loading } from 'ember-loading';
+
+export default class ScopesScopeAddStoragePolicyCreateController extends Controller {
+  // =services
+
+  @service router;
+
+  // =actions
+
+  /**
+   * Handle save
+   * @param {PolicyModel} policy
+   */
+  @action
+  @loading
+  @notifyError(({ message }) => message)
+  @notifySuccess('notifications.save-success')
+  async save(policy) {
+    await policy.save();
+    await this.router.transitionTo('scopes.scope.add-storage-policy');
+    await this.router.refresh();
+  }
+
+  /**
+   * Rollback changes on policies.
+   * @param {PolicyModel} policy
+   */
+  @action
+  cancel(policy) {
+    policy.rollbackAttributes();
+    this.router.transitionTo('scopes.scope.add-storage-policy');
+  }
+}

--- a/ui/admin/app/controllers/scopes/scope/add-storage-policy/index.js
+++ b/ui/admin/app/controllers/scopes/scope/add-storage-policy/index.js
@@ -1,0 +1,40 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { loading } from 'ember-loading';
+import { notifySuccess, notifyError } from 'core/decorators/notify';
+
+export default class ScopesScopeAddStoragePolicyIndexController extends Controller {
+  // =services
+
+  @service router;
+
+  // =actions
+
+  /**
+   * Deletes the scope and redirects to index.
+   * @param {Model} scope
+   */
+  @action
+  @loading
+  @notifyError(({ message }) => message, { catch: true })
+  @notifySuccess('notifications.save-success')
+  async attachStoragePolicy(scope) {
+    const { storage_policy_id } = scope;
+    if (storage_policy_id) {
+      await scope.attachStoragePolicy(storage_policy_id);
+    }
+    await scope.save();
+    await this.router.transitionTo('scopes.scope.edit', scope);
+  }
+
+  /**
+   * Rollback changes on add storage policy.
+   * @param {ScopeModel} scope
+   */
+  @action
+  cancel(scope) {
+    scope.rollbackAttributes();
+    this.router.transitionTo('scopes.scope.edit', scope);
+  }
+}

--- a/ui/admin/app/controllers/scopes/scope/policies/index.js
+++ b/ui/admin/app/controllers/scopes/scope/policies/index.js
@@ -1,0 +1,53 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { loading } from 'ember-loading';
+import { confirm } from 'core/decorators/confirm';
+import { notifySuccess, notifyError } from 'core/decorators/notify';
+
+export default class ScopesScopePoliciesIndexController extends Controller {
+  // =services
+
+  //@service can;
+  @service router;
+
+  // =actions
+
+  /**
+   * Rollback changes on a policy.
+   * @param {PolicyModel} policy
+   */
+  @action
+  cancel(policy) {
+    const { isNew } = policy;
+    policy.rollbackAttributes();
+    if (isNew) this.router.transitionTo('scopes.scope.policies');
+  }
+
+  /**
+   * Save a policy in current scope.
+   * @param {PolicyModel} policy
+   */
+  @action
+  @loading
+  @notifyError(({ message }) => message)
+  @notifySuccess('notifications.save-success')
+  async save(policy) {
+    await policy.save();
+    await this.router.transitionTo('scopes.scope.policies.policy', policy);
+
+    await this.router.refresh();
+  }
+  /**
+   * Deletes the policy.
+   * @param {PolicyModel} policy
+   */
+  @action
+  @loading
+  @confirm('questions.delete-confirm')
+  @notifyError(({ message }) => message, { catch: true })
+  @notifySuccess('notifications.delete-success')
+  async delete(policy) {
+    await policy.destroyRecord();
+  }
+}

--- a/ui/admin/app/controllers/scopes/scope/policies/index.js
+++ b/ui/admin/app/controllers/scopes/scope/policies/index.js
@@ -8,7 +8,7 @@ import { notifySuccess, notifyError } from 'core/decorators/notify';
 export default class ScopesScopePoliciesIndexController extends Controller {
   // =services
 
-  //@service can;
+  @service can;
   @service router;
 
   // =actions
@@ -34,10 +34,14 @@ export default class ScopesScopePoliciesIndexController extends Controller {
   @notifySuccess('notifications.save-success')
   async save(policy) {
     await policy.save();
-    await this.router.transitionTo('scopes.scope.policies.policy', policy);
-
+    if (this.can.can('read model', policy)) {
+      await this.router.transitionTo('scopes.scope.policies.policy', policy);
+    } else {
+      await this.router.transitionTo('scopes.scope.policies');
+    }
     await this.router.refresh();
   }
+
   /**
    * Deletes the policy.
    * @param {PolicyModel} policy

--- a/ui/admin/app/controllers/scopes/scope/policies/new.js
+++ b/ui/admin/app/controllers/scopes/scope/policies/new.js
@@ -1,0 +1,5 @@
+import Controller, { inject as controller } from '@ember/controller';
+
+export default class ScopesScopePoliciesNewController extends Controller {
+  @controller('scopes/scope/policies/index') policies;
+}

--- a/ui/admin/app/controllers/scopes/scope/policies/policy/index.js
+++ b/ui/admin/app/controllers/scopes/scope/policies/policy/index.js
@@ -1,0 +1,5 @@
+import Controller, { inject as controller } from '@ember/controller';
+
+export default class ScopesScopePoliciesPolicyIndexController extends Controller {
+  @controller('scopes/scope/policies/index') policies;
+}

--- a/ui/admin/app/routes/scopes/scope/add-storage-policy/create.js
+++ b/ui/admin/app/routes/scopes/scope/add-storage-policy/create.js
@@ -6,15 +6,12 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { TYPE_POLICY } from 'api/models/policy';
-import { action } from '@ember/object';
-import { notifySuccess, notifyError } from 'core/decorators/notify';
-import { loading } from 'ember-loading';
 
 export default class ScopesScopeAddStoragePolicyCreateRoute extends Route {
   // =services
 
   @service store;
-  @service router;
+
   // =methods
 
   /**
@@ -29,31 +26,5 @@ export default class ScopesScopeAddStoragePolicyCreateRoute extends Route {
     });
     record.scopeModel = scopeModel;
     return record;
-  }
-
-  // =actions
-
-  /**
-   * Handle save
-   * @param {PolicyModel} policy
-   */
-  @action
-  @loading
-  @notifyError(({ message }) => message)
-  @notifySuccess('notifications.save-success')
-  async save(policy) {
-    await policy.save();
-    await this.router.transitionTo('scopes.scope.add-storage-policy');
-    this.refresh();
-  }
-
-  /**
-   * Rollback changes on policies.
-   * @param {PolicyModel} policy
-   */
-  @action
-  cancel(policy) {
-    policy.rollbackAttributes();
-    this.router.transitionTo('scopes.scope.add-storage-policy');
   }
 }

--- a/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
+++ b/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
@@ -5,9 +5,6 @@
 
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { action } from '@ember/object';
-import { loading } from 'ember-loading';
-import { notifySuccess, notifyError } from 'core/decorators/notify';
 
 export default class ScopesScopeAddStoragePolicyIndexRoute extends Route {
   // =services
@@ -46,32 +43,5 @@ export default class ScopesScopeAddStoragePolicyIndexRoute extends Route {
   setupController(controller) {
     super.setupController(...arguments);
     controller.set('policyList', this.policyList);
-  }
-
-  /**
-   * Deletes the scope and redirects to index.
-   * @param {Model} scope
-   */
-  @action
-  @loading
-  @notifyError(({ message }) => message, { catch: true })
-  @notifySuccess('notifications.save-success')
-  async attachStoragePolicy(scope) {
-    const { storage_policy_id } = scope;
-    if (storage_policy_id) {
-      await scope.attachStoragePolicy(storage_policy_id);
-    }
-    await scope.save();
-    await this.router.transitionTo('scopes.scope.edit', scope);
-  }
-
-  /**
-   * Rollback changes on add storage policy.
-   * @param {PolicyModel} policy
-   */
-  @action
-  cancel(scope) {
-    scope.rollbackAttributes();
-    this.router.transitionTo('scopes.scope.edit', scope);
   }
 }

--- a/ui/admin/app/routes/scopes/scope/policies.js
+++ b/ui/admin/app/routes/scopes/scope/policies.js
@@ -5,10 +5,6 @@
 
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { action } from '@ember/object';
-import { loading } from 'ember-loading';
-import { confirm } from 'core/decorators/confirm';
-import { notifySuccess, notifyError } from 'core/decorators/notify';
 
 export default class ScopesScopePoliciesRoute extends Route {
   // =services
@@ -42,45 +38,5 @@ export default class ScopesScopePoliciesRoute extends Route {
     ) {
       return this.store.query('policy', { scope_id });
     }
-  }
-
-  //actions
-
-  /**
-   * Rollback changes on a policy.
-   * @param {PolicyModel} policy
-   */
-  @action
-  cancel(policy) {
-    const { isNew } = policy;
-    policy.rollbackAttributes();
-    if (isNew) this.router.transitionTo('scopes.scope.policies');
-  }
-
-  /**
-   * Save a policy in current scope.
-   * @param {PolicyModel} policy
-   */
-  @action
-  @loading
-  @notifyError(({ message }) => message)
-  @notifySuccess('notifications.save-success')
-  async save(policy) {
-    await policy.save();
-    await this.router.transitionTo('scopes.scope.policies.policy', policy);
-
-    this.refresh();
-  }
-  /**
-   * Deletes the policy.
-   * @param {PolicyModel} policy
-   */
-  @action
-  @loading
-  @confirm('questions.delete-confirm')
-  @notifyError(({ message }) => message, { catch: true })
-  @notifySuccess('notifications.delete-success')
-  async delete(policy) {
-    await policy.destroyRecord();
   }
 }

--- a/ui/admin/app/templates/scopes/scope/add-storage-policy/create.hbs
+++ b/ui/admin/app/templates/scopes/scope/add-storage-policy/create.hbs
@@ -25,8 +25,8 @@
   <page.body>
     <Form::Policy
       @model={{@model}}
-      @submit={{route-action 'save' @model}}
-      @cancel={{route-action 'cancel' @model}}
+      @submit={{fn this.save @model}}
+      @cancel={{fn this.cancel @model}}
     />
   </page.body>
 

--- a/ui/admin/app/templates/scopes/scope/add-storage-policy/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/add-storage-policy/index.hbs
@@ -24,8 +24,8 @@
     <Form::Scope::AddStoragePolicy
       @model={{@model}}
       @policyList={{this.policyList}}
-      @submit={{route-action 'attachStoragePolicy' @model}}
-      @cancel={{route-action 'cancel' @model}}
+      @submit={{fn this.attachStoragePolicy @model}}
+      @cancel={{fn this.cancel @model}}
     />
   </page.body>
 

--- a/ui/admin/app/templates/scopes/scope/policies/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/policies/index.hbs
@@ -107,7 +107,7 @@
                       <dd.Interactive
                         @text={{t 'resources.policy.actions.delete'}}
                         @color='critical'
-                        {{on 'click' (route-action 'delete' B.data)}}
+                        {{on 'click' (fn this.delete B.data)}}
                       />
                     {{/if}}
                   </Hds::Dropdown>

--- a/ui/admin/app/templates/scopes/scope/policies/new.hbs
+++ b/ui/admin/app/templates/scopes/scope/policies/new.hbs
@@ -25,8 +25,8 @@
   <page.body>
     <Form::Policy
       @model={{@model}}
-      @submit={{route-action 'save' @model}}
-      @cancel={{route-action 'cancel' @model}}
+      @submit={{fn this.policies.save @model}}
+      @cancel={{fn this.policies.cancel @model}}
     />
   </page.body>
 

--- a/ui/admin/app/templates/scopes/scope/policies/policy/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/policies/policy/index.hbs
@@ -28,8 +28,8 @@
   <page.body>
     <Form::Policy
       @model={{@model}}
-      @submit={{route-action 'save' @model}}
-      @cancel={{route-action 'cancel' @model}}
+      @submit={{fn this.policies.save @model}}
+      @cancel={{fn this.policies.cancel @model}}
     />
   </page.body>
 </Rose::Layout::Page>

--- a/ui/admin/tests/unit/controllers/scopes/scope/add-storage-policy/create-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/add-storage-policy/create-test.js
@@ -1,0 +1,79 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { visit } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module(
+  'Unit | Controller | scopes/scope/add-storage-policy/create',
+  function (hooks) {
+    setupTest(hooks);
+    setupMirage(hooks);
+
+    let store;
+    let controller;
+
+    const instances = {
+      scopes: {
+        global: null,
+      },
+      policy: null,
+    };
+
+    const urls = {
+      globalScope: null,
+      addStoragePolicy: null,
+    };
+
+    hooks.beforeEach(async function () {
+      authenticateSession({});
+      store = this.owner.lookup('service:store');
+      controller = this.owner.lookup(
+        'controller:scopes/scope/add-storage-policy/create',
+      );
+
+      instances.scopes.global = this.server.create('scope', { id: 'global' });
+      instances.policy = this.server.create('policy', {
+        scopeId: 'global',
+      });
+
+      urls.globalScope = `/scopes/global`;
+      urls.addStoragePolicy = `${urls.globalScope}/add-storage-policy`;
+    });
+
+    test('it exists', function (assert) {
+      assert.ok(controller);
+    });
+
+    test('cancel action rolls-back changes on the specified model', async function (assert) {
+      await visit(urls.addStoragePolicy);
+      const policyBefore = await store.findRecord(
+        'policy',
+        instances.policy.id,
+      );
+      policyBefore.name = 'test';
+
+      assert.strictEqual(policyBefore.name, 'test');
+
+      await controller.cancel(policyBefore);
+      const policyAfter = await store.findRecord('policy', instances.policy.id);
+
+      assert.notEqual(policyAfter.name, 'test');
+      assert.deepEqual(policyBefore, policyAfter);
+    });
+
+    test('save action saves changes on the specified model', async function (assert) {
+      await visit(urls.addStoragePolicy);
+      const policyBefore = await store.findRecord(
+        'policy',
+        instances.policy.id,
+      );
+      policyBefore.name = 'test';
+
+      await controller.save(policyBefore);
+      const policyAfter = await store.findRecord('policy', instances.policy.id);
+
+      assert.strictEqual(policyAfter.name, 'test');
+    });
+  },
+);

--- a/ui/admin/tests/unit/controllers/scopes/scope/add-storage-policy/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/add-storage-policy/index-test.js
@@ -1,0 +1,85 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { visit } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module(
+  'Unit | Controller | scopes/scope/add-storage-policy/index',
+  function (hooks) {
+    setupTest(hooks);
+    setupMirage(hooks);
+
+    let store;
+    let controller;
+
+    const instances = {
+      scopes: {
+        global: null,
+      },
+      policy: null,
+    };
+
+    const urls = {
+      globalScope: null,
+      addStoragePolicy: null,
+    };
+
+    hooks.beforeEach(async function () {
+      authenticateSession({});
+      store = this.owner.lookup('service:store');
+      controller = this.owner.lookup(
+        'controller:scopes/scope/add-storage-policy/index',
+      );
+
+      instances.scopes.global = this.server.create('scope', { id: 'global' });
+      instances.policy = this.server.create('policy', {
+        scopeId: 'global',
+      });
+
+      urls.globalScope = `/scopes/global`;
+      urls.addStoragePolicy = `${urls.globalScope}/add-storage-policy`;
+    });
+
+    test('it exists', function (assert) {
+      assert.ok(controller);
+    });
+
+    test('cancel action rolls-back changes on the specified model', async function (assert) {
+      await visit(urls.addStoragePolicy);
+      const scopeBefore = await store.findRecord(
+        'scope',
+        instances.scopes.global.id,
+      );
+      scopeBefore.storage_policy_id = instances.policy.id;
+
+      assert.strictEqual(scopeBefore.storage_policy_id, instances.policy.id);
+
+      await controller.cancel(scopeBefore);
+      const scopeAfter = await store.findRecord(
+        'scope',
+        instances.scopes.global.id,
+      );
+
+      assert.notOk(scopeAfter.storage_policy_id);
+      assert.deepEqual(scopeBefore, scopeAfter);
+    });
+
+    test('attachStoragePolicy action saves changes on the specified model', async function (assert) {
+      await visit(urls.addStoragePolicy);
+      const scopeBefore = await store.findRecord(
+        'scope',
+        instances.scopes.global.id,
+      );
+      scopeBefore.storage_policy_id = instances.policy.id;
+
+      await controller.attachStoragePolicy(scopeBefore);
+      const scopeAfter = await store.findRecord(
+        'scope',
+        instances.scopes.global.id,
+      );
+
+      assert.strictEqual(scopeAfter.storage_policy_id, instances.policy.id);
+    });
+  },
+);

--- a/ui/admin/tests/unit/controllers/scopes/scope/policies/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/policies/index-test.js
@@ -1,0 +1,83 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { visit } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module('Unit | Controller | scopes/scope/policies/index', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+  setupIndexedDb(hooks);
+
+  let store;
+  let controller;
+  let getPolicyCount;
+
+  const instances = {
+    scopes: {
+      global: null,
+    },
+    policy: null,
+  };
+
+  const urls = {
+    globalScope: null,
+    policies: null,
+  };
+
+  hooks.beforeEach(async function () {
+    authenticateSession({});
+    store = this.owner.lookup('service:store');
+    controller = this.owner.lookup('controller:scopes/scope/policies/index');
+
+    instances.scopes.global = this.server.create('scope', { id: 'global' });
+    instances.policy = this.server.create('policy', {
+      scopeId: 'global',
+    });
+
+    urls.globalScope = `/scopes/global`;
+    urls.policies = `${urls.globalScope}/policies`;
+
+    getPolicyCount = () => this.server.schema.policies.all().models.length;
+  });
+
+  test('it exists', function (assert) {
+    assert.ok(controller);
+  });
+
+  test('cancel action rolls-back changes on the specified model', async function (assert) {
+    await visit(urls.policies);
+    const policyBefore = await store.findRecord('policy', instances.policy.id);
+    policyBefore.name = 'test';
+
+    assert.strictEqual(policyBefore.name, 'test');
+
+    await controller.cancel(policyBefore);
+    const policyAfter = await store.findRecord('policy', instances.policy.id);
+
+    assert.notEqual(policyAfter.name, 'test');
+    assert.deepEqual(policyBefore, policyAfter);
+  });
+
+  test('save action saves changes on the specified model', async function (assert) {
+    await visit(urls.policies);
+    const policyBefore = await store.findRecord('policy', instances.policy.id);
+    policyBefore.name = 'test';
+
+    await controller.save(policyBefore);
+    const policyAfter = await store.findRecord('policy', instances.policy.id);
+
+    assert.strictEqual(policyAfter.name, 'test');
+  });
+
+  test('delete action destroys specified model', async function (assert) {
+    await visit(urls.globalScope);
+    const policy = await store.findRecord('policy', instances.policy.id);
+    const policyCount = getPolicyCount();
+
+    await controller.delete(policy);
+
+    assert.strictEqual(getPolicyCount(), policyCount - 1);
+  });
+});

--- a/ui/admin/tests/unit/controllers/scopes/scope/policies/new-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/policies/new-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | scopes/scope/policies/new', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:scopes/scope/policies/new');
+    assert.ok(controller);
+  });
+});

--- a/ui/admin/tests/unit/controllers/scopes/scope/policies/policy/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/policies/policy/index-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module(
+  'Unit | Controller | scopes/scope/policies/policy/index',
+  function (hooks) {
+    setupTest(hooks);
+
+    test('it exists', function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/policies/policy/index',
+      );
+      assert.ok(controller);
+    });
+  },
+);


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12607

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-12607)

## Description
remove route-action usage for storage policies routes

<!-- Add a brief description of changes here -->

## Screenshots (if appropriate):

## How to Test

<!-- Add steps to test this change. Include any other necessary relevant links -->
1. start boundary dev instance
2. test crudl for policies in org and global levels
3. test attaching a storage policy to a scope

## Checklist:
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
