### PR TITLE
test(e2e): Add alias test

### DIFF
--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -898,6 +898,7 @@ exports.addBrokeredCredentialsToTarget = async (
     .getByRole('navigation', { name: 'Resources' })
     .getByRole('link', { name: 'Targets' })
     .click();
+  await expect(page.getByRole('heading', { name: 'Targets' })).toBeVisible();
   await page.getByRole('link', { name: targetName }).click();
   await page
     .getByRole('link', { name: 'Brokered Credentials', exact: true })

--- a/ui/admin/tests/e2e/helpers/boundary-ui.js
+++ b/ui/admin/tests/e2e/helpers/boundary-ui.js
@@ -502,6 +502,49 @@ exports.createTargetWithAddress = async (page, address, port) => {
 };
 
 /**
+ * Uses the UI to create a new target with address and alias. Assumes you have selected the desired project.
+ * @param {Page} page Playwright page object
+ * @param {string} address Address of the target
+ * @param {string} port Port of the target
+ * @param {string} alias alias used for the target
+ * @returns Name of the target
+ */
+exports.createTargetWithAddressAndAlias = async (
+  page,
+  address,
+  port,
+  alias,
+) => {
+  const targetName = 'Target ' + nanoid();
+  await page
+    .getByRole('navigation', { name: 'Resources' })
+    .getByRole('link', { name: 'Targets' })
+    .click();
+  await page.getByRole('link', { name: 'New', exact: true }).click();
+  await page.getByLabel('Name').fill(targetName);
+  await page.getByLabel('Description').fill('This is an automated test');
+  await page.getByLabel('Target Address').fill(address);
+  await page.getByLabel('Default Port').fill(port);
+  await page
+    .getByRole('group', { name: 'Aliases' })
+    .getByLabel('value')
+    .last()
+    .fill(alias);
+  await page.getByRole('button', { name: 'Add' }).click();
+
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').getByText('Success', { exact: true }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Dismiss' }).click();
+  await expect(
+    page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(targetName),
+  ).toBeVisible();
+
+  return targetName;
+};
+
+/**
  * Uses the UI to create a new TCP target with address in boundary-enterprise
  * Assumes you have selected the desired project.
  * @param {Page} page Playwright page object
@@ -596,6 +639,51 @@ exports.createSshTargetWithAddressEnt = async (page, address, port) => {
 };
 
 /**
+ * Uses the UI to create a new SSH target with address and alias.
+ * Assumes you have selected the desired project.
+ * @param {Page} page Playwright page object
+ * @param {string} address Address of the target
+ * @param {string} port Port of the target
+ * @param {string} alias alias used for the target
+ * @returns Name of the target
+ */
+exports.createSshTargetWithAddressAndAlias = async (
+  page,
+  address,
+  port,
+  alias,
+) => {
+  const targetName = 'Target ' + nanoid();
+  await page
+    .getByRole('navigation', { name: 'Resources' })
+    .getByRole('link', { name: 'Targets' })
+    .click();
+  await page.getByRole('link', { name: 'New', exact: true }).click();
+  await page.getByLabel('Name').fill(targetName);
+  await page.getByLabel('Description').fill('This is an automated test');
+  await page.getByRole('group', { name: 'Type' }).getByLabel('SSH').click();
+  await page.getByLabel('Target Address').fill(address);
+  await page.getByLabel('Default Port').fill(port);
+  await page
+    .getByRole('group', { name: 'Aliases' })
+    .getByLabel('value')
+    .last()
+    .fill(alias);
+  await page.getByRole('button', { name: 'Add' }).click();
+
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').getByText('Success', { exact: true }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Dismiss' }).click();
+  await expect(
+    page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(targetName),
+  ).toBeVisible();
+
+  return targetName;
+};
+
+/**
  * Uses the UI to create a new SSH target with address in boundary-enterprise
  * Assumes you have selected the desired project.
  * @param {Page} page Playwright page object
@@ -633,6 +721,50 @@ exports.createSshTargetWithAddressAndWorkerFilterEnt = async (
   ).toBeVisible();
 
   return targetName;
+};
+
+/**
+ * Uses the UI to create an alias
+ * @param {Page} page Playwright page object
+ * @param {string} alias Value of the alias
+ * @param {string} targetId ID of the target
+ * @returns Name of the alias
+ */
+exports.createAliasForTarget = async (page, alias, targetId) => {
+  const aliasName = 'Alias ' + nanoid();
+
+  await page.getByRole('link', { name: 'Orgs', exact: true }).click();
+  await page.getByRole('link', { name: 'Aliases' }).click();
+  await expect(
+    page.getByRole('navigation', { name: 'breadcrumbs' }).getByText('Aliases'),
+  ).toBeVisible();
+
+  const newButtonIsVisible = await page
+    .getByRole('link', { name: 'Create a new alias', exact: true })
+    .isVisible();
+  if (newButtonIsVisible) {
+    await page
+      .getByRole('link', { name: 'Create a new alias', exact: true })
+      .click();
+  } else {
+    await page.getByRole('link', { name: 'New Alias', exact: true }).click();
+  }
+
+  await page.getByLabel('Name').fill(aliasName);
+  await page.getByLabel('Description').fill('This is an automated test');
+  await page.getByLabel('Alias Value').fill(alias);
+  await page.getByLabel('Target ID').fill(targetId);
+
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByRole('alert').getByText('Success', { exact: true }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Dismiss' }).click();
+  await expect(
+    page.getByRole('navigation', { name: 'breadcrumbs' }).getByText(aliasName),
+  ).toBeVisible();
+
+  return aliasName;
 };
 
 /**

--- a/ui/admin/tests/e2e/tests/alias-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/alias-ent.spec.js
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+/* eslint-disable no-undef */
+const { test, expect } = require('@playwright/test');
+import { execSync } from 'child_process';
+import { customAlphabet } from 'nanoid';
+const { checkEnv, authenticatedState } = require('../helpers/general');
+const {
+  authenticateBoundaryCli,
+  authorizeAlias,
+  checkBoundaryCli,
+  deleteAliasCli,
+  deleteOrgCli,
+} = require('../helpers/boundary-cli');
+const {
+  addInjectedCredentialsToTarget,
+  createAliasForTarget,
+  createOrg,
+  createProject,
+  createSshTargetWithAddressEnt,
+  createStaticCredentialKeyPair,
+  createStaticCredentialStore,
+  createTargetWithAddressAndAlias,
+} = require('../helpers/boundary-ui');
+
+test.use({ storageState: authenticatedState });
+
+test.beforeAll(async () => {
+  await checkEnv([
+    'E2E_SSH_USER',
+    'E2E_SSH_KEY_PATH',
+    'E2E_TARGET_ADDRESS',
+    'E2E_TARGET_PORT',
+  ]);
+
+  await checkBoundaryCli();
+});
+
+test.describe('Aliases (Enterprise)', async () => {
+  test('Set up alias from target details page @ent @aws @docker', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    let orgName;
+    let alias;
+    const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
+    try {
+      orgName = await createOrg(page);
+      await createProject(page);
+      const targetName = await createSshTargetWithAddressEnt(
+        page,
+        process.env.E2E_TARGET_ADDRESS,
+        process.env.E2E_TARGET_PORT,
+      );
+      await createStaticCredentialStore(page);
+      const credentialName = await createStaticCredentialKeyPair(
+        page,
+        process.env.E2E_SSH_USER,
+        process.env.E2E_SSH_KEY_PATH,
+      );
+      await addInjectedCredentialsToTarget(page, targetName, credentialName);
+
+      // Create alias for target
+      await page
+        .getByRole('navigation', { name: 'breadcrumbs' })
+        .getByText(targetName)
+        .click();
+      const aliasName = 'Alias ' + nanoid();
+      alias = 'example.alias.' + nanoid();
+      await page.getByRole('link', { name: 'Add an alias' }).click();
+      await page.getByLabel('Name').fill(aliasName);
+      await page.getByLabel('Description').fill('This is an automated test');
+      await page.getByLabel('Alias Value').fill(alias);
+      await page.getByRole('button', { name: 'Save' }).click();
+      await expect(
+        page.getByRole('alert').getByText('Success', { exact: true }),
+      ).toBeVisible();
+      await page.getByRole('button', { name: 'Dismiss' }).click();
+
+      // Connect to target using alias
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+      await authorizeAlias(alias);
+
+      // Clear destination from alias
+      await page.getByRole('link', { name: alias }).click();
+      await page.getByRole('button', { name: 'Manage' }).click();
+      await page.getByText('Clear', { exact: true }).click();
+      await page.getByText('OK', { exact: true }).click();
+      await expect(
+        page.getByRole('alert').getByText('Success', { exact: true }),
+      ).toBeVisible();
+      await page.getByRole('button', { name: 'Dismiss' }).click();
+    } finally {
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+      if (orgName) {
+        const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+        const org = orgs.items.filter((obj) => obj.name == orgName)[0];
+        if (org) {
+          await deleteOrgCli(org.id);
+        }
+      }
+      if (alias) {
+        await deleteAliasCli(alias);
+      }
+    }
+  });
+
+  test('Set up alias from new target page @ent @aws @docker', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    let orgName;
+    let alias;
+    const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
+    try {
+      orgName = await createOrg(page);
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+      await createProject(page);
+      alias = 'example.alias.' + nanoid();
+      const targetName = await createTargetWithAddressAndAlias(
+        page,
+        process.env.E2E_TARGET_ADDRESS,
+        process.env.E2E_TARGET_PORT,
+        alias,
+      );
+      await createStaticCredentialStore(page);
+      const credentialName = await createStaticCredentialKeyPair(
+        page,
+        process.env.E2E_SSH_USER,
+        process.env.E2E_SSH_KEY_PATH,
+      );
+      await addInjectedCredentialsToTarget(page, targetName, credentialName);
+
+      // Connect to target using alias
+      await authorizeAlias(alias);
+    } finally {
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+
+      if (orgName) {
+        const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+        const org = orgs.items.filter((obj) => obj.name == orgName)[0];
+        if (org) {
+          await deleteOrgCli(org.id);
+        }
+        if (alias) {
+          await deleteAliasCli(alias);
+        }
+      }
+    }
+  });
+
+  test('Set up alias from aliases page @ent @aws @docker', async ({ page }) => {
+    await page.goto('/');
+    const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
+    let org;
+    let alias;
+    try {
+      const orgName = await createOrg(page);
+      const projectName = await createProject(page);
+      const targetName = await createSshTargetWithAddressEnt(
+        page,
+        process.env.E2E_TARGET_ADDRESS,
+        process.env.E2E_TARGET_PORT,
+      );
+      await createStaticCredentialStore(page);
+      const credentialName = await createStaticCredentialKeyPair(
+        page,
+        process.env.E2E_SSH_USER,
+        process.env.E2E_SSH_KEY_PATH,
+      );
+      await addInjectedCredentialsToTarget(page, targetName, credentialName);
+
+      // Create new alias from scope page
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+
+      const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+      org = orgs.items.filter((obj) => obj.name == orgName)[0];
+      const projects = JSON.parse(
+        execSync('boundary scopes list -format json -scope-id ' + org.id),
+      );
+      const project = projects.items.filter(
+        (obj) => obj.name == projectName,
+      )[0];
+      const targets = JSON.parse(
+        execSync('boundary targets list -format json -scope-id ' + project.id),
+      );
+      const target = targets.items.filter((obj) => obj.name == targetName)[0];
+
+      alias = 'example.alias.' + nanoid();
+      await createAliasForTarget(page, alias, target.id);
+      await authorizeAlias(alias);
+    } finally {
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+
+      if (org) {
+        await deleteOrgCli(org.id);
+      }
+      if (alias) {
+        await deleteAliasCli(alias);
+      }
+    }
+  });
+});

