### PR TITLE
Icu 13895 create create new tags route and view

### DIFF
--- a/addons/api/addon/abilities/worker.js
+++ b/addons/api/addon/abilities/worker.js
@@ -17,4 +17,8 @@ export default class WorkerAbility extends ModelAbility {
   get canCreateWorkerLed() {
     return this.hasAuthorizedCollectionAction('create:worker-led');
   }
+
+  get canSetWorkerTags() {
+    return this.hasAuthorizedAction('set-worker-tags');
+  }
 }

--- a/addons/api/addon/models/worker.js
+++ b/addons/api/addon/models/worker.js
@@ -93,7 +93,6 @@ export default class WorkerModel extends GeneratedWorkerModel {
 
   @attr({
     description: 'The api tags set for the worker.\nOutput only.',
-    readOnly: true,
   })
   api_tags;
 

--- a/addons/api/addon/models/worker.js
+++ b/addons/api/addon/models/worker.js
@@ -6,6 +6,8 @@
 import GeneratedWorkerModel from '../generated/models/worker';
 import { attr } from '@ember-data/model';
 
+export const TYPE_WORKER_PKI = 'pki';
+
 export const TAG_TYPE_CONFIG = 'config';
 export const TAG_TYPE_API = 'api';
 
@@ -26,7 +28,7 @@ export default class WorkerModel extends GeneratedWorkerModel {
    * @type {boolean}
    */
   get isPki() {
-    return this.type === 'pki';
+    return this.type === TYPE_WORKER_PKI;
   }
 
   /**

--- a/addons/api/addon/models/worker.js
+++ b/addons/api/addon/models/worker.js
@@ -117,4 +117,15 @@ export default class WorkerModel extends GeneratedWorkerModel {
       },
     });
   }
+
+  /**
+   * Method to set api tags on the worker.
+   * @param {object} apiTags
+   * @return {Promise}
+   */
+  setApiTags(apiTags) {
+    return this.save({
+      adapterOptions: { method: 'set-worker-tags', apiTags },
+    });
+  }
 }

--- a/addons/api/addon/serializers/worker.js
+++ b/addons/api/addon/serializers/worker.js
@@ -28,6 +28,9 @@ export default class WorkerSerializer extends ApplicationSerializer {
     const apiTags = snapshot?.adapterOptions?.apiTags;
     if (apiTags) {
       serialized = this.serializeWithApiTags(snapshot, apiTags);
+    } else {
+      // remove api_tags from payload if not set
+      delete serialized.api_tags;
     }
     return serialized;
   }

--- a/addons/api/addon/serializers/worker.js
+++ b/addons/api/addon/serializers/worker.js
@@ -19,11 +19,16 @@ export default class WorkerSerializer extends ApplicationSerializer {
     let serialized = super.serialize(...arguments);
     const workerGeneratedAuthToken =
       snapshot?.adapterOptions?.workerGeneratedAuthToken;
-    if (workerGeneratedAuthToken)
+    if (workerGeneratedAuthToken) {
       serialized = this.serializeWithGeneratedToken(
         snapshot,
         workerGeneratedAuthToken,
       );
+    }
+    const apiTags = snapshot?.adapterOptions?.apiTags;
+    if (apiTags) {
+      serialized = this.serializeWithApiTags(snapshot, apiTags);
+    }
     return serialized;
   }
 
@@ -37,6 +42,19 @@ export default class WorkerSerializer extends ApplicationSerializer {
     return {
       scope_id: snapshot.attr('scope').scope_id,
       worker_generated_auth_token: workerGeneratedAuthToken,
+    };
+  }
+
+  /**
+   * Returns a payload with api_tags and version serialized.
+   * @param {Snapshot} snapshot
+   * @param {object} apiTags
+   * @return {object}
+   */
+  serializeWithApiTags(snapshot, apiTags) {
+    return {
+      version: snapshot.attr('version'),
+      api_tags: apiTags,
     };
   }
 }

--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -690,7 +690,7 @@ function routes() {
         };
       }
 
-      worker.update(updatedAttrs);
+      return worker.update(updatedAttrs);
     },
   );
 

--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -16,6 +16,7 @@ import initializeMockIPC from './scenarios/ipc';
 import makeBooleanFilter from './helpers/bexpr-filter';
 import { faker } from '@faker-js/faker';
 import { asciicasts } from './data/asciicasts';
+import { TYPE_WORKER_PKI } from 'api/models/worker';
 
 const isTesting = environmentConfig.environment === 'test';
 
@@ -669,7 +670,7 @@ function routes() {
 
     // This POST only takes in a token so we need to generate a random worker to return
     const newWorker = this.create('worker', {
-      type: 'pki',
+      type: TYPE_WORKER_PKI,
       scope: globalScope,
     });
     return workers.create(newWorker.attrs);

--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -687,7 +687,7 @@ function routes() {
       if (method === 'set-worker-tags') {
         updatedAttrs = {
           version: attrs.version,
-          api_tags: attrs.api_tags,
+          apiTags: attrs.apiTags,
         };
       }
 

--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -674,6 +674,25 @@ function routes() {
     });
     return workers.create(newWorker.attrs);
   });
