### PR TITLE
Add a postMake arch conversion from x64 to amd64

### DIFF
--- a/ui/desktop/electron-app/config/forge.config.js
+++ b/ui/desktop/electron-app/config/forge.config.js
@@ -103,6 +103,9 @@ module.exports = {
           fs.mkdirSync(destination, { recursive: true });
         // Copy artifacts
         artifacts.forEach(async (artifact) => {
+          if (arch === 'x64') {
+            arch = 'amd64';
+          }
           const name = `boundary-desktop_${version}_${platform}_${arch}${path.extname(
             artifact,
           )}`;

--- a/ui/desktop/electron-app/config/forge.config.js
+++ b/ui/desktop/electron-app/config/forge.config.js
@@ -103,8 +103,12 @@ module.exports = {
           fs.mkdirSync(destination, { recursive: true });
         // Copy artifacts
         artifacts.forEach(async (artifact) => {
+          // Changing arch and platform to be compliant with artifact namings.
           if (arch === 'x64') {
             arch = 'amd64';
+          }
+          if (platform === 'win32') {
+            platform = 'windows';
           }
           const name = `boundary-desktop_${version}_${platform}_${arch}${path.extname(
             artifact,


### PR DESCRIPTION
# Description

This PR introduces changes to the DC binary built process. These changes should be merged along with this boundary-ui-releases PR. Otherwise, the pipeline runs will fail.

Changes:
When the `arch` is x64 (electron-forge default) change it to amd64.
When the `platform` is win32 (electron-forge default) change it to `windows`. Otherwise, if win32 is present in the artifact name, the signature process fails because it just accepts windows.


<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
