### PR TITLE
fix: 🐛 copyright syntax

### DIFF
--- a/ui/admin/app/components/breadcrumbs/container/index.hbs
+++ b/ui/admin/app/components/breadcrumbs/container/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <Hds::Breadcrumb
   ...attributes

--- a/ui/admin/app/components/breadcrumbs/item/index.hbs
+++ b/ui/admin/app/components/breadcrumbs/item/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{#each this.breadcrumbsService.containers as |container|}}
   {{#in-element container.element insertBefore=null}}

--- a/ui/admin/app/templates/scopes/index.hbs
+++ b/ui/admin/app/templates/scopes/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 {{outlet}}
 

--- a/ui/desktop/app/components/session/proxy-url/index.hbs
+++ b/ui/desktop/app/components/session/proxy-url/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
-~}}
+}}
 
 <div class='proxy-url-container'>
   <Hds::Dropdown @listPosition='bottom-left' as |dd|>


### PR DESCRIPTION
# Description
noticed some warnings due to this copyright syntax in some of the files 
<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
![copywrite](https://github.com/hashicorp/boundary-ui/assets/15043878/a26b1289-1d57-43c1-b3c4-5cc64b5e5ae9)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
- do yarn run test and you should not see the warnings anymore
## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- ~[ ] My changes generate no new warnings~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
