### PR TITLE
feat: 🎸 Change the default notification on mac to be alert

### DIFF
--- a/ui/desktop/electron-app/config/forge.config.js
+++ b/ui/desktop/electron-app/config/forge.config.js
@@ -20,6 +20,11 @@ module.exports = {
       'entitlements-inherit': './assets/macos/entitlements.plist',
       'signature-flags': 'library',
     },
+    // Add extra keys to our Info.plist
+    extendInfo: {
+      // Set the default notification style to be alert instead of banner
+      NSUserNotificationAlertStyle: 'alert',
+    },
     asar: {
       // We need to unpack node-pty helpers so we have them available
       // outside of the ASAR when they are called
@@ -78,13 +83,13 @@ module.exports = {
         !process.env.BUILD_DEBIAN
       )
         console.warn(
-          '[package] WARNING: Could not find signing identity. Proceeding without signing.'
+          '[package] WARNING: Could not find signing identity. Proceeding without signing.',
         );
     },
     postPackage: async (forgeConfig, options) => {
       if (options.spinner) {
         options.spinner.info(
-          `Packaged for ${options.platform}-${options.arch} at ${options.outputPaths[0]}`
+          `Packaged for ${options.platform}-${options.arch} at ${options.outputPaths[0]}`,
         );
       }
     },
@@ -99,14 +104,14 @@ module.exports = {
         // Copy artifacts
         artifacts.forEach(async (artifact) => {
           const name = `boundary-desktop_${version}_${platform}_${arch}${path.extname(
-            artifact
+            artifact,
           )}`;
           const artifactDestination = path.join(destination, name);
           console.log(`[release] Found artifact: ${artifact}`);
           try {
             await fs.promises.copyFile(artifact, artifactDestination);
             console.log(
-              `[release] Copied artifact: ${path.resolve(artifactDestination)}`
+              `[release] Copied artifact: ${path.resolve(artifactDestination)}`,
             );
           } catch (e) {
             console.warn(`[release] Could not copy ${artifact}`, e);
@@ -126,7 +131,7 @@ module.exports = {
         'node_modules',
         'node-pty',
         'build',
-        'node_gyp_bins'
+        'node_gyp_bins',
       );
       await fs.promises.rm(gypPath, { recursive: true, force: true });
     },


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-13931

# Description
Sets an Info.plist key for our app ([NSUserNotificationAlertStyle](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW19)) to use alerts by default.

More context [here](https://hashicorp.slack.com/archives/C05EHAH84HE/p1717011178082889).
## Screenshots (if appropriate)

## How to Test
Run the build [here](https://github.com/hashicorp/boundary-ui-releases/actions/runs/9293151768) to confirm that boundary notifications are using alerts by default now. (Not sure of behavior if you've already changed the setting, I don't think it is likely to change?)

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- ~[ ] My changes generate no new warnings~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
