### PR TITLE
fix: 🐛 targets not displaying even after they are cached

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects/sessions/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions/index.js
@@ -105,10 +105,10 @@ export default class ScopesScopeProjectsSessionsIndexRoute extends Route {
     const totalItems = sessions.meta?.totalItems;
 
     // Query all sessions and all targets for defining filtering values if entering route for the first time
-    if (!this.allSessions) {
+    if (!this.allSessions?.length) {
       await this.getAllSessions(orgScope, scopes, orgFilter);
     }
-    if (!this.allTargets) {
+    if (!this.allTargets?.length) {
       await this.getAllTargets(orgScope, orgFilter);
     }
 

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
@@ -100,7 +100,7 @@ export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
       scope_id: 'global',
       force_refresh: true,
     });
-    const allTargetsPromise = !this.allTargets
+    const allTargetsPromise = !this.allTargets?.length
       ? this.makeAllTargetsQuery(orgScope, orgFilter)
       : Promise.resolve();
 
@@ -126,7 +126,7 @@ export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
     );
 
     const allTargets = await allTargetsPromise;
-    if (!this.allTargets) {
+    if (!this.allTargets?.length) {
       // Filter out targets to which users do not have the connect ability
       this.allTargets = allTargets.filter((target) =>
         target.authorized_actions.includes('authorize-session'),


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

The main issue is that the daemon returns empty array for targets since it times out. But even after the targets are finished getting cached, they are not displayed in the UI. That is because in first attempt to load the `this.allTargets` variable got set to empty array which was causing the `this.makeAllTargetsQuery` to not even run. As a result the `this.showFilters` check in the template was coming back as false.

## Screenshots (if appropriate)
Before:

https://github.com/user-attachments/assets/77e9eb06-5f21-4e42-8780-f85bac467e52


After:

https://github.com/user-attachments/assets/0bee5a97-74ae-4b68-bd06-a0719cc0e78c


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
