### PR TITLE
feat: 🎸 create get allTags method that includes tag type

### DIFF
--- a/addons/api/addon/models/worker.js
+++ b/addons/api/addon/models/worker.js
@@ -44,7 +44,7 @@ export default class WorkerModel extends GeneratedWorkerModel {
    * Returns the config tags as an array of key/value pair objects.
    * @type {[object]}
    */
-  getConfigTagList() {
+  get configTagList() {
     if (!this.config_tags) {
       return null;
     }
@@ -58,7 +58,7 @@ export default class WorkerModel extends GeneratedWorkerModel {
    * Returns the api tags as an array of key/value pair objects.
    * @type {[object]}
    */
-  getApiTagList() {
+  get apiTagList() {
     if (!this.api_tags) {
       return null;
     }
@@ -72,11 +72,8 @@ export default class WorkerModel extends GeneratedWorkerModel {
    * Returns all tags as an array of key/value pair objects with tag type.
    * @type {[object]}
    */
-  getAllTags() {
-    return [
-      ...(this.getConfigTagList() ?? []),
-      ...(this.getApiTagList() ?? []),
-    ];
+  get allTags() {
+    return [...(this.configTagList ?? []), ...(this.apiTagList ?? [])];
   }
 
   @attr({

--- a/addons/api/addon/models/worker.js
+++ b/addons/api/addon/models/worker.js
@@ -31,14 +31,24 @@ export default class WorkerModel extends GeneratedWorkerModel {
    * @type {number}
    */
   get tagCount() {
-    if (!this.config_tags) {
+    if (!this.config_tags && !this.api_tags) {
       return 0;
     }
 
-    return Object.values(this.config_tags).reduce(
-      (previousCount, currentTags) => previousCount + currentTags.length,
-      0,
-    );
+    const configTagCount = this.config_tags
+      ? Object.values(this.config_tags).reduce(
+          (previousCount, currentTags) => previousCount + currentTags.length,
+          0,
+        )
+      : 0;
+    const apiTagCount = this.api_tags
+      ? Object.values(this.api_tags).reduce(
+          (previousCount, currentTags) => previousCount + currentTags.length,
+          0,
+        )
+      : 0;
+
+    return configTagCount + apiTagCount;
   }
 
   /**
@@ -55,6 +65,34 @@ export default class WorkerModel extends GeneratedWorkerModel {
     );
   }
 
+  /**
+   * Returns the api tags as an array of key/value pair objects.
+   * @type {[object]}
+   */
+  getApiTagList() {
+    if (!this.api_tags) {
+      return null;
+    }
+
+    return Object.entries(this.api_tags).flatMap(([key, value]) =>
+      value.map((tag) => ({ key, value: tag })),
+    );
+  }
+
+  /**
+   * Returns all tags as an array of key/value pair objects with tag type.
+   * @type {[object]}
+   */
+  getAllTags() {
+    return [
+      ...(this.getConfigTagList() || []).map((tag) => ({
+        ...tag,
+        type: 'config',
+      })),
+      ...(this.getApiTagList() || []).map((tag) => ({ ...tag, type: 'api' })),
+    ];
+  }
+
   @attr({
     description:
       'The deduplicated union of the tags reported by the worker ' +
@@ -69,6 +107,12 @@ export default class WorkerModel extends GeneratedWorkerModel {
     readOnly: true,
   })
   config_tags;
+
+  @attr({
+    description: 'The api tags set for the worker.\nOutput only.',
+    readOnly: true,
+  })
+  api_tags;
 
   /**
    * Method to modify the adapter to handle custom POST route for creating worker.

--- a/addons/api/addon/models/worker.js
+++ b/addons/api/addon/models/worker.js
@@ -50,7 +50,7 @@ export default class WorkerModel extends GeneratedWorkerModel {
     }
 
     return Object.entries(this.config_tags).flatMap(([key, value]) =>
-      value.map((tag) => ({ key, value: tag })),
+      value.map((tag) => ({ key, value: tag, type: 'config' })),
     );
   }
 
@@ -64,7 +64,7 @@ export default class WorkerModel extends GeneratedWorkerModel {
     }
 
     return Object.entries(this.api_tags).flatMap(([key, value]) =>
-      value.map((tag) => ({ key, value: tag })),
+      value.map((tag) => ({ key, value: tag, type: 'api' })),
     );
   }
 
@@ -74,11 +74,8 @@ export default class WorkerModel extends GeneratedWorkerModel {
    */
   getAllTags() {
     return [
-      ...(this.getConfigTagList() || []).map((tag) => ({
-        ...tag,
-        type: 'config',
-      })),
-      ...(this.getApiTagList() || []).map((tag) => ({ ...tag, type: 'api' })),
+      ...(this.getConfigTagList() ?? []),
+      ...(this.getApiTagList() ?? []),
     ];
   }
 

--- a/addons/api/addon/models/worker.js
+++ b/addons/api/addon/models/worker.js
@@ -27,28 +27,17 @@ export default class WorkerModel extends GeneratedWorkerModel {
   }
 
   /**
-   * Returns the number of config tags present on the worker.
+   * Returns the number of canonical tags present on the worker.
    * @type {number}
    */
   get tagCount() {
-    if (!this.config_tags && !this.api_tags) {
+    if (!this.canonical_tags) {
       return 0;
     }
-
-    const configTagCount = this.config_tags
-      ? Object.values(this.config_tags).reduce(
-          (previousCount, currentTags) => previousCount + currentTags.length,
-          0,
-        )
-      : 0;
-    const apiTagCount = this.api_tags
-      ? Object.values(this.api_tags).reduce(
-          (previousCount, currentTags) => previousCount + currentTags.length,
-          0,
-        )
-      : 0;
-
-    return configTagCount + apiTagCount;
+    return Object.values(this.canonical_tags).reduce(
+      (previousCount, currentTags) => previousCount + currentTags.length,
+      0,
+    );
   }
 
   /**

--- a/addons/api/tests/unit/models/worker-test.js
+++ b/addons/api/tests/unit/models/worker-test.js
@@ -48,9 +48,9 @@ module('Unit | Model | worker', function (hooks) {
       },
     });
     const expected = [
-      { key: 'tag1', value: 'value1' },
-      { key: 'tag1', value: 'value2' },
-      { key: 'tag2', value: 'value3' },
+      { key: 'tag1', value: 'value1', type: 'config' },
+      { key: 'tag1', value: 'value2', type: 'config' },
+      { key: 'tag2', value: 'value3', type: 'config' },
     ];
 
     assert.deepEqual(model.getConfigTagList(), expected);
@@ -72,9 +72,9 @@ module('Unit | Model | worker', function (hooks) {
       },
     });
     const expected = [
-      { key: 'tag1', value: 'value1' },
-      { key: 'tag1', value: 'value2' },
-      { key: 'tag2', value: 'value3' },
+      { key: 'tag1', value: 'value1', type: 'api' },
+      { key: 'tag1', value: 'value2', type: 'api' },
+      { key: 'tag2', value: 'value3', type: 'api' },
     ];
 
     assert.deepEqual(model.getApiTagList(), expected);

--- a/addons/api/tests/unit/models/worker-test.js
+++ b/addons/api/tests/unit/models/worker-test.js
@@ -32,8 +32,136 @@ module('Unit | Model | worker', function (hooks) {
         type: 'global',
       },
     });
+
     await model.createWorkerLed(workerGeneratedAuthToken);
     const worker = store.peekRecord('worker', '123abc');
+
     assert.ok(worker);
+  });
+
+  test('it has a `getConfigTagList` method that returns an array of key/value pair objects', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('worker', {
+      config_tags: {
+        tag1: ['value1', 'value2'],
+        tag2: ['value3'],
+      },
+    });
+    const expected = [
+      { key: 'tag1', value: 'value1' },
+      { key: 'tag1', value: 'value2' },
+      { key: 'tag2', value: 'value3' },
+    ];
+
+    assert.deepEqual(model.getConfigTagList(), expected);
+  });
+
+  test('it has a `getConfigTagList` method that returns null if there are no config tags', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('worker');
+
+    assert.deepEqual(model.getConfigTagList(), null);
+  });
+
+  test('it has a `getApiTagList` method that returns an array of key/value pair objects', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('worker', {
+      api_tags: {
+        tag1: ['value1', 'value2'],
+        tag2: ['value3'],
+      },
+    });
+    const expected = [
+      { key: 'tag1', value: 'value1' },
+      { key: 'tag1', value: 'value2' },
+      { key: 'tag2', value: 'value3' },
+    ];
+
+    assert.deepEqual(model.getApiTagList(), expected);
+  });
+
+  test('it has a `getApiTagList` method that returns null if there are no api tags', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('worker');
+
+    assert.deepEqual(model.getApiTagList(), null);
+  });
+
+  test('it has a `getAllTags` method that returns an array of key/value pair objects with tag type', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('worker', {
+      config_tags: {
+        tag1: ['value1', 'value2'],
+        tag2: ['value3'],
+      },
+      api_tags: {
+        tag1: ['value1', 'value2'],
+        tag2: ['value3'],
+      },
+    });
+    const expected = [
+      { key: 'tag1', value: 'value1', type: 'config' },
+      { key: 'tag1', value: 'value2', type: 'config' },
+      { key: 'tag2', value: 'value3', type: 'config' },
+      { key: 'tag1', value: 'value1', type: 'api' },
+      { key: 'tag1', value: 'value2', type: 'api' },
+      { key: 'tag2', value: 'value3', type: 'api' },
+    ];
+
+    assert.deepEqual(model.getAllTags(), expected);
+  });
+
+  test('it has a `getAllTags` method that returns an empty array if there are no config or api tags', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('worker');
+
+    assert.deepEqual(model.getAllTags(), []);
+  });
+
+  test('tagCount returns the total number of config and api tags', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('worker', {
+      config_tags: {
+        tag1: ['value1', 'value2'],
+        tag2: ['value3'],
+      },
+      api_tags: {
+        tag1: ['value1', 'value2'],
+        tag2: ['value3'],
+      },
+    });
+
+    assert.strictEqual(model.tagCount, 6);
+  });
+
+  test('tagCount returns 0 if there are no config or api tags', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('worker');
+
+    assert.strictEqual(model.tagCount, 0);
+  });
+
+  test('tagCount returns the total number of config tags if there are no api tags', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('worker', {
+      config_tags: {
+        tag1: ['value1', 'value2'],
+        tag2: ['value3'],
+      },
+    });
+
+    assert.strictEqual(model.tagCount, 3);
+  });
+
+  test('tagCount returns the total number of api tags if there are no config tags', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('worker', {
+      api_tags: {
+        tag1: ['value1', 'value2'],
+        tag2: ['value3'],
+      },
+    });
+
+    assert.strictEqual(model.tagCount, 3);
   });
 });

--- a/addons/api/tests/unit/models/worker-test.js
+++ b/addons/api/tests/unit/models/worker-test.js
@@ -39,7 +39,7 @@ module('Unit | Model | worker', function (hooks) {
     assert.ok(worker);
   });
 
-  test('it has a `getConfigTagList` method that returns an array of key/value pair objects', function (assert) {
+  test('it has a `configTagList` method that returns an array of key/value pair objects', function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('worker', {
       config_tags: {
@@ -53,17 +53,17 @@ module('Unit | Model | worker', function (hooks) {
       { key: 'tag2', value: 'value3', type: 'config' },
     ];
 
-    assert.deepEqual(model.getConfigTagList(), expected);
+    assert.deepEqual(model.configTagList, expected);
   });
 
-  test('it has a `getConfigTagList` method that returns null if there are no config tags', function (assert) {
+  test('it has a `configTagList` method that returns null if there are no config tags', function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('worker');
 
-    assert.deepEqual(model.getConfigTagList(), null);
+    assert.deepEqual(model.configTagList, null);
   });
 
-  test('it has a `getApiTagList` method that returns an array of key/value pair objects', function (assert) {
+  test('it has a `apiTagList` method that returns an array of key/value pair objects', function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('worker', {
       api_tags: {
@@ -77,17 +77,17 @@ module('Unit | Model | worker', function (hooks) {
       { key: 'tag2', value: 'value3', type: 'api' },
     ];
 
-    assert.deepEqual(model.getApiTagList(), expected);
+    assert.deepEqual(model.apiTagList, expected);
   });
 
-  test('it has a `getApiTagList` method that returns null if there are no api tags', function (assert) {
+  test('it has a `apiTagList` method that returns null if there are no api tags', function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('worker');
 
-    assert.deepEqual(model.getApiTagList(), null);
+    assert.deepEqual(model.apiTagList, null);
   });
 
-  test('it has a `getAllTags` method that returns an array of key/value pair objects with tag type', function (assert) {
+  test('it has a `allTags` method that returns an array of key/value pair objects with tag type', function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('worker', {
       config_tags: {
@@ -108,14 +108,14 @@ module('Unit | Model | worker', function (hooks) {
       { key: 'tag2', value: 'value3', type: 'api' },
     ];
 
-    assert.deepEqual(model.getAllTags(), expected);
+    assert.deepEqual(model.allTags, expected);
   });
 
-  test('it has a `getAllTags` method that returns an empty array if there are no config or api tags', function (assert) {
+  test('it has a `allTags` method that returns an empty array if there are no config or api tags', function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('worker');
 
-    assert.deepEqual(model.getAllTags(), []);
+    assert.deepEqual(model.allTags, []);
   });
 
   test('tagCount returns the total number of tags', function (assert) {

--- a/addons/api/tests/unit/models/worker-test.js
+++ b/addons/api/tests/unit/models/worker-test.js
@@ -118,50 +118,22 @@ module('Unit | Model | worker', function (hooks) {
     assert.deepEqual(model.getAllTags(), []);
   });
 
-  test('tagCount returns the total number of config and api tags', function (assert) {
+  test('tagCount returns the total number of tags', function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('worker', {
-      config_tags: {
-        tag1: ['value1', 'value2'],
-        tag2: ['value3'],
-      },
-      api_tags: {
+      canonical_tags: {
         tag1: ['value1', 'value2'],
         tag2: ['value3'],
       },
     });
 
-    assert.strictEqual(model.tagCount, 6);
+    assert.strictEqual(model.tagCount, 3);
   });
 
-  test('tagCount returns 0 if there are no config or api tags', function (assert) {
+  test('tagCount returns 0 if there are no tags', function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('worker');
 
     assert.strictEqual(model.tagCount, 0);
-  });
-
-  test('tagCount returns the total number of config tags if there are no api tags', function (assert) {
-    const store = this.owner.lookup('service:store');
-    const model = store.createRecord('worker', {
-      config_tags: {
-        tag1: ['value1', 'value2'],
-        tag2: ['value3'],
-      },
-    });
-
-    assert.strictEqual(model.tagCount, 3);
-  });
-
-  test('tagCount returns the total number of api tags if there are no config tags', function (assert) {
-    const store = this.owner.lookup('service:store');
-    const model = store.createRecord('worker', {
-      api_tags: {
-        tag1: ['value1', 'value2'],
-        tag2: ['value3'],
-      },
-    });
-
-    assert.strictEqual(model.tagCount, 3);
   });
 });

--- a/ui/admin/app/routes/scopes/scope/workers/index.js
+++ b/ui/admin/app/routes/scopes/scope/workers/index.js
@@ -19,7 +19,7 @@ export default class ScopesScopeWorkersIndexRoute extends Route {
     allowed: (route) => {
       const configTags = route
         .modelFor('scopes.scope.workers')
-        .flatMap((worker) => worker.getConfigTagList())
+        .flatMap((worker) => worker.configTagList)
         .filter(Boolean);
 
       // Filter out duplicate tags
@@ -56,7 +56,7 @@ export default class ScopesScopeWorkersIndexRoute extends Route {
           return null;
         }
 
-        const workerTags = worker.getConfigTagList();
+        const workerTags = worker.configTagList;
         return this.tags.some((tag) =>
           workerTags.some(
             (workerTag) =>


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-13891

# Description
<!-- Add a brief description of changes here -->
This is some of the initial api/model changes for worker tag improvements. We have a story that will need data organized in a specific way from how it is returned from the API. The `getAllTags` method will combine the config and api tags into a single list that also denotes their tag type. Here is the [design](https://www.figma.com/design/ZzeL7kAVjNENx6kzZutua3/Worker-Tags-Improvements?node-id=803-24752&t=EH3Wc78KnpSAImBa-0) of how this data will be used in a table.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
![Screenshot 2024-06-14 at 11 32 24 AM](https://github.com/hashicorp/boundary-ui/assets/29386339/255caea3-5c33-4357-9b1f-c639e4665689)


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [x] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