--- a/ui/admin/tests/e2e/tests/alias.spec.js
+++ b/ui/admin/tests/e2e/tests/alias.spec.js
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+/* eslint-disable no-undef */
+const { test, expect } = require('@playwright/test');
+import { execSync } from 'child_process';
+import { customAlphabet } from 'nanoid';
+const { checkEnv, authenticatedState } = require('../helpers/general');
+const {
+  authenticateBoundaryCli,
+  authorizeAlias,
+  checkBoundaryCli,
+  deleteAliasCli,
+  deleteOrgCli,
+} = require('../helpers/boundary-cli');
+const {
+  createAliasForTarget,
+  createOrg,
+  createProject,
+  createTargetWithAddress,
+  createTargetWithAddressAndAlias,
+} = require('../helpers/boundary-ui');
+
+test.use({ storageState: authenticatedState });
+
+test.beforeAll(async () => {
+  await checkEnv([
+    'E2E_SSH_USER',
+    'E2E_SSH_KEY_PATH',
+    'E2E_TARGET_ADDRESS',
+    'E2E_TARGET_PORT',
+  ]);
+
+  await checkBoundaryCli();
+});
+
+test.describe('Aliases', async () => {
+  test('Set up alias from target details page @ce @aws @docker', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    let orgName;
+    let alias;
+    const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
+    try {
+      orgName = await createOrg(page);
+      await createProject(page);
+      await createTargetWithAddress(
+        page,
+        process.env.E2E_TARGET_ADDRESS,
+        process.env.E2E_TARGET_PORT,
+      );
+
+      // Create alias for target
+      const aliasName = 'Alias ' + nanoid();
+      alias = 'example.alias.' + nanoid();
+      await page.getByRole('link', { name: 'Add an alias' }).click();
+      await page.getByLabel('Name').fill(aliasName);
+      await page.getByLabel('Description').fill('This is an automated test');
+      await page.getByLabel('Alias Value').fill(alias);
+      await page.getByRole('button', { name: 'Save' }).click();
+      await expect(
+        page.getByRole('alert').getByText('Success', { exact: true }),
+      ).toBeVisible();
+      await page.getByRole('button', { name: 'Dismiss' }).click();
+
+      // Connect to target using alias
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+      await authorizeAlias(alias);
+
+      // Clear destination from alias
+      await page.getByRole('link', { name: alias }).click();
+      await page.getByRole('button', { name: 'Manage' }).click();
+      await page.getByText('Clear', { exact: true }).click();
+      await page.getByText('OK', { exact: true }).click();
+      await expect(
+        page.getByRole('alert').getByText('Success', { exact: true }),
+      ).toBeVisible();
+      await page.getByRole('button', { name: 'Dismiss' }).click();
+    } finally {
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+      if (orgName) {
+        const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+        const org = orgs.items.filter((obj) => obj.name == orgName)[0];
+        if (org) {
+          await deleteOrgCli(org.id);
+        }
+      }
+      if (alias) {
+        await deleteAliasCli(alias);
+      }
+    }
+  });
+
+  test('Set up alias from new target page @ce @aws @docker', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    let orgName;
+    let alias;
+    const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
+    try {
+      orgName = await createOrg(page);
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+      await createProject(page);
+      alias = 'example.alias.' + nanoid();
+      await createTargetWithAddressAndAlias(
+        page,
+        process.env.E2E_TARGET_ADDRESS,
+        process.env.E2E_TARGET_PORT,
+        alias,
+      );
+
+      // Connect to target using alias
+      await authorizeAlias(alias);
+    } finally {
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+
+      if (orgName) {
+        const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+        const org = orgs.items.filter((obj) => obj.name == orgName)[0];
+        if (org) {
+          await deleteOrgCli(org.id);
+        }
+        if (alias) {
+          await deleteAliasCli(alias);
+        }
+      }
+    }
+  });
+
+  test('Set up alias from aliases page @ce @aws @docker', async ({ page }) => {
+    await page.goto('/');
+    const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
+    let org;
+    let alias;
+    try {
+      const orgName = await createOrg(page);
+      const projectName = await createProject(page);
+      const targetName = await createTargetWithAddress(
+        page,
+        process.env.E2E_TARGET_ADDRESS,
+        process.env.E2E_TARGET_PORT,
+      );
+
+      // Create new alias from scope page
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+
+      const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+      org = orgs.items.filter((obj) => obj.name == orgName)[0];
+      const projects = JSON.parse(
+        execSync('boundary scopes list -format json -scope-id ' + org.id),
+      );
+      const project = projects.items.filter(
+        (obj) => obj.name == projectName,
+      )[0];
+      const targets = JSON.parse(
+        execSync('boundary targets list -format json -scope-id ' + project.id),
+      );
+      const target = targets.items.filter((obj) => obj.name == targetName)[0];
+
+      alias = 'example.alias.' + nanoid();
+      await createAliasForTarget(page, alias, target.id);
+      await authorizeAlias(alias);
+    } finally {
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+
+      if (org) {
+        await deleteOrgCli(org.id);
+      }
+      if (alias) {
+        await deleteAliasCli(alias);
+      }
+    }
+  });
+});