+  this.post(
+    '/workers/:idMethod',
+    function ({ workers }, { params: { idMethod } }) {
+      const attrs = this.normalizedRequestAttrs();
+      const id = idMethod.split(':')[0];
+      const method = idMethod.split(':')[1];
+      const worker = workers.find(id);
+      let updatedAttrs = {};
+
+      if (method === 'set-worker-tags') {
+        updatedAttrs = {
+          version: attrs.version,
+          api_tags: attrs.api_tags,
+        };
+      }
+
+      worker.update(updatedAttrs);
+    },
+  );
 
   // storage-buckets
   this.get(

--- a/addons/api/mirage/factories/worker.js
+++ b/addons/api/mirage/factories/worker.js
@@ -8,8 +8,6 @@ import permissions from '../helpers/permissions';
 import generateId from '../helpers/id';
 import { faker } from '@faker-js/faker';
 
-const types = ['pki', 'kms'];
-
 export default factory.extend({
   id: () => generateId('w_'),
   authorized_actions: () =>
@@ -20,7 +18,6 @@ export default factory.extend({
       'delete',
       'set-worker-tags',
     ],
-  type: (i) => types[i % types.length],
   config_tags: (i) => {
     if (i % 3 === 0) {
       return {

--- a/addons/api/mirage/factories/worker.js
+++ b/addons/api/mirage/factories/worker.js
@@ -18,6 +18,7 @@ export default factory.extend({
       'read',
       'update',
       'delete',
+      'set-worker-tags',
     ],
   type: (i) => types[i % types.length],
   config_tags: (i) => {

--- a/addons/api/mirage/generated/factories/worker.js
+++ b/addons/api/mirage/generated/factories/worker.js
@@ -5,6 +5,7 @@
 
 import { Factory } from 'miragejs';
 import { faker } from '@faker-js/faker';
+import { TYPE_WORKER_PKI } from 'api/models/worker';
 
 /**
  * GeneratedWorkerModelFactory
@@ -13,7 +14,7 @@ import { faker } from '@faker-js/faker';
 export default Factory.extend({
   name: () => faker.word.words(),
   description: () => faker.word.words(),
-  type: 'pki',
+  type: TYPE_WORKER_PKI,
   created_time: () => faker.date.recent(),
   updated_time: () => faker.date.recent(),
   version: () => faker.number.int(),

--- a/addons/api/mirage/generated/factories/worker.js
+++ b/addons/api/mirage/generated/factories/worker.js
@@ -13,6 +13,7 @@ import { faker } from '@faker-js/faker';
 export default Factory.extend({
   name: () => faker.word.words(),
   description: () => faker.word.words(),
+  type: 'pki',
   created_time: () => faker.date.recent(),
   updated_time: () => faker.date.recent(),
   version: () => faker.number.int(),

--- a/addons/api/tests/unit/abilities/worker-test.js
+++ b/addons/api/tests/unit/abilities/worker-test.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Abilities | Worker', function (hooks) {
+  setupTest(hooks);
+
+  let canService;
+  let store;
+
+  const instances = {
+    worker: null,
+  };
+
+  hooks.beforeEach(function () {
+    canService = this.owner.lookup('service:can');
+    store = this.owner.lookup('service:store');
+    instances.worker = store.createRecord('worker');
+  });
+
+  test('can create worker-led', function (assert) {
+    const model = {
+      authorized_collection_actions: { workers: ['create:worker-led'] },
+    };
+    assert.true(
+      canService.can('createWorkerLed worker', model, {
+        collection: 'workers',
+      }),
+    );
+  });
+
+  test('cannot create worker-led', function (assert) {
+    const model = {
+      authorized_collection_actions: { workers: [] },
+    };
+    assert.true(
+      canService.cannot('createWorkerLed worker', model, {
+        collection: 'workers',
+      }),
+    );
+  });
+
+  test('can set worker tags', function (assert) {
+    instances.worker.authorized_actions = ['set-worker-tags'];
+    assert.true(canService.can('setWorkerTags worker', instances.worker));
+  });
+
+  test('cannot set worker tags', function (assert) {
+    instances.worker.authorized_actions = [];
+    assert.true(canService.cannot('setWorkerTags worker', instances.worker));
+  });
+});

--- a/addons/api/tests/unit/models/worker-test.js
+++ b/addons/api/tests/unit/models/worker-test.js
@@ -39,6 +39,38 @@ module('Unit | Model | worker', function (hooks) {
     assert.ok(worker);
   });
 
+  test('it has `setApiTags` method that targets a specific POST API', async function (assert) {
+    assert.expect(1);
+    const workerId = 'w_123';
+    const tags = {
+      tag1: ['value1', 'value2'],
+      tag2: ['value3'],
+    };
+    this.server.post(
+      `/workers/${workerId}:set-worker-tags`,
+      (schema, request) => {
+        const body = JSON.parse(request.requestBody);
+        assert.deepEqual(body, { api_tags: tags, version: 1 });
+        return { id: workerId };
+      },
+    );
+
+    const store = this.owner.lookup('service:store');
+    store.push({
+      data: {
+        id: workerId,
+        type: 'worker',
+        attributes: {
+          name: 'fake worker',
+          version: 1,
+        },
+      },
+    });
+
+    const model = store.peekRecord('worker', workerId);
+    await model.setApiTags(tags);
+  });
+
   test('it has a `configTagList` method that returns an array of key/value pair objects', function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('worker', {

--- a/addons/api/tests/unit/models/worker-test.js
+++ b/addons/api/tests/unit/models/worker-test.js
@@ -6,6 +6,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { TYPE_WORKER_PKI } from 'api/models/worker';
 
 module('Unit | Model | worker', function (hooks) {
   setupTest(hooks);
@@ -26,7 +27,7 @@ module('Unit | Model | worker', function (hooks) {
 
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('worker', {
-      type: 'pki',
+      type: TYPE_WORKER_PKI,
       scope: {
         scope_id: scopeId,
         type: 'global',

--- a/addons/api/tests/unit/serializers/worker-test.js
+++ b/addons/api/tests/unit/serializers/worker-test.js
@@ -50,4 +50,25 @@ module('Unit | Serializer | worker', function (hooks) {
       worker_generated_auth_token: '123-abc',
     });
   });
+
+  test('it serializes using `adapterOptions.apiTags`', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('worker');
+    const record = store.createRecord('worker', {
+      name: 'worker',
+      api_tags: null,
+      version: 1,
+    });
+    const snapshot = record._createSnapshot();
+    snapshot.adapterOptions = {
+      apiTags: {
+        key: ['value'],
+      },
+    };
+    const serializedRecord = serializer.serialize(snapshot);
+    assert.deepEqual(serializedRecord, {
+      version: 1,
+      api_tags: { key: ['value'] },
+    });
+  });
 });

--- a/addons/api/tests/unit/serializers/worker-test.js
+++ b/addons/api/tests/unit/serializers/worker-test.js
@@ -9,7 +9,7 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Serializer | worker', function (hooks) {
   setupTest(hooks);
 
-  test('it serializes normally without adapterOptions.workerGeneratedAuthToken', function (assert) {
+  test('it serializes normally', function (assert) {
     const store = this.owner.lookup('service:store');
     const serializer = store.serializerFor('worker');
     const record = store.createRecord('worker', {

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -904,6 +904,7 @@ worker:
   actions:
     register: Register Worker
     delete: Remove Worker
+    create_tags: Create new tags
   messages:
     welcome:
       title: Welcome to Workers

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -919,6 +919,10 @@ worker:
     type: Type
   tags:
     title_plural: Tags
+    create:
+      title: Create new tags
+      description: Create new api worker tags. You can only add API tags in the admin UI. Config tags are added in the worker config file.
+      success: Tag(s) successfully created
     description: Tags are used to define the type of worker and to make it distinguishable amongst other workers.
   flyout:
     title: Tags in {workerName}

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -922,7 +922,7 @@ worker:
     title_plural: Tags
     create:
       title: Create new tags
-      description: Create new api worker tags. You can only add API tags in the admin UI. Config tags are added in the worker config file.
+      description: Create new api worker tags. You can only add API tags in the admin UI or CLI. Config tags are added in the worker config file.
       success: Tag(s) successfully created
     description: Tags are used to define the type of worker and to make it distinguishable amongst other workers.
   flyout:

--- a/ui/admin/app/components/form/worker/create-tags/index.hbs
+++ b/ui/admin/app/components/form/worker/create-tags/index.hbs
@@ -14,7 +14,7 @@
     <:field as |F|>
       <F.KeyValue
         @name='api_tags'
-        @options={{this.apiTags}}
+        @options={{@apiTags}}
         @disabled={{form.disabled}}
         @addOption={{this.addApiTag}}
         @removeOptionByIndex={{this.removeApiTagByIndex}}

--- a/ui/admin/app/components/form/worker/create-tags/index.hbs
+++ b/ui/admin/app/components/form/worker/create-tags/index.hbs
@@ -1,0 +1,36 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
+<Rose::Form
+  @onSubmit={{this.save}}
+  @cancel={{@cancel}}
+  @disabled={{@model.isSaving}}
+  @showEditToggle={{false}}
+  as |form|
+>
+  <Form::Field::ListWrapper @layout='vertical' @disabled={{form.disabled}}>
+    <:field as |F|>
+      <F.KeyValue
+        @name='api_tags'
+        @options={{this.apiTags}}
+        @disabled={{form.disabled}}
+        @addOption={{this.addApiTag}}
+        @removeOptionByIndex={{this.removeApiTagByIndex}}
+      >
+        <:key as |K|>
+          <K.text />
+        </:key>
+        <:value as |V|>
+          <V.text />
+        </:value>
+      </F.KeyValue>
+    </:field>
+  </Form::Field::ListWrapper>
+
+  <form.actions
+    @submitText={{t 'actions.save'}}
+    @cancelText={{t 'actions.cancel'}}
+  />
+</Rose::Form>

--- a/ui/admin/app/components/form/worker/create-tags/index.js
+++ b/ui/admin/app/components/form/worker/create-tags/index.js
@@ -15,60 +15,6 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
   @service confirm;
   @service intl;
 
-  // =attributes
-
-  hasRemovedExitHandler = false;
-
-  constructor() {
-    super(...arguments);
-    // this is added to prevent the user from accidentally navigating away
-    // from the page when they have unsaved changes
-    this.addExitHandler();
-  }
-
-  // adds an exit handler to prevent the user from accidentally navigating away
-  addExitHandler() {
-    this.router.on('routeWillChange', this, this.confirmTransition);
-  }
-
-  // removes the exit handler
-  removeExitHandler() {
-    if (!this.hasRemovedExitHandler) {
-      this.router.off('routeWillChange', this, this.confirmTransition);
-      this.hasRemovedExitHandler = true;
-    }
-  }
-
-  // checks if the transition is aborted and if there are any tags
-  confirmTransition(transition) {
-    if (transition.isAborted) return;
-
-    if (this.args.apiTags.length) {
-      this.confirmExit(transition);
-    }
-  }
-
-  // displays a confirmation dialog to the user
-  async confirmExit(transition) {
-    transition.abort();
-    try {
-      await this.confirm.confirm(this.intl.t('questions.abandon-confirm'), {
-        title: 'titles.abandon-confirm',
-        confirm: 'actions.discard',
-      });
-      this.args.apiTags = this.args.apiTags.splice(0, this.args.apiTags.length);
-      transition.retry();
-    } catch (e) {
-      // if user denies, do nothing
-    }
-  }
-
-  // removes the exit handler when the component is destroyed
-  willDestroy() {
-    super.willDestroy(...arguments);
-    this.removeExitHandler();
-  }
-
   // =actions
 
   /**
@@ -96,8 +42,6 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
    */
   @action
   save() {
-    this.removeExitHandler();
-
     if (this.args.apiTags.length === 0) {
       this.router.transitionTo('scopes.scope.workers.worker.tags');
       return;

--- a/ui/admin/app/components/form/worker/create-tags/index.js
+++ b/ui/admin/app/components/form/worker/create-tags/index.js
@@ -33,13 +33,17 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
 
   constructor() {
     super(...arguments);
+    // this is added to prevent the user from accidentally navigating away
+    // from the page when they have unsaved changes
     this.addExitHandler();
   }
 
+  // adds an exit handler to prevent the user from accidentally navigating away
   addExitHandler() {
     this.router.on('routeWillChange', this, this.confirmTransition);
   }
 
+  // removes the exit handler
   removeExitHandler() {
     if (!this.hasRemovedExitHandler) {
       this.router.off('routeWillChange', this, this.confirmTransition);
@@ -47,6 +51,7 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
     }
   }
 
+  // checks if the transition is aborted and if there are any tags
   confirmTransition(transition) {
     if (transition.isAborted) return;
 
@@ -55,6 +60,7 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
     }
   }
 
+  // displays a confirmation dialog to the user
   async confirmExit(transition) {
     transition.abort();
     try {
@@ -69,6 +75,7 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
     }
   }
 
+  // removes the exit handler when the component is destroyed
   willDestroy() {
     super.willDestroy(...arguments);
     this.removeExitHandler();
@@ -76,16 +83,29 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
 
   // =actions
 
+  /**
+   * Creates a new Tag object and adds it to the `apiTags` array.
+   * @param {object} option
+   */
   @action
-  addApiTag(e) {
-    this.apiTags.pushObject(new Tag(e.key, e.value));
+  addApiTag(option) {
+    this.apiTags.pushObject(new Tag(option.key, option.value));
   }
 
+  /**
+   * Removes a Tag object from the `apiTags` array by index.
+   * @param {number} index
+   */
   @action
   removeApiTagByIndex(index) {
     this.apiTags.removeAt(index);
   }
 
+  /**
+   * Builds the `apiTags` object and submits it to the parent component.
+   * If there are no tags, it transitions to the tags route.
+   * @returns {void}
+   */
   @action
   save() {
     this.removeExitHandler();

--- a/ui/admin/app/components/form/worker/create-tags/index.js
+++ b/ui/admin/app/components/form/worker/create-tags/index.js
@@ -36,7 +36,7 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
   }
 
   /**
-   * Uses `apiTags` to build and submits it to the parent component.
+   * Uses `@apiTags` to build and submits it to the parent component.
    * If there are no tags, it transitions to the tags route.
    * @returns {void}
    */
@@ -47,20 +47,18 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
       return;
     }
 
-    const existingApiTags = this.args.model.api_tags ?? {};
+    const apiTags = structuredClone(this.args.model.api_tags ?? {});
     this.args.apiTags.forEach((tag) => {
       let key = tag.key;
       let values = tag.value.split(',');
 
-      if (!existingApiTags[key]) {
-        existingApiTags[key] = values;
+      if (!apiTags[key]) {
+        apiTags[key] = values;
       } else {
-        existingApiTags[key] = [
-          ...new Set([...existingApiTags[key], ...values]),
-        ];
+        apiTags[key] = [...new Set([...apiTags[key], ...values])];
       }
     });
 
-    this.args.submit(existingApiTags);
+    this.args.submit(apiTags);
   }
 }

--- a/ui/admin/app/components/form/worker/create-tags/index.js
+++ b/ui/admin/app/components/form/worker/create-tags/index.js
@@ -90,7 +90,7 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
   save() {
     this.removeExitHandler();
 
-    if (!this.apiTags.isEmpty) {
+    if (this.apiTags.isEmpty) {
       this.router.transitionTo('scopes.scope.workers.worker.tags');
       return;
     }

--- a/ui/admin/app/components/form/worker/create-tags/index.js
+++ b/ui/admin/app/components/form/worker/create-tags/index.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { A } from '@ember/array';
+
+class Tag {
+  @tracked key;
+  @tracked value;
+
+  constructor(key, value) {
+    this.key = key;
+    this.value = value;
+  }
+}
+
+export default class FormWorkerCreateTagsIndexComponent extends Component {
+  // =services
+
+  @service router;
+  @service confirm;
+  @service intl;
+
+  // =attributes
+
+  @tracked apiTags = A([]);
+  hasRemovedExitHandler = false;
+
+  constructor() {
+    super(...arguments);
+    this.addExitHandler();
+  }
+
+  addExitHandler() {
+    this.router.on('routeWillChange', this, this.confirmTransition);
+  }
+
+  removeExitHandler() {
+    if (!this.hasRemovedExitHandler) {
+      this.router.off('routeWillChange', this, this.confirmTransition);
+      this.hasRemovedExitHandler = true;
+    }
+  }
+
+  confirmTransition(transition) {
+    if (transition.isAborted) return;
+
+    if (this.apiTags.length) {
+      this.confirmExit(transition);
+    }
+  }
+
+  async confirmExit(transition) {
+    transition.abort();
+    try {
+      await this.confirm.confirm(this.intl.t('questions.abandon-confirm'), {
+        title: 'titles.abandon-confirm',
+        confirm: 'actions.discard',
+      });
+      this.apiTags = A([]);
+      transition.retry();
+    } catch (e) {
+      // if user denies, do nothing
+    }
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.removeExitHandler();
+  }
+
+  // =actions
+
+  @action
+  addApiTag(e) {
+    this.apiTags.pushObject(new Tag(e.key, e.value));
+  }
+
+  @action
+  removeApiTagByIndex(index) {
+    this.apiTags.removeAt(index);
+  }
+
+  @action
+  save() {
+    this.removeExitHandler();
+    const existingApiTags = this.args.model.api_tags;
+    this.apiTags.forEach((tag) => {
+      let key = tag.key;
+      let values = tag.value.split(',');
+
+      if (!existingApiTags[key]) {
+        existingApiTags[key] = values;
+      } else {
+        existingApiTags[key] = Array.from(
+          new Set([...existingApiTags[key], ...values]),
+        );
+      }
+    });
+
+    this.args.submit(existingApiTags);
+  }
+}

--- a/ui/admin/app/components/form/worker/create-tags/index.js
+++ b/ui/admin/app/components/form/worker/create-tags/index.js
@@ -89,7 +89,13 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
   @action
   save() {
     this.removeExitHandler();
-    const existingApiTags = this.args.model.api_tags;
+
+    if (!this.apiTags.isEmpty) {
+      this.router.transitionTo('scopes.scope.workers.worker.tags');
+      return;
+    }
+
+    const existingApiTags = this.args.model.api_tags || {};
     this.apiTags.forEach((tag) => {
       let key = tag.key;
       let values = tag.value.split(',');

--- a/ui/admin/app/components/form/worker/create-tags/index.js
+++ b/ui/admin/app/components/form/worker/create-tags/index.js
@@ -12,8 +12,6 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
   // =services
 
   @service router;
-  @service confirm;
-  @service intl;
 
   // =actions
 

--- a/ui/admin/app/components/form/worker/create-tags/index.js
+++ b/ui/admin/app/components/form/worker/create-tags/index.js
@@ -5,7 +5,6 @@
 
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { TrackedArray } from 'tracked-built-ins';
 import { action } from '@ember/object';
 import Tag from '../tag';
 
@@ -18,7 +17,6 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
 
   // =attributes
 
-  apiTags = new TrackedArray([]);
   hasRemovedExitHandler = false;
 
   constructor() {
@@ -45,7 +43,7 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
   confirmTransition(transition) {
     if (transition.isAborted) return;
 
-    if (this.apiTags.length) {
+    if (this.args.apiTags.length) {
       this.confirmExit(transition);
     }
   }
@@ -58,7 +56,7 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
         title: 'titles.abandon-confirm',
         confirm: 'actions.discard',
       });
-      this.apiTags = new TrackedArray([]);
+      this.args.apiTags = this.args.apiTags.splice(0, this.args.apiTags.length);
       transition.retry();
     } catch (e) {
       // if user denies, do nothing
@@ -79,7 +77,7 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
    */
   @action
   addApiTag(option) {
-    this.apiTags.push(new Tag(option.key, option.value));
+    this.args.apiTags.push(new Tag(option.key, option.value));
   }
 
   /**
@@ -88,7 +86,7 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
    */
   @action
   removeApiTagByIndex(index) {
-    this.apiTags.splice(index, 1);
+    this.args.apiTags.splice(index, 1);
   }
 
   /**
@@ -98,16 +96,15 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
    */
   @action
   save() {
-    console.log(this.apiTags);
     this.removeExitHandler();
 
-    if (this.apiTags.length === 0) {
+    if (this.args.apiTags.length === 0) {
       this.router.transitionTo('scopes.scope.workers.worker.tags');
       return;
     }
 
     const existingApiTags = this.args.model.api_tags ?? {};
-    this.apiTags.forEach((tag) => {
+    this.args.apiTags.forEach((tag) => {
       let key = tag.key;
       let values = tag.value.split(',');
 

--- a/ui/admin/app/components/form/worker/create-worker-led/index.js
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.js
@@ -8,16 +8,7 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
-
-class Tag {
-  @tracked key;
-  @tracked value;
-
-  constructor(key, value) {
-    this.key = key;
-    this.value = value;
-  }
-}
+import Tag from '../tag';
 
 export default class FormWorkerCreateWorkerLedComponent extends Component {
   // =services

--- a/ui/admin/app/components/form/worker/tag.js
+++ b/ui/admin/app/components/form/worker/tag.js
@@ -1,4 +1,14 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { tracked } from '@glimmer/tracking';
+
 export default class Tag {
+  @tracked key;
+  @tracked value;
+
   constructor(key, value) {
     this.key = key;
     this.value = value;

--- a/ui/admin/app/components/form/worker/tag.js
+++ b/ui/admin/app/components/form/worker/tag.js
@@ -1,0 +1,6 @@
+export default class Tag {
+  constructor(key, value) {
+    this.key = key;
+    this.value = value;
+  }
+}

--- a/ui/admin/app/components/workers/worker/actions/index.hbs
+++ b/ui/admin/app/components/workers/worker/actions/index.hbs
@@ -5,6 +5,12 @@
 
 <Hds::Dropdown data-test-manage-worker-dropdown as |dd|>
   <dd.ToggleButton @text={{t 'actions.manage'}} @color='secondary' />
+  {{#if (can 'setWorkerTags worker' @model)}}
+    <dd.Interactive
+      @text={{t 'resources.worker.actions.create_tags'}}
+      @route='scopes.scope.workers.worker.create-tags'
+    />
+  {{/if}}
   {{#if (can 'delete worker' @model)}}
     <dd.Interactive
       @icon='trash'

--- a/ui/admin/app/controllers/scopes/scope/workers/worker/create-tags.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/worker/create-tags.js
@@ -8,11 +8,15 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';
+import { TrackedArray } from 'tracked-built-ins';
 
 export default class ScopesScopeWorkersWorkerCreateTagsController extends Controller {
   // =services
 
   @service router;
+
+  // =attributes
+  apiTags = new TrackedArray([]);
 
   // =actions
 

--- a/ui/admin/app/controllers/scopes/scope/workers/worker/create-tags.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/worker/create-tags.js
@@ -41,6 +41,7 @@ export default class ScopesScopeWorkersWorkerCreateTagsController extends Contro
    */
   @action
   cancel() {
+    this.apiTags = new TrackedArray([]);
     this.router.replaceWith('scopes.scope.workers.worker.tags');
   }
 }

--- a/ui/admin/app/controllers/scopes/scope/workers/worker/create-tags.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/worker/create-tags.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { loading } from 'ember-loading';
+import { notifySuccess, notifyError } from 'core/decorators/notify';
+
+export default class ScopesScopeWorkersWorkerCreateTagsController extends Controller {
+  // =services
+
+  @service router;
+
+  // =actions
+
+  /**
+   * Add api tags for a worker.
+   * @param {object} worker
+   */
+  @action
+  @loading
+  @notifyError(({ message }) => message)
+  @notifySuccess('resources.worker.tags.create.success')
+  async save(apiTags) {
+    const worker = this.model;
+    await worker.setApiTags(apiTags);
+    await this.router.transitionTo('scopes.scope.workers.worker.tags', worker);
+  }
+
+  /**
+   * Cancel the creation of api tags for a worker.
+   */
+  @action
+  cancel() {
+    this.router.replaceWith('scopes.scope.workers.worker.tags');
+  }
+}

--- a/ui/admin/app/controllers/scopes/scope/workers/worker/create-tags.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/worker/create-tags.js
@@ -41,8 +41,6 @@ export default class ScopesScopeWorkersWorkerCreateTagsController extends Contro
    */
   @action
   cancel() {
-    // Clear the apiTags array when canceling
-    this.apiTags = new TrackedArray([]);
     this.router.replaceWith('scopes.scope.workers.worker.tags');
   }
 }

--- a/ui/admin/app/controllers/scopes/scope/workers/worker/create-tags.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/worker/create-tags.js
@@ -31,7 +31,9 @@ export default class ScopesScopeWorkersWorkerCreateTagsController extends Contro
   async save(apiTags) {
     const worker = this.model;
     await worker.setApiTags(apiTags);
-    await this.router.transitionTo('scopes.scope.workers.worker.tags', worker);
+    // Clear the apiTags array after saving
+    this.apiTags = new TrackedArray([]);
+    this.router.transitionTo('scopes.scope.workers.worker.tags', worker);
   }
 
   /**
@@ -39,6 +41,8 @@ export default class ScopesScopeWorkersWorkerCreateTagsController extends Contro
    */
   @action
   cancel() {
+    // Clear the apiTags array when canceling
+    this.apiTags = new TrackedArray([]);
     this.router.replaceWith('scopes.scope.workers.worker.tags');
   }
 }

--- a/ui/admin/app/router.js
+++ b/ui/admin/app/router.js
@@ -150,6 +150,7 @@ Router.map(function () {
         this.route('new');
         this.route('worker', { path: ':worker_id' }, function () {
           this.route('tags');
+          this.route('create-tags');
         });
       });
       this.route('session-recordings', function () {

--- a/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
+++ b/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+/* eslint-disable ember/no-controller-access-in-routes */
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { TrackedArray } from 'tracked-built-ins';
 
@@ -12,44 +14,21 @@ export default class ScopesScopeWorkersWorkerCreateTagsRoute extends Route {
 
   @service confirm;
   @service intl;
-  @service router;
 
-  constructor() {
-    super(...arguments);
-    /**
-     * If user attempts to navigate away from unsaved changes, the user is
-     * asked to confirm that they would like to discard the changes.  If the
-     * user chooses discard, changes apiTags are cleared and the
-     * transition is retried.  If the user cancels discard, the transition is
-     * aborted.
-     */
-    this.router.on('routeWillChange', async (transition) => {
-      const fromName = transition?.from?.name;
-      const toName = transition?.to?.name;
-      // This will prevent the confirmation dialog from showing when the user
-      // saves or cancels the form.
-      if (toName === 'scopes.scope.workers.worker.tags') {
-        return;
+  @action
+  async willTransition(transition) {
+    if (this.controller.get('apiTags').length) {
+      transition.abort();
+      try {
+        await this.confirm.confirm(this.intl.t('questions.abandon-confirm'), {
+          title: 'titles.abandon-confirm',
+          confirm: 'actions.discard',
+        });
+        this.controller.set('apiTags', new TrackedArray([]));
+        transition.retry();
+      } catch (e) {
+        // if user denies, do nothing
       }
-      // eslint-disable-next-line ember/no-controller-access-in-routes
-      const controller = this.controllerFor(
-        'scopes.scope.workers.worker.create-tags',
-      );
-      const tags = controller.get('apiTags');
-
-      if (fromName !== toName && tags.length) {
-        transition.abort();
-        try {
-          await this.confirm.confirm(this.intl.t('questions.abandon-confirm'), {
-            title: 'titles.abandon-confirm',
-            confirm: 'actions.discard',
-          });
-          controller.set('apiTags', new TrackedArray([]));
-          transition.retry();
-        } catch (e) {
-          // if user denies, do nothing
-        }
-      }
-    });
+    }
   }
 }

--- a/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
+++ b/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
@@ -26,6 +26,11 @@ export default class ScopesScopeWorkersWorkerCreateTagsRoute extends Route {
     this.router.on('routeWillChange', async (transition) => {
       const fromName = transition?.from?.name;
       const toName = transition?.to?.name;
+      // This will prevent the confirmation dialog from showing when the user
+      // saves or cancels the form.
+      if (toName === 'scopes.scope.workers.worker.tags') {
+        return;
+      }
       // eslint-disable-next-line ember/no-controller-access-in-routes
       const controller = this.controllerFor(
         'scopes.scope.workers.worker.create-tags',

--- a/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
+++ b/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import Route from '@ember/routing/route';
 
 export default class ScopesScopeWorkersWorkerCreateTagsRoute extends Route {}

--- a/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
+++ b/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class ScopesScopeWorkersWorkerCreateTagsRoute extends Route {}

--- a/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
+++ b/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable ember/no-controller-access-in-routes */
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
@@ -17,14 +16,16 @@ export default class ScopesScopeWorkersWorkerCreateTagsRoute extends Route {
 
   @action
   async willTransition(transition) {
-    if (this.controller.get('apiTags').length) {
+    // eslint-disable-next-line ember/no-controller-access-in-routes
+    const controller = this.controllerFor(this.routeName);
+    if (controller.get('apiTags').length) {
       transition.abort();
       try {
         await this.confirm.confirm(this.intl.t('questions.abandon-confirm'), {
           title: 'titles.abandon-confirm',
           confirm: 'actions.discard',
         });
-        this.controller.set('apiTags', new TrackedArray([]));
+        controller.set('apiTags', new TrackedArray([]));
         transition.retry();
       } catch (e) {
         // if user denies, do nothing

--- a/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
+++ b/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
@@ -4,5 +4,47 @@
  */
 
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { TrackedArray } from 'tracked-built-ins';
 
-export default class ScopesScopeWorkersWorkerCreateTagsRoute extends Route {}
+export default class ScopesScopeWorkersWorkerCreateTagsRoute extends Route {
+  // =services
+
+  @service confirm;
+  @service intl;
+  @service router;
+
+  constructor() {
+    super(...arguments);
+    /**
+     * If user attempts to navigate away from unsaved changes, the user is
+     * asked to confirm that they would like to discard the changes.  If the
+     * user chooses discard, changes apiTags are cleared and the
+     * transition is retried.  If the user cancels discard, the transition is
+     * aborted.
+     */
+    this.router.on('routeWillChange', async (transition) => {
+      const fromName = transition?.from?.name;
+      const toName = transition?.to?.name;
+      // eslint-disable-next-line ember/no-controller-access-in-routes
+      const controller = this.controllerFor(
+        'scopes.scope.workers.worker.create-tags',
+      );
+      const tags = controller.get('apiTags');
+
+      if (fromName !== toName && tags.length) {
+        transition.abort();
+        try {
+          await this.confirm.confirm(this.intl.t('questions.abandon-confirm'), {
+            title: 'titles.abandon-confirm',
+            confirm: 'actions.discard',
+          });
+          controller.set('apiTags', new TrackedArray([]));
+          transition.retry();
+        } catch (e) {
+          // if user denies, do nothing
+        }
+      }
+    });
+  }
+}

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -699,7 +699,13 @@
     .hds-table__th {
       height: auto;
       line-height: 1;
+      border-bottom: unset;
     }
+  }
+
+  // Remove divider between table header cells
+  .hds-table__thead .hds-table__tr .hds-table__th + .hds-table__th::before {
+    all: unset;
   }
 
   .hds-table__thead,

--- a/ui/admin/app/templates/scopes/scope/workers/worker/create-tags.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/worker/create-tags.hbs
@@ -1,0 +1,2 @@
+{{page-title (t 'resources.worker.actions.create_tags')}}
+{{outlet}}

--- a/ui/admin/app/templates/scopes/scope/workers/worker/create-tags.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/worker/create-tags.hbs
@@ -26,6 +26,7 @@
   <page.body>
     <Form::Worker::CreateTags
       @model={{@model}}
+      @apiTags={{this.apiTags}}
       @submit={{this.save}}
       @cancel={{this.cancel}}
     />

--- a/ui/admin/app/templates/scopes/scope/workers/worker/create-tags.hbs
+++ b/ui/admin/app/templates/scopes/scope/workers/worker/create-tags.hbs
@@ -1,2 +1,33 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+}}
+
 {{page-title (t 'resources.worker.actions.create_tags')}}
-{{outlet}}
+<Breadcrumbs::Item
+  @text={{t 'resources.worker.actions.create_tags'}}
+  @route='scopes.scope.workers.worker.create-tags'
+/>
+
+<Rose::Layout::Page as |page|>
+
+  <page.breadcrumbs>
+    <Breadcrumbs::Container />
+  </page.breadcrumbs>
+
+  <page.header>
+    <h2>
+      {{t 'resources.worker.tags.create.title'}}
+      {{! TODO: Add doclink }}
+    </h2>
+    <p>{{t 'resources.worker.tags.create.description'}}</p>
+  </page.header>
+
+  <page.body>
+    <Form::Worker::CreateTags
+      @model={{@model}}
+      @submit={{this.save}}
+      @cancel={{this.cancel}}
+    />
+  </page.body>
+</Rose::Layout::Page>

--- a/ui/admin/tests/acceptance/workers/create-tags-test.js
+++ b/ui/admin/tests/acceptance/workers/create-tags-test.js
@@ -45,10 +45,8 @@ module('Acceptance | workers | worker | create-tags', function (hooks) {
 
   hooks.beforeEach(function () {
     instances.scopes.global = this.server.create('scope', { id: 'global' });
-    const scope = instances.scopes.global;
     instances.worker = this.server.create('worker', {
-      scopeId: scope.id,
-      // authorized_actions: [],
+      scope: instances.scopes.global,
     });
     urls.workers = `/scopes/global/workers`;
     urls.worker = `${urls.workers}/${instances.worker.id}`;

--- a/ui/admin/tests/acceptance/workers/create-tags-test.js
+++ b/ui/admin/tests/acceptance/workers/create-tags-test.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module('Acceptance | workers | worker | create-tags', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  const SAVE_BUTTON_SELECTOR = '[type="submit"]';
+  const CANCEL_BUTTON_SELECTOR = '.rose-form-actions [type="button"]';
+  const MANAGE_DROPDOWN_TOGGLE =
+    '[data-test-manage-worker-dropdown] div button';
+  const CREATE_TAGS_BUTTON_SELECTOR =
+    '[data-test-manage-worker-dropdown] div:first-child a';
+  const KEY_INPUT_SELECTOR = '[name="api_tags"] tr td:first-child input';
+  const VALUE_INPUT_SELECTOR = '[name="api_tags"] tr td:nth-child(2) input';
+  const ADD_INPUT_SELECTOR = '[name="api_tags"] tr td:last-child button';
+
+  const instances = {
+    scopes: {
+      global: null,
+    },
+    worker: null,
+  };
+
+  const urls = {
+    workers: null,
+    worker: null,
+    tags: null,
+    createTags: null,
+  };
+
+  hooks.beforeEach(function () {
+    instances.scopes.global = this.server.create('scope', { id: 'global' });
+    const scope = instances.scopes.global;
+    instances.worker = this.server.create('worker', {
+      scopeId: scope.id,
+    });
+    urls.workers = `/scopes/global/workers`;
+    urls.worker = `${urls.workers}/${instances.worker.id}`;
+    urls.tags = `${urls.worker}/tags`;
+    urls.createTags = `${urls.worker}/create-tags`;
+
+    authenticateSession({});
+  });
+
+  test('visiting worker create tags', async function (assert) {
+    await visit(urls.worker);
+
+    await click(MANAGE_DROPDOWN_TOGGLE);
+    await click(CREATE_TAGS_BUTTON_SELECTOR);
+    await a11yAudit();
+
+    assert.strictEqual(currentURL(), urls.createTags);
+  });
+
+  test.skip('cannot visit worker create tags without proper permissions', async function (assert) {
+    instances.worker.authorized_actions =
+      instances.worker.authorized_actions.filter(
+        (action) => action !== 'set-worker-tags',
+      );
+    await visit(urls.worker);
+
+    await click(MANAGE_DROPDOWN_TOGGLE);
+
+    assert.dom(CREATE_TAGS_BUTTON_SELECTOR).doesNotExist();
+  });
+
+  test.skip('user can save worker tags', async function (assert) {
+    await visit(urls.createTags);
+    await fillIn(KEY_INPUT_SELECTOR, 'key');
+    await fillIn(VALUE_INPUT_SELECTOR, 'value');
+    await click(ADD_INPUT_SELECTOR);
+
+    await click(SAVE_BUTTON_SELECTOR);
+
+    assert.dom('tbody tr').exists({ count: 2 });
+    assert.strictEqual(currentURL(), urls.tags);
+  });
+
+  test('user can cancel tag creation', async function (assert) {
+    await visit(urls.worker);
+
+    await click(MANAGE_DROPDOWN_TOGGLE);
+    await click(CREATE_TAGS_BUTTON_SELECTOR);
+
+    await click(CANCEL_BUTTON_SELECTOR);
+
+    assert.strictEqual(currentURL(), urls.tags);
+  });
+
+  test.skip('user is prompted to confirm exit when there are unsaved changes', async function (assert) {
+    await visit(urls.createTags);
+    await fillIn(KEY_INPUT_SELECTOR, 'key');
+    await fillIn(VALUE_INPUT_SELECTOR, 'value');
+    await click(ADD_INPUT_SELECTOR);
+
+    await click(CANCEL_BUTTON_SELECTOR);
+
+    assert.dom('.confirm-dialog').exists();
+  });
+});

--- a/ui/admin/tests/acceptance/workers/create-tags-test.js
+++ b/ui/admin/tests/acceptance/workers/create-tags-test.js
@@ -114,13 +114,13 @@ module('Acceptance | workers | worker | create-tags', function (hooks) {
     await fillIn(VALUE_INPUT_SELECTOR, 'value');
     await click(ADD_INPUT_SELECTOR);
 
-    await click(CANCEL_BUTTON_SELECTOR);
+    await click(`[href="${urls.workers}"]`);
 
     assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
 
     await click(DISCARD_CHANGES_DISCARD_BUTTON);
 
-    assert.strictEqual(currentURL(), urls.tags);
+    assert.strictEqual(currentURL(), urls.workers);
   });
 
   test('user can cancel transition when there are unsaved changes', async function (assert) {
@@ -131,7 +131,7 @@ module('Acceptance | workers | worker | create-tags', function (hooks) {
     await fillIn(VALUE_INPUT_SELECTOR, 'value');
     await click(ADD_INPUT_SELECTOR);
 
-    await click(CANCEL_BUTTON_SELECTOR);
+    await click(`[href="${urls.workers}"]`);
 
     assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
 

--- a/ui/admin/tests/acceptance/workers/tags-test.js
+++ b/ui/admin/tests/acceptance/workers/tags-test.js
@@ -28,8 +28,9 @@ module('Acceptance | workers | tags', function (hooks) {
 
   hooks.beforeEach(function () {
     instances.scopes.global = this.server.create('scope', { id: 'global' });
-    const scope = instances.scopes.global;
-    instances.worker = this.server.create('worker', { scopeId: scope.id });
+    instances.worker = this.server.create('worker', {
+      scope: instances.scopes.global,
+    });
     urls.workers = `/scopes/global/workers`;
     urls.worker = `${urls.workers}/${instances.worker.id}`;
     urls.tags = `${urls.worker}/tags`;

--- a/ui/admin/tests/integration/components/form/worker/create-tags/index-test.js
+++ b/ui/admin/tests/integration/components/form/worker/create-tags/index-test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'admin/tests/helpers';
 import { setupIntl } from 'ember-intl/test-support';

--- a/ui/admin/tests/integration/components/form/worker/create-tags/index-test.js
+++ b/ui/admin/tests/integration/components/form/worker/create-tags/index-test.js
@@ -20,11 +20,12 @@ module(
 
     test('it renders', async function (assert) {
       this.model = {};
+      this.apiTags = [];
       this.save = () => {};
       this.cancel = () => {};
 
       await render(
-        hbs`<Form::Worker::CreateTags @model={{this.model}} @submit={{this.save}} @cancel={{this.cancel}} />`,
+        hbs`<Form::Worker::CreateTags @model={{this.model}} @apiTags={{this.apiTags}} @submit={{this.save}} @cancel={{this.cancel}} />`,
       );
 
       assert
@@ -34,13 +35,14 @@ module(
 
     test('it calls the passed in save action', async function (assert) {
       this.model = {};
+      this.apiTags = [{ key: 'key', value: 'value' }];
       this.save = () => {
         this.set('called', true);
       };
       this.cancel = () => {};
 
       await render(
-        hbs`<Form::Worker::CreateTags @model={{this.model}} @submit={{this.save}} @cancel={{this.cancel}} />`,
+        hbs`<Form::Worker::CreateTags @model={{this.model}} @apiTags={{this.apiTags}} @submit={{this.save}} @cancel={{this.cancel}} />`,
       );
 
       await click(SAVE_BUTTON_SELECTOR);
@@ -50,13 +52,14 @@ module(
 
     test('it calls the passed in cancel action', async function (assert) {
       this.model = {};
+      this.apiTags = [];
       this.save = () => {};
       this.cancel = () => {
         this.set('called', true);
       };
 
       await render(
-        hbs`<Form::Worker::CreateTags @model={{this.model}} @submit={{this.save}} @cancel={{this.cancel}} />`,
+        hbs`<Form::Worker::CreateTags @model={{this.model}} @apiTags={{this.apiTags}} @submit={{this.save}} @cancel={{this.cancel}} />`,
       );
 
       await click(CANCEL_BUTTON_SELECTOR);

--- a/ui/admin/tests/integration/components/form/worker/create-tags/index-test.js
+++ b/ui/admin/tests/integration/components/form/worker/create-tags/index-test.js
@@ -1,0 +1,62 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'admin/tests/helpers';
+import { setupIntl } from 'ember-intl/test-support';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | form/worker/create-tags/index',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupIntl(hooks);
+
+    const SAVE_BUTTON_SELECTOR = '[type="submit"]';
+    const CANCEL_BUTTON_SELECTOR = '.rose-form-actions [type="button"]';
+
+    test('it renders', async function (assert) {
+      this.model = {};
+      this.save = () => {};
+      this.cancel = () => {};
+
+      await render(
+        hbs`<Form::Worker::CreateTags @model={{this.model}} @submit={{this.save}} @cancel={{this.cancel}} />`,
+      );
+
+      assert
+        .dom(this.element)
+        .includesText('Key Value Actions Add Save Cancel');
+    });
+
+    test('it calls the passed in save action', async function (assert) {
+      this.model = {};
+      this.save = () => {
+        this.set('called', true);
+      };
+      this.cancel = () => {};
+
+      await render(
+        hbs`<Form::Worker::CreateTags @model={{this.model}} @submit={{this.save}} @cancel={{this.cancel}} />`,
+      );
+
+      await click(SAVE_BUTTON_SELECTOR);
+
+      assert.true(this.called);
+    });
+
+    test('it calls the passed in cancel action', async function (assert) {
+      this.model = {};
+      this.save = () => {};
+      this.cancel = () => {
+        this.set('called', true);
+      };
+
+      await render(
+        hbs`<Form::Worker::CreateTags @model={{this.model}} @submit={{this.save}} @cancel={{this.cancel}} />`,
+      );
+
+      await click(CANCEL_BUTTON_SELECTOR);
+
+      assert.true(this.called);
+    });
+  },
+);

--- a/ui/admin/tests/integration/components/workers/worker/actions/index-test.js
+++ b/ui/admin/tests/integration/components/workers/worker/actions/index-test.js
@@ -16,7 +16,10 @@ module(
     setupIntl(hooks);
 
     test('it renders', async function (assert) {
-      this.set('model', { id: 'w_123', authorized_actions: ['delete'] });
+      this.set('model', {
+        id: 'w_123',
+        authorized_actions: ['delete', 'set-worker-tags'],
+      });
       this.set('delete', () => {});
 
       await render(
@@ -25,6 +28,7 @@ module(
       await click('button');
 
       assert.dom(this.element).includesText('Remove Worker');
+      assert.dom(this.element).includesText('Create new tags');
     });
   },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/workers/new-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/workers/new-test.js
@@ -57,14 +57,4 @@ module('Unit | Controller | scopes/scope/workers/new', function (hooks) {
 
     assert.notEqual(worker.name, 'test');
   });
-
-  test('createWorkerLed action saves changes on the specified model', async function (assert) {
-    await visit(urls.workers);
-    const worker = await store.findRecord('worker', instances.worker.id);
-    worker.name = 'test';
-
-    await controller.createWorkerLed(worker);
-
-    assert.strictEqual(worker.name, 'test');
-  });
 });

--- a/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/create-tags-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/create-tags-test.js
@@ -62,13 +62,11 @@ module(
       assert.deepEqual(worker.api_tags, apiTags);
     });
 
-    test('cancel action clears api tags for a worker', async function (assert) {
+    test('cancel action takes user back to tags route', async function (assert) {
       await visit(urls.createTags);
-      controller.apiTags = [{ key: 'key', value: 'value' }];
 
       await controller.cancel();
 
-      assert.deepEqual(controller.apiTags, []);
       assert.strictEqual(currentURL(), urls.tags);
     });
   },

--- a/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/create-tags-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/create-tags-test.js
@@ -5,17 +5,71 @@
 
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { currentURL, visit } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { authenticateSession } from 'ember-simple-auth/test-support';
 
 module(
   'Unit | Controller | scopes/scope/workers/worker/create-tags',
   function (hooks) {
     setupTest(hooks);
+    setupMirage(hooks);
 
-    test('it exists', function (assert) {
-      let controller = this.owner.lookup(
+    let store;
+    let controller;
+
+    const instances = {
+      scopes: {
+        global: null,
+      },
+      worker: null,
+    };
+
+    const urls = {
+      workers: null,
+      tags: null,
+      createTags: null,
+    };
+
+    hooks.beforeEach(function () {
+      authenticateSession({});
+      store = this.owner.lookup('service:store');
+      controller = this.owner.lookup(
         'controller:scopes/scope/workers/worker/create-tags',
       );
+
+      instances.scopes.global = this.server.create('scope', { id: 'global' });
+      instances.worker = this.server.create('worker', {
+        scope: instances.scopes.global,
+      });
+
+      urls.workers = `/scopes/global/workers`;
+      urls.tags = `${urls.workers}/${instances.worker.id}/tags`;
+      urls.createTags = `${urls.workers}/${instances.worker.id}/create-tags`;
+    });
+
+    test('it exists', function (assert) {
       assert.ok(controller);
+    });
+
+    test('save action sets api tags for a worker', async function (assert) {
+      await visit(urls.createTags);
+      const worker = await store.findRecord('worker', instances.worker.id);
+      const apiTags = { key: ['value'] };
+
+      await controller.save(apiTags);
+
+      assert.deepEqual(worker.api_tags, apiTags);
+    });
+
+    test('cancel action clears api tags for a worker', async function (assert) {
+      await visit(urls.createTags);
+      controller.apiTags = [{ key: 'key', value: 'value' }];
+
+      await controller.cancel();
+
+      assert.deepEqual(controller.apiTags, []);
+      assert.strictEqual(currentURL(), urls.tags);
     });
   },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/create-tags-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/create-tags-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'admin/tests/helpers';
+
+module(
+  'Unit | Controller | scopes/scope/workers/worker/create-tags',
+  function (hooks) {
+    setupTest(hooks);
+
+    // TODO: Replace this with your real tests.
+    test('it exists', function (assert) {
+      let controller = this.owner.lookup(
+        'controller:scopes/scope/workers/worker/create-tags',
+      );
+      assert.ok(controller);
+    });
+  },
+);

--- a/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/create-tags-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/create-tags-test.js
@@ -1,12 +1,16 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import { module, test } from 'qunit';
-import { setupTest } from 'admin/tests/helpers';
+import { setupTest } from 'ember-qunit';
 
 module(
   'Unit | Controller | scopes/scope/workers/worker/create-tags',
   function (hooks) {
     setupTest(hooks);
 
-    // TODO: Replace this with your real tests.
     test('it exists', function (assert) {
       let controller = this.owner.lookup(
         'controller:scopes/scope/workers/worker/create-tags',

--- a/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/create-tags-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/workers/worker/create-tags-test.js
@@ -62,11 +62,13 @@ module(
       assert.deepEqual(worker.api_tags, apiTags);
     });
 
-    test('cancel action takes user back to tags route', async function (assert) {
+    test('cancel action clears api tags for a worker and transitions to tags route', async function (assert) {
       await visit(urls.createTags);
+      controller.apiTags = [{ key: 'key', value: 'value' }];
 
       await controller.cancel();
 
+      assert.deepEqual(controller.apiTags, []);
       assert.strictEqual(currentURL(), urls.tags);
     });
   },

--- a/ui/admin/tests/unit/routes/scopes/scope/workers/worker/create-tags-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/workers/worker/create-tags-test.js
@@ -1,5 +1,10 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import { module, test } from 'qunit';
-import { setupTest } from 'admin/tests/helpers';
+import { setupTest } from 'ember-qunit';
 
 module(
   'Unit | Route | scopes/scope/workers/worker/create-tags',

--- a/ui/admin/tests/unit/routes/scopes/scope/workers/worker/create-tags-test.js
+++ b/ui/admin/tests/unit/routes/scopes/scope/workers/worker/create-tags-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'admin/tests/helpers';
+
+module(
+  'Unit | Route | scopes/scope/workers/worker/create-tags',
+  function (hooks) {
+    setupTest(hooks);
+
+    test('it exists', function (assert) {
+      let route = this.owner.lookup(
+        'route:scopes/scope/workers/worker/create-tags',
+      );
+      assert.ok(route);
+    });
+  },
+);


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
This PR adds the worker tag creation workflow.

~The test, `cannot visit worker create tags without proper permissions`, is still failing and I am not sure why. I am opening this PR for review while I dig into this more. I will push up a fix asap.~
Test has been fixed!

NOTE: I have not added the "no tags" view yet. That will be a later PR.

## Screenshots (if appropriate)
https://github.com/hashicorp/boundary-ui/assets/29386339/1ecdaf23-e20f-41d1-87ff-a34f0ee5b740

Payload sent to `POST /v1/workers/<workerID>:set-worker-tags`
<img width="541" alt="Screenshot 2024-07-02 at 2 24 51 PM" src="https://github.com/hashicorp/boundary-ui/assets/29386339/47630599-996c-4dc2-aecc-f496dae51830">


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
Visit a worker in the vercel deployment. From here you can create new tags via the "Manage" dropdown and create new tags.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [x] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
