### PR TITLE
Icu 13451 desktop client logging

### DIFF
--- a/addons/api/.eslintrc.js
+++ b/addons/api/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
   env: {
     browser: true,
   },
+  globals: { __electronLog: 'true' },
   rules: {
     'ember/no-get': 'off',
     'ember/no-get-with-default': 'off',

--- a/addons/api/.eslintrc.js
+++ b/addons/api/.eslintrc.js
@@ -25,7 +25,6 @@ module.exports = {
   env: {
     browser: true,
   },
-  globals: { __electronLog: 'true' },
   rules: {
     'ember/no-get': 'off',
     'ember/no-get-with-default': 'off',

--- a/addons/api/addon/handlers/client-daemon-handler.js
+++ b/addons/api/addon/handlers/client-daemon-handler.js
@@ -120,8 +120,9 @@ export default class ClientDaemonHandler {
                 'searchClientDaemon',
                 remainingQuery,
               );
-            } catch {
+            } catch (err) {
               // If it fails again just fall back to fetching controller data
+              __electronLog?.info('Failed to add token to client daemon', err);
             }
           }
 

--- a/addons/api/addon/handlers/client-daemon-handler.js
+++ b/addons/api/addon/handlers/client-daemon-handler.js
@@ -122,11 +122,16 @@ export default class ClientDaemonHandler {
               );
             } catch (err) {
               // If it fails again just fall back to fetching controller data
-              __electronLog?.info('Failed to add token to client daemon', err);
+              __electronLog?.error('Failed to add token to daemons', err);
             }
-          }
+          } else {
+            __electronLog?.error(
+              'Failed to search cache daemon; falling back to search controller',
+              e,
+            );
 
-          return fetchControllerData(context, next);
+            return fetchControllerData(context, next);
+          }
         }
 
         // Currently returns with a singular top level field with resource name

--- a/addons/api/addon/handlers/client-daemon-handler.js
+++ b/addons/api/addon/handlers/client-daemon-handler.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+/* global __electronLog */
 import { inject as service } from '@ember/service';
 import { getOwner, setOwner } from '@ember/application';
 import { generateMQLExpression } from '../utils/mql-query';

--- a/ui/desktop/.eslintrc.js
+++ b/ui/desktop/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
   env: {
     browser: true,
   },
+  globals: { __electronLog: 'true' },
   rules: {
     'ember/no-get': 'off',
     'ember/no-get-with-default': 'off',

--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "electron-devtools-installer": "^3.2.0",
     "electron-is-dev": "^2.0.0",
+    "electron-log": "^5.1.2",
     "electron-squirrel-startup": "^1.0.0",
     "node-html-parser": "^5.3.3",
     "node-pty": "^1.0.0",

--- a/ui/desktop/electron-app/src/helpers/request-promise.js
+++ b/ui/desktop/electron-app/src/helpers/request-promise.js
@@ -5,6 +5,7 @@
 
 const { net } = require('electron');
 const http = require('http');
+const log = require('electron-log/main');
 
 const requestTimeoutSeconds = 10;
 // Simple promise wrapper around Electron's net.request feature.
@@ -65,6 +66,14 @@ const unixSocketRequest = (options, reqBody) =>
 
         resolve(parsedResponse);
       } catch (e) {
+        log.error(
+          `unixSocketRequest(${JSON.stringify({
+            path: options.path,
+            socketPath: options.socketPath,
+          })}):`,
+          e,
+        );
+
         reject(e);
       }
     });

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -57,6 +57,7 @@ fixPath();
 
 // Setup logger
 log.initialize();
+log.transports.console.level = false;
 log.transports.file.format =
   '[{y}-{m}-{d} {h}:{i}:{s}.{ms}{z}] [{level}] {text}';
 

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -21,6 +21,7 @@ const {
   shell,
 } = require('electron');
 require('./ipc/handlers.js');
+const log = require('electron-log/main');
 
 const { generateCSPHeader } = require('./config/content-security-policy.js');
 const runtimeSettings = require('./services/runtime-settings.js');
