### PR TITLE
chore: Fix error in Jira Sync workflow

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -87,7 +87,7 @@ jobs:
           echo "name=Done" >> $GITHUB_OUTPUT
         elif [[ "${{ github.event.action }}" == "reopened" ]]; then
           echo "Reopening ticket"
-          echo "name='To Do'" >> $GITHUB_OUTPUT
+          echo "name=Reopen" >> $GITHUB_OUTPUT
         fi
 
     # Transition issue API reference: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-post


### PR DESCRIPTION
After merging https://github.com/hashicorp/boundary-ui/pull/2283 and testing with https://github.com/hashicorp/boundary-ui/issues/2288, there was an error when reopening the issue
```
Run transitions="$(curl --silent \
  transitions="$(curl --silent \
    --url "***rest/api/3/issue/ICU-13742/transitions" \
    --user "***:***" \
    --header "Accept: application/json")"
  id="$(echo "${transitions}" | jq -r '.transitions[] | select(.name == "'To Do'") | .id')"
  curl --silent \
    --url "***rest/api/3/issue/ICU-13742/transitions" \
    --user "***:***" \
    --header "Accept: application/json" \
    --header "Content-Type: application/json" \
    --data "$(printf '{"transition": {"id": "%s"}}' "${id}")"
  shell: /usr/bin/bash -e {0}
jq: error: syntax error, unexpected $end, expecting QQSTRING_TEXT or QQSTRING_INTERP_START or QQSTRING_END (Unix shell quoting issues?) at <top-level>, line 1:
.transitions[] | select(.name == "To                                  
jq: 1 compile error
```
It seems like it was unhappy with how I was quoting `To Do`. Instead, this PR opts to use the "Reopen" status