### PR TITLE
test(e2e): Add check to detach bucket from target

### DIFF
--- a/ui/admin/tests/e2e/tests/session-recording-aws-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/session-recording-aws-ent.spec.js
@@ -95,6 +95,7 @@ test('Session Recording Test (AWS) @ent @aws', async ({ page }) => {
 
     // Create target
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'Orgs' })).toBeVisible();
     await page.getByRole('link', { name: orgName }).click();
     await page.getByRole('link', { name: projectName }).click();
     const targetName = await createSshTargetWithAddressAndWorkerFilterEnt(
@@ -119,6 +120,7 @@ test('Session Recording Test (AWS) @ent @aws', async ({ page }) => {
 
     // Create storage policy in org scope: keep session recordings forever
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'Orgs' })).toBeVisible();
     await page.getByRole('link', { name: orgName }).click();
     await expect(
       page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(orgName),
@@ -186,6 +188,7 @@ test('Session Recording Test (AWS) @ent @aws', async ({ page }) => {
       (obj) => obj.name == policyName,
     )[0];
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'Orgs' })).toBeVisible();
     await page.getByRole('link', { name: orgName }).click();
     await expect(
       page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(orgName),
@@ -230,6 +233,23 @@ test('Session Recording Test (AWS) @ent @aws', async ({ page }) => {
     await page.getByText('Manage').click();
     await page.getByRole('button', { name: 'Delete recording' }).click();
     await page.getByRole('button', { name: 'OK', exact: true }).click();
+    await expect(
+      page.getByRole('alert').getByText('Success', { exact: true }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+
+    // Detach storage bucket from target
+    await page.getByRole('link', { name: 'Orgs', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'Orgs' })).toBeVisible();
+    await page.getByRole('link', { name: orgName }).click();
+    await page.getByRole('link', { name: projectName }).click();
+    await page.getByRole('link', { name: 'Targets', exact: true }).click();
+    await page.getByRole('link', { name: targetName }).click();
+    await page
+      .getByRole('link', { name: 'Session Recording settings' })
+      .click();
+    await page.getByLabel('Record sessions for this target').uncheck();
+    await page.getByRole('button', { name: 'Save' }).click();
     await expect(
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();

--- a/ui/admin/tests/e2e/tests/session-recording-minio-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/session-recording-minio-ent.spec.js
@@ -97,6 +97,7 @@ test('Session Recording Test (MinIO) @ent @docker', async ({ page }) => {
 
     // Create target
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'Orgs' })).toBeVisible();
     await page.getByRole('link', { name: orgName }).click();
     await page.getByRole('link', { name: projectName }).click();
     const targetName = await createSshTargetWithAddressAndWorkerFilterEnt(
@@ -121,6 +122,7 @@ test('Session Recording Test (MinIO) @ent @docker', async ({ page }) => {
 
     // Create storage policy in org scope: keep session recordings forever
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'Orgs' })).toBeVisible();
     await page.getByRole('link', { name: orgName }).click();
     await expect(
       page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(orgName),
@@ -188,6 +190,7 @@ test('Session Recording Test (MinIO) @ent @docker', async ({ page }) => {
       (obj) => obj.name == policyName,
     )[0];
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'Orgs' })).toBeVisible();
     await page.getByRole('link', { name: orgName }).click();
     await expect(
       page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(orgName),
@@ -232,6 +235,23 @@ test('Session Recording Test (MinIO) @ent @docker', async ({ page }) => {
     await page.getByText('Manage').click();
     await page.getByRole('button', { name: 'Delete recording' }).click();
     await page.getByRole('button', { name: 'OK', exact: true }).click();
+    await expect(
+      page.getByRole('alert').getByText('Success', { exact: true }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Dismiss' }).click();
+
+    // Detach storage bucket from target
+    await page.getByRole('link', { name: 'Orgs', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'Orgs' })).toBeVisible();
+    await page.getByRole('link', { name: orgName }).click();
+    await page.getByRole('link', { name: projectName }).click();
+    await page.getByRole('link', { name: 'Targets', exact: true }).click();
+    await page.getByRole('link', { name: targetName }).click();
+    await page
+      .getByRole('link', { name: 'Session Recording settings' })
+      .click();
+    await page.getByLabel('Record sessions for this target').uncheck();
+    await page.getByRole('button', { name: 'Save' }).click();
     await expect(
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();


### PR DESCRIPTION
This PR updates some Admin UI e2e tests to add a check to detach a storage bucket from a target.

## Testing
The tests that are affected by this include...
- Session Recording (AWS)
- Session Recording (MinIO)

To be able to run all of the tests, you'll need to use the boundary-enterprise and run tests against 2 different scenarios.
```
enos scenario launch e2e_ui_docker_ent builder:local
yarn run e2e:ent:docker

enos scenario launch e2e_ui_aws_ent builder:local
yarn run e2e:ent:aws
```

https://hashicorp.atlassian.net/browse/ICU-14076