--- a/ui/admin/tests/e2e/tests/auth-method-ldap.spec.js
+++ b/ui/admin/tests/e2e/tests/auth-method-ldap.spec.js
@@ -288,16 +288,18 @@ test('Set up LDAP auth method @ce @ent @docker', async ({ page }) => {
         .innerText(),
     ).toContain(process.env.E2E_LDAP_USER_NAME + '@mail.com');
   } finally {
-    await authenticateBoundaryCli(
-      process.env.BOUNDARY_ADDR,
-      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
-      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
-      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
-    );
-    const orgs = JSON.parse(execSync('boundary scopes list -format json'));
-    const org = orgs.items.filter((obj) => obj.name == orgName)[0];
-    if (org) {
-      await deleteOrgCli(org.id);
+    if (orgName) {
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+      const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+      const org = orgs.items.filter((obj) => obj.name == orgName)[0];
+      if (org) {
+        await deleteOrgCli(org.id);
+      }
     }
   }
 });

--- a/ui/admin/tests/e2e/tests/credential-store-static-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static-ent.spec.js
@@ -95,16 +95,18 @@ test('Multiple Credential Stores (ENT) @ent @aws @docker', async ({ page }) => {
     ).toBeVisible();
     await page.getByRole('button', { name: 'Dismiss' }).click();
   } finally {
-    await authenticateBoundaryCli(
-      process.env.BOUNDARY_ADDR,
-      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
-      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
-      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
-    );
-    const orgs = JSON.parse(execSync('boundary scopes list -format json'));
-    const org = orgs.items.filter((obj) => obj.name == orgName)[0];
-    if (org) {
-      await deleteOrgCli(org.id);
+    if (orgName) {
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+      const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+      const org = orgs.items.filter((obj) => obj.name == orgName)[0];
+      if (org) {
+        await deleteOrgCli(org.id);
+      }
     }
   }
 });

