### PR TITLE
refactor: 💡 Rename client daemon to cache daemon

### DIFF
--- a/addons/api/addon-test-support/handlers/cache-daemon-search.js
+++ b/addons/api/addon-test-support/handlers/cache-daemon-search.js
@@ -5,7 +5,7 @@
 
 import sinon from 'sinon';
 import { typeOf } from '@ember/utils';
-import { resourceNames } from 'api/handlers/client-daemon-handler';
+import { resourceNames } from 'api/handlers/cache-daemon-handler';
 import { singularize } from 'ember-inflector';
 
 /**
@@ -13,7 +13,7 @@ import { singularize } from 'ember-inflector';
  * Must be called after setupMirage.
  *
  * ```js
- * import setupStubs from 'api/test-support/handlers/client-daemon-search';
+ * import setupStubs from 'api/test-support/handlers/cache-daemon-search';
  *
  * module('Acceptance | my test', function(hooks) {
  *  setupApplicationTest(hooks);
@@ -25,7 +25,7 @@ import { singularize } from 'ember-inflector';
  * ```
  *
  * This will setup a stub for the IPC service and include helper methods to
- * help setup what the client daemon search command returns.
+ * help setup what the cache daemon search command returns.
  *
  * @module Test Helpers
  * @public
@@ -38,20 +38,20 @@ export default function setupStubs(hooks) {
     this.ipcStub = sinon.stub(ipcService, 'invoke');
 
     /**
-     * We aim to still use mirage data when stubbing out the client daemon
+     * We aim to still use mirage data when stubbing out the cache daemon
      * search. However, the handler expects the search data to be raw JSON from
      * the API which will get serialized. We add back the scope object for it to
      * get correctly normalized and other fields such as "attributes" from the
      * API will already be hoisted and will not be re-normalized from mirage data.
      *
      * This convenience method can take in multiple types,
-     * e.g. this.stubClientDaemonSearch('targets', 'sessions').
+     * e.g. this.stubCacheDaemonSearch('targets', 'sessions').
      * This will have sinon stub out each call so the first call to search will
      * provide all the models from the first parameter you specify,
      * the second call will provide all the models from the second argument, etc.
      * @param types
      */
