### PR TITLE
test(e2e): Add test for worker

### DIFF
--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -159,6 +159,7 @@
       @value={{this.createConfigText}}
       @hasCopyButton={{true}}
       @hasLineNumbers={{false}}
+      data-test-worker-directory
     />
 
     <p>

--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -170,6 +170,7 @@
       @value={{this.workerConfigText}}
       @hasCopyButton={{true}}
       @hasLineNumbers={{false}}
+      data-test-worker-config
     />
 
     <p>

--- a/ui/admin/tests/e2e/tests/worker-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/worker-ent.spec.js
@@ -10,7 +10,12 @@ const { authenticatedState } = require('../helpers/general');
 
 test.use({ storageState: authenticatedState });
 
-test('Create a worker (enterprise) @ent @docker @aws', async ({ page }) => {
+test('Create a worker (enterprise) @ent @docker @aws', async ({
+  page,
+  browserName,
+}) => {
+  test.skip(browserName === 'webkit', 'Bug in worker form on Safari');
+
   await page.goto('/');
   await page
     .getByRole('navigation', { name: 'General' })

--- a/ui/admin/tests/e2e/tests/worker-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/worker-ent.spec.js
@@ -58,6 +58,14 @@ test('Create a worker (enterprise) @ent @docker @aws', async ({
   await page.getByLabel('Recording Storage Path').fill('/tmp/recordings');
 
   // Check auto-populated config
+  const dirLocator = '[data-test-worker-directory]';
+  await expect(page.locator(dirLocator)).toContainText(
+    'mkdir /home/ubuntu/boundary/ ;',
+  );
+  await expect(page.locator(dirLocator)).toContainText(
+    'touch /home/ubuntu/boundary/pki-worker.hcl',
+  );
+
   const configLocator = '[data-test-worker-config]';
   await expect(page.locator(configLocator)).toContainText(
     'public_addr = "worker1.example.com"',

--- a/ui/admin/tests/e2e/tests/worker-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/worker-ent.spec.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/* eslint-disable no-undef */
+const { expect } = require('@playwright/test');
+const { test } = require('@playwright/test');
+const { authenticatedState } = require('../helpers/general');
+
+test.use({ storageState: authenticatedState });
+
+test('Create a worker (enterprise) @ent @docker @aws', async ({ page }) => {
+  await page.goto('/');
+  await page
+    .getByRole('navigation', { name: 'General' })
+    .getByRole('link', { name: 'Workers' })
+    .click();
+  await page.getByRole('link', { name: 'New', exact: true }).click();
+
+  // Populate config fields
+  await page.getByLabel('Worker public address').fill('worker1.example.com');
+  await page.getByLabel('Config file path').fill('/home/ubuntu/boundary');
+  await page.getByLabel('Initial upstreams').fill('10.0.0.1, 10.0.0.2');
+  await page
+    .getByRole('group', { name: 'Worker Tags' })
+    .getByLabel('Key')
+    .fill('type');
+  await page
+    .getByRole('group', { name: 'Worker Tags' })
+    .getByLabel('Value')
+    .fill('downstream, pki');
+  await page
+    .getByRole('group', { name: 'Worker Tags' })
+    .getByRole('button', { name: 'Add' })
+    .click();
+  await page
+    .getByRole('group', { name: 'Worker Tags' })
+    .getByLabel('Key')
+    .last()
+    .fill('test');
+  await page
+    .getByRole('group', { name: 'Worker Tags' })
+    .getByLabel('Value')
+    .last()
+    .fill('example');
+  await page
+    .getByRole('group', { name: 'Worker Tags' })
+    .getByRole('button', { name: 'Add' })
+    .click();
+
+  await page.getByRole('switch', { name: 'Enable Recording Storage' }).click();
+  await page.getByLabel('Recording Storage Path').fill('/tmp/recordings');
+
+  // Check auto-populated config
+  const configLocator = '[data-test-worker-config=""]';
+  await expect(page.locator(configLocator)).toContainText(
+    'public_addr = "worker1.example.com"',
+  );
+  await expect(page.locator(configLocator)).toContainText(
+    'auth_storage_path = "/home/ubuntu/boundary/worker1"',
+  );
+  await expect(page.locator(configLocator)).toContainText(
+    'initial_upstreams = ["10.0.0.1", "10.0.0.2"]',
+  );
+  await expect(page.locator(configLocator)).toContainText(
+    'type = ["downstream", "pki"]',
+  );
+  await expect(page.locator(configLocator)).toContainText('test = ["example"]');
+  await expect(page.locator(configLocator)).toContainText(
+    'recording_storage_path = "/tmp/recordings"',
+  );
+
+  // Try using an invalid worker token. Expect an error
+  await page.getByLabel('Worker Auth Registration Request').fill('test');
+  await page.getByRole('button', { name: 'Register' }).click();
+  await expect(
+    page.getByRole('alert').getByText('Error', { exact: true }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Dismiss' }).click();
+});

--- a/ui/admin/tests/e2e/tests/worker-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/worker-ent.spec.js
@@ -53,7 +53,7 @@ test('Create a worker (enterprise) @ent @docker @aws', async ({ page }) => {
   await page.getByLabel('Recording Storage Path').fill('/tmp/recordings');
 
   // Check auto-populated config
-  const configLocator = '[data-test-worker-config=""]';
+  const configLocator = '[data-test-worker-config]';
   await expect(page.locator(configLocator)).toContainText(
     'public_addr = "worker1.example.com"',
   );

--- a/ui/admin/tests/e2e/tests/worker.spec.js
+++ b/ui/admin/tests/e2e/tests/worker.spec.js
@@ -10,7 +10,9 @@ const { authenticatedState } = require('../helpers/general');
 
 test.use({ storageState: authenticatedState });
 
-test('Create a worker @ce @docker @aws', async ({ page }) => {
+test('Create a worker @ce @docker @aws', async ({ page, browserName }) => {
+  test.skip(browserName === 'webkit', 'Bug in worker form on Safari');
+
   await page.goto('/');
   await page
     .getByRole('navigation', { name: 'General' })

--- a/ui/admin/tests/e2e/tests/worker.spec.js
+++ b/ui/admin/tests/e2e/tests/worker.spec.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/* eslint-disable no-undef */
+const { expect } = require('@playwright/test');
+const { test } = require('@playwright/test');
+const { authenticatedState } = require('../helpers/general');
+
+test.use({ storageState: authenticatedState });
+
+test('Create a worker @ce @docker @aws', async ({ page }) => {
+  await page.goto('/');
+  await page
+    .getByRole('navigation', { name: 'General' })
+    .getByRole('link', { name: 'Workers' })
+    .click();
+  await page.getByRole('link', { name: 'New', exact: true }).click();
+
+  // Populate config fields
+  await page.getByLabel('Worker public address').fill('worker1.example.com');
+  await page.getByLabel('Config file path').fill('/home/ubuntu/boundary');
+  await page.getByLabel('Initial upstreams').fill('10.0.0.1, 10.0.0.2');
+  await page
+    .getByRole('group', { name: 'Worker Tags' })
+    .getByLabel('Key')
+    .fill('type');
+  await page
+    .getByRole('group', { name: 'Worker Tags' })
+    .getByLabel('Value')
+    .fill('downstream, pki');
+  await page
+    .getByRole('group', { name: 'Worker Tags' })
+    .getByRole('button', { name: 'Add' })
+    .click();
+  await page
+    .getByRole('group', { name: 'Worker Tags' })
+    .getByLabel('Key')
+    .last()
+    .fill('test');
+  await page
+    .getByRole('group', { name: 'Worker Tags' })
+    .getByLabel('Value')
+    .last()
+    .fill('example');
+  await page
+    .getByRole('group', { name: 'Worker Tags' })
+    .getByRole('button', { name: 'Add' })
+    .click();
+
+  // Check auto-populated config
+  const configLocator = '[data-test-worker-config=""]';
+  await expect(page.locator(configLocator)).toContainText(
+    'public_addr = "worker1.example.com"',
+  );
+  await expect(page.locator(configLocator)).toContainText(
+    'auth_storage_path = "/home/ubuntu/boundary/worker1"',
+  );
+  await expect(page.locator(configLocator)).toContainText(
+    'initial_upstreams = ["10.0.0.1", "10.0.0.2"]',
+  );
+  await expect(page.locator(configLocator)).toContainText(
+    'type = ["downstream", "pki"]',
+  );
+  await expect(page.locator(configLocator)).toContainText('test = ["example"]');
+
+  // Try using an invalid worker token. Expect an error
+  await page.getByLabel('Worker Auth Registration Request').fill('test');
+  await page.getByRole('button', { name: 'Register' }).click();
+  await expect(
+    page.getByRole('alert').getByText('Error', { exact: true }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Dismiss' }).click();
+});

--- a/ui/admin/tests/e2e/tests/worker.spec.js
+++ b/ui/admin/tests/e2e/tests/worker.spec.js
@@ -50,7 +50,7 @@ test('Create a worker @ce @docker @aws', async ({ page }) => {
     .click();
 
   // Check auto-populated config
-  const configLocator = '[data-test-worker-config=""]';
+  const configLocator = '[data-test-worker-config]';
   await expect(page.locator(configLocator)).toContainText(
     'public_addr = "worker1.example.com"',
   );

--- a/ui/admin/tests/e2e/tests/worker.spec.js
+++ b/ui/admin/tests/e2e/tests/worker.spec.js
@@ -51,7 +51,15 @@ test('Create a worker @ce @docker @aws', async ({ page, browserName }) => {
     .getByRole('button', { name: 'Add' })
     .click();
 
-  // Check auto-populated config
+  // Check auto-populated configs
+  const dirLocator = '[data-test-worker-directory]';
+  await expect(page.locator(dirLocator)).toContainText(
+    'mkdir /home/ubuntu/boundary/ ;',
+  );
+  await expect(page.locator(dirLocator)).toContainText(
+    'touch /home/ubuntu/boundary/pki-worker.hcl',
+  );
+
   const configLocator = '[data-test-worker-config]';
   await expect(page.locator(configLocator)).toContainText(
     'public_addr = "worker1.example.com"',


### PR DESCRIPTION
This PR adds an e2e test for the worker page. There are two tests (the worker page is slightly different on the enterprise version). The test does the following
- Populate the config fields
- Validate that the example config is auto-populated with the right information
- Try to register an invalid worker token  
 
![Screenshot 2024-06-04 at 10 28 39 AM](https://github.com/hashicorp/boundary-ui/assets/2474253/d46da00e-aecb-437f-ba5c-705a9f3ba1d4)

https://hashicorp.atlassian.net/browse/ICU-13030