### PR TITLE
test(e2e): 0.16.1 updates

### DIFF
--- a/ui/admin/tests/e2e/helpers/boundary-cli.js
+++ b/ui/admin/tests/e2e/helpers/boundary-cli.js
@@ -359,9 +359,10 @@ exports.createStaticHostCatalogCli = async (projectId) => {
 /**
  * Uses the boundary CLI to create a new dynamic AWS host catalog.
  * @param {string} projectId ID of the project under which the host catalog will be created.
+ * @param {string} region Name of the AWS region that the host catalog will be created for.
  * @returns {Promise<string>} new host catalog's ID
  */
-exports.createDynamicAwsHostCatalogCli = async (projectId) => {
+exports.createDynamicAwsHostCatalogCli = async (projectId, region) => {
   const hostCatalogName = 'dynamic-aws-host-catalog-' + nanoid();
   let hostCatalog;
   try {
@@ -372,7 +373,7 @@ exports.createDynamicAwsHostCatalogCli = async (projectId) => {
           -scope-id ${projectId} \
           -plugin-name aws \
           -attr disable_credential_rotation=true \
-          -attr region=us-east-1 \
+          -attr region=${region} \
           -secret access_key_id=env://E2E_AWS_ACCESS_KEY_ID \
           -secret secret_access_key=env://E2E_AWS_SECRET_ACCESS_KEY \
           -format json`,

--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -985,7 +985,7 @@ exports.enableSessionRecording = async (page, storageBucketName) => {
   await page.getByText('Enable recording').click();
   await page.getByLabel('Record sessions for this target').click();
   await page
-    .getByLabel('AWS storage buckets')
+    .getByLabel('Storage buckets')
     .selectOption({ label: storageBucketName });
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(

--- a/ui/admin/tests/e2e/tests/delete-resources-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/delete-resources-ent.spec.js
@@ -66,6 +66,7 @@ test.beforeEach(async () => {
     process.env.E2E_PASSWORD_AUTH_METHOD_ID,
     process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
     process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    process.env.E2E_AWS_REGION,
   );
 });
 
@@ -88,8 +89,10 @@ test('Verify resources can be deleted (enterprise) @ent @aws', async ({
     let groupId = await createGroupCli(orgId);
     let userId = await createUserCli(orgId);
     let staticHostCatalogId = await createStaticHostCatalogCli(projectId);
-    let dynamicAwsHostCatalogId =
-      await createDynamicAwsHostCatalogCli(projectId);
+    let dynamicAwsHostCatalogId = await createDynamicAwsHostCatalogCli(
+      projectId,
+      process.env.E2E_AWS_REGION,
+    );
     let staticHostId = await createStaticHostCli(staticHostCatalogId);
     let staticHostSetId = await createHostSetCli(staticHostCatalogId);
     let staticCredentialStoreId =

--- a/ui/admin/tests/e2e/tests/delete-resources.spec.js
+++ b/ui/admin/tests/e2e/tests/delete-resources.spec.js
@@ -65,6 +65,7 @@ test.beforeEach(async () => {
     process.env.E2E_PASSWORD_AUTH_METHOD_ID,
     process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
     process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    process.env.E2E_AWS_REGION,
   );
 });
 
@@ -84,8 +85,10 @@ test('Verify resources can be deleted @ce @aws', async ({ page }) => {
     let groupId = await createGroupCli(orgId);
     let userId = await createUserCli(orgId);
     let staticHostCatalogId = await createStaticHostCatalogCli(projectId);
-    let dynamicAwsHostCatalogId =
-      await createDynamicAwsHostCatalogCli(projectId);
+    let dynamicAwsHostCatalogId = await createDynamicAwsHostCatalogCli(
+      projectId,
+      process.env.E2E_AWS_REGION,
+    );
     let staticHostId = await createStaticHostCli(staticHostCatalogId);
     let staticHostSetId = await createHostSetCli(staticHostCatalogId);
     let staticCredentialStoreId =

--- a/ui/admin/tests/e2e/tests/dynamic-host-catalog.spec.js
+++ b/ui/admin/tests/e2e/tests/dynamic-host-catalog.spec.js
@@ -17,6 +17,7 @@ test.beforeAll(async () => {
     'E2E_AWS_SECRET_ACCESS_KEY',
     'E2E_AWS_HOST_SET_FILTER',
     'E2E_AWS_HOST_SET_IPS',
+    'E2E_AWS_REGION',
   ]);
 });
 
@@ -47,7 +48,7 @@ test.describe('AWS', async () => {
       .getByRole('group', { name: 'Provider' })
       .getByLabel('AWS')
       .click();
-    await page.getByLabel('AWS Region').fill('us-east-1');
+    await page.getByLabel('AWS Region').fill(process.env.E2E_AWS_REGION);
     await page
       .getByLabel('Access Key ID')
       .fill(process.env.E2E_AWS_ACCESS_KEY_ID);


### PR DESCRIPTION
This PR updates the Admin UI e2e test suite based on results from testing Boundary 0.16.1. There are two changes here
1. Updates the test suite to utilize the AWS region specified in the environment. The end-to-end test suite can now run against different AWS regions, and this change uses the information passed from infra creation
2. Updates a locator for a label that was used to attach a storage bucket to a target.