### PR TITLE
test(e2e): Add checks for LDAP account attributes

### DIFF
--- a/ui/admin/tests/e2e/tests/credential-store-static.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static.spec.js
@@ -76,14 +76,7 @@ test('Static Credential Store (User & Key Pair) @ce @aws @docker', async ({
     const retrievedUser = session.item.credentials[0].credential.username;
     const retrievedKey = session.item.credentials[0].credential.private_key;
 
-    if (process.env.E2E_SSH_USER != retrievedUser) {
-      throw new Error(
-        'Stored User does not match. EXPECTED: ' +
-          process.env.E2E_SSH_USER +
-          ', ACTUAL: ' +
-          retrievedUser,
-      );
-    }
+    expect(retrievedUser).toBe(process.env.E2E_SSH_USER);
 
     const keyData = await readFile(process.env.E2E_SSH_KEY_PATH, {
       encoding: 'utf-8',
@@ -128,22 +121,8 @@ test('Static Credential Store (Username & Password) @ce @aws @docker', async ({
     const retrievedUser = session.item.credentials[0].credential.username;
     const retrievedPassword = session.item.credentials[0].credential.password;
 
-    if (process.env.E2E_SSH_USER != retrievedUser) {
-      throw new Error(
-        'Stored User does not match. EXPECTED: ' +
-          process.env.E2E_SSH_USER +
-          ', ACTUAL: ' +
-          retrievedUser,
-      );
-    }
-    if (testPassword != retrievedPassword) {
-      throw new Error(
-        'Stored Password does not match. EXPECTED: ' +
-          testPassword +
-          ', ACTUAL: ' +
-          retrievedPassword,
-      );
-    }
+    expect(retrievedUser).toBe(process.env.E2E_SSH_USER);
+    expect(retrievedPassword).toBe(testPassword);
   } finally {
     await authenticateBoundaryCli(
       process.env.BOUNDARY_ADDR,
@@ -200,30 +179,9 @@ test('Static Credential Store (JSON) @ce @aws @docker', async ({ page }) => {
     const retrievedPassword = session.item.credentials[0].credential.password;
     const retrievedId = session.item.credentials[0].credential.id;
 
-    if (testName != retrievedUser) {
-      throw new Error(
-        'Stored User does not match. EXPECTED: ' +
-          process.env.E2E_SSH_USER +
-          ', ACTUAL: ' +
-          retrievedUser,
-      );
-    }
-    if (testPassword != retrievedPassword) {
-      throw new Error(
-        'Stored Password does not match. EXPECTED: ' +
-          testPassword +
-          ', ACTUAL: ' +
-          retrievedPassword,
-      );
-    }
-    if (testId != retrievedId) {
-      throw new Error(
-        'Stored ID does not match. EXPECTED: ' +
-          testId +
-          ', ACTUAL: ' +
-          retrievedId,
-      );
-    }
+    expect(retrievedUser).toBe(testName);
+    expect(retrievedPassword).toBe(testPassword);
+    expect(retrievedId).toBe(testId);
   } finally {
     await authenticateBoundaryCli(
       process.env.BOUNDARY_ADDR,

--- a/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
@@ -148,14 +148,9 @@ test('Vault Credential Store (User & Key Pair) @ce @aws @docker', async ({
       session.item.credentials[0].secret.decoded.data.username;
     const retrievedKey =
       session.item.credentials[0].secret.decoded.data.private_key;
-    if (process.env.E2E_SSH_USER != retrievedUser) {
-      throw new Error(
-        'Stored User does not match. EXPECTED: ' +
-          process.env.E2E_SSH_USER +
-          ', ACTUAL: ' +
-          retrievedUser,
-      );
-    }
+
+    expect(retrievedUser).toBe(process.env.E2E_SSH_USER);
+
     const keyData = await readFile(process.env.E2E_SSH_KEY_PATH, {
       encoding: 'utf-8',
     });

--- a/ui/admin/tests/e2e/tests/dynamic-host-catalog-aws.spec.js
+++ b/ui/admin/tests/e2e/tests/dynamic-host-catalog-aws.spec.js
@@ -109,7 +109,6 @@ test.describe('AWS', async () => {
     // Check number of hosts in host set
     let i = 0;
     let rowCount = 0;
-    let hostsAreVisible = false;
     let expectedHosts = JSON.parse(process.env.E2E_AWS_HOST_SET_IPS);
     do {
       i = i + 1;
@@ -120,10 +119,6 @@ test.describe('AWS', async () => {
         .nth(1)
         .getByRole('row')
         .count();
-      if (rowCount == expectedHosts.length) {
-        hostsAreVisible = true;
-        break;
-      }
       await page.reload();
       await page
         .getByRole('navigation', { name: 'breadcrumbs' })
@@ -131,14 +126,7 @@ test.describe('AWS', async () => {
         .waitFor();
     } while (i < 5);
 
-    if (!hostsAreVisible) {
-      throw new Error(
-        'Hosts are not visible. EXPECTED: ' +
-          expectedHosts.length +
-          ', ACTUAL: ' +
-          rowCount,
-      );
-    }
+    expect(rowCount).toBe(expectedHosts.length);
 
     // Navigate to each host in the host set
     for (let i = 0; i < expectedHosts.length; i++) {


### PR DESCRIPTION
This PR updates an Admin UI e2e test to check for the population of LDAP account attributes.

## Testing
This test works on both CE and ENT, but only on docker scenarios
```
# CE
enos scenario launch e2e_ui_docker builder:local
yarn run e2e:ce:docker

# ENT
enos scenario launch e2e_ui_docker_ent builder:local
yarn run e2e:ent:docker
```

![Screenshot 2024-06-14 at 10 56 29 AM](https://github.com/hashicorp/boundary-ui/assets/2474253/f9745b15-20c1-4731-83a2-07b0836e05ad)
![Screenshot 2024-06-14 at 10 56 32 AM](https://github.com/hashicorp/boundary-ui/assets/2474253/154dc511-8eb4-488e-9f3a-1ed8e4f28e04)
![Screenshot 2024-06-14 at 10 56 36 AM](https://github.com/hashicorp/boundary-ui/assets/2474253/3d136d1e-c640-436f-8d8f-09e2ec6b8cef)

https://hashicorp.atlassian.net/browse/ICU-14065