@@ -53,6 +54,11 @@ protocol.registerSchemesAsPrivileged([
 // This is to correctly set the process.env.PATH as electron does not
 // correctly inherit the path variable in production
 fixPath();
+
+// Setup logger
+log.initialize();
+log.transports.file.format =
+  '[{y}-{m}-{d} {h}:{i}:{s}.{ms}{z}] [{level}] {text}';
 
 const createWindow = (partition, closeWindowCB) => {
   /**

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -62,26 +62,8 @@ log.transports.console.level = false;
 log.transports.file.format =
   '[{y}-{m}-{d} {h}:{i}:{s}.{ms}{z}] [{level}] {text}';
 log.transports.file.fileName = 'desktop-client.log';
-log.transports.file.archiveLogFn = (file) => {
-  file = file.toString();
-  const info = path.parse(file);
-
-  // This renames old files to the format of `desktop-client-(iso string date).log`
-  // TODO: Should we compress or delete old log files after a certain time?
-  try {
-    fs.renameSync(
-      file,
-      path.join(
-        info.dir,
-        info.name +
-          `-${new Date().toISOString().replace(/:/g, '-')}` +
-          info.ext,
-      ),
-    );
-  } catch (e) {
-    console.error('Could not rotate log', e);
-  }
-};
+// Set the max file size to 10MB
+log.transports.file.maxSize = 10485760;
 
 const createWindow = (partition, closeWindowCB) => {
   /**

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -14,7 +14,6 @@ const { isLinux, isMac, isWindows } = require('../helpers/platform.js');
 const os = require('node:os');
 const pty = require('node-pty');
 const which = require('which');
-const { unixSocketRequest } = require('../helpers/request-promise');
 const clientDaemonManager = require('../services/client-daemon-manager');
 
 /**

--- a/ui/desktop/electron-app/src/services/client-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/client-daemon-manager.js
@@ -10,6 +10,7 @@ const runtimeSettings = require('./runtime-settings');
 const sanitizer = require('../utils/sanitizer.js');
 const { isWindows } = require('../helpers/platform.js');
 const treeKill = require('tree-kill');
+const log = require('electron-log/main');
 
 class ClientDaemonManager {
   #socketPath;
@@ -48,6 +49,8 @@ class ClientDaemonManager {
     if (stderr && !stderr.includes('The daemon is already running')) {
       this.#isClientDaemonAlreadyRunning = false;
     }
+
+    log.info('Client daemon started', stderr);
     this.status();
   }
 
@@ -152,6 +155,7 @@ const searchCliCommand = (requestData) => {
   }
 
   parsedResponse = jsonify(stderr);
+  log.info(`Search Request Failed`, parsedResponse);
   return Promise.reject({
     statusCode: parsedResponse?.status_code,
     ...parsedResponse?.api_error,

--- a/ui/desktop/electron-app/src/utils/jsonify.js
+++ b/ui/desktop/electron-app/src/utils/jsonify.js
@@ -3,12 +3,15 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+const log = require('electron-log/main');
+
 // Convert to json
 const jsonify = (data) => {
   if (typeof data !== 'string') data = JSON.stringify(data);
   try {
     return JSON.parse(data);
   } catch (e) {
+    log.info('Error parsing JSON', e);
     // Ignore parse errors
   }
 };

--- a/ui/desktop/electron-app/src/utils/jsonify.js
+++ b/ui/desktop/electron-app/src/utils/jsonify.js
@@ -11,7 +11,7 @@ const jsonify = (data) => {
   try {
     return JSON.parse(data);
   } catch (e) {
-    log.info('Error parsing JSON', e);
+    log.error('jsonify:', e);
     // Ignore parse errors
   }
 };

--- a/ui/desktop/electron-app/yarn.lock
+++ b/ui/desktop/electron-app/yarn.lock
@@ -1155,6 +1155,11 @@ electron-is-dev@^2.0.0:
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-2.0.0.tgz#833487a069b8dad21425c67a19847d9064ab19bd"
   integrity sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA==
 
+electron-log@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-5.1.2.tgz#fb40ad7f4ae694dd0e4c02c662d1a65c03e1243e"
+  integrity sha512-Cpg4hAZ27yM9wzE77c4TvgzxzavZ+dVltCczParXN+Vb3jocojCSAuSMCVOI9fhFuuOR+iuu3tZLX1cu0y0kgQ==
+
 electron-squirrel-startup@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/electron-squirrel-startup/-/electron-squirrel-startup-1.0.0.tgz#19b4e55933fa0ef8f556784b9c660f772546a0b8"


### PR DESCRIPTION
# Description
This adds desktop client logging on all environments with an initial pass of things to log. 

By default, the logs are written to:

### Linux: 

    ~/.config/Boundary/logs/desktop-client.log

### macOS: 

    ~/Library/Logs/Boundary/desktop-client.log

### Windows:

    %USERPROFILE%\AppData\Roaming\Boundary\logs\desktop-client.log

## Screenshots (if appropriate)
[desktop-client.log](https://github.com/user-attachments/files/15539786/desktop-client.log)


## How to Test
Run the desktop client and experiment with generating errors. You'll have to manually do this usually by throwing manual errors. You can `tail -f` the log file to watch for new log entries.

To test log rotation, you can set the [maxSize](https://github.com/megahertz/electron-log/blob/master/docs/transports/file.md#maxsize-number) to something smaller.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
