### PR TITLE
chore(e2e): Fix eslint for Admin UI e2e tests

### DIFF
--- a/ui/admin/.eslintrc.js
+++ b/ui/admin/.eslintrc.js
@@ -64,5 +64,19 @@ module.exports = {
         'qunit/require-expect': [2, 'except-simple'],
       },
     },
+    {
+      // e2e files
+      files: ['tests/e2e/**'],
+      env: {
+        node: true,
+      },
+      extends: ['eslint:recommended', 'prettier'],
+      rules: {
+        'no-empty-pattern': [
+          'error',
+          { allowObjectPatternsAsParameters: true },
+        ],
+      },
+    },
   ],
 };

--- a/ui/admin/tests/e2e/global-setup.js
+++ b/ui/admin/tests/e2e/global-setup.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { chromium } = require('@playwright/test');
 const { checkEnv, authenticatedState } = require('./helpers/general');
 

--- a/ui/admin/tests/e2e/helpers/boundary-cli.js
+++ b/ui/admin/tests/e2e/helpers/boundary-cli.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { execSync, exec } = require('child_process');
 const { nanoid } = require('nanoid');
 

--- a/ui/admin/tests/e2e/helpers/general.js
+++ b/ui/admin/tests/e2e/helpers/general.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 exports.authenticatedState = './tests/e2e/artifacts/authenticated-state.json';
 
 /**

--- a/ui/admin/tests/e2e/helpers/vault-cli.js
+++ b/ui/admin/tests/e2e/helpers/vault-cli.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { execSync } = require('child_process');
 
 /**

--- a/ui/admin/tests/e2e/pages/aliases.js
+++ b/ui/admin/tests/e2e/pages/aliases.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { nanoid } = require('nanoid');
 

--- a/ui/admin/tests/e2e/pages/auth-methods.js
+++ b/ui/admin/tests/e2e/pages/auth-methods.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { nanoid } = require('nanoid');
 

--- a/ui/admin/tests/e2e/pages/base-resource.js
+++ b/ui/admin/tests/e2e/pages/base-resource.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const BasePage = require('./base');
 
 class BaseResourcePage extends BasePage {

--- a/ui/admin/tests/e2e/pages/base.js
+++ b/ui/admin/tests/e2e/pages/base.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 
 class BasePage {

--- a/ui/admin/tests/e2e/pages/credential-stores.js
+++ b/ui/admin/tests/e2e/pages/credential-stores.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { nanoid } = require('nanoid');
 const { readFile } = require('fs/promises');

--- a/ui/admin/tests/e2e/pages/groups.js
+++ b/ui/admin/tests/e2e/pages/groups.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { nanoid } = require('nanoid');
 

--- a/ui/admin/tests/e2e/pages/host-catalogs.js
+++ b/ui/admin/tests/e2e/pages/host-catalogs.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { nanoid } = require('nanoid');
 

--- a/ui/admin/tests/e2e/pages/orgs.js
+++ b/ui/admin/tests/e2e/pages/orgs.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { nanoid } = require('nanoid');
 

--- a/ui/admin/tests/e2e/pages/projects.js
+++ b/ui/admin/tests/e2e/pages/projects.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { nanoid } = require('nanoid');
 

--- a/ui/admin/tests/e2e/pages/roles.js
+++ b/ui/admin/tests/e2e/pages/roles.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { nanoid } = require('nanoid');
 

--- a/ui/admin/tests/e2e/pages/sessions.js
+++ b/ui/admin/tests/e2e/pages/sessions.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 
 const BasePage = require('./base');

--- a/ui/admin/tests/e2e/pages/storage-buckets.js
+++ b/ui/admin/tests/e2e/pages/storage-buckets.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { nanoid } = require('nanoid');
 

--- a/ui/admin/tests/e2e/pages/storage-policies.js
+++ b/ui/admin/tests/e2e/pages/storage-policies.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { nanoid } = require('nanoid');
 

--- a/ui/admin/tests/e2e/pages/targets.js
+++ b/ui/admin/tests/e2e/pages/targets.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { nanoid } = require('nanoid');
 

--- a/ui/admin/tests/e2e/pages/users.js
+++ b/ui/admin/tests/e2e/pages/users.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { nanoid } = require('nanoid');
 

--- a/ui/admin/tests/e2e/pages/workers.js
+++ b/ui/admin/tests/e2e/pages/workers.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const BaseResourcePage = require('./base-resource');
 
 class WorkersPage extends BaseResourcePage {

--- a/ui/admin/tests/e2e/playwright.config.js
+++ b/ui/admin/tests/e2e/playwright.config.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { devices } = require('@playwright/test');
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */

--- a/ui/admin/tests/e2e/tests/alias-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/alias-ent.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 import { execSync } from 'child_process';
 import { customAlphabet } from 'nanoid';

