### PR TITLE
Icu 13892 create tags tab route and view

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -914,6 +914,7 @@ worker:
     tag_count: '{tagCount, plural, =1 {# tag} other {# tags}}'
   tags:
     title_plural: Tags
+    description: Tags are used to define the type of worker and to make it distinguishable amongst other workers.
   form:
     cluster_id:
       label: Boundary Cluster ID

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -912,6 +912,9 @@ worker:
     ip_address: IP Address
     release_version: Release Version
     tag_count: '{tagCount, plural, =1 {# tag} other {# tags}}'
+    key: Key
+    value: Value
+    type: Type
   tags:
     title_plural: Tags
     description: Tags are used to define the type of worker and to make it distinguishable amongst other workers.

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -912,6 +912,8 @@ worker:
     ip_address: IP Address
     release_version: Release Version
     tag_count: '{tagCount, plural, =1 {# tag} other {# tags}}'
+  tags:
+    title_plural: Tags
   form:
     cluster_id:
       label: Boundary Cluster ID

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -912,6 +912,7 @@ worker:
     ip_address: IP Address
     release_version: Release Version
     tag_count: '{tagCount, plural, =1 {# tag} other {# tags}}'
+    tag: Tag
     key: Key
     value: Value
     type: Type
@@ -920,9 +921,6 @@ worker:
     description: Tags are used to define the type of worker and to make it distinguishable amongst other workers.
   flyout:
     title: Tags in {workerName}
-    table:
-      tag: Tag
-      type: Type
     action:
       view_more: View more tags
   form:

--- a/ui/admin/app/components/workers/worker/actions/index.hbs
+++ b/ui/admin/app/components/workers/worker/actions/index.hbs
@@ -1,0 +1,20 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+<Rose::Dropdown
+  @text={{t 'actions.manage'}}
+  @dropdownRight={{true}}
+  as |dropdown|
+>
+  {{#if (can 'delete worker' @model)}}
+    <dropdown.button
+      @style='danger'
+      @disabled={{@model.canSave}}
+      {{on 'click' (fn @delete @model)}}
+    >
+      {{t 'resources.worker.actions.delete'}}
+    </dropdown.button>
+  {{/if}}
+</Rose::Dropdown>

--- a/ui/admin/app/components/workers/worker/actions/index.hbs
+++ b/ui/admin/app/components/workers/worker/actions/index.hbs
@@ -3,18 +3,14 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<Rose::Dropdown
-  @text={{t 'actions.manage'}}
-  @dropdownRight={{true}}
-  as |dropdown|
->
+<Hds::Dropdown data-test-manage-worker-dropdown as |dd|>
+  <dd.ToggleButton @text={{t 'actions.manage'}} @color='secondary' />
   {{#if (can 'delete worker' @model)}}
-    <dropdown.button
-      @style='danger'
-      @disabled={{@model.canSave}}
+    <dd.Interactive
+      @icon='trash'
+      @text={{t 'resources.worker.actions.delete'}}
+      @color='critical'
       {{on 'click' (fn @delete @model)}}
-    >
-      {{t 'resources.worker.actions.delete'}}
-    </dropdown.button>
+    />
   {{/if}}
-</Rose::Dropdown>
+</Hds::Dropdown>

--- a/ui/admin/app/components/workers/worker/header/index.hbs
+++ b/ui/admin/app/components/workers/worker/header/index.hbs
@@ -1,0 +1,11 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+<h2>
+  {{t 'resources.worker.title'}}
+  <DocLink @doc='worker' @iconSize='large' />
+</h2>
+<p>{{t 'resources.worker.description'}}</p>
+<Hds::Copy::Snippet @textToCopy={{@model.id}} @color='secondary' />

--- a/ui/admin/app/components/workers/worker/nav/index.hbs
+++ b/ui/admin/app/components/workers/worker/nav/index.hbs
@@ -1,0 +1,13 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+<Rose::Nav::Tabs as |nav|>
+  <nav.link @route='scopes.scope.workers.worker.index'>
+    {{t 'titles.details'}}
+  </nav.link>
+  <nav.link @route='scopes.scope.workers.worker.tags'>
+    {{t 'resources.worker.tags.title_plural'}}
+  </nav.link>
+</Rose::Nav::Tabs>

--- a/ui/admin/app/controllers/scopes/scope/workers/worker/tags.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/worker/tags.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Controller, { inject as controller } from '@ember/controller';
+
+export default class ScopesScopeWorkersWorkerTagsController extends Controller {
+  @controller('scopes/scope/workers/index') workers;
+}

--- a/ui/admin/app/router.js
+++ b/ui/admin/app/router.js
@@ -148,7 +148,9 @@ Router.map(function () {
       });
       this.route('workers', function () {
         this.route('new');
-        this.route('worker', { path: ':worker_id' }, function () {});
+        this.route('worker', { path: ':worker_id' }, function () {
+          this.route('tags');
+        });
       });
       this.route('session-recordings', function () {
         this.route(

--- a/ui/admin/app/routes/scopes/scope/workers/worker/tags.js
+++ b/ui/admin/app/routes/scopes/scope/workers/worker/tags.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class ScopesScopeWorkersWorkerTagsRoute extends Route {}

--- a/ui/admin/app/routes/scopes/scope/workers/worker/tags.js
+++ b/ui/admin/app/routes/scopes/scope/workers/worker/tags.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import Route from '@ember/routing/route';
 
 export default class ScopesScopeWorkersWorkerTagsRoute extends Route {}

--- a/ui/admin/app/templates/scopes/scope/workers/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/index.hbs
@@ -166,8 +166,8 @@
             <Hds::Table
               @model={{this.selectedWorkerTags}}
               @columns={{array
-                (hash label=(t 'resources.worker.flyout.table.tag'))
-                (hash label=(t 'resources.worker.flyout.table.type'))
+                (hash label=(t 'resources.worker.table.tag'))
+                (hash label=(t 'resources.worker.table.type'))
               }}
               @valign='middle'
             >
@@ -186,12 +186,11 @@
             </Hds::Table>
             {{#if (gt this.selectedWorker.allTags.length 10)}}
               <div class='view-more-tags'>
-                {{! TODO: Update route to worker.tags once route is added }}
                 <Hds::Link::Standalone
                   @icon='arrow-right'
                   @iconPosition='trailing'
                   @text={{t 'resources.worker.flyout.action.view_more'}}
-                  @route='scopes.scope.workers.worker'
+                  @route='scopes.scope.workers.worker.tags'
                   @model={{this.selectedWorker}}
                 />
               </div>

--- a/ui/admin/app/templates/scopes/scope/workers/worker/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/worker/index.hbs
@@ -14,14 +14,7 @@
   </page.header>
 
   <page.navigation>
-    <Rose::Nav::Tabs as |nav|>
-      <nav.link @route='scopes.scope.workers.worker.index'>
-        {{t 'titles.details'}}
-      </nav.link>
-      <nav.link @route='scopes.scope.workers.worker.tags'>
-        {{t 'resources.worker.tags.title_plural'}}
-      </nav.link>
-    </Rose::Nav::Tabs>
+    <Workers::Worker::Nav />
   </page.navigation>
 
   <page.actions>

--- a/ui/admin/app/templates/scopes/scope/workers/worker/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/worker/index.hbs
@@ -23,6 +23,9 @@
       <nav.link @route='scopes.scope.workers.worker.index'>
         {{t 'titles.details'}}
       </nav.link>
+      <nav.link @route='scopes.scope.workers.worker.tags'>
+        {{t 'resources.worker.tags.title_plural'}}
+      </nav.link>
     </Rose::Nav::Tabs>
   </page.navigation>
 

--- a/ui/admin/app/templates/scopes/scope/workers/worker/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/worker/index.hbs
@@ -10,12 +10,7 @@
   </page.breadcrumbs>
 
   <page.header>
-    <h2>
-      {{t 'resources.worker.title'}}
-      <DocLink @doc='worker' @iconSize='large' />
-    </h2>
-    <p>{{t 'resources.worker.description'}}</p>
-    <Hds::Copy::Snippet @textToCopy={{@model.id}} @color='secondary' />
+    <Workers::Worker::Header @model={{@model}} />
   </page.header>
 
   <page.navigation>

--- a/ui/admin/app/templates/scopes/scope/workers/worker/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/worker/index.hbs
@@ -18,21 +18,10 @@
   </page.navigation>
 
   <page.actions>
-    <Rose::Dropdown
-      @text={{t 'actions.manage'}}
-      @dropdownRight={{true}}
-      as |dropdown|
-    >
-      {{#if (can 'delete worker' @model)}}
-        <dropdown.button
-          @style='danger'
-          @disabled={{@model.canSave}}
-          {{on 'click' (fn this.workers.delete @model)}}
-        >
-          {{t 'resources.worker.actions.delete'}}
-        </dropdown.button>
-      {{/if}}
-    </Rose::Dropdown>
+    <Workers::Worker::Actions
+      @model={{@model}}
+      @delete={{this.workers.delete}}
+    />
   </page.actions>
 
   <page.body>

--- a/ui/admin/app/templates/scopes/scope/workers/worker/tags.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/worker/tags.hbs
@@ -1,0 +1,2 @@
+{{page-title (t 'resources.worker.tags.title_plural')}}
+{{outlet}}

--- a/ui/admin/app/templates/scopes/scope/workers/worker/tags.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/worker/tags.hbs
@@ -30,4 +30,33 @@
     />
   </page.actions>
 
+  <page.body>
+    {{#if @model.allTags}}
+      <Hds::Table
+        @model={{@model.allTags}}
+        @columns={{array
+          (hash label=(t 'resources.worker.table.key'))
+          (hash label=(t 'resources.worker.table.value'))
+          (hash label=(t 'resources.worker.table.type'))
+        }}
+        @valign='middle'
+      >
+        <:body as |B|>
+          <B.Tr>
+            <B.Td>
+              <Hds::Text::Code @tag='pre'>{{B.data.key}}</Hds::Text::Code>
+            </B.Td>
+            <B.Td>
+              <Hds::Text::Code @tag='pre'>{{B.data.value}}</Hds::Text::Code>
+            </B.Td>
+            <B.Td>
+              <Hds::Badge @text={{B.data.type}} />
+            </B.Td>
+          </B.Tr>
+        </:body>
+      </Hds::Table>
+    {{/if}}
+
+  </page.body>
+
 </Rose::Layout::Page>

--- a/ui/admin/app/templates/scopes/scope/workers/worker/tags.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/worker/tags.hbs
@@ -1,2 +1,33 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
 {{page-title (t 'resources.worker.tags.title_plural')}}
-{{outlet}}
+<Breadcrumbs::Item
+  @text={{t 'resources.worker.tags.title_plural'}}
+  @route='scopes.scope.workers.worker.tags'
+/>
+
+<Rose::Layout::Page as |page|>
+
+  <page.breadcrumbs>
+    <Breadcrumbs::Container />
+  </page.breadcrumbs>
+
+  <page.header>
+    <Workers::Worker::Header @model={{@model}} />
+  </page.header>
+
+  <page.navigation>
+    <Workers::Worker::Nav />
+  </page.navigation>
+
+  <page.actions>
+    <Workers::Worker::Actions
+      @model={{@model}}
+      @delete={{this.workers.delete}}
+    />
+  </page.actions>
+
+</Rose::Layout::Page>

--- a/ui/admin/tests/acceptance/workers/delete-test.js
+++ b/ui/admin/tests/acceptance/workers/delete-test.js
@@ -21,6 +21,10 @@ module('Acceptance | workers | delete', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
+  const MANAGE_DROPDOWN_TOGGLE =
+    '[data-test-manage-worker-dropdown] div button';
+  const REMOVE_WORKER_BUTTON =
+    '[data-test-manage-worker-dropdown] div:nth-child(2) button';
   let getWorkerCount;
 
   const instances = {
@@ -54,7 +58,8 @@ module('Acceptance | workers | delete', function (hooks) {
   test('can delete a worker', async function (assert) {
     const count = getWorkerCount();
     await visit(urls.worker);
-    await click('.rose-layout-page-actions .rose-dropdown-button-danger');
+    await click(MANAGE_DROPDOWN_TOGGLE);
+    await click(REMOVE_WORKER_BUTTON);
     assert.strictEqual(getWorkerCount(), count - 1);
   });
 
@@ -64,7 +69,8 @@ module('Acceptance | workers | delete', function (hooks) {
     confirmService.confirm = sinon.fake.returns(resolve());
     const count = getWorkerCount();
     await visit(urls.worker);
-    await click('.rose-layout-page-actions .rose-dropdown-button-danger');
+    await click(MANAGE_DROPDOWN_TOGGLE);
+    await click(REMOVE_WORKER_BUTTON);
     assert.strictEqual(getWorkerCount(), count - 1);
     assert.ok(confirmService.confirm.calledOnce);
   });
@@ -75,7 +81,8 @@ module('Acceptance | workers | delete', function (hooks) {
     confirmService.confirm = sinon.fake.returns(reject());
     const count = getWorkerCount();
     await visit(urls.worker);
-    await click('.rose-layout-page-actions .rose-dropdown-button-danger');
+    await click(MANAGE_DROPDOWN_TOGGLE);
+    await click(REMOVE_WORKER_BUTTON);
     assert.strictEqual(getWorkerCount(), count);
     assert.ok(confirmService.confirm.calledOnce);
   });
@@ -84,9 +91,8 @@ module('Acceptance | workers | delete', function (hooks) {
     instances.worker.authorized_actions =
       instances.worker.authorized_actions.filter((item) => item !== 'delete');
     await visit(urls.worker);
-    assert
-      .dom('.rose-layout-page-actions .rose-dropdown-button-danger')
-      .isNotVisible();
+    await click(MANAGE_DROPDOWN_TOGGLE);
+    assert.dom(REMOVE_WORKER_BUTTON).isNotVisible();
   });
 
   test('deleting a worker which errors displays error messages', async function (assert) {
@@ -102,7 +108,8 @@ module('Acceptance | workers | delete', function (hooks) {
       );
     });
     await visit(urls.worker);
-    await click('.rose-layout-page-actions .rose-dropdown-button-danger');
+    await click(MANAGE_DROPDOWN_TOGGLE);
+    await click(REMOVE_WORKER_BUTTON);
     assert.ok(find('[role="alert"]').textContent.trim(), 'Oops.');
   });
 });

--- a/ui/admin/tests/acceptance/workers/list-test.js
+++ b/ui/admin/tests/acceptance/workers/list-test.js
@@ -42,6 +42,7 @@ module('Acceptance | workers | list', function (hooks) {
     globalScope: null,
     workers: null,
     worker: null,
+    workerTags: null,
   };
 
   hooks.beforeEach(function () {
@@ -51,6 +52,7 @@ module('Acceptance | workers | list', function (hooks) {
     urls.globalScope = `/scopes/global/scopes`;
     urls.workers = `/scopes/global/workers`;
     urls.worker = `${urls.workers}/${instances.worker.id}`;
+    urls.workerTags = `${urls.worker}/tags`;
     authenticateSession({});
     featuresService = this.owner.lookup('service:features');
   });
@@ -189,7 +191,7 @@ module('Acceptance | workers | list', function (hooks) {
 
     await click(WORKERS_FLYOUT_VIEW_MORE_TAGS);
 
-    assert.strictEqual(currentURL(), urls.worker);
+    assert.strictEqual(currentURL(), urls.workerTags);
 
     await click(`[href="${urls.workers}"]`);
 

--- a/ui/admin/tests/acceptance/workers/tags-test.js
+++ b/ui/admin/tests/acceptance/workers/tags-test.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { visit, currentURL, click, findAll } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module('Acceptance | workers | tags', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  const instances = {
+    scopes: {
+      global: null,
+    },
+  };
+
+  const urls = {
+    workers: null,
+    worker: null,
+    tags: null,
+  };
+
+  hooks.beforeEach(function () {
+    instances.scopes.global = this.server.create('scope', { id: 'global' });
+    const scope = instances.scopes.global;
+    instances.worker = this.server.create('worker', { scopeId: scope.id });
+    urls.workers = `/scopes/global/workers`;
+    urls.worker = `${urls.workers}/${instances.worker.id}`;
+    urls.tags = `${urls.worker}/tags`;
+    authenticateSession({});
+  });
+
+  test('visiting worker tags', async function (assert) {
+    await visit(urls.worker);
+    await click(`[href="${urls.tags}"]`);
+    await a11yAudit();
+
+    assert.strictEqual(currentURL(), urls.tags);
+    assert.strictEqual(findAll('tbody tr').length, 1);
+  });
+});

--- a/ui/admin/tests/acceptance/workers/tags-test.js
+++ b/ui/admin/tests/acceptance/workers/tags-test.js
@@ -42,6 +42,6 @@ module('Acceptance | workers | tags', function (hooks) {
     await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.tags);
-    assert.strictEqual(findAll('tbody tr').length, 1);
+    assert.strictEqual(findAll('tbody tr').length, 11);
   });
 });

--- a/ui/admin/tests/integration/components/workers/worker/actions/index-test.js
+++ b/ui/admin/tests/integration/components/workers/worker/actions/index-test.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'admin/tests/helpers';
+import { setupIntl } from 'ember-intl/test-support';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | workers/worker/actions/index',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupIntl(hooks);
+
+    test('it renders', async function (assert) {
+      this.set('model', { id: 'w_123', authorized_actions: ['delete'] });
+      this.set('delete', () => {});
+
+      await render(
+        hbs`<Workers::Worker::Actions @model={{this.model}} @delete={{this.delete}} />`,
+      );
+
+      assert.dom(this.element).includesText('Remove Worker');
+    });
+  },
+);

--- a/ui/admin/tests/integration/components/workers/worker/actions/index-test.js
+++ b/ui/admin/tests/integration/components/workers/worker/actions/index-test.js
@@ -6,7 +6,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'admin/tests/helpers';
 import { setupIntl } from 'ember-intl/test-support';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module(
@@ -22,6 +22,7 @@ module(
       await render(
         hbs`<Workers::Worker::Actions @model={{this.model}} @delete={{this.delete}} />`,
       );
+      await click('button');
 
       assert.dom(this.element).includesText('Remove Worker');
     });

--- a/ui/admin/tests/integration/components/workers/worker/header/index-test.js
+++ b/ui/admin/tests/integration/components/workers/worker/header/index-test.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'admin/tests/helpers';
+import { setupIntl } from 'ember-intl/test-support';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | workers/worker/header/index',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupIntl(hooks);
+
+    test('it renders with the id of the model passed in', async function (assert) {
+      this.set('model', { id: 'w_123' });
+
+      await render(hbs`
+      <Workers::Worker::Header @model={{this.model}} />
+    `);
+
+      assert.dom(this.element).includesText('w_123');
+    });
+  },
+);

--- a/ui/admin/tests/integration/components/workers/worker/nav/index-test.js
+++ b/ui/admin/tests/integration/components/workers/worker/nav/index-test.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'admin/tests/helpers';
+import { setupIntl } from 'ember-intl/test-support';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | workers/worker/nav/index', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <Workers::Worker::Nav />
+    `);
+
+    assert.dom(this.element).hasText('Details Tags');
+  });
+});

--- a/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/tags-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/tags-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'admin/tests/helpers';
+
+module(
+  'Unit | Controller | scopes/scope/workers/worker/tags',
+  function (hooks) {
+    setupTest(hooks);
+
+    // TODO: Replace this with your real tests.
+    test('it exists', function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/workers/worker/tags',
+      );
+      assert.ok(controller);
+    });
+  },
+);

--- a/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/tags-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/tags-test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import { module, test } from 'qunit';
 import { setupTest } from 'admin/tests/helpers';
 
@@ -6,7 +11,6 @@ module(
   function (hooks) {
     setupTest(hooks);
 
-    // TODO: Replace this with your real tests.
     test('it exists', function (assert) {
       let controller = this.owner.lookup(
         'controller:scopes/scope/workers/worker/tags',

--- a/ui/admin/tests/unit/routes/scopes/scope/workers/worker/tags-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/workers/worker/tags-test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import { module, test } from 'qunit';
 import { setupTest } from 'admin/tests/helpers';
 

--- a/ui/admin/tests/unit/routes/scopes/scope/workers/worker/tags-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/workers/worker/tags-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'admin/tests/helpers';
+
+module('Unit | Route | scopes/scope/workers/worker/tags', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:scopes/scope/workers/worker/tags');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
This PR adds the new `/workers/worker/tags` route and table view for displaying worker tags.

NOTE: This does not include removing tags from the details view of a worker yet. That will come in a later PR.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
https://github.com/hashicorp/boundary-ui/assets/29386339/5d6c388a-5226-4139-bc35-dc4ba17a60e0


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
Using the vercel deployment:
Navigate to a worker that has tags and click on the new "Tags" tab of a worker.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