-    this.stubClientDaemonSearch = (...types) => {
+    this.stubCacheDaemonSearch = (...types) => {
       stubTypes = types;
 
       types.forEach((type, i) => {
@@ -66,7 +66,7 @@ export default function setupStubs(hooks) {
         }
 
         this.ipcStub
-          .withArgs('searchClientDaemon')
+          .withArgs('searchCacheDaemon')
           .onCall(i)
           .returns({
             [resourceName]: models.map((model) => {
@@ -76,7 +76,7 @@ export default function setupStubs(hooks) {
                 this.server.serializerOrRegistry.serialize(model);
 
               // Serialize the data properly to standard JSON as that is what
-              // we're expecting from the client daemon response
+              // we're expecting from the cache daemon response
               return JSON.parse(JSON.stringify(modelData));
             }),
           });
@@ -86,16 +86,16 @@ export default function setupStubs(hooks) {
 
   hooks.afterEach(function () {
     // Verify the number of mocks we set up match with how
-    // many times the client daemon was called with
+    // many times the cache daemon was called with
     sinon.assert.callCount(
-      this.ipcStub.withArgs('searchClientDaemon'),
+      this.ipcStub.withArgs('searchCacheDaemon'),
       stubTypes.length,
     );
 
     stubTypes.forEach((type, i) => {
       // Assert that the stub was called with the resource we're trying to mock
       // so we don't mistakenly mock the wrong resource
-      const ipcCall = this.ipcStub.withArgs('searchClientDaemon').getCall(i);
+      const ipcCall = this.ipcStub.withArgs('searchCacheDaemon').getCall(i);
       let resource = type;
       if (typeOf(type) === 'object') {
         resource = type.resource;

--- a/addons/api/addon/utils/mql-query.js
+++ b/addons/api/addon/utils/mql-query.js
@@ -5,7 +5,7 @@
 
 /**
  * Takes a POJO representing a filter query and converts it to an
- * MQL expression string which is understood by the client daemon.
+ * MQL expression string which is understood by the cache daemon.
  *
  * @example
  *   const filter = generateMQLFilterExpression({
@@ -68,7 +68,7 @@ export function generateMQLFilterExpression(filterObj) {
 
 /**
  * Takes a POJO representing a search query and converts it to an
- * MQL expression string which is understood by the client daemon.
+ * MQL expression string which is understood by the cache daemon.
  *
  * @example
  *   const search = generateMQLSearchExpression({

--- a/addons/api/app/handlers/client-daemon-handler.js
+++ b/addons/api/app/handlers/client-daemon-handler.js
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-export { default, resourceNames } from 'api/handlers/client-daemon-handler';
+export { default, resourceNames } from 'api/handlers/cache-daemon-handler';

--- a/addons/api/mirage/scenarios/ipc.js
+++ b/addons/api/mirage/scenarios/ipc.js
@@ -183,8 +183,8 @@ export default function initializeMockIPC(server, config) {
       return faker.system.filePath();
     }
     addTokenToDaemons() {}
-    searchClientDaemon() {}
-    isClientDaemonRunning() {
+    searchCacheDaemon() {}
+    isCacheDaemonRunning() {
       return false;
     }
     isClientAgentRunning() {

--- a/ui/desktop/app/routes/application.js
+++ b/ui/desktop/app/routes/application.js
@@ -38,7 +38,7 @@ export default class ApplicationRoute extends Route {
     this.toggleTheme(theme);
     await this.clusterUrl.updateClusterUrl();
 
-    // Add token to client daemon after a successful authentication restoration
+    // Add token to cache daemon after a successful authentication restoration
     if (this.session.isAuthenticated) {
       const sessionData = this.session.data?.authenticated;
       await this.ipc.invoke('addTokenToDaemons', {

--- a/ui/desktop/app/routes/scopes/scope/projects/sessions/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions/index.js
@@ -118,7 +118,7 @@ export default class ScopesScopeProjectsSessionsIndexRoute extends Route {
       allSessions: this.allSessions,
       allTargets: this.allTargets,
       totalItems,
-      isClientDaemonRunning: await this.ipc.invoke('isClientDaemonRunning'),
+      isCacheDaemonRunning: await this.ipc.invoke('isCacheDaemonRunning'),
     };
   }
 

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
@@ -154,7 +154,7 @@ export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
       projects,
       allTargets: this.allTargets,
       totalItems,
-      isClientDaemonRunning: await this.ipc.invoke('isClientDaemonRunning'),
+      isCacheDaemonRunning: await this.ipc.invoke('isCacheDaemonRunning'),
     };
   }
 

--- a/ui/desktop/app/services/session.js
+++ b/ui/desktop/app/services/session.js
@@ -12,7 +12,7 @@ export default class SessionService extends BaseSessionService {
 
   /**
    * Extend ember simple auth's handleAuthentication method
-   * so we can hook in and add the user's token to the client daemon
+   * so we can hook in and add the user's token to the cache daemon
    */
   @notifyError(({ message }) => message, { catch: true })
   async handleAuthentication() {

--- a/ui/desktop/app/services/store.js
+++ b/ui/desktop/app/services/store.js
@@ -6,7 +6,7 @@
 import Store, { CacheHandler } from '@ember-data/store';
 import RequestManager from '@ember-data/request';
 import { LegacyNetworkHandler } from '@ember-data/legacy-compat';
-import ClientDaemonHandler from 'api/handlers/client-daemon-handler';
+import CacheDaemonHandler from 'api/handlers/cache-daemon-handler';
 
 export default class extends Store {
   requestManager = new RequestManager();
@@ -14,9 +14,9 @@ export default class extends Store {
   constructor(args) {
     super(args);
 
-    const clientDaemonHandler = new ClientDaemonHandler(this);
+    const cacheDaemonHandler = new CacheDaemonHandler(this);
 
-    this.requestManager.use([clientDaemonHandler, LegacyNetworkHandler]);
+    this.requestManager.use([cacheDaemonHandler, LegacyNetworkHandler]);
     this.requestManager.useCache(CacheHandler);
   }
 }

--- a/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/sessions/index.hbs
@@ -4,7 +4,7 @@
 }}
 
 {{#if (or @model.sessions @model.allSessions)}}
-  {{#if @model.isClientDaemonRunning}}
+  {{#if @model.isCacheDaemonRunning}}
     <div class='search-filtering-toolbar'>
       <Hds::SegmentedGroup as |S|>
         <S.Generic>

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/index.hbs
@@ -4,7 +4,7 @@
 }}
 
 {{#if this.showFilters}}
-  {{#if @model.isClientDaemonRunning}}
+  {{#if @model.isCacheDaemonRunning}}
     <div class='search-filtering-toolbar'>
       <Hds::SegmentedGroup as |S|>
         <S.TextInput

--- a/ui/desktop/electron-app/src/helpers/request-promise.js
+++ b/ui/desktop/electron-app/src/helpers/request-promise.js
@@ -33,7 +33,7 @@ const netRequest = (url) =>
 /**
  * Promise wrapper around node's http request function. The primary
  * use case is to pass in a socket path to be able to make http
- * requests to the client daemon.
+ * requests to the cache daemon.
  * @param options
  * @param reqBody
  * @returns {Promise}

--- a/ui/desktop/electron-app/src/helpers/spawn-promise.js
+++ b/ui/desktop/electron-app/src/helpers/spawn-promise.js
@@ -78,7 +78,7 @@ module.exports = {
    * @returns {{stdout: string | undefined, stderr: string | undefined}}   */
   spawnSync(args, envVars = {}) {
     const childProcess = spawnSync(path(), args, {
-      // Some of our outputs (namely client daemon searching) can be very large.
+      // Some of our outputs (namely cache daemon searching) can be very large.
       // This an undocumented hack to allow for an unlimited buffer size which
       // could change at any time. If it does, we should just set an arbitrarily
       // large buffer size or switch to spawn and stream the output and handle

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -27,7 +27,7 @@ const fs = require('fs');
 const { generateCSPHeader } = require('./config/content-security-policy.js');
 const runtimeSettings = require('./services/runtime-settings.js');
 const sessionManager = require('./services/session-manager.js');
-const clientDaemonManager = require('./services/client-daemon-manager');
+const cacheDaemonManager = require('./services/cache-daemon-manager');
 
 const menu = require('./config/menu.js');
 const appUpdater = require('./helpers/app-updater.js');
@@ -260,7 +260,7 @@ app.on('ready', async () => {
     }
   });
 
-  await clientDaemonManager.start();
+  await cacheDaemonManager.start();
 });
 
 /**
@@ -280,7 +280,7 @@ app.on('before-quit', (event) => {
 });
 
 app.on('quit', () => {
-  clientDaemonManager.stop();
+  cacheDaemonManager.stop();
 });
 
 // Handle an unhandled error in the main thread

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -14,7 +14,7 @@ const { isLinux, isMac, isWindows } = require('../helpers/platform.js');
 const os = require('node:os');
 const pty = require('node-pty');
 const which = require('which');
-const clientDaemonManager = require('../services/client-daemon-manager');
+const cacheDaemonManager = require('../services/cache-daemon-manager');
 const clientAgentDaemonManager = require('../services/client-agent-daemon-manager');
 
 /**
@@ -133,7 +133,7 @@ handle('checkCommand', async (command) => which(command, { nothrow: true }));
 /**
  * Adds the user's token to the daemons.
  */
-handle('addTokenToDaemons', async (data) => clientDaemonManager.addToken(data));
+handle('addTokenToDaemons', async (data) => cacheDaemonManager.addToken(data));
 
 /**
  * Return an object containing helper fields for determining what OS we're running on
@@ -145,19 +145,19 @@ handle('checkOS', () => ({
 }));
 
 /**
- * Call the client daemon's search endpoint to retrieve cached results.
+ * Call the cache daemon's search endpoint to retrieve cached results.
  */
-handle('searchClientDaemon', async (request) =>
-  clientDaemonManager.search(request),
+handle('searchCacheDaemon', async (request) =>
+  cacheDaemonManager.search(request),
 );
 
 /**
- * Check to see if the client daemon is running. We use the presence of a
+ * Check to see if the cache daemon is running. We use the presence of a
  * socket path as a proxy for whether the daemon is running.
  */
-handle('isClientDaemonRunning', async () => {
-  clientDaemonManager.status();
-  return Boolean(clientDaemonManager.socketPath);
+handle('isCacheDaemonRunning', async () => {
+  cacheDaemonManager.status();
+  return Boolean(cacheDaemonManager.socketPath);
 });
 
 /**
@@ -168,7 +168,7 @@ handle('getClientAgentSessions', async () => {
 });
 
 /**
- * Check to see if the client daemon is running.
+ * Check to see if the client agent daemon is running.
  */
 handle('isClientAgentRunning', async () => {
   try {

--- a/ui/desktop/tests/acceptance/projects/sessions/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/index-test.js
@@ -21,7 +21,7 @@ import {
   STATUS_SESSION_CANCELING,
   STATUS_SESSION_TERMINATED,
 } from 'api/models/session';
-import setupStubs from 'api/test-support/handlers/client-daemon-search';
+import setupStubs from 'api/test-support/handlers/cache-daemon-search';
 
 module('Acceptance | projects | sessions | index', function (hooks) {
   setupApplicationTest(hooks);
@@ -158,13 +158,13 @@ module('Acceptance | projects | sessions | index', function (hooks) {
     this.owner.register('service:browser/window', WindowMockIPC);
     setDefaultClusterUrl(this);
 
-    this.ipcStub.withArgs('isClientDaemonRunning').returns(true);
-    this.stubClientDaemonSearch('sessions', 'sessions', 'targets');
+    this.ipcStub.withArgs('isCacheDaemonRunning').returns(true);
+    this.stubCacheDaemonSearch('sessions', 'sessions', 'targets');
   });
 
   test('visiting index while unauthenticated redirects to global authenticate method', async function (assert) {
     invalidateSession();
-    this.stubClientDaemonSearch();
+    this.stubCacheDaemonSearch();
 
     await visit(urls.sessions);
     await a11yAudit();
@@ -186,7 +186,7 @@ module('Acceptance | projects | sessions | index', function (hooks) {
 
   test('visiting empty sessions', async function (assert) {
     this.server.db.sessions.remove();
-    this.stubClientDaemonSearch('sessions', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('sessions', 'sessions', 'targets');
     await visit(urls.projects);
 
     await click(`[href="${urls.sessions}"]`);
@@ -229,7 +229,7 @@ module('Acceptance | projects | sessions | index', function (hooks) {
 
   test('can link to an active session with read:self permissions', async function (assert) {
     instances.session.update({ authorized_actions: ['read:self'] });
-    this.stubClientDaemonSearch('sessions', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('sessions', 'sessions', 'targets');
     await visit(urls.projects);
 
     await click(`[href="${urls.sessions}"]`);
@@ -241,7 +241,7 @@ module('Acceptance | projects | sessions | index', function (hooks) {
 
   test('can link to a pending session', async function (assert) {
     instances.session.update({ status: STATUS_SESSION_PENDING });
-    this.stubClientDaemonSearch('sessions', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('sessions', 'sessions', 'targets');
     await visit(urls.projects);
 
     await click(`[href="${urls.sessions}"]`);
@@ -253,7 +253,7 @@ module('Acceptance | projects | sessions | index', function (hooks) {
 
   test('can link to session even without read permissions', async function (assert) {
     instances.session.update({ authorized_actions: [] });
-    this.stubClientDaemonSearch('sessions', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('sessions', 'sessions', 'targets');
     await visit(urls.projects);
 
     await click(`[href="${urls.sessions}"]`);
@@ -265,7 +265,7 @@ module('Acceptance | projects | sessions | index', function (hooks) {
 
   test('cannot link to a canceling session', async function (assert) {
     instances.session.update({ status: STATUS_SESSION_CANCELING });
-    this.stubClientDaemonSearch('sessions', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('sessions', 'sessions', 'targets');
     await visit(urls.sessions);
 
     assert
@@ -278,7 +278,7 @@ module('Acceptance | projects | sessions | index', function (hooks) {
 
   test('cannot link to a terminated session', async function (assert) {
     instances.session.update({ status: STATUS_SESSION_TERMINATED });
-    this.stubClientDaemonSearch('sessions', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('sessions', 'sessions', 'targets');
     await visit(urls.sessions);
     assert
       .dom(`[data-test-session-detail-link="${instances.session.id}"]`)
@@ -300,7 +300,7 @@ module('Acceptance | projects | sessions | index', function (hooks) {
 
   test('can cancel an active session with cancel:self permissions', async function (assert) {
     instances.session.update({ authorized_actions: ['cancel:self'] });
-    this.stubClientDaemonSearch('sessions', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('sessions', 'sessions', 'targets');
     await visit(urls.projects);
 
     await click(`[href="${urls.sessions}"]`);
@@ -312,7 +312,7 @@ module('Acceptance | projects | sessions | index', function (hooks) {
 
   test('cannot click cancel button without cancel permissions', async function (assert) {
     instances.session.update({ authorized_actions: [] });
-    this.stubClientDaemonSearch('sessions', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('sessions', 'sessions', 'targets');
     await visit(urls.sessions);
 
     assert
@@ -361,7 +361,7 @@ module('Acceptance | projects | sessions | index', function (hooks) {
   });
 
   test('user can change org scope and only sessions for that org will be displayed', async function (assert) {
-    this.stubClientDaemonSearch(
+    this.stubCacheDaemonSearch(
       'sessions',
       'sessions',
       'targets',
@@ -396,9 +396,9 @@ module('Acceptance | projects | sessions | index', function (hooks) {
       .isVisible();
   });
 
-  test('sessions list view still loads with no client daemon', async function (assert) {
-    this.ipcStub.withArgs('isClientDaemonRunning').returns(false);
-    this.stubClientDaemonSearch();
+  test('sessions list view still loads with no cache daemon', async function (assert) {
+    this.ipcStub.withArgs('isCacheDaemonRunning').returns(false);
+    this.stubCacheDaemonSearch();
     const sessionsCount = this.server.schema.sessions.all().models.length;
 
     await visit(urls.globalSessions);

--- a/ui/desktop/tests/acceptance/projects/sessions/session-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/session-test.js
@@ -14,7 +14,7 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import WindowMockIPC from '../../../helpers/window-mock-ipc';
 import { STATUS_SESSION_ACTIVE } from 'api/models/session';
-import setupStubs from 'api/test-support/handlers/client-daemon-search';
+import setupStubs from 'api/test-support/handlers/cache-daemon-search';
 
 module('Acceptance | projects | sessions | session', function (hooks) {
   setupApplicationTest(hooks);
@@ -114,7 +114,7 @@ module('Acceptance | projects | sessions | session', function (hooks) {
     this.owner.register('service:browser/window', WindowMockIPC);
     setDefaultClusterUrl(this);
 
-    this.ipcStub.withArgs('isClientDaemonRunning').returns(false);
+    this.ipcStub.withArgs('isCacheDaemonRunning').returns(false);
   });
 
   hooks.afterEach(function () {

--- a/ui/desktop/tests/acceptance/projects/targets/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/index-test.js
@@ -19,7 +19,7 @@ import {
   invalidateSession,
   currentSession,
 } from 'ember-simple-auth/test-support';
-import setupStubs from 'api/test-support/handlers/client-daemon-search';
+import setupStubs from 'api/test-support/handlers/cache-daemon-search';
 
 module('Acceptance | projects | targets | index', function (hooks) {
   setupApplicationTest(hooks);
@@ -160,13 +160,13 @@ module('Acceptance | projects | targets | index', function (hooks) {
     this.owner.register('service:browser/window', WindowMockIPC);
     setDefaultClusterUrl(this);
 
-    this.ipcStub.withArgs('isClientDaemonRunning').returns(true);
-    this.stubClientDaemonSearch('aliases', 'targets', 'sessions', 'targets');
+    this.ipcStub.withArgs('isCacheDaemonRunning').returns(true);
+    this.stubCacheDaemonSearch('aliases', 'targets', 'sessions', 'targets');
   });
 
   test('visiting index while unauthenticated redirects to global authenticate method', async function (assert) {
     invalidateSession();
-    this.stubClientDaemonSearch();
+    this.stubCacheDaemonSearch();
     await visit(urls.targets);
     await a11yAudit();
 
@@ -201,7 +201,7 @@ module('Acceptance | projects | targets | index', function (hooks) {
   test('visiting targets list view with no targets', async function (assert) {
     this.server.db.targets.remove();
     this.server.db.sessions.remove();
-    this.stubClientDaemonSearch('aliases', 'targets', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('aliases', 'targets', 'sessions', 'targets');
 
     await visit(urls.projects);
 
@@ -213,7 +213,7 @@ module('Acceptance | projects | targets | index', function (hooks) {
   test('user cannot navigate to a target without proper authorization', async function (assert) {
     instances.target.authorized_actions =
       instances.target.authorized_actions.filter((item) => item !== 'read');
-    this.stubClientDaemonSearch('aliases', 'targets', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('aliases', 'targets', 'sessions', 'targets');
 
     await visit(urls.projects);
 
@@ -242,7 +242,7 @@ module('Acceptance | projects | targets | index', function (hooks) {
       instances.target.authorized_actions.filter(
         (item) => item !== 'authorize-session',
       );
-    this.stubClientDaemonSearch('aliases', 'targets', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('aliases', 'targets', 'sessions', 'targets');
 
     await visit(urls.projects);
 
@@ -275,7 +275,7 @@ module('Acceptance | projects | targets | index', function (hooks) {
   test('user can connect without target read permissions', async function (assert) {
     instances.target.authorized_actions =
       instances.target.authorized_actions.filter((item) => item !== 'read');
-    this.stubClientDaemonSearch('aliases', 'targets', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('aliases', 'targets', 'sessions', 'targets');
     this.ipcStub.withArgs('cliExists').returns(true);
     this.ipcStub.withArgs('connect').returns({
       session_id: instances.session.id,
@@ -301,7 +301,7 @@ module('Acceptance | projects | targets | index', function (hooks) {
       instances.target.authorized_actions.filter((item) => item !== 'read');
     this.ipcStub.withArgs('cliExists').returns(true);
     this.ipcStub.withArgs('connect').rejects();
-    this.stubClientDaemonSearch('aliases', 'targets', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('aliases', 'targets', 'sessions', 'targets');
     const confirmService = this.owner.lookup('service:confirm');
     confirmService.enabled = true;
     await visit(urls.projects);
@@ -341,7 +341,7 @@ module('Acceptance | projects | targets | index', function (hooks) {
   });
 
   test('user can cancel a session from inside target sessions flyout', async function (assert) {
-    this.stubClientDaemonSearch(
+    this.stubCacheDaemonSearch(
       'aliases',
       'targets',
       'sessions',
@@ -381,7 +381,7 @@ module('Acceptance | projects | targets | index', function (hooks) {
   test('user cannot cancel a session from inside target sessions flyout without permissions', async function (assert) {
     instances.session.authorized_actions =
       instances.session.authorized_actions.filter((item) => item !== 'cancel');
-    this.stubClientDaemonSearch('aliases', 'targets', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('aliases', 'targets', 'sessions', 'targets');
     await visit(urls.projects);
 
     await click(`[href="${urls.targets}"]`);
@@ -419,7 +419,7 @@ module('Acceptance | projects | targets | index', function (hooks) {
   test('user can navigate to session details from sessions table in flyout without permissions', async function (assert) {
     instances.session.authorized_actions =
       instances.session.authorized_actions.filter((item) => item !== 'read');
-    this.stubClientDaemonSearch('aliases', 'targets', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('aliases', 'targets', 'sessions', 'targets');
     await visit(urls.projects);
 
     await click(`[href="${urls.targets}"]`);
@@ -440,7 +440,7 @@ module('Acceptance | projects | targets | index', function (hooks) {
   });
 
   test('user can change org scope and only targets for that org will be displayed', async function (assert) {
-    this.stubClientDaemonSearch(
+    this.stubCacheDaemonSearch(
       'aliases',
       'targets',
       'sessions',
@@ -471,9 +471,9 @@ module('Acceptance | projects | targets | index', function (hooks) {
       .doesNotExist();
   });
 
-  test('targets list view still loads with no client daemon', async function (assert) {
-    this.ipcStub.withArgs('isClientDaemonRunning').returns(false);
-    this.stubClientDaemonSearch();
+  test('targets list view still loads with no cache daemon', async function (assert) {
+    this.ipcStub.withArgs('isCacheDaemonRunning').returns(false);
+    this.stubCacheDaemonSearch();
     const targetsCount = getTargetCount();
 
     await visit(urls.projects);

--- a/ui/desktop/tests/acceptance/projects/targets/target-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/target-test.js
@@ -9,7 +9,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import WindowMockIPC from '../../../helpers/window-mock-ipc';
-import setupStubs from 'api/test-support/handlers/client-daemon-search';
+import setupStubs from 'api/test-support/handlers/cache-daemon-search';
 
 module('Acceptance | projects | targets | target', function (hooks) {
   setupApplicationTest(hooks);
@@ -129,8 +129,8 @@ module('Acceptance | projects | targets | target', function (hooks) {
     this.owner.register('service:browser/window', WindowMockIPC);
     setDefaultClusterUrl(this);
 
-    this.ipcStub.withArgs('isClientDaemonRunning').returns(true);
-    this.stubClientDaemonSearch('aliases', 'targets', 'sessions', 'targets');
+    this.ipcStub.withArgs('isCacheDaemonRunning').returns(true);
+    this.stubCacheDaemonSearch('aliases', 'targets', 'sessions', 'targets');
   });
 
   test('user can connect to a target with an address', async function (assert) {
@@ -142,7 +142,7 @@ module('Acceptance | projects | targets | target', function (hooks) {
       port: 'p_123',
       protocol: 'tcp',
     });
-    this.stubClientDaemonSearch();
+    this.stubCacheDaemonSearch();
 
     await visit(urls.target);
 
@@ -190,7 +190,7 @@ module('Acceptance | projects | targets | target', function (hooks) {
   test('user can retry on error', async function (assert) {
     assert.expect(1);
     this.ipcStub.withArgs('cliExists').rejects();
-    this.stubClientDaemonSearch();
+    this.stubCacheDaemonSearch();
     const confirmService = this.owner.lookup('service:confirm');
     confirmService.enabled = true;
 

--- a/ui/desktop/tests/acceptance/scopes-test.js
+++ b/ui/desktop/tests/acceptance/scopes-test.js
@@ -22,7 +22,7 @@ import {
   invalidateSession,
 } from 'ember-simple-auth/test-support';
 import WindowMockIPC from '../helpers/window-mock-ipc';
-import setupStubs from 'api/test-support/handlers/client-daemon-search';
+import setupStubs from 'api/test-support/handlers/cache-daemon-search';
 
 module('Acceptance | scopes', function (hooks) {
   setupApplicationTest(hooks);
@@ -142,8 +142,8 @@ module('Acceptance | scopes', function (hooks) {
     this.owner.register('service:browser/window', WindowMockIPC);
     setDefaultClusterUrl(this);
 
-    this.ipcStub.withArgs('isClientDaemonRunning').returns(true);
-    this.stubClientDaemonSearch('aliases', 'targets', 'sessions', 'targets');
+    this.ipcStub.withArgs('isCacheDaemonRunning').returns(true);
+    this.stubCacheDaemonSearch('aliases', 'targets', 'sessions', 'targets');
   });
 
   test('visiting index', async function (assert) {
@@ -194,7 +194,7 @@ module('Acceptance | scopes', function (hooks) {
 
   test('can navigate among org scopes via header navigation', async function (assert) {
     assert.expect(3);
-    this.stubClientDaemonSearch(
+    this.stubCacheDaemonSearch(
       'aliases',
       'targets',
       'sessions',
@@ -224,7 +224,7 @@ module('Acceptance | scopes', function (hooks) {
   test('visiting index while unauthenticated redirects to global authenticate method', async function (assert) {
     invalidateSession();
     assert.expect(2);
-    this.stubClientDaemonSearch();
+    this.stubCacheDaemonSearch();
 
     await visit(urls.targets);
     await a11yAudit();
@@ -246,7 +246,7 @@ module('Acceptance | scopes', function (hooks) {
     assert.expect(1);
     this.server.db.targets.remove();
     this.server.db.sessions.remove();
-    this.stubClientDaemonSearch('aliases', 'targets', 'sessions', 'targets');
+    this.stubCacheDaemonSearch('aliases', 'targets', 'sessions', 'targets');
 
     await visit(urls.targets);
 
@@ -347,7 +347,7 @@ module('Acceptance | scopes', function (hooks) {
 
   test('pagination is not supported - navigate to cluster url page', async function (assert) {
     invalidateSession();
-    this.stubClientDaemonSearch();
+    this.stubCacheDaemonSearch();
     this.ipcStub.withArgs('checkOS').returns({
       isWindows: true,
       isMac: false,

--- a/ui/desktop/tests/helpers/window-mock-ipc.js
+++ b/ui/desktop/tests/helpers/window-mock-ipc.js
@@ -25,8 +25,8 @@ class MockIPC {
   hasMacOSChrome() {}
   showWindowActions() {}
   addTokenToDaemons() {}
-  searchClientDaemon() {}
-  isClientDaemonRunning() {
+  searchCacheDaemon() {}
+  isCacheDaemonRunning() {
     return false;
   }
   isClientAgentRunning() {


### PR DESCRIPTION
# Description
Renamed the client agent to cache daemon as backend has updated their naming of dameons. 

## Checklist

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
