### PR TITLE
Icu 13889 update tags column to action that opens hds flyout and add link to tags tab if more than 10 tags

### DIFF
--- a/addons/api/mirage/factories/worker.js
+++ b/addons/api/mirage/factories/worker.js
@@ -23,10 +23,6 @@ export default factory.extend({
   config_tags: (i) => {
     if (i % 3 === 0) {
       return {
-        typeissuddenlyareallylongword: [
-          faker.word.words(1),
-          faker.word.words(1),
-        ],
         os: ['ubuntu'],
         env: ['dev', 'local'],
       };

--- a/addons/api/mirage/factories/worker.js
+++ b/addons/api/mirage/factories/worker.js
@@ -39,6 +39,7 @@ export default factory.extend({
         os: ['z-os'],
         env: ['prod', 'qa'],
         sample: [faker.word.words(1), faker.word.words(1)],
+        path: [faker.word.words(1)],
       };
     }
     if (i % 2 === 0) {

--- a/addons/api/mirage/factories/worker.js
+++ b/addons/api/mirage/factories/worker.js
@@ -20,30 +20,57 @@ export default factory.extend({
       'delete',
     ],
   type: (i) => types[i % types.length],
-  canonical_tags: (i) => {
+  config_tags: (i) => {
     if (i % 3 === 0) {
-      return { os: ['ubuntu'] };
-    }
-    if (i % 2 === 0) {
       return {
-        type: [faker.word.words(1), faker.word.words(1)],
+        typeissuddenlyareallylongword: [
+          faker.word.words(1),
+          faker.word.words(1),
+        ],
         os: ['ubuntu'],
         env: ['dev', 'local'],
       };
+    }
+    if (i % 2 === 0) {
+      return { os: ['ubuntu'] };
     }
     return undefined;
   },
-  config_tags: (i) => {
+  api_tags: (i) => {
     if (i % 3 === 0) {
-      return { os: ['ubuntu'] };
-    }
-    if (i % 2 === 0) {
       return {
         type: [faker.word.words(1), faker.word.words(1)],
-        os: ['ubuntu'],
-        env: ['dev', 'local'],
+        os: ['z-os'],
+        env: ['prod', 'qa'],
+        sample: [faker.word.words(1), faker.word.words(1)],
       };
     }
+    if (i % 2 === 0) {
+      return { os: ['z-os'] };
+    }
     return undefined;
+  },
+  canonical_tags() {
+    const configTags = this.config_tags || {};
+    const apiTags = this.api_tags || {};
+    const canonicalTags = {};
+
+    Object.keys(configTags).forEach((key) => {
+      canonicalTags[key] = new Set(configTags[key]);
+    });
+
+    Object.keys(apiTags).forEach((key) => {
+      if (canonicalTags[key]) {
+        apiTags[key].forEach((tag) => canonicalTags[key].add(tag));
+      } else {
+        canonicalTags[key] = new Set(apiTags[key]);
+      }
+    });
+
+    Object.keys(canonicalTags).forEach((key) => {
+      canonicalTags[key] = Array.from(canonicalTags[key]);
+    });
+
+    return canonicalTags;
   },
 });

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -912,6 +912,13 @@ worker:
     ip_address: IP Address
     release_version: Release Version
     tag_count: '{tagCount, plural, =1 {# tag} other {# tags}}'
+  flyout:
+    title: Tags in {workerName}
+    table:
+      tag: Tag
+      type: Type
+    action:
+      view_more: View more tags
   form:
     cluster_id:
       label: Boundary Cluster ID

--- a/ui/admin/app/controllers/scopes/scope/workers/index.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/index.js
@@ -31,8 +31,7 @@ export default class ScopesScopeWorkersIndexController extends Controller {
   }
 
   /**
-   * Build the display name for a worker tag and will
-   * truncate the key if it's too long.
+   * Build the display name for a worker tag
    * @param {object} tag
    * @returns {string}
    */

--- a/ui/admin/app/controllers/scopes/scope/workers/index.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/index.js
@@ -7,6 +7,7 @@ import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
+import { tracked } from '@glimmer/tracking';
 import { confirm } from 'core/decorators/confirm';
 import { notifySuccess, notifyError } from 'core/decorators/notify';
 
@@ -16,7 +17,41 @@ export default class ScopesScopeWorkersIndexController extends Controller {
   @service router;
   @service can;
 
+  // =attributes
+
+  @tracked selectedWorker;
+
+  /**
+   * Get the first 10 tags of the selected worker.
+   * @type {object[]}
+   */
+  get selectedWorkerTags() {
+    // only show the first 10 tags if there are more than 10
+    return this.selectedWorker.allTags.slice(0, 10);
+  }
+
+  /**
+   * Build the display name for a worker tag and will
+   * truncate the key if it's too long.
+   * @param {object} tag
+   * @returns {string}
+   */
+  tagDisplayName(tag) {
+    const key =
+      tag.key.length > 16 ? tag.key.substring(0, 16) + '...' : tag.key;
+    return `${key} = ${tag.value}`;
+  }
+
   // =actions
+
+  /**
+   * Toggle the tags flyout to display or hide the tags of a worker.
+   * @param {object} selectedWorker
+   */
+  @action
+  selectWorker(selectedWorker) {
+    this.selectedWorker = selectedWorker;
+  }
 
   /**
    * Rollback changes on workers.

--- a/ui/admin/app/controllers/scopes/scope/workers/index.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/index.js
@@ -37,9 +37,7 @@ export default class ScopesScopeWorkersIndexController extends Controller {
    * @returns {string}
    */
   tagDisplayName(tag) {
-    const key =
-      tag.key.length > 16 ? tag.key.substring(0, 16) + '...' : tag.key;
-    return `${key} = ${tag.value}`;
+    return `${tag.key} = ${tag.value}`;
   }
 
   // =actions

--- a/ui/admin/app/routes/scopes/scope/workers/index.js
+++ b/ui/admin/app/routes/scopes/scope/workers/index.js
@@ -68,6 +68,16 @@ export default class ScopesScopeWorkersIndexRoute extends Route {
     return workers;
   }
 
+  resetController(controller, isExiting) {
+    // Clear selected worker when exiting route to prevent
+    // the flyout from showing when returning to this route
+    if (isExiting) {
+      controller.setProperties({
+        selectedWorker: null,
+      });
+    }
+  }
+
   /**
    * Clears filter selections.
    */

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -1036,3 +1036,7 @@
 .loading-indicator {
   margin-top: 20%;
 }
+
+.view-more-tags {
+  margin-top: 1.5rem;
+}

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -1037,6 +1037,17 @@
   margin-top: 20%;
 }
 
+// workers
 .view-more-tags {
   margin-top: 1.5rem;
+}
+
+.tag-container {
+  display: flex;
+  max-width: 310px;
+}
+
+.tag-shortener {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -1042,12 +1042,9 @@
   margin-top: 1.5rem;
 }
 
-.tag-container {
-  display: flex;
-  max-width: 310px;
-}
-
 .tag-shortener {
+  display: inline-block;
+  max-width: 310px;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/ui/admin/app/templates/scopes/scope/workers/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/index.hbs
@@ -184,7 +184,7 @@
                 </B.Tr>
               </:body>
             </Hds::Table>
-            {{#if (eq this.selectedWorkerTags.length 10)}}
+            {{#if (gt this.selectedWorker.allTags.length 10)}}
               <div class='view-more-tags'>
                 {{! TODO: Update route to worker.tags once route is added }}
                 <Hds::Link::Standalone

--- a/ui/admin/app/templates/scopes/scope/workers/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/index.hbs
@@ -174,10 +174,8 @@
               <:body as |B|>
                 <B.Tr>
                   <B.Td>
-                    <Hds::Text::Code class='tag-container'>
-                      <div class='tag-shortener'>
-                        {{this.tagDisplayName B.data}}
-                      </div>
+                    <Hds::Text::Code class='tag-shortener'>
+                      {{this.tagDisplayName B.data}}
                     </Hds::Text::Code>
                   </B.Td>
                   <B.Td>

--- a/ui/admin/app/templates/scopes/scope/workers/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/index.hbs
@@ -27,7 +27,7 @@
     {{/if}}
   </page.actions>
 
-  <page.body class='workers'>
+  <page.body>
     {{#if @model}}
       <Rose::Toolbar as |toolbar|>
         <toolbar.primary>

--- a/ui/admin/app/templates/scopes/scope/workers/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/index.hbs
@@ -27,7 +27,7 @@
     {{/if}}
   </page.actions>
 
-  <page.body>
+  <page.body class='workers'>
     {{#if @model}}
       <Rose::Toolbar as |toolbar|>
         <toolbar.primary>
@@ -124,12 +124,16 @@
             </B.Td>
             <B.Td>
               {{#if B.data.tagCount}}
-                <Hds::Badge
+                <Hds::Button
+                  data-test-worker-tags-flyout-button={{B.data.id}}
                   @icon='tag'
                   @text={{t
                     'resources.worker.table.tag_count'
                     tagCount=B.data.tagCount
                   }}
+                  @color='tertiary'
+                  @size='small'
+                  {{on 'click' (fn this.selectWorker B.data)}}
                 />
               {{/if}}
             </B.Td>
@@ -145,6 +149,56 @@
           </B.Tr>
         </:body>
       </Hds::Table>
+
+      {{#if this.selectedWorker}}
+        <Hds::Flyout
+          data-test-worker-tags-flyout
+          @onClose={{fn this.selectWorker null}}
+          as |M|
+        >
+          <M.Header>
+            {{t
+              'resources.worker.flyout.title'
+              workerName=this.selectedWorker.displayName
+            }}
+          </M.Header>
+          <M.Body>
+            <Hds::Table
+              @model={{this.selectedWorkerTags}}
+              @columns={{array
+                (hash label=(t 'resources.worker.flyout.table.tag'))
+                (hash label=(t 'resources.worker.flyout.table.type'))
+              }}
+              @valign='middle'
+            >
+              <:body as |B|>
+                <B.Tr>
+                  <B.Td>
+                    <Hds::Text::Code>
+                      {{this.tagDisplayName B.data}}
+                    </Hds::Text::Code>
+                  </B.Td>
+                  <B.Td>
+                    <Hds::Badge @text={{B.data.type}} />
+                  </B.Td>
+                </B.Tr>
+              </:body>
+            </Hds::Table>
+            {{#if (eq this.selectedWorkerTags.length 10)}}
+              <div class='view-more-tags'>
+                {{! TODO: Update route to worker.tags once route is added }}
+                <Hds::Link::Standalone
+                  @icon='arrow-right'
+                  @iconPosition='trailing'
+                  @text={{t 'resources.worker.flyout.action.view_more'}}
+                  @route='scopes.scope.workers.worker'
+                  @model={{this.selectedWorker}}
+                />
+              </div>
+            {{/if}}
+          </M.Body>
+        </Hds::Flyout>
+      {{/if}}
     {{else}}
       <Rose::Layout::Centered>
         <Rose::Message

--- a/ui/admin/app/templates/scopes/scope/workers/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/index.hbs
@@ -174,8 +174,10 @@
               <:body as |B|>
                 <B.Tr>
                   <B.Td>
-                    <Hds::Text::Code>
-                      {{this.tagDisplayName B.data}}
+                    <Hds::Text::Code class='tag-container'>
+                      <div class='tag-shortener'>
+                        {{this.tagDisplayName B.data}}
+                      </div>
                     </Hds::Text::Code>
                   </B.Td>
                   <B.Td>

--- a/ui/admin/tests/acceptance/workers/list-test.js
+++ b/ui/admin/tests/acceptance/workers/list-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
+import { visit, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
@@ -14,6 +14,13 @@ import {
   //currentSession,
   //invalidateSession,
 } from 'ember-simple-auth/test-support';
+
+const WORKERS_FLYOUT = '[data-test-worker-tags-flyout]';
+const WORKERS_FLYOUT_DISMISS = '[data-test-worker-tags-flyout] div button';
+const WORKERS_FLYOUT_TABLE_BODY = '[data-test-worker-tags-flyout] tbody';
+const WORKERS_FLYOUT_TABLE_ROWS = '[data-test-worker-tags-flyout] tbody tr';
+const WORKER_TAG_BUTTON = (workerId) =>
+  `[data-test-worker-tags-flyout-button="${workerId}"]`;
 
 module('Acceptance | workers | list', function (hooks) {
   setupApplicationTest(hooks);
@@ -26,6 +33,7 @@ module('Acceptance | workers | list', function (hooks) {
     scopes: {
       global: null,
     },
+    worker: null,
   };
 
   const urls = {
@@ -35,6 +43,8 @@ module('Acceptance | workers | list', function (hooks) {
 
   hooks.beforeEach(function () {
     instances.scopes.global = this.server.create('scope', { id: 'global' });
+    const scope = instances.scopes.global;
+    instances.worker = this.server.create('worker', { scopeId: scope.id });
     urls.globalScope = `/scopes/global/scopes`;
     urls.workers = `/scopes/global/workers`;
     authenticateSession({});
@@ -76,5 +86,93 @@ module('Acceptance | workers | list', function (hooks) {
 
     await visit(urls.globalScope);
     assert.dom(`[href="${urls.workers}"]`).isVisible();
+  });
+
+  test('Users can open and close tags flyout for a specific worker', async function (assert) {
+    featuresService.enable('byow');
+    await visit(urls.workers);
+    assert.dom(WORKERS_FLYOUT).isNotVisible();
+
+    await click(WORKER_TAG_BUTTON(instances.worker.id));
+    assert.dom(WORKERS_FLYOUT).isVisible();
+
+    await click(WORKERS_FLYOUT_DISMISS);
+    assert.dom(WORKERS_FLYOUT).isNotVisible();
+  });
+
+  test('Users can see config tags in the tags flyout', async function (assert) {
+    featuresService.enable('byow');
+    await visit(urls.workers);
+    await click(WORKER_TAG_BUTTON(instances.worker.id));
+
+    assert.dom(WORKERS_FLYOUT_TABLE_BODY).includesText('os = z-os');
+  });
+
+  test('Users can only see first 10 tags in the tags flyout', async function (assert) {
+    featuresService.enable('byow');
+    instances.worker.update({
+      configTags: {
+        tag1: ['value1', 'value2'],
+        tag2: ['value3'],
+        tag3: ['value4'],
+        tag4: ['value5'],
+        tag5: ['value6'],
+        tag6: ['value7'],
+        tag7: ['value8'],
+        tag8: ['value9'],
+        tag9: ['value10'],
+        tag10: ['value11'],
+        tag11: ['value12'],
+      },
+    });
+
+    await visit(urls.workers);
+    await click(WORKER_TAG_BUTTON(instances.worker.id));
+
+    assert.dom(WORKERS_FLYOUT_TABLE_ROWS).exists({ count: 10 });
+  });
+
+  test('Users can click on "view more tags" if there are more than 10 tags', async function (assert) {
+    featuresService.enable('byow');
+    instances.worker.update({
+      configTags: {
+        tag1: ['value1', 'value2'],
+        tag2: ['value3'],
+        tag3: ['value4'],
+        tag4: ['value5'],
+        tag5: ['value6'],
+        tag6: ['value7'],
+        tag7: ['value8'],
+        tag8: ['value9'],
+        tag9: ['value10'],
+        tag10: ['value11'],
+        tag11: ['value12'],
+      },
+    });
+
+    await visit(urls.workers);
+    await click(WORKER_TAG_BUTTON(instances.worker.id));
+
+    assert.dom(WORKERS_FLYOUT_TABLE_ROWS).exists({ count: 10 });
+    assert.dom('.view-more-tags').isVisible();
+  });
+
+  test('Users do not see "view more tags" if there are less than 10 tags', async function (assert) {
+    featuresService.enable('byow');
+    instances.worker.update({
+      configTags: {
+        tag1: ['value1', 'value2'],
+        tag2: ['value3'],
+        tag3: ['value4'],
+        tag4: ['value5'],
+      },
+      apiTags: null,
+    });
+
+    await visit(urls.workers);
+    await click(WORKER_TAG_BUTTON(instances.worker.id));
+
+    assert.dom(WORKERS_FLYOUT_TABLE_ROWS).exists({ count: 5 });
+    assert.dom('.view-more-tags').isNotVisible();
   });
 });

--- a/ui/admin/tests/acceptance/workers/list-test.js
+++ b/ui/admin/tests/acceptance/workers/list-test.js
@@ -161,7 +161,7 @@ module('Acceptance | workers | list', function (hooks) {
     assert.dom(WORKERS_FLYOUT_VIEW_MORE_TAGS).isVisible();
   });
 
-  test('Users do not see "view more tags" if there are less than 10 tags', async function (assert) {
+  test('Users do not see "view more tags" if there are 10 or less tags', async function (assert) {
     featuresService.enable('byow');
     instances.worker.update({
       configTags: {

--- a/ui/admin/tests/acceptance/workers/list-test.js
+++ b/ui/admin/tests/acceptance/workers/list-test.js
@@ -19,6 +19,8 @@ const WORKERS_FLYOUT = '[data-test-worker-tags-flyout]';
 const WORKERS_FLYOUT_DISMISS = '[data-test-worker-tags-flyout] div button';
 const WORKERS_FLYOUT_TABLE_BODY = '[data-test-worker-tags-flyout] tbody';
 const WORKERS_FLYOUT_TABLE_ROWS = '[data-test-worker-tags-flyout] tbody tr';
+const WORKERS_FLYOUT_VIEW_MORE_TAGS =
+  '[data-test-worker-tags-flyout] .view-more-tags';
 const WORKER_TAG_BUTTON = (workerId) =>
   `[data-test-worker-tags-flyout-button="${workerId}"]`;
 
@@ -154,7 +156,7 @@ module('Acceptance | workers | list', function (hooks) {
     await click(WORKER_TAG_BUTTON(instances.worker.id));
 
     assert.dom(WORKERS_FLYOUT_TABLE_ROWS).exists({ count: 10 });
-    assert.dom('.view-more-tags').isVisible();
+    assert.dom(WORKERS_FLYOUT_VIEW_MORE_TAGS).isVisible();
   });
 
   test('Users do not see "view more tags" if there are less than 10 tags', async function (assert) {
@@ -173,6 +175,6 @@ module('Acceptance | workers | list', function (hooks) {
     await click(WORKER_TAG_BUTTON(instances.worker.id));
 
     assert.dom(WORKERS_FLYOUT_TABLE_ROWS).exists({ count: 5 });
-    assert.dom('.view-more-tags').isNotVisible();
+    assert.dom(WORKERS_FLYOUT_VIEW_MORE_TAGS).isNotVisible();
   });
 });


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
When viewing the workers table, you can now quickly view the tags on a worker with an Hds Flyout

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

https://github.com/hashicorp/boundary-ui/assets/29386339/d8534048-50ce-46e0-b763-94ca83620a99

Example of a key that is longer than 16 characters
<img width="488" alt="Screenshot 2024-06-18 at 3 23 20 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/9fb7cd84-1ba7-4b3d-89d4-41fdc5bb4ea3">


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
Visit vercel build and view workers. You should be able to click on the tags count in a table row and view the tags for that specific worker. If there are 10 or more tags, it should only show 10 and navigate the user to the worker route.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
