### PR TITLE
feat: 🎸 Fix text and persist windows notification

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects.js
+++ b/ui/desktop/app/routes/scopes/scope/projects.js
@@ -130,6 +130,8 @@ export default class ScopesScopeProjectsRoute extends Route {
         }),
         {
           body: this.intl.t('notifications.connected-to-target.description'),
+          // This only has an effect on windows
+          requireInteraction: true,
         },
       ).onclick = async () => {
         let orgScope = 'global';

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -31,7 +31,7 @@ const clientDaemonManager = require('./services/client-daemon-manager');
 
 const menu = require('./config/menu.js');
 const appUpdater = require('./helpers/app-updater.js');
-const { isMac, isLinux } = require('./helpers/platform.js');
+const { isMac, isLinux, isWindows } = require('./helpers/platform.js');
 const fixPath = require('./utils/fixPath');
 const isDev = require('electron-is-dev');
 
@@ -64,6 +64,12 @@ log.transports.file.format =
 log.transports.file.fileName = 'desktop-client.log';
 // Set the max file size to 10MB
 log.transports.file.maxSize = 10485760;
+
+if (isWindows()) {
+  // Set the app user model ID to the app name as it will display the ID
+  // in any notifications on windows unless a squirrel installation is used.
+  app.setAppUserModelId(app.name);
+}
 
 const createWindow = (partition, closeWindowCB) => {
   /**


### PR DESCRIPTION
# Description
Persists windows notifications so they don't go to windows action center and fix the text in the notification.
See this [thread](https://hashicorp.slack.com/archives/C05EHAH84HE/p1717200501817919) for more details.

## Screenshots (if appropriate)
<img width="411" alt="image" src="https://github.com/hashicorp/boundary-ui/assets/5783847/25f4a4cb-d5d1-4454-9568-2d94598fc08c">

## How to Test
1. Use windows vm in parallels and setup ferry + dev instance.
2. Have a target with brokered credentials and an alias and ssh to the alias
3. Check that the notification looks correct


## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
