### PR TITLE
feat: 🎸 Add support for polling transparent sessions

### DIFF
--- a/addons/api/addon/handlers/client-daemon-handler.js
+++ b/addons/api/addon/handlers/client-daemon-handler.js
@@ -112,7 +112,7 @@ export default class ClientDaemonHandler {
           // I'm not sure if we can get a 401 since we always send a token but we'll handle it in the same way
           if (e.statusCode === 403 || e.statusCode === 401) {
             try {
-              await this.ipc.invoke('addTokenToClientDaemon', {
+              await this.ipc.invoke('addTokenToDaemons', {
                 tokenId: auth_token_id,
                 token,
               });

--- a/addons/api/mirage/scenarios/ipc.js
+++ b/addons/api/mirage/scenarios/ipc.js
@@ -182,9 +182,12 @@ export default function initializeMockIPC(server, config) {
     checkCommand() {
       return faker.system.filePath();
     }
-    addTokenToClientDaemon() {}
+    addTokenToDaemons() {}
     searchClientDaemon() {}
     isClientDaemonRunning() {
+      return false;
+    }
+    isClientAgentRunning() {
       return false;
     }
   }

--- a/addons/core/addon/decorators/notify.js
+++ b/addons/core/addon/decorators/notify.js
@@ -31,7 +31,7 @@ export function notifySuccess(notification) {
       const text = intlService.t(candidateKey);
       const value = await method.apply(this, arguments);
       notifyService.success(text, {
-        noticationType: 'success',
+        notificationType: 'success',
         dismiss: (flash) => flash.destroyMessage(),
       });
       return value;
@@ -86,7 +86,7 @@ export function notifyError(
         const sticky = options.sticky === undefined ? true : options.sticky;
 
         notifyService.danger(text, {
-          noticationType: 'error',
+          notificationType: 'error',
           sticky,
           dismiss: (flash) => flash.destroyMessage(),
         });

--- a/addons/core/translations/errors/en-us.yaml
+++ b/addons/core/translations/errors/en-us.yaml
@@ -25,3 +25,5 @@ cluster-url-verification-failed:
 onboarding-failed:
   description: We're sorry, onboarding was unable to generate a TCP target.
 required-field: This is a required field.
+client-agent-failed:
+  sessions: Unable to retrieve sessions from the client agent.

--- a/addons/core/translations/notifications/en-us.yaml
+++ b/addons/core/translations/notifications/en-us.yaml
@@ -8,3 +8,6 @@ add-success: Added successfully.
 remove-success: Removed successfully.
 canceled-success: Canceled successfully.
 clear-success: Cleared successfully
+connected-to-target:
+  title: Connected to {target}
+  description: View more details and credentials provided by your administrator.

--- a/ui/admin/app/templates/application.hbs
+++ b/ui/admin/app/templates/application.hbs
@@ -132,12 +132,12 @@
     {{#each this.flashMessages.queue as |flash|}}
       <div
         class='ember-notify-show callout
-          {{flash.noticationType}}
+          {{flash.notificationType}}
           ember-view ember-notify clearfix'
       >
         <Rose::Notification
-          @style={{flash.noticationType}}
-          @heading={{t (concat 'states.' flash.noticationType)}}
+          @style={{flash.notificationType}}
+          @heading={{t (concat 'states.' flash.notificationType)}}
           @dismiss={{fn flash.dismiss flash}}
           @dismissText={{t 'actions.dismiss'}}
         >

--- a/ui/desktop/app/routes/application.js
+++ b/ui/desktop/app/routes/application.js
@@ -41,7 +41,7 @@ export default class ApplicationRoute extends Route {
     // Add token to client daemon after a successful authentication restoration
     if (this.session.isAuthenticated) {
       const sessionData = this.session.data?.authenticated;
-      await this.ipc.invoke('addTokenToClientDaemon', {
+      await this.ipc.invoke('addTokenToDaemons', {
         tokenId: sessionData?.id,
         token: sessionData?.token,
       });

--- a/ui/desktop/app/routes/cluster-url.js
+++ b/ui/desktop/app/routes/cluster-url.js
@@ -74,7 +74,7 @@ export default class ClusterUrlRoute extends Route {
         'errors.cluster-url-verification-failed.description',
       );
       this.flashMessages.danger(errorMessage, {
-        noticationType: 'error',
+        notificationType: 'error',
         sticky: true,
         dismiss: (flash) => flash.destroyMessage(),
       });

--- a/ui/desktop/app/routes/scopes/scope/projects.js
+++ b/ui/desktop/app/routes/scopes/scope/projects.js
@@ -76,7 +76,6 @@ export default class ScopesScopeProjectsRoute extends Route {
 
         try {
           const aliases = await this.store.query('alias', {
-            recursive: true,
             scope_id: 'global',
             force_refresh: true,
           });
@@ -92,7 +91,7 @@ export default class ScopesScopeProjectsRoute extends Route {
         }
 
         window.location.href = `serve://boundary/#/scopes/${orgScope}/projects/sessions/${session.session_authorization.session_id}`;
-        this.ipc.invoke('focusWindow');
+        await this.ipc.invoke('focusWindow');
       };
     });
   }

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
@@ -97,7 +97,6 @@ export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
     });
 
     const aliasPromise = this.store.query('alias', {
-      recursive: true,
       scope_id: 'global',
       force_refresh: true,
     });

--- a/ui/desktop/app/services/client-agent-sessions.js
+++ b/ui/desktop/app/services/client-agent-sessions.js
@@ -1,0 +1,76 @@
+import Service, { inject as service } from '@ember/service';
+
+export default class ClientAgentSessionsService extends Service {
+  // =services
+  @service ipc;
+
+  // =attributes
+  #sessionsSet;
+
+  // =methods
+
+  /**
+   * Returns a list of client agent sessions.
+   * @returns {Promise<*>}
+   */
+  async getClientAgentSessions() {
+    try {
+      return await this.ipc.invoke('getClientAgentSessions');
+    } catch (e) {
+      console.error('Error getting client agent sessions:', e);
+    }
+  }
+
+  /**
+   * Returns a client agent session by its session ID.
+   * @param id
+   * @returns {Promise<*>}
+   */
+  async getClientAgentSession(id) {
+    const sessions = await this.getClientAgentSessions();
+
+    return sessions?.find(
+      (session) => session.session_authorization.session_id === id,
+    );
+  }
+
+  /**
+   * Returns a list of new sessions that have credentials.
+   * @returns {Promise<Array<*>>}
+   */
+  async getNewSessionsWithCredentials() {
+    const sessions = (await this.getClientAgentSessions()) ?? [];
+
+    // Get sessions with credentials
+    const sessionsWithCredentials = sessions.filter(
+      (session) => session.session_authorization.credentials?.length > 0,
+    );
+
+    // If the set hasn't been initialized, this is our first run so we set the
+    // initial sessions and return an empty array as these sessions are not new
+    if (!this.#sessionsSet) {
+      this.#sessionsSet = new Set(
+        sessionsWithCredentials.map(
+          (session) => session.session_authorization.session_id,
+        ),
+      );
+
+      return [];
+    }
+
+    // Get the sessions that weren't present since the last check
+    const newSessions = sessionsWithCredentials.filter(
+      (session) =>
+        !this.#sessionsSet.has(session.session_authorization.session_id),
+    );
+
+    // Set current sessions that have credentials
+    this.#sessionsSet = new Set(
+      sessionsWithCredentials.map(
+        (session) => session.session_authorization.session_id,
+      ),
+    );
+
+    return newSessions;
+  }
+}

--- a/ui/desktop/app/services/client-agent-sessions.js
+++ b/ui/desktop/app/services/client-agent-sessions.js
@@ -14,11 +14,7 @@ export default class ClientAgentSessionsService extends Service {
    * @returns {Promise<*>}
    */
   async getClientAgentSessions() {
-    try {
-      return await this.ipc.invoke('getClientAgentSessions');
-    } catch (e) {
-      console.error('Error getting client agent sessions:', e);
-    }
+    return this.ipc.invoke('getClientAgentSessions');
   }
 
   /**

--- a/ui/desktop/app/services/session.js
+++ b/ui/desktop/app/services/session.js
@@ -20,7 +20,7 @@ export default class SessionService extends BaseSessionService {
 
     if (this.session.isAuthenticated) {
       const sessionData = this.data?.authenticated;
-      await this.ipc.invoke('addTokenToClientDaemon', {
+      await this.ipc.invoke('addTokenToDaemons', {
         tokenId: sessionData?.id,
         token: sessionData?.token,
       });

--- a/ui/desktop/app/templates/application.hbs
+++ b/ui/desktop/app/templates/application.hbs
@@ -106,12 +106,12 @@
     {{#each this.flashMessages.queue as |flash|}}
       <div
         class='ember-notify-show callout
-          {{flash.noticationType}}
+          {{flash.notificationType}}
           ember-view ember-notify clearfix'
       >
         <Rose::Notification
-          @style={{flash.noticationType}}
-          @heading={{t (concat 'states.' flash.noticationType)}}
+          @style={{flash.notificationType}}
+          @heading={{t (concat 'states.' flash.notificationType)}}
           @dismiss={{fn flash.dismiss flash}}
           @dismissText={{t 'actions.dismiss'}}
         >

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -192,7 +192,10 @@ app.on('ready', async () => {
   // per Electronegativity PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK
   ses.setPermissionRequestHandler((webContents, permission, callback) => {
     // We need to allow this for native clipboard usage
-    if (permission === 'clipboard-sanitized-write') {
+    if (
+      permission === 'clipboard-sanitized-write' ||
+      permission === 'notifications'
+    ) {
       // Approves the permissions request
       return callback(true);
     }

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -16,6 +16,7 @@ const pty = require('node-pty');
 const which = require('which');
 const { unixSocketRequest } = require('../helpers/request-promise');
 const clientDaemonManager = require('../services/client-daemon-manager');
+const clientAgentDaemonManager = require('../services/client-agent-daemon-manager');
 
 /**
  * Returns the current runtime clusterUrl, which is used by the main thread to
@@ -115,6 +116,13 @@ handle('toggleFullscreenWindow', () => {
 handle('closeWindow', () => app.quit());
 
 /**
+ * Focus the window
+ */
+handle('focusWindow', async () => {
+  BrowserWindow.getFocusedWindow().show();
+});
+
+/**
  * Return the location of where a user's binary for a command is. If it isn't found, return null.
  */
 handle('checkCommand', async (command) => which(command, { nothrow: true }));
@@ -149,6 +157,13 @@ handle('searchClientDaemon', async (request) =>
 handle('isClientDaemonRunning', async () => {
   clientDaemonManager.status();
   return Boolean(clientDaemonManager.socketPath);
+});
+
+/**
+ * Gets the client agent's sessions
+ */
+handle('getClientAgentSessions', async () => {
+  return clientAgentDaemonManager.getSessions();
 });
 
 /**

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -132,11 +132,9 @@ handle('focusWindow', () => {
 handle('checkCommand', async (command) => which(command, { nothrow: true }));
 
 /**
- * Adds the user's token to the client daemon.
+ * Adds the user's token to the daemons.
  */
-handle('addTokenToClientDaemon', async (data) =>
-  clientDaemonManager.addToken(data),
-);
+handle('addTokenToDaemons', async (data) => clientDaemonManager.addToken(data));
 
 /**
  * Return an object containing helper fields for determining what OS we're running on
@@ -168,6 +166,28 @@ handle('isClientDaemonRunning', async () => {
  */
 handle('getClientAgentSessions', async () => {
   return clientAgentDaemonManager.getSessions();
+});
+
+/**
+ * Check to see if the client daemon is running.
+ */
+handle('isClientAgentRunning', async () => {
+  try {
+    const status = await clientAgentDaemonManager.status();
+
+    // Check if we got an error for connecting to a non-enterprise controller
+    const isWrongControllerError = status.errors?.some((error) =>
+      error.includes('controller is not an enterprise edition controller'),
+    );
+    if (isWrongControllerError) {
+      return false;
+    }
+
+    return status.status === 'running';
+  } catch (e) {
+    // There was likely an error connecting to client agent.
+    return false;
+  }
 });
 
 /**

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -118,7 +118,7 @@ handle('closeWindow', () => app.quit());
 /**
  * Focus the window
  */
-handle('focusWindow', async () => {
+handle('focusWindow', () => {
   BrowserWindow.getFocusedWindow().show();
 });
 

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -119,7 +119,11 @@ handle('closeWindow', () => app.quit());
  * Focus the window
  */
 handle('focusWindow', () => {
-  BrowserWindow.getFocusedWindow().show();
+  // On windows, `Browser.getFocusedWindow()` can return null depending on
+  // the context so we just grab the first window from all windows. Because we
+  // currently only ever have one window active, this should be the same window.
+  const window = BrowserWindow.getAllWindows()[0];
+  window.show();
 });
 
 /**

--- a/ui/desktop/electron-app/src/services/client-agent-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/client-agent-daemon-manager.js
@@ -5,15 +5,13 @@
 
 const { spawnSync, spawn } = require('../helpers/spawn-promise');
 
-// TODO: Rename commands from ferry to client-agent
-
 class ClientAgentDaemonManager {
   /**
    * Checks the status of the client agent daemon.
    * @returns {string}
    */
   status() {
-    const clientAgentStatusCommand = ['ferry', 'status', '-format=json'];
+    const clientAgentStatusCommand = ['client-agent', 'status', '-format=json'];
     const { stdout } = spawnSync(clientAgentStatusCommand);
 
     return JSON.parse(stdout);
@@ -24,7 +22,11 @@ class ClientAgentDaemonManager {
    * @returns {*|Promise}
    */
   getSessions() {
-    const clientAgentSessionsCommand = ['ferry', 'sessions', '-format=json'];
+    const clientAgentSessionsCommand = [
+      'client-agent',
+      'sessions',
+      '-format=json',
+    ];
     const { stdout, stderr } = spawnSync(clientAgentSessionsCommand);
 
     let parsedResponse = JSON.parse(stdout);

--- a/ui/desktop/electron-app/src/services/client-agent-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/client-agent-daemon-manager.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+const { spawnSync, spawn } = require('../helpers/spawn-promise');
+
+// TODO: Rename commands from ferry to client-agent
+
+class ClientAgentDaemonManager {
+  /**
+   * Checks the status of the client agent daemon.
+   * @returns {string}
+   */
+  status() {
+    const clientAgentStatusCommand = ['ferry', 'status', '-format=json'];
+    const { stdout } = spawnSync(clientAgentStatusCommand);
+
+    return JSON.parse(stdout);
+  }
+
+  /**
+   * Gets the sessions from the client agent daemon.
+   * @returns {*|Promise}
+   */
+  getSessions() {
+    const clientAgentSessionsCommand = ['ferry', 'sessions', '-format=json'];
+    const { stdout, stderr } = spawnSync(clientAgentSessionsCommand);
+
+    let parsedResponse = JSON.parse(stdout);
+
+    if (parsedResponse?.status_code === 200) {
+      return parsedResponse.items;
+    }
+
+    parsedResponse = JSON.parse(stderr);
+    return Promise.reject({
+      statusCode: parsedResponse?.status_code,
+      ...parsedResponse?.api_error,
+    });
+  }
+}
+
+// Export an instance so we get a singleton
+module.exports = new ClientAgentDaemonManager();

--- a/ui/desktop/electron-app/src/utils/generateErrorPromise.js
+++ b/ui/desktop/electron-app/src/utils/generateErrorPromise.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+const jsonify = require('./jsonify');
+
+// Convert to json
+const generateErrorPromise = async (stderr) => {
+  const parsedResponse = jsonify(stderr);
+
+  if (parsedResponse?.status_code) {
+    return Promise.reject({
+      statusCode: parsedResponse?.status_code,
+      error: parsedResponse?.api_error,
+    });
+  }
+
+  return Promise.reject({
+    error: parsedResponse?.error,
+  });
+};
+
+module.exports = generateErrorPromise;

--- a/ui/desktop/tests/helpers/window-mock-ipc.js
+++ b/ui/desktop/tests/helpers/window-mock-ipc.js
@@ -24,9 +24,12 @@ class MockIPC {
   resetClusterUrl() {}
   hasMacOSChrome() {}
   showWindowActions() {}
-  addTokenToClientDaemon() {}
+  addTokenToDaemons() {}
   searchClientDaemon() {}
   isClientDaemonRunning() {
+    return false;
+  }
+  isClientAgentRunning() {
     return false;
   }
 }

--- a/ui/desktop/tests/unit/services/client-agent-sessions-test.js
+++ b/ui/desktop/tests/unit/services/client-agent-sessions-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'desktop/tests/helpers';
+
+module('Unit | Service | client-agent-sessions', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:client-agent-sessions');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-13831

# Description
Added functionality to poll the new `boundary ferry sessions` API. Still trying to figure out how to test this.

## Screenshots (if appropriate)
<img width="366" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/5783847/26c372db-273e-4a08-9480-2c5356585cbe">

## How to Test
* Setup ferry and boundary according to the docs [here](https://github.com/hashicorp/ferry?tab=readme-ov-file#ferry).
* Copy over the new CLI to our cli folder and use `BYPASS_CLI_SETUP=true`
* Add a brokered credential to the `Generated localhost ssh target with an alias` target.
* SSH to the default `ssh.boundary.dev` alias and you should get a notification (though you might need to also enable it on your OS). 
* Clicking the notification should open up the correct session with credentials displayed.


## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
