### PR TITLE
fix: 🐛 Fix intel macs not getting proper auto-update prompt

### DIFF
--- a/ui/desktop/electron-app/src/helpers/app-updater.js
+++ b/ui/desktop/electron-app/src/helpers/app-updater.js
@@ -35,7 +35,7 @@ const returnArchitectureToUpdate = () => {
   } catch (err) {
     log.error(`returnArchitectureToUpdate:`, err.message);
   }
-  return nodeArchitecture;
+  return 'amd64';
 };
 
 // Query releases url to find latest version
@@ -61,9 +61,11 @@ const findUpdateArchive = (version) => {
   const url = `${releasesUrl}${version}/boundary-desktop_${version}_darwin_${architecture}.zip`;
   return new Promise((resolve, reject) => {
     https.get(url, (response) => {
-      if (response.statusCode === 403)
+      if (response.statusCode === 200) {
+        resolve(url);
+      } else {
         reject({ message: 'Archive not available' });
-      if (response.statusCode === 200) resolve(url);
+      }
       response.on('error', (err) => reject(err));
     });
   });


### PR DESCRIPTION
# Description
Fixes an issue we were seeing where intel macs weren't properly getting auto-updated. We were returning `x64` instead of `amd64` and being unable to find the URL because of that. 

## Screenshots (if appropriate)

## How to Test
Creating a build [here](https://github.com/hashicorp/boundary-ui-releases/actions/runs/10170588076) and will test on our mac instance.

## Checklist

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
