### PR TITLE
Revert "fix: 🐛 Fix active session display in targets table (#2321)"

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
@@ -10,7 +10,6 @@ import {
   STATUS_SESSION_PENDING,
 } from 'api/models/session';
 import { action } from '@ember/object';
-import { run } from '@ember/runloop';
 
 export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
   // =services
@@ -73,13 +72,6 @@ export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
    */
   beforeModel() {
     if (!this.session.isAuthenticated) this.router.transitionTo('index');
-
-    // Unload all sessions from the store as we might have sessions still in store
-    // if they were canceled outside of the desktop client
-    // Not wrapping it an ember run seems to cause a test to fail as well as an error
-    // if you switch between orgs due to a similar issue as this
-    // https://github.com/emberjs/data/issues/5447#issuecomment-845672812
-    run(() => this.store.unloadAll('session'));
   }
 
   /**


### PR DESCRIPTION
This reverts commit fc82980d6849e7a747d8cd3f48fd05eaf816afbd.

# Description
It turns out this change caused another issue when switching between sessions and targets if there's any active ones.

## Screenshots (if appropriate)
Before:

https://github.com/hashicorp/boundary-ui/assets/5783847/107c3c8f-b3bc-42ef-a51e-a5974e766fb0

## How to Test
Start up boundary dev and connect to a target. Switch between targets and sessions a few times to confirm it doesn't error out.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
