### PR TITLE
feat: 🎸 Add debug logging for search times

### DIFF
--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -61,6 +61,7 @@ fixPath();
 // Setup logger
 log.initialize();
 log.transports.console.level = false;
+log.transports.file.level = process.env.BOUNDARY_DESKTOP_LOG_LEVEL ?? 'info';
 log.transports.file.format =
   '[{y}-{m}-{d}T{h}:{i}:{s}.{ms}{z}] [{level}] {text}';
 log.transports.file.fileName = 'desktop-client.log';


### PR DESCRIPTION
# Description
Added debug statements to allow a user to see how long search requests are taking. Also added a `BOUNDARY_DESKTOP_LOG_LEVEL` which they can set when starting DC to change log levels for now.

## Screenshots (if appropriate)
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/afd97d89-a6dc-4d2b-9825-ec08a6ccc2db">

## How to Test
Create a build either with a CLI from main or 0.17. Run the DC from your terminal with the `BOUNDARY_DESKTOP_LOG_LEVEL` set to `debug`. 

My binary for mac is located at `boundary-ui/ui/desktop/electron-app/out/Boundary-darwin-arm64/Boundary.app/Contents/MacOS/` and I just run `BOUNDARY_DESKTOP_LOG_LEVEL=debug ./Boundary`

Also running the pipeline for a build [here](https://github.com/hashicorp/boundary-ui-releases/actions/runs/10012570932). Will need to test windows.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
