### PR TITLE
fix: 🐛 styles import file not being found

### DIFF
--- a/addons/rose/addon/styles/addon.scss
+++ b/addons/rose/addon/styles/addon.scss
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-@import '@hashicorp/design-system-components.css';
+@import '@hashicorp/design-system-components';
 @import 'hds/themes/dark-mode';
 @import 'hds/overrides';

--- a/addons/rose/index.js
+++ b/addons/rose/index.js
@@ -13,14 +13,13 @@ module.exports = {
   name: require('./package').name,
   included(app) {
     this._super.included.apply(this, arguments);
-    app.import(
-      'node_modules/@hashicorp/design-system-components/dist/styles/@hashicorp/design-system-components.css',
-    );
+
     app.import('node_modules/codemirror/lib/codemirror.css');
     app.import('node_modules/codemirror/theme/monokai.css');
     app.import('node_modules/codemirror/addon/lint/lint.css');
     app.import('node_modules/jsonlint/lib/jsonlint.js');
 
+    this.includeHDSStyles(app);
     this.includeFlightIcons(app);
     this.includePublic(app);
     this.setupSVGO(app);
@@ -35,6 +34,29 @@ module.exports = {
     return this.findOwnAddonByName('@hashicorp/design-system-components')
       .findOwnAddonByName('@hashicorp/ember-flight-icons')
       .contentFor(type, config);
+  },
+
+  /**
+   * Finds the HDS styles folder and includes it into the running
+   * application's `sassOptions.includePaths`.
+   */
+  includeHDSStyles(app) {
+    const tokensPath =
+      '../../node_modules/@hashicorp/design-system-tokens/dist/products/css';
+    const hdsPath =
+      '../../node_modules/@hashicorp/design-system-components/dist/styles';
+    const iconsPath =
+      '../../node_modules/@hashicorp/ember-flight-icons/dist/styles';
+
+    // Setup default sassOptions on the running application
+    app.options.sassOptions = app.options.sassOptions || {};
+    app.options.sassOptions.includePaths =
+      app.options.sassOptions.includePaths || [];
+
+    // Include the addon styles
+    app.options.sassOptions.includePaths.push(tokensPath);
+    app.options.sassOptions.includePaths.push(hdsPath);
+    app.options.sassOptions.includePaths.push(iconsPath);
   },
 
   /**


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
Previous [PR](https://github.com/hashicorp/boundary-ui/pull/2350) to upgrade to hds v4 broke our [build workflows](https://github.com/hashicorp/boundary-ui/actions/runs/9555072433/job/26337734431) 😭
<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->
Due to the errors encountered we are opting to import all hds styles manually like we were doing before. In addition to also importing the styles for flight-icons. If we don't include the style path for the icons we get an error so it is necessary to include.

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
1. run all admin-ui build commands locally: `yarn run build:ui:admin:oss` `yarn run build:ui:admin:enterprise` `yarn run build:ui:admin:hcp`
2. start ui/admin and ui/desktop apps locally and make sure there are no unexpected warnings or errors
## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
