### PR TITLE
fix: 🐛 add trim() to values when creating tags

### DIFF
--- a/ui/admin/app/components/form/worker/create-tags/index.js
+++ b/ui/admin/app/components/form/worker/create-tags/index.js
@@ -48,7 +48,7 @@ export default class FormWorkerCreateTagsIndexComponent extends Component {
     const apiTags = structuredClone(this.args.model.api_tags ?? {});
     this.args.apiTags.forEach((tag) => {
       let key = tag.key;
-      let values = tag.value.split(',');
+      let values = tag.value.split(',').map((value) => value.trim());
 
       if (!apiTags[key]) {
         apiTags[key] = values;


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
🐛 There was a bug when creating new tags for a worker. The `values` array did not have trimmed values to remove the empty space.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

https://github.com/user-attachments/assets/6f41b62b-5147-48b8-b2c4-edab6ea01eec



## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
Navigate to the create tags route and create an api tag with a comma separated value `dev, qa` and the request should return a 200.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