--- a/ui/admin/tests/e2e/tests/credential-store-static.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static.spec.js
@@ -85,16 +85,18 @@ test('Static Credential Store (User & Key Pair) @ce @aws @docker', async ({
       throw new Error('Stored Key does not match');
     }
   } finally {
-    await authenticateBoundaryCli(
-      process.env.BOUNDARY_ADDR,
-      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
-      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
-      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
-    );
-    const orgs = JSON.parse(execSync('boundary scopes list -format json'));
-    const org = orgs.items.filter((obj) => obj.name == orgName)[0];
-    if (org) {
-      await deleteOrgCli(org.id);
+    if (orgName) {
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+      const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+      const org = orgs.items.filter((obj) => obj.name == orgName)[0];
+      if (org) {
+        await deleteOrgCli(org.id);
+      }
     }
   }
 });
@@ -124,16 +126,18 @@ test('Static Credential Store (Username & Password) @ce @aws @docker', async ({
     expect(retrievedUser).toBe(process.env.E2E_SSH_USER);
     expect(retrievedPassword).toBe(testPassword);
   } finally {
-    await authenticateBoundaryCli(
-      process.env.BOUNDARY_ADDR,
-      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
-      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
-      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
-    );
-    const orgs = JSON.parse(execSync('boundary scopes list -format json'));
-    const org = orgs.items.filter((obj) => obj.name == orgName)[0];
-    if (org) {
-      await deleteOrgCli(org.id);
+    if (orgName) {
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+      const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+      const org = orgs.items.filter((obj) => obj.name == orgName)[0];
+      if (org) {
+        await deleteOrgCli(org.id);
+      }
     }
   }
 });
@@ -183,16 +187,18 @@ test('Static Credential Store (JSON) @ce @aws @docker', async ({ page }) => {
     expect(retrievedPassword).toBe(testPassword);
     expect(retrievedId).toBe(testId);
   } finally {
-    await authenticateBoundaryCli(
-      process.env.BOUNDARY_ADDR,
-      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
-      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
-      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
-    );
-    const orgs = JSON.parse(execSync('boundary scopes list -format json'));
-    const org = orgs.items.filter((obj) => obj.name == orgName)[0];
-    if (org) {
-      await deleteOrgCli(org.id);
+    if (orgName) {
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+      const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+      const org = orgs.items.filter((obj) => obj.name == orgName)[0];
+      if (org) {
+        await deleteOrgCli(org.id);
+      }
     }
   }
 });
@@ -227,16 +233,18 @@ test('Multiple Credential Stores (CE) @ce @aws @docker', async ({ page }) => {
     ).toBeVisible();
     await page.getByRole('button', { name: 'Dismiss' }).click();
   } finally {
-    await authenticateBoundaryCli(
-      process.env.BOUNDARY_ADDR,
-      process.env.E2E_PASSWORD_AUTH_METHOD_ID,
-      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
-      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
-    );
-    const orgs = JSON.parse(execSync('boundary scopes list -format json'));
-    const org = orgs.items.filter((obj) => obj.name == orgName)[0];
-    if (org) {
-      await deleteOrgCli(org.id);
+    if (orgName) {
+      await authenticateBoundaryCli(
+        process.env.BOUNDARY_ADDR,
+        process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+        process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+        process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+      );
+      const orgs = JSON.parse(execSync('boundary scopes list -format json'));
+      const org = orgs.items.filter((obj) => obj.name == orgName)[0];
+      if (org) {
+        await deleteOrgCli(org.id);
+      }
     }
   }
 });

