### PR TITLE
fix: 🐛 Fix active session display in targets table

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
@@ -10,6 +10,7 @@ import {
   STATUS_SESSION_PENDING,
 } from 'api/models/session';
 import { action } from '@ember/object';
+import { run } from '@ember/runloop';
 
 export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
   // =services
@@ -72,6 +73,13 @@ export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
    */
   beforeModel() {
     if (!this.session.isAuthenticated) this.router.transitionTo('index');
+
+    // Unload all sessions from the store as we might have sessions still in store
+    // if they were canceled outside of the desktop client
+    // Not wrapping it an ember run seems to cause a test to fail as well as an error
+    // if you switch between orgs due to a similar issue as this
+    // https://github.com/emberjs/data/issues/5447#issuecomment-845672812
+    run(() => this.store.unloadAll('session'));
   }
 
   /**


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-13981

# Description
There's a small display bug where if you cancel a session outside of the desktop client, refreshing the targets doesn't remove the corresponding active session on the target. This is just a display bug as filtering still works as expected but can be very confusing. See this [thread](https://hashicorp.slack.com/archives/C012GTH1C4E/p1717183385186269) for more details.

The underlying issue is the cache is correctly returning no sessions but they're not getting removed from the ember data store. So the target (which does a `peekAll` on sessions) still thinks there are sessions. 

## How to Test
1. Start boundary dev and connect to a target, navigate back to the targets page
2. Cancel the target using admin ui or the CLI
3. Refresh the targets page, there should not be an active session for the corresponding target

## Checklist

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
