### PR TITLE
fix: 🐛 Fix session erroring out when getting session from ferry

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects/sessions/session.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions/session.js
@@ -12,6 +12,8 @@ export default class ScopesScopeProjectsSessionsSessionRoute extends Route {
   @service store;
   @service ipc;
   @service clientAgentSessions;
+  @service flashMessages;
+  @service intl;
 
   // =methods
 
@@ -33,11 +35,9 @@ export default class ScopesScopeProjectsSessionsSessionRoute extends Route {
       try {
         const clientAgentSession =
           await this.clientAgentSessions.getClientAgentSession(session.id);
-        if (clientAgentSession) {
-          clientAgentSession.session_authorization.credentials.forEach((cred) =>
-            session.addCredential(cred),
-          );
-        }
+        clientAgentSession?.session_authorization?.credentials?.forEach(
+          (cred) => session.addCredential(cred),
+        );
       } catch (e) {
         // TODO: Log this error
         this.flashMessages.danger(


### PR DESCRIPTION
# Description
Fix an error where sessions with no brokered credentials errored out. 

## Screenshots (if appropriate)

## How to Test
SSH to a target without brokered credentials using the client agent and go to the session in DC. It shouldn't error out.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