--- a/ui/admin/tests/e2e/tests/session-recording-aws-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/session-recording-aws-ent.spec.js
@@ -258,11 +258,11 @@ test('Session Recording Test (AWS) @ent @aws', async ({ page }) => {
     if (storagePolicy) {
       await deletePolicyCli(storagePolicy.id);
     }
-    if (orgId) {
-      await deleteOrgCli(orgId);
-    }
     if (storageBucket) {
       await deleteStorageBucketCli(storageBucket.id);
+    }
+    if (orgId) {
+      await deleteOrgCli(orgId);
     }
     // End `boundary connect` process
     if (connect) {

--- a/ui/admin/tests/e2e/tests/session-recording-minio-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/session-recording-minio-ent.spec.js
@@ -260,11 +260,11 @@ test('Session Recording Test (MinIO) @ent @docker', async ({ page }) => {
     if (storagePolicy) {
       await deletePolicyCli(storagePolicy.id);
     }
-    if (orgId) {
-      await deleteOrgCli(orgId);
-    }
     if (storageBucket) {
       await deleteStorageBucketCli(storageBucket.id);
+    }
+    if (orgId) {
+      await deleteOrgCli(orgId);
     }
     // End `boundary connect` process
     if (connect) {


### PR DESCRIPTION
This PR adds some Admin UI e2e tests for Aliases. It attempts to create aliases using 3 different methods
- Create an alias from the target details page
- Create an alias from a new target page
- Create an alias from the aliases page

## Testing
There were 6 tests added in total, 3 for each edition (CE, ENT).
```
# boundary
enos scenario launch e2e_ui_docker builder:local
yarn run e2e:ce:docker

# boundary-enterprise
enos scenario launch e2e_ui_docker_ent builder:local
yarn run e2e:ent:docker
```

https://hashicorp.atlassian.net/browse/ICU-14084