### PR TITLE
fix: 🐛 tag count in list view

### DIFF
--- a/addons/api/addon/generated/models/worker.js
+++ b/addons/api/addon/generated/models/worker.js
@@ -72,4 +72,27 @@ export default class GeneratedWorkerModel extends BaseModel {
     readOnly: true,
   })
   type;
+
+  @attr({
+    description:
+      'The deduplicated union of the tags reported by the worker ' +
+      'from its configuration and any tags added through other means.\nOutput only.',
+    readOnly: true,
+    emptyObjectIfMissing: true,
+  })
+  canonical_tags;
+
+  @attr({
+    description:
+      "The tags set in the worker's configuration file.\nOutput only.",
+    readOnly: true,
+    emptyObjectIfMissing: true,
+  })
+  config_tags;
+
+  @attr({
+    description: 'The api tags set for the worker.\nOutput only.',
+    emptyObjectIfMissing: true,
+  })
+  api_tags;
 }

--- a/addons/api/addon/models/worker.js
+++ b/addons/api/addon/models/worker.js
@@ -37,9 +37,6 @@ export default class WorkerModel extends GeneratedWorkerModel {
    * @type {number}
    */
   get tagCount() {
-    if (!this.config_tags && !this.api_tags) {
-      return 0;
-    }
     const allTags = [
       ...Object.values(this.config_tags ?? {}),
       ...Object.values(this.api_tags ?? {}),

--- a/addons/api/addon/models/worker.js
+++ b/addons/api/addon/models/worker.js
@@ -4,7 +4,6 @@
  */
 
 import GeneratedWorkerModel from '../generated/models/worker';
-import { attr } from '@ember-data/model';
 
 export const TYPE_WORKER_PKI = 'pki';
 
@@ -38,15 +37,12 @@ export default class WorkerModel extends GeneratedWorkerModel {
    * @type {number}
    */
   get tagCount() {
-    if (
-      !Object.keys(this.config_tags).length &&
-      !Object.keys(this.api_tags).length
-    ) {
+    if (!this.config_tags && !this.api_tags) {
       return 0;
     }
     const allTags = [
-      ...Object.values(this.config_tags),
-      ...Object.values(this.api_tags),
+      ...Object.values(this.config_tags ?? {}),
+      ...Object.values(this.api_tags ?? {}),
     ];
     return allTags.reduce(
       (previousCount, currentTags) => previousCount + currentTags.length,
@@ -89,29 +85,6 @@ export default class WorkerModel extends GeneratedWorkerModel {
   get allTags() {
     return [...(this.configTagList ?? []), ...(this.apiTagList ?? [])];
   }
-
-  @attr({
-    description:
-      'The deduplicated union of the tags reported by the worker ' +
-      'from its configuration and any tags added through other means.\nOutput only.',
-    readOnly: true,
-    emptyObjectIfMissing: true,
-  })
-  canonical_tags;
-
-  @attr({
-    description:
-      "The tags set in the worker's configuration file.\nOutput only.",
-    readOnly: true,
-    emptyObjectIfMissing: true,
-  })
-  config_tags;
-
-  @attr({
-    description: 'The api tags set for the worker.\nOutput only.',
-    emptyObjectIfMissing: true,
-  })
-  api_tags;
 
   /**
    * Method to modify the adapter to handle custom POST route for creating worker.

--- a/addons/api/addon/models/worker.js
+++ b/addons/api/addon/models/worker.js
@@ -34,14 +34,18 @@ export default class WorkerModel extends GeneratedWorkerModel {
   }
 
   /**
-   * Returns the number of canonical tags present on the worker.
+   * Returns the number of tags present on the worker.
    * @type {number}
    */
   get tagCount() {
     if (!this.canonical_tags) {
       return 0;
     }
-    return Object.values(this.canonical_tags).reduce(
+    const allTags = [
+      ...Object.values(this.config_tags),
+      ...Object.values(this.api_tags),
+    ];
+    return allTags.reduce(
       (previousCount, currentTags) => previousCount + currentTags.length,
       0,
     );

--- a/addons/api/addon/models/worker.js
+++ b/addons/api/addon/models/worker.js
@@ -38,7 +38,10 @@ export default class WorkerModel extends GeneratedWorkerModel {
    * @type {number}
    */
   get tagCount() {
-    if (!this.canonical_tags) {
+    if (
+      !Object.keys(this.config_tags).length &&
+      !Object.keys(this.api_tags).length
+    ) {
       return 0;
     }
     const allTags = [

--- a/addons/api/tests/unit/models/worker-test.js
+++ b/addons/api/tests/unit/models/worker-test.js
@@ -71,7 +71,7 @@ module('Unit | Model | worker', function (hooks) {
     const model = store.peekRecord('worker', workerId);
     await model.setApiTags(tags);
   });
-  
+
   test('it has a `removeApiTags` method that targets a specific POST API', async function (assert) {
     assert.expect(1);
     const workerId = 'w_123';
@@ -186,13 +186,16 @@ module('Unit | Model | worker', function (hooks) {
   test('tagCount returns the total number of tags', function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('worker', {
-      canonical_tags: {
+      config_tags: {
         tag1: ['value1', 'value2'],
+        tag2: ['value3'],
+      },
+      api_tags: {
         tag2: ['value3'],
       },
     });
 
-    assert.strictEqual(model.tagCount, 3);
+    assert.strictEqual(model.tagCount, 4);
   });
 
   test('tagCount returns 0 if there are no tags', function (assert) {


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
Before:

<img width="1439" alt="Screenshot 2024-07-24 at 6 24 32 PM" src="https://github.com/user-attachments/assets/d7ba054d-358a-4db8-92bc-9423da0d0ef6">

After:

![image](https://github.com/user-attachments/assets/1de0aa4e-4a09-461f-a87d-df9e7a50dd8d)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
1. start boundary dev instance
2. create an api tag that has the same key and value as an existing config tag
3. make sure that the count in list view for workers is accurate. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