--- a/ui/admin/tests/e2e/tests/alias.spec.js
+++ b/ui/admin/tests/e2e/tests/alias.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 import { execSync } from 'child_process';
 import { customAlphabet } from 'nanoid';

--- a/ui/admin/tests/e2e/tests/auth-method-ldap.spec.js
+++ b/ui/admin/tests/e2e/tests/auth-method-ldap.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');
 const { nanoid } = require('nanoid');

--- a/ui/admin/tests/e2e/tests/auth-method-password.spec.js
+++ b/ui/admin/tests/e2e/tests/auth-method-password.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');
 

--- a/ui/admin/tests/e2e/tests/credential-store-static-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static-ent.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');
 

--- a/ui/admin/tests/e2e/tests/credential-store-static.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-static.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');
 const { readFile } = require('fs/promises');

--- a/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
+++ b/ui/admin/tests/e2e/tests/credential-store-vault.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');
 const { nanoid } = require('nanoid');

--- a/ui/admin/tests/e2e/tests/delete-resources-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/delete-resources-ent.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test } = require('@playwright/test');
 const { execSync } = require('child_process');
 

--- a/ui/admin/tests/e2e/tests/delete-resources.spec.js
+++ b/ui/admin/tests/e2e/tests/delete-resources.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test } = require('@playwright/test');
 const { execSync } = require('child_process');
 

--- a/ui/admin/tests/e2e/tests/dynamic-host-catalog-aws.spec.js
+++ b/ui/admin/tests/e2e/tests/dynamic-host-catalog-aws.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 const { nanoid } = require('nanoid');
 import { execSync } from 'child_process';

--- a/ui/admin/tests/e2e/tests/global-settings.spec.js
+++ b/ui/admin/tests/e2e/tests/global-settings.spec.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
+ * SPDX-License-Identifier: BUSL-1.1
  */
 
 const { test, expect } = require('@playwright/test');

--- a/ui/admin/tests/e2e/tests/global-settings.spec.js
+++ b/ui/admin/tests/e2e/tests/global-settings.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 
 const { authenticatedState } = require('../helpers/general');

--- a/ui/admin/tests/e2e/tests/group-role.spec.js
+++ b/ui/admin/tests/e2e/tests/group-role.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test } = require('@playwright/test');
 const { execSync } = require('child_process');
 

--- a/ui/admin/tests/e2e/tests/login.spec.js
+++ b/ui/admin/tests/e2e/tests/login.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 
 test('Log in, log out, and then log back in @ce @ent @aws @docker', async ({

--- a/ui/admin/tests/e2e/tests/pagination.spec.js
+++ b/ui/admin/tests/e2e/tests/pagination.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 import { nanoid } from 'nanoid';
 

--- a/ui/admin/tests/e2e/tests/session-recording-aws-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/session-recording-aws-ent.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');
 

--- a/ui/admin/tests/e2e/tests/session-recording-minio-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/session-recording-minio-ent.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');
 

--- a/ui/admin/tests/e2e/tests/ssh-certificate-injection-vault-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/ssh-certificate-injection-vault-ent.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test } = require('@playwright/test');
 const { execSync } = require('child_process');
 

--- a/ui/admin/tests/e2e/tests/ssh-credential-injection-vault-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/ssh-credential-injection-vault-ent.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test } = require('@playwright/test');
 const { execSync } = require('child_process');
 

--- a/ui/admin/tests/e2e/tests/target-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/target-ent.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');
 

--- a/ui/admin/tests/e2e/tests/target.spec.js
+++ b/ui/admin/tests/e2e/tests/target.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* eslint-disable no-undef */
 const { test, expect } = require('@playwright/test');
 const { execSync } = require('child_process');
 

--- a/ui/admin/tests/e2e/tests/worker-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/worker-ent.spec.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
+ * SPDX-License-Identifier: BUSL-1.1
  */
 
 const { expect } = require('@playwright/test');

--- a/ui/admin/tests/e2e/tests/worker-ent.spec.js
+++ b/ui/admin/tests/e2e/tests/worker-ent.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { test } = require('@playwright/test');
 

--- a/ui/admin/tests/e2e/tests/worker.spec.js
+++ b/ui/admin/tests/e2e/tests/worker.spec.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: MPL-2.0
+ * SPDX-License-Identifier: BUSL-1.1
  */
 
 const { expect } = require('@playwright/test');

--- a/ui/admin/tests/e2e/tests/worker.spec.js
+++ b/ui/admin/tests/e2e/tests/worker.spec.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-/* eslint-disable no-undef */
 const { expect } = require('@playwright/test');
 const { test } = require('@playwright/test');
 


### PR DESCRIPTION
This PR updates the eslint configuration in Admin UI to remove the need for e2e test files to include this line
```
/* eslint-disable no-undef */
```

This configuration was borrowed from an update for the Desktop Client e2e tests: https://github.com/hashicorp/boundary-ui/pull/2416.

https://hashicorp.atlassian.net/browse/ICU-14751