### PR TITLE
refactor: Update Manage Dropdown in Groups Form

### DIFF
--- a/ui/admin/app/components/groups/group/actions/index.hbs
+++ b/ui/admin/app/components/groups/group/actions/index.hbs
@@ -3,24 +3,24 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<Rose::Dropdown
-  @text={{t 'actions.manage'}}
-  @dropdownRight={{true}}
-  as |dropdown|
->
+<Hds::Dropdown data-test-manage-group-dropdown as |dd|>
+  <dd.ToggleButton 
+    @text={{t 'actions.manage'}} 
+    @color='secondary'
+  />
   {{#if (can 'addMembers group' @model)}}
-    <dropdown.link @route='scopes.scope.groups.group.add-members'>
-      {{t 'resources.group.actions.add-members'}}
-    </dropdown.link>
+    <dd.Interactive 
+      @route='scopes.scope.groups.group.add-members'
+      @text={{t 'resources.group.actions.add-members'}}
+    />
   {{/if}}
   {{#if (can 'delete model' @model)}}
-    <dropdown.separator />
-    <dropdown.button
-      @style='danger'
+    <dd.Separator />
+    <dd.Interactive
+      @color='critical'
       @disabled={{@model.canSave}}
+      @text={{t 'resources.group.actions.delete'}}
       {{on 'click' @delete}}
-    >
-      {{t 'resources.group.actions.delete'}}
-    </dropdown.button>
+    />
   {{/if}}
-</Rose::Dropdown>
+</Hds::Dropdown>

--- a/ui/admin/app/components/users/user/actions/index.hbs
+++ b/ui/admin/app/components/users/user/actions/index.hbs
@@ -2,25 +2,23 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
 }}
+<Hds::Dropdown data-test-manage-user-dropdown as |dd|>
+  <dd.ToggleButton @text={{t 'actions.manage'}} @color='secondary' />
 
-<Rose::Dropdown
-  @text={{t 'actions.manage'}}
-  @dropdownRight={{true}}
-  as |dropdown|
->
   {{#if (can 'addAccounts user' @model)}}
-    <dropdown.link @route='scopes.scope.users.user.add-accounts'>
-      {{t 'resources.user.actions.add-accounts'}}
-    </dropdown.link>
+    <dd.Interactive
+      @route='scopes.scope.users.user.add-accounts'
+      @text={{t 'resources.user.actions.add-accounts'}}
+    />
   {{/if}}
+
   {{#if (can 'delete model' @model)}}
-    <dropdown.separator />
-    <dropdown.button
-      @style='danger'
+    <dd.Separator />
+    <dd.Interactive
+      @color='critical'
       @disabled={{@model.canSave}}
+      @text={{t 'resources.user.actions.delete'}}
       {{on 'click' (fn @delete @model)}}
-    >
-      {{t 'resources.user.actions.delete'}}
-    </dropdown.button>
+    />
   {{/if}}
-</Rose::Dropdown>
+</Hds::Dropdown>

--- a/ui/admin/tests/acceptance/groups/delete-test.js
+++ b/ui/admin/tests/acceptance/groups/delete-test.js
@@ -19,6 +19,9 @@ module('Acceptance | groups | delete', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
+  const MANAGE_DROPDOWN_SELECTOR = "[data-test-manage-group-dropdown] div:first-child button"
+  const DELETE_ACTION_SELECTOR = "[data-test-manage-group-dropdown] ul li button"
+
   const instances = {
     scopes: {
       global: null,
@@ -51,7 +54,8 @@ module('Acceptance | groups | delete', function (hooks) {
   test('can delete a group', async function (assert) {
     const groupsCount = this.server.db.groups.length;
     await visit(urls.group);
-    await click('.rose-layout-page-actions .rose-dropdown-button-danger');
+    await click(MANAGE_DROPDOWN_SELECTOR);
+    await click(DELETE_ACTION_SELECTOR);
     assert.strictEqual(this.server.db.groups.length, groupsCount - 1);
   });
 
@@ -77,7 +81,8 @@ module('Acceptance | groups | delete', function (hooks) {
       );
     });
     await visit(urls.group);
-    await click('.rose-layout-page-actions .rose-dropdown-button-danger');
+    await click(MANAGE_DROPDOWN_SELECTOR);
+    await click(DELETE_ACTION_SELECTOR);
     assert.strictEqual(
       find('.rose-notification-body').textContent.trim(),
       'Oops.',

--- a/ui/admin/tests/acceptance/groups/members-test.js
+++ b/ui/admin/tests/acceptance/groups/members-test.js
@@ -37,6 +37,8 @@ module('Acceptance | groups | members', function (hooks) {
     addMembers: null,
   };
   let membersCount;
+  const MANAGE_DROPDOWN_SELECTOR = "[data-test-manage-group-dropdown] div:first-child button"
+  const ADD_MEMBERS_ACTION_SELECTOR = "[data-test-manage-group-dropdown] ul li a"
 
   hooks.beforeEach(function () {
     authenticateSession({});
@@ -111,7 +113,8 @@ module('Acceptance | groups | members', function (hooks) {
 
   test('can navigate to add members with proper authorization', async function (assert) {
     await visit(urls.group);
-    assert.ok(find(`[href="${urls.addMembers}"]`));
+    await click(MANAGE_DROPDOWN_SELECTOR);
+    assert.dom(ADD_MEMBERS_ACTION_SELECTOR).isVisible()
   });
 
   test('cannot navigate to add members without proper authorization', async function (assert) {
@@ -127,7 +130,8 @@ module('Acceptance | groups | members', function (hooks) {
     instances.group.update({ memberIds: [] });
     await visit(urls.members);
     assert.strictEqual(findAll('tbody tr').length, 0);
-    await click('.rose-layout-page-actions a');
+    await click(MANAGE_DROPDOWN_SELECTOR);
+    await click(ADD_MEMBERS_ACTION_SELECTOR);
     assert.strictEqual(currentURL(), urls.addMembers);
     // Click three times to select, unselect, then reselect (for coverage)
     await click('tbody label');
@@ -144,7 +148,8 @@ module('Acceptance | groups | members', function (hooks) {
     await click('.hds-dropdown-toggle-icon');
     await click('tbody tr .hds-dropdown-list-item button');
     assert.strictEqual(findAll('tbody tr').length, membersCount - 1);
-    await click('.rose-layout-page-actions a');
+    await click(MANAGE_DROPDOWN_SELECTOR);
+    await click(ADD_MEMBERS_ACTION_SELECTOR);
     assert.strictEqual(currentURL(), urls.addMembers);
     await click('tbody label');
     await click('form [type="button"]');

--- a/ui/admin/tests/acceptance/users/accounts-test.js
+++ b/ui/admin/tests/acceptance/users/accounts-test.js
@@ -25,7 +25,8 @@ module('Acceptance | users | accounts', function (hooks) {
   let features;
 
   const ACCOUNTS_TYPE_SELECTOR = 'tbody tr .hds-badge__text';
-  const ADD_ACCOUNTS_ACTION_SELECTOR = '.rose-layout-page-actions a';
+  const ADD_ACCOUNTS_ACTION_SELECTOR = "[data-test-manage-user-dropdown] ul li:first-child a"
+  const MANAGE_DROPDOWN_SELECTOR = "[data-test-manage-user-dropdown] div:first-child button"
   const ERROR_MSG_SELECTOR = '[role="alert"]';
   const TABLE_ROWS_SELECTOR = 'tbody tr';
   const CHECKBOX_SELECTOR = 'tbody label';
@@ -168,7 +169,7 @@ module('Acceptance | users | accounts', function (hooks) {
 
   test('visiting account add accounts', async function (assert) {
     await visit(urls.accounts);
-
+    await click(MANAGE_DROPDOWN_SELECTOR);
     await click(ADD_ACCOUNTS_ACTION_SELECTOR);
     await a11yAudit();
 
@@ -177,10 +178,10 @@ module('Acceptance | users | accounts', function (hooks) {
 
   test('can navigate to add accounts with proper authorization', async function (assert) {
     await visit(urls.user);
-
     await click(`[href="${urls.accounts}"]`);
+    await click(MANAGE_DROPDOWN_SELECTOR);
 
-    assert.dom(`[href="${urls.addAccounts}"]`).exists();
+    assert.dom(`[href="${urls.addAccounts}"]`).isVisible();
   });
 
   test('cannot navigate to add accounts without proper authorization', async function (assert) {
@@ -210,6 +211,7 @@ module('Acceptance | users | accounts', function (hooks) {
     await visit(urls.user);
 
     await click(`[href="${urls.accounts}"]`);
+    await click(MANAGE_DROPDOWN_SELECTOR);
     await click(ADD_ACCOUNTS_ACTION_SELECTOR);
 
     assert
@@ -234,7 +236,10 @@ module('Acceptance | users | accounts', function (hooks) {
     await visit(urls.user);
 
     await click(`[href="${urls.accounts}"]`);
+    
+    await click(MANAGE_DROPDOWN_SELECTOR);
     await click(ADD_ACCOUNTS_ACTION_SELECTOR);
+
 
     assert.dom(TABLE_ROWS_SELECTOR).exists({ count: accountsAvailableCount });
   });
@@ -245,6 +250,7 @@ module('Acceptance | users | accounts', function (hooks) {
 
     await click(`[href="${urls.accounts}"]`);
     assert.dom(TABLE_ROWS_SELECTOR).exists({ count: 0 });
+    await click(MANAGE_DROPDOWN_SELECTOR);
     await click(ADD_ACCOUNTS_ACTION_SELECTOR);
     assert.strictEqual(currentURL(), urls.addAccounts);
     // Click three times to select, unselect, then reselect (for coverage)
@@ -260,18 +266,20 @@ module('Acceptance | users | accounts', function (hooks) {
 
   test('select and cancel accounts to add', async function (assert) {
     await visit(urls.user);
-
-    await click(`[href="${urls.accounts}"]`);
+    await click(`[href="${urls.accounts}"]`)
+    
     assert.dom(TABLE_ROWS_SELECTOR).exists({ count: accountsCount });
-    await click(ACCOUNTS_ACTION_SELECTOR);
-    await click(REMOVE_ACTION_SELECTOR);
-    assert.dom(TABLE_ROWS_SELECTOR).exists({ count: accountsCount - 1 });
+
+    await click(MANAGE_DROPDOWN_SELECTOR);
     await click(ADD_ACCOUNTS_ACTION_SELECTOR);
+
     assert.strictEqual(currentURL(), urls.addAccounts);
+
     await click(CHECKBOX_SELECTOR);
     await click(CANCEL_BTN_SELECTOR);
-    await visit(urls.accounts);
-    assert.dom(TABLE_ROWS_SELECTOR).exists({ count: accountsCount - 1 });
+    
+    assert.strictEqual(currentURL(), urls.accounts);
+    assert.dom(TABLE_ROWS_SELECTOR).exists({ count: accountsCount});
   });
 
   test('shows error message on account add', async function (assert) {

--- a/ui/admin/tests/acceptance/users/delete-test.js
+++ b/ui/admin/tests/acceptance/users/delete-test.js
@@ -20,7 +20,8 @@ module('Acceptance | users | delete', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   setupIndexedDb(hooks);
-
+  const DELETE_ACTION_SELECTOR = "[data-test-manage-user-dropdown] ul li button"
+  const MANAGE_DROPDOWN_SELECTOR = "[data-test-manage-user-dropdown] div:first-child button"
   const instances = {
     scopes: {
       global: null,
@@ -57,7 +58,8 @@ module('Acceptance | users | delete', function (hooks) {
 
     await click(`[href="${urls.user}"]`);
 
-    await click('.rose-layout-page-actions .rose-dropdown-button-danger');
+    await click(MANAGE_DROPDOWN_SELECTOR);
+    await click(DELETE_ACTION_SELECTOR);
 
     assert.strictEqual(this.server.db.users.length, usersCount - 1);
   });
@@ -66,11 +68,12 @@ module('Acceptance | users | delete', function (hooks) {
     instances.user.authorized_actions =
       instances.user.authorized_actions.filter((item) => item !== 'delete');
     await visit(urls.users);
-
+    
     await click(`[href="${urls.user}"]`);
-
+    
+    await click(MANAGE_DROPDOWN_SELECTOR);
     assert
-      .dom('.rose-layout-page-actions .rose-dropdown-button-danger')
+      .dom('[data-test-manage-user-dropdown] ul li button')
       .doesNotExist();
   });
 
@@ -79,9 +82,11 @@ module('Acceptance | users | delete', function (hooks) {
     confirmService.enabled = true;
     const usersCount = this.server.db.users.length;
     await visit(urls.users);
+    
 
     await click(`[href="${urls.user}"]`);
-    await click('.rose-layout-page-actions .rose-dropdown-button-danger');
+    await click(MANAGE_DROPDOWN_SELECTOR);
+    await click(DELETE_ACTION_SELECTOR);
     await click('.rose-dialog .rose-button-primary');
 
     assert.dom('.rose-notification-body').hasText('Deleted successfully.');
@@ -96,7 +101,8 @@ module('Acceptance | users | delete', function (hooks) {
     await visit(urls.users);
 
     await click(`[href="${urls.user}"]`);
-    await click('.rose-layout-page-actions .rose-dropdown-button-danger');
+    await click(MANAGE_DROPDOWN_SELECTOR);
+    await click(DELETE_ACTION_SELECTOR);
     await click('.rose-dialog .rose-button-secondary');
 
     assert.strictEqual(this.server.db.users.length, usersCount);
@@ -118,8 +124,8 @@ module('Acceptance | users | delete', function (hooks) {
     });
 
     await click(`[href="${urls.user}"]`);
-    await click('.rose-layout-page-actions .rose-dropdown-button-danger');
-
+    await click(MANAGE_DROPDOWN_SELECTOR);
+    await click(DELETE_ACTION_SELECTOR);
     assert.dom('.rose-notification-body').hasText('Oops.');
   });
 });


### PR DESCRIPTION
# Description
Refactoring of manage dropdown in the groups menu to reflect HDS upgrade. Functionality is kept from previous dropdown and tests were updated to reflect these changes. The dropdown should have two functions, to add members to a group and delete groups entirely.

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-14344)

## Screenshots (if appropriate)
**Before**
<img width="1882" alt="Screenshot 2024-07-09 at 11 22 30 AM" src="https://github.com/user-attachments/assets/748ceeea-fe51-4c01-9107-b21e980c74e8">

**After**
<img width="2032" alt="Screenshot 2024-07-26 at 10 49 59 AM" src="https://github.com/user-attachments/assets/1af3dc39-9938-4ced-9d6a-40d20675274d">
<img width="2032" alt="Screenshot 2024-07-26 at 10 50 09 AM" src="https://github.com/user-attachments/assets/7340db14-65bb-439b-b6c0-bd889a49b70d">

## How to Test
1. Start up test server/Login to Boundary
2. Navigate to Groups Scope
3. Select a resource on the table
4. Dropdown should reflect the HDS upgrade.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
~- [ ] I have added JSON response output for API changes~
- [X] I have added steps to reproduce and test for bug fixes in the description
~~- [] I have commented on my code, particularly in hard-to-understand areas~~
~~- [ ] My changes generate no new warnings~~
- [X] I have added tests that prove my fix is effective or that my feature works
