### PR TITLE
test(e2e): Add check for multiple host sources

### DIFF
--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -113,7 +113,22 @@ exports.createHostCatalog = async (page) => {
 exports.createHostSet = async (page) => {
   const hostSetName = 'Host Set ' + nanoid();
   await page.getByRole('link', { name: 'Host Sets' }).click();
-  await page.getByRole('link', { name: 'New', exact: true }).click();
+  await expect(
+    page
+      .getByRole('navigation', { name: 'breadcrumbs' })
+      .getByText('Host Sets'),
+  ).toBeVisible();
+
+  const emptyLinkIsVisible = await page
+    .getByRole('link', { name: 'New', exact: true })
+    .isVisible();
+  if (emptyLinkIsVisible) {
+    await page.getByRole('link', { name: 'New', exact: true }).click();
+  } else {
+    await page.getByText('Manage').click();
+    await page.getByRole('link', { name: 'New Host Set' }).click();
+  }
+
   await page.getByLabel('Name').fill(hostSetName);
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('button', { name: 'Save' }).click();
@@ -419,6 +434,36 @@ exports.createTcpTargetWithAddressEnt = async (page, address, port) => {
   await page.getByLabel('Description').fill('This is an automated test');
   await page.getByRole('group', { name: 'Type' }).getByLabel('TCP').click();
   await page.getByLabel('Target Address').fill(address);
+  await page.getByLabel('Default Port').fill(port);
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').getByText('Success', { exact: true }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Dismiss' }).click();
+  await expect(
+    page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(targetName),
+  ).toBeVisible();
+
+  return targetName;
+};
+
+/**
+ * Uses the UI to create a new SSH target
+ * Assumes you have selected the desired project.
+ * @param {Page} page Playwright page object
+ * @param {string} port Port of the target
+ * @returns Name of the target
+ */
+exports.createSshTargetEnt = async (page, port) => {
+  const targetName = 'Target ' + nanoid();
+  await page
+    .getByRole('navigation', { name: 'Resources' })
+    .getByRole('link', { name: 'Targets' })
+    .click();
+  await page.getByRole('link', { name: 'New', exact: true }).click();
+  await page.getByLabel('Name').fill(targetName);
+  await page.getByLabel('Description').fill('This is an automated test');
+  await page.getByRole('group', { name: 'Type' }).getByLabel('SSH').click();
   await page.getByLabel('Default Port').fill(port);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(

--- a/ui/admin/tests/e2e/tests/dynamic-host-catalog-aws.spec.js
+++ b/ui/admin/tests/e2e/tests/dynamic-host-catalog-aws.spec.js
@@ -187,7 +187,7 @@ test.describe('AWS', async () => {
       .getByRole('button', { name: 'Manage' })
       .click();
     await page.getByRole('button', { name: 'Remove' }).click();
-    await page.getByRole('button', { name: 'OK' }).click();
+    await page.getByRole('button', { name: 'OK', exact: true }).click();
     await expect(
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();

--- a/ui/admin/tests/e2e/tests/session-recording-aws-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/session-recording-aws-ent.spec.js
@@ -223,7 +223,7 @@ test('Session Recording Test (AWS) @ent @aws', async ({ page }) => {
     // Delete session recording
     await page.getByText('Manage').click();
     await page.getByRole('button', { name: 'Delete recording' }).click();
-    await page.getByRole('button', { name: 'OK' }).click();
+    await page.getByRole('button', { name: 'OK', exact: true }).click();
     await expect(
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();

--- a/ui/admin/tests/e2e/tests/session-recording-minio-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/session-recording-minio-ent.spec.js
@@ -225,7 +225,7 @@ test('Session Recording Test (MinIO) @ent @docker', async ({ page }) => {
     // Delete session recording
     await page.getByText('Manage').click();
     await page.getByRole('button', { name: 'Delete recording' }).click();
-    await page.getByRole('button', { name: 'OK' }).click();
+    await page.getByRole('button', { name: 'OK', exact: true }).click();
     await expect(
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();

--- a/ui/admin/tests/e2e/tests/target-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/target-ent.spec.js
@@ -10,6 +10,7 @@ const { checkEnv, authenticatedState } = require('../helpers/general');
 const {
   authenticateBoundaryCli,
   checkBoundaryCli,
+  connectToTarget,
   connectSshToTarget,
   deleteOrgCli,
 } = require('../helpers/boundary-cli');
@@ -76,7 +77,11 @@ test('Verify session created for TCP target @ent @aws @docker', async ({
     );
     const target = targets.items.filter((obj) => obj.name == targetName)[0];
 
-    connect = await connectSshToTarget(target.id);
+    connect = await connectToTarget(
+      target.id,
+      process.env.E2E_SSH_USER,
+      process.env.E2E_SSH_KEY_PATH,
+    );
     await waitForSessionToBeVisible(page, targetName);
     await page
       .getByRole('cell', { name: targetName })

--- a/ui/admin/tests/e2e/tests/target-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/target-ent.spec.js
@@ -4,23 +4,27 @@
  */
 
 /* eslint-disable no-undef */
-const { test } = require('@playwright/test');
+const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');
 const { checkEnv, authenticatedState } = require('../helpers/general');
 const {
   authenticateBoundaryCli,
   checkBoundaryCli,
-  connectToTarget,
   connectSshToTarget,
   deleteOrgCli,
 } = require('../helpers/boundary-cli');
 const {
+  addHostSourceToTarget,
+  createHostCatalog,
+  createHostInHostSet,
+  createHostSet,
   createOrg,
   createProject,
   createStaticCredentialStore,
   createStaticCredentialKeyPair,
   addInjectedCredentialsToTarget,
   createTcpTargetWithAddressEnt,
+  createSshTargetEnt,
   createSshTargetWithAddressEnt,
   waitForSessionToBeVisible,
 } = require('../helpers/boundary-ui');
@@ -72,11 +76,7 @@ test('Verify session created for TCP target @ent @aws @docker', async ({
     );
     const target = targets.items.filter((obj) => obj.name == targetName)[0];
 
-    connect = await connectToTarget(
-      target.id,
-      process.env.E2E_SSH_USER,
-      process.env.E2E_SSH_KEY_PATH,
-    );
+    connect = await connectSshToTarget(target.id);
     await waitForSessionToBeVisible(page, targetName);
     await page
       .getByRole('cell', { name: targetName })
@@ -135,6 +135,93 @@ test('Verify session created for SSH target @ent @aws @docker', async ({
     );
     await addInjectedCredentialsToTarget(page, targetName, credentialName);
 
+    connect = await connectSshToTarget(target.id);
+    await waitForSessionToBeVisible(page, targetName);
+    await page
+      .getByRole('cell', { name: targetName })
+      .locator('..')
+      .getByRole('button', { name: 'Cancel' })
+      .click();
+  } finally {
+    if (org) {
+      await deleteOrgCli(org.id);
+    }
+    // End `boundary connect` process
+    if (connect) {
+      connect.kill('SIGTERM');
+    }
+  }
+});
+
+test('SSH target with host sources @ent @aws @docker', async ({ page }) => {
+  await page.goto('/');
+  let org;
+  let connect;
+  try {
+    const orgName = await createOrg(page);
+    const projectName = await createProject(page);
+
+    // Create host set
+    const hostCatalogName = await createHostCatalog(page);
+    const hostSetName = await createHostSet(page);
+    await createHostInHostSet(page, process.env.E2E_TARGET_ADDRESS);
+
+    // Create another host set
+    await page
+      .getByRole('navigation', { name: 'Resources' })
+      .getByRole('link', { name: 'Host Catalogs' })
+      .click();
+    await page.getByRole('link', { name: hostCatalogName }).click();
+    const hostSetName2 = await createHostSet(page);
+
+    // Create target
+    const targetName = await createSshTargetEnt(
+      page,
+      process.env.E2E_TARGET_PORT,
+    );
+    await addHostSourceToTarget(page, hostSetName);
+
+    // Add/Remove another host source
+    await addHostSourceToTarget(page, hostSetName2);
+    await page
+      .getByRole('link', { name: hostSetName2 })
+      .locator('..')
+      .locator('..')
+      .getByRole('button', { name: 'Manage' })
+      .click();
+    await page.getByRole('button', { name: 'Remove' }).click();
+    await page.getByRole('button', { name: 'OK' }).click();
+    await expect(
+      page.getByRole('alert').getByText('Success', { exact: true }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+
+    // Create credentials and attach to target
+    await createStaticCredentialStore(page);
+    const credentialName = await createStaticCredentialKeyPair(
+      page,
+      process.env.E2E_SSH_USER,
+      process.env.E2E_SSH_KEY_PATH,
+    );
+    await addInjectedCredentialsToTarget(page, targetName, credentialName);
+
+    // Connect to target
+    await authenticateBoundaryCli(
+      process.env.BOUNDARY_ADDR,
+      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
+    const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+    org = orgs.items.filter((obj) => obj.name == orgName)[0];
+    const projects = JSON.parse(
+      execSync('boundary scopes list -format json -scope-id ' + org.id),
+    );
+    const project = projects.items.filter((obj) => obj.name == projectName)[0];
+    const targets = JSON.parse(
+      execSync('boundary targets list -format json -scope-id ' + project.id),
+    );
+    const target = targets.items.filter((obj) => obj.name == targetName)[0];
     connect = await connectSshToTarget(target.id);
     await waitForSessionToBeVisible(page, targetName);
     await page

--- a/ui/admin/tests/e2e/tests/target-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/target-ent.spec.js
@@ -195,7 +195,7 @@ test('SSH target with host sources @ent @aws @docker', async ({ page }) => {
       .getByRole('button', { name: 'Manage' })
       .click();
     await page.getByRole('button', { name: 'Remove' }).click();
-    await page.getByRole('button', { name: 'OK' }).click();
+    await page.getByRole('button', { name: 'OK', exact: true }).click();
     await expect(
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();

--- a/ui/admin/tests/e2e/tests/target.spec.js
+++ b/ui/admin/tests/e2e/tests/target.spec.js
@@ -74,7 +74,7 @@ test('Verify session created to target with host, then cancel the session @ce @a
       .getByRole('button', { name: 'Manage' })
       .click();
     await page.getByRole('button', { name: 'Remove' }).click();
-    await page.getByRole('button', { name: 'OK' }).click();
+    await page.getByRole('button', { name: 'OK', exact: true }).click();
     await expect(
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();


### PR DESCRIPTION
This PR updates some Admin UI e2e tests to add/remove additional host sources to a target. 
- The existing test (CE only) was updated to add and remove a second host source to a target
- A second test (ENT only) mirrors the existing test, but uses SSH targets

## Testing
There are two tests modified in this PR
- One is a CE test that can be run on either Docker or AWS infra
- One is an ENT test that can be run on either Docker or AWS infra
```
# CE
enos scenario launch e2e_ui_docker builder:local
yarn run e2e:ce:docker 

# Enterprise
enos scenario launch e2e_ui_docker_ent builder:local
yarn run e2e:ent:docker
```

https://hashicorp.atlassian.net/browse/ICU-14009