### PR TITLE
fix: 🐛 Fix breaking change for changing page size

### DIFF
--- a/addons/rose/addon/components/rose/pagination/index.hbs
+++ b/addons/rose/addon/components/rose/pagination/index.hbs
@@ -10,4 +10,5 @@
   @route={{this.router.currentRouteName}}
   @model={{@model}}
   @queryFunction={{this.paginationQueryParams}}
+  @onPageSizeChange={{this.handlePageSizeChange}}
 />

--- a/addons/rose/addon/components/rose/pagination/index.js
+++ b/addons/rose/addon/components/rose/pagination/index.js
@@ -5,6 +5,7 @@
 
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class RosePaginationComponent extends Component {
   @service router;
@@ -20,5 +21,13 @@ export default class RosePaginationComponent extends Component {
         pageSize,
       };
     };
+  }
+
+  @action
+  async handlePageSizeChange(pageSize) {
+    // Reset to the first page when changing the page size
+    const queryParams = { page: 1, pageSize };
+
+    await this.router.transitionTo({ queryParams });
   }
 }


### PR DESCRIPTION
# Description
It seems `onPageSizeChange` is now required for pageSize changes. When I had read the [breaking changes](https://helios.hashicorp.design/whats-new/release-notes#400) in HDS originally, I took it as it's only an issue if you didn't manage the query parameters outside of the component but it turns out this was happening with internal logic regardless. The pages themselves work as they were just `a` links with query parameters. 

I added our own function to handle page size changes.

## Screenshots
https://github.com/user-attachments/assets/4fcb5da6-8451-4a84-9f97-5af431bcc20b



## How to Test
Use or start up an instance with many resources. Confirm that changing the page sizes works. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
