### PR TITLE
Icu 14834 remove duplicate selectors and use common selectors instead

### DIFF
--- a/ui/admin/tests/acceptance/storage-buckets/create-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/create-test.js
@@ -235,7 +235,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await click(`[href="${urls.newStorageBucket}"]`);
     await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
 
-    await click(selectors.CANCEL_BTN);
+    await click(commonSelectors.CANCEL_BTN);
 
     assert.strictEqual(currentURL(), urls.storageBuckets);
     assert.strictEqual(getStorageBucketCount(), storageBucketCount);

--- a/ui/admin/tests/acceptance/storage-buckets/create-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/create-test.js
@@ -55,7 +55,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await visit(urls.storageBuckets);
 
     await click(`[href="${urls.newStorageBucket}"]`);
-    await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
+    await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
     await select(selectors.FIELD_SCOPE, 'global');
 
     assert.dom(selectors.FIELD_BUCKET_NAME).isNotDisabled();
@@ -65,10 +65,10 @@ module('Acceptance | storage-buckets | create', function (hooks) {
 
     await click(commonSelectors.SAVE_BTN);
     const storageBucket = this.server.schema.storageBuckets.findBy({
-      name: selectors.FIELD_NAME_VALUE,
+      name: commonSelectors.FIELD_NAME_VALUE,
     });
 
-    assert.strictEqual(storageBucket.name, selectors.FIELD_NAME_VALUE);
+    assert.strictEqual(storageBucket.name, commonSelectors.FIELD_NAME_VALUE);
     assert.strictEqual(storageBucket.scopeId, 'global');
     assert.strictEqual(getStorageBucketCount(), storageBucketCount + 1);
   });
@@ -78,7 +78,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await visit(urls.storageBuckets);
 
     await click(`[href="${urls.newStorageBucket}"]`);
-    await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
+    await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
     await select(selectors.FIELD_SCOPE, instances.scopes.org.id);
 
     assert.dom(selectors.FIELD_BUCKET_NAME).isNotDisabled();
@@ -88,11 +88,11 @@ module('Acceptance | storage-buckets | create', function (hooks) {
 
     await click(commonSelectors.SAVE_BTN);
     const storageBucket = this.server.schema.storageBuckets.findBy({
-      name: selectors.FIELD_NAME_VALUE,
+      name: commonSelectors.FIELD_NAME_VALUE,
     });
 
     assert.dom(selectors.TOAST).hasText(selectors.TOAST_SUCCESSFULL_VALUE);
-    assert.strictEqual(storageBucket.name, selectors.FIELD_NAME_VALUE);
+    assert.strictEqual(storageBucket.name, commonSelectors.FIELD_NAME_VALUE);
     assert.strictEqual(storageBucket.scopeId, instances.scopes.org.id);
     assert.strictEqual(getStorageBucketCount(), storageBucketCount + 1);
   });
@@ -105,7 +105,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await click(`[href="${urls.newStorageBucket}"]`);
 
     // Fill the form
-    await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
+    await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
     await click(selectors.FIELD_PLUGIN_TYPE_MINIO);
     await select(selectors.FIELD_SCOPE, instances.scopes.org.id);
     await fillIn(
@@ -122,10 +122,10 @@ module('Acceptance | storage-buckets | create', function (hooks) {
 
     // Assertions
     const storageBucket = this.server.schema.storageBuckets.findBy({
-      name: selectors.FIELD_NAME_VALUE,
+      name: commonSelectors.FIELD_NAME_VALUE,
     });
     assert.dom(selectors.TOAST).hasText(selectors.TOAST_SUCCESSFULL_VALUE);
-    assert.strictEqual(storageBucket.name, selectors.FIELD_NAME_VALUE);
+    assert.strictEqual(storageBucket.name, commonSelectors.FIELD_NAME_VALUE);
     assert.strictEqual(
       storageBucket.attributes.endpoint_url,
       selectors.FIELD_ENDPOINT_URL_VALUE,
@@ -141,7 +141,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await visit(urls.storageBuckets);
 
     await click(`[href="${urls.newStorageBucket}"]`);
-    await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
+    await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
 
     // There are 2 credential types
     assert
@@ -153,10 +153,10 @@ module('Acceptance | storage-buckets | create', function (hooks) {
 
     await click(commonSelectors.SAVE_BTN);
     const storageBucket = this.server.schema.storageBuckets.findBy({
-      name: selectors.FIELD_NAME_VALUE,
+      name: commonSelectors.FIELD_NAME_VALUE,
     });
 
-    assert.strictEqual(storageBucket.name, selectors.FIELD_NAME_VALUE);
+    assert.strictEqual(storageBucket.name, commonSelectors.FIELD_NAME_VALUE);
     //for dynamic credentials, there should be no secret field
     assert.notOk(storageBucket.secret);
     assert.strictEqual(getStorageBucketCount(), storageBucketCount + 1);
@@ -167,7 +167,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await visit(urls.storageBuckets);
 
     await click(`[href="${urls.newStorageBucket}"]`);
-    await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
+    await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
     assert
       .dom(`${selectors.GROUP_CREDENTIAL_TYPE} .hds-form-radio-card`)
       .exists({ count: 2 });
@@ -179,10 +179,10 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await click(commonSelectors.SAVE_BTN);
 
     const storageBucket = this.server.schema.storageBuckets.findBy({
-      name: selectors.FIELD_NAME_VALUE,
+      name: commonSelectors.FIELD_NAME_VALUE,
     });
 
-    assert.strictEqual(storageBucket.name, selectors.FIELD_NAME_VALUE);
+    assert.strictEqual(storageBucket.name, commonSelectors.FIELD_NAME_VALUE);
     //for static credentials, role_arn should be null
     assert.strictEqual(storageBucket.attributes.role_arn, null);
     assert.strictEqual(getStorageBucketCount(), storageBucketCount + 1);
@@ -196,7 +196,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await click(`[href="${urls.newStorageBucket}"]`);
 
     // Fill the form
-    await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
+    await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
     await click(selectors.FIELD_PLUGIN_TYPE_MINIO);
     await fillIn(
       selectors.FIELD_ENDPOINT_URL,
@@ -213,11 +213,11 @@ module('Acceptance | storage-buckets | create', function (hooks) {
 
     // Retrieve recently created SB
     const storageBucket = await this.server.schema.storageBuckets.findBy({
-      name: selectors.FIELD_NAME_VALUE,
+      name: commonSelectors.FIELD_NAME_VALUE,
     });
 
     // Assertions
-    assert.strictEqual(storageBucket.name, selectors.FIELD_NAME_VALUE);
+    assert.strictEqual(storageBucket.name, commonSelectors.FIELD_NAME_VALUE);
     assert.strictEqual(
       storageBucket.attributes.endpoint_url,
       selectors.FIELD_ENDPOINT_URL_VALUE,
@@ -233,7 +233,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await visit(urls.storageBuckets);
 
     await click(`[href="${urls.newStorageBucket}"]`);
-    await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
+    await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
 
     await click(commonSelectors.CANCEL_BTN);
 

--- a/ui/admin/tests/acceptance/storage-buckets/create-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/create-test.js
@@ -11,6 +11,7 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as selectors from './selectors';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | storage-buckets | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -62,7 +63,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     assert.dom(selectors.FIELD_BUCKET_NAME).doesNotHaveAttribute('readOnly');
     assert.dom(selectors.FIELD_BUCKET_PREFIX).doesNotHaveAttribute('readOnly');
 
-    await click(selectors.SAVE_BTN);
+    await click(commonSelectors.SAVE_BTN);
     const storageBucket = this.server.schema.storageBuckets.findBy({
       name: selectors.FIELD_NAME_VALUE,
     });
@@ -85,7 +86,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     assert.dom(selectors.FIELD_BUCKET_NAME).doesNotHaveAttribute('readOnly');
     assert.dom(selectors.FIELD_BUCKET_PREFIX).doesNotHaveAttribute('readOnly');
 
-    await click(selectors.SAVE_BTN);
+    await click(commonSelectors.SAVE_BTN);
     const storageBucket = this.server.schema.storageBuckets.findBy({
       name: selectors.FIELD_NAME_VALUE,
     });
@@ -117,7 +118,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     );
     await fillIn(selectors.FIELD_ACCESS_KEY, selectors.FIELD_ACCESS_KEY_VALUE);
     await fillIn(selectors.FIELD_SECRET_KEY, selectors.FIELD_SECRET_KEY_VALUE);
-    await click(selectors.SAVE_BTN);
+    await click(commonSelectors.SAVE_BTN);
 
     // Assertions
     const storageBucket = this.server.schema.storageBuckets.findBy({
@@ -150,7 +151,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await click(selectors.FIELD_DYNAMIC_CREDENTIAL);
     await fillIn(selectors.FIELD_ROLE_ARN, selectors.FIELD_ROLE_ARN_VALUE);
 
-    await click(selectors.SAVE_BTN);
+    await click(commonSelectors.SAVE_BTN);
     const storageBucket = this.server.schema.storageBuckets.findBy({
       name: selectors.FIELD_NAME_VALUE,
     });
@@ -175,7 +176,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await fillIn(selectors.FIELD_ACCESS_KEY, selectors.FIELD_ACCESS_KEY_VALUE);
     await fillIn(selectors.FIELD_SECRET_KEY, selectors.FIELD_SECRET_KEY_VALUE);
 
-    await click(selectors.SAVE_BTN);
+    await click(commonSelectors.SAVE_BTN);
 
     const storageBucket = this.server.schema.storageBuckets.findBy({
       name: selectors.FIELD_NAME_VALUE,
@@ -208,7 +209,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await fillIn(selectors.FIELD_ACCESS_KEY, selectors.FIELD_ACCESS_KEY_VALUE);
     await fillIn(selectors.FIELD_SECRET_KEY, selectors.FIELD_SECRET_KEY_VALUE);
 
-    await click(selectors.SAVE_BTN);
+    await click(commonSelectors.SAVE_BTN);
 
     // Retrieve recently created SB
     const storageBucket = await this.server.schema.storageBuckets.findBy({
@@ -263,7 +264,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await visit(urls.storageBuckets);
 
     await click(`[href="${urls.newStorageBucket}"]`);
-    await click(selectors.SAVE_BTN);
+    await click(commonSelectors.SAVE_BTN);
     await a11yAudit();
 
     assert.dom(selectors.TOAST).hasText('The request was invalid.');

--- a/ui/admin/tests/acceptance/storage-buckets/selectors.js
+++ b/ui/admin/tests/acceptance/storage-buckets/selectors.js
@@ -4,7 +4,6 @@
  */
 
 // START TODO: Remove common selectors from storage-bucket specific selectors
-export const EDIT_BTN = '.rose-form-actions [type=button]';
 export const FIELD_NAME = '[name=name]';
 export const FIELD_NAME_VALUE = 'Random name';
 // END TODO: Remove common selectors from storage-bucket specific selectors

--- a/ui/admin/tests/acceptance/storage-buckets/selectors.js
+++ b/ui/admin/tests/acceptance/storage-buckets/selectors.js
@@ -3,11 +3,6 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-// START TODO: Remove common selectors from storage-bucket specific selectors
-export const FIELD_NAME = '[name=name]';
-export const FIELD_NAME_VALUE = 'Random name';
-// END TODO: Remove common selectors from storage-bucket specific selectors
-
 export const FIELD_SCOPE = '[name=scope]';
 export const FIELD_PLUGIN_TYPE = '[name=plugin_type]';
 export const FIELD_PLUGIN_TYPE_MINIO = '[value=minio]'; // Provider

--- a/ui/admin/tests/acceptance/storage-buckets/selectors.js
+++ b/ui/admin/tests/acceptance/storage-buckets/selectors.js
@@ -4,7 +4,6 @@
  */
 
 // START TODO: Remove common selectors from storage-bucket specific selectors
-export const SAVE_BTN = '[type=submit]';
 export const CANCEL_BTN = '.rose-form-actions [type=button]';
 export const EDIT_BTN = '.rose-form-actions [type=button]';
 export const FIELD_NAME = '[name=name]';

--- a/ui/admin/tests/acceptance/storage-buckets/selectors.js
+++ b/ui/admin/tests/acceptance/storage-buckets/selectors.js
@@ -4,7 +4,6 @@
  */
 
 // START TODO: Remove common selectors from storage-bucket specific selectors
-export const CANCEL_BTN = '.rose-form-actions [type=button]';
 export const EDIT_BTN = '.rose-form-actions [type=button]';
 export const FIELD_NAME = '[name=name]';
 export const FIELD_NAME_VALUE = 'Random name';

--- a/ui/admin/tests/acceptance/storage-buckets/update-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/update-test.js
@@ -73,7 +73,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     await click(`[href="${urls.storageBucket}"]`);
     await click(selectors.EDIT_BTN, 'Click edit mode');
     await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
-    await click(selectors.CANCEL_BTN, 'Click cancel');
+    await click(commonSelectors.CANCEL_BTN, 'Click cancel');
 
     assert.dom(selectors.FIELD_NAME).hasValue(`${name}`);
     assert.strictEqual(instances.storageBucket.name, name);

--- a/ui/admin/tests/acceptance/storage-buckets/update-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/update-test.js
@@ -55,14 +55,16 @@ module('Acceptance | storage-buckets | update', function (hooks) {
 
     await click(`[href="${urls.storageBucket}"]`);
     await click(commonSelectors.EDIT_BTN, 'Click edit mode');
-    await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
+    await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
     await click(commonSelectors.SAVE_BTN, 'Click save');
 
     assert.dom(`[href="${urls.storageBucket}"]`).isVisible();
-    assert.dom(selectors.FIELD_NAME).hasValue(selectors.FIELD_NAME_VALUE);
+    assert
+      .dom(commonSelectors.FIELD_NAME)
+      .hasValue(commonSelectors.FIELD_NAME_VALUE);
     assert.strictEqual(
       instances.storageBucket.name,
-      selectors.FIELD_NAME_VALUE,
+      commonSelectors.FIELD_NAME_VALUE,
     );
   });
 
@@ -72,10 +74,10 @@ module('Acceptance | storage-buckets | update', function (hooks) {
 
     await click(`[href="${urls.storageBucket}"]`);
     await click(commonSelectors.EDIT_BTN, 'Click edit mode');
-    await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
+    await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
     await click(commonSelectors.CANCEL_BTN, 'Click cancel');
 
-    assert.dom(selectors.FIELD_NAME).hasValue(`${name}`);
+    assert.dom(commonSelectors.FIELD_NAME).hasValue(`${name}`);
     assert.strictEqual(instances.storageBucket.name, name);
   });
 

--- a/ui/admin/tests/acceptance/storage-buckets/update-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/update-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as selectors from './selectors';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | storage-buckets | update', function (hooks) {
   setupApplicationTest(hooks);
@@ -55,7 +56,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     await click(`[href="${urls.storageBucket}"]`);
     await click(selectors.EDIT_BTN, 'Click edit mode');
     await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
-    await click(selectors.SAVE_BTN, 'Click save');
+    await click(commonSelectors.SAVE_BTN, 'Click save');
 
     assert.dom(`[href="${urls.storageBucket}"]`).isVisible();
     assert.dom(selectors.FIELD_NAME).hasValue(selectors.FIELD_NAME_VALUE);
@@ -104,7 +105,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     await fillIn(selectors.FIELD_ACCESS_KEY, selectors.FIELD_ACCESS_KEY_VALUE);
     await fillIn(selectors.FIELD_SECRET_KEY, selectors.FIELD_SECRET_KEY_VALUE);
 
-    await click(selectors.SAVE_BTN, 'Click save');
+    await click(commonSelectors.SAVE_BTN, 'Click save');
 
     assert.dom(selectors.FIELD_ACCESS_KEY_EDIT_BTN).isDisabled();
     assert.dom(selectors.FIELD_SECRET_KEY_EDIT_BTN).isDisabled();
@@ -127,7 +128,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     await click(selectors.FIELD_ACCESS_KEY_EDIT_BTN, 'Click cancel button');
     await click(selectors.FIELD_SECRET_KEY_EDIT_BTN, 'Click cancel button');
 
-    await click(selectors.SAVE_BTN, 'Click save');
+    await click(commonSelectors.SAVE_BTN, 'Click save');
 
     assert.dom(selectors.FIELD_ACCESS_KEY_EDIT_BTN).isDisabled();
     assert.dom(selectors.FIELD_SECRET_KEY_EDIT_BTN).isDisabled();
@@ -165,7 +166,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     await click(`[href="${urls.storageBucket}"]`);
     await click(selectors.EDIT_BTN, 'Activate edit mode');
     await fillIn(selectors.FIELD_WORKER_FILTER, 'random string');
-    await click(selectors.SAVE_BTN);
+    await click(commonSelectors.SAVE_BTN);
 
     assert.dom(selectors.TOAST).hasText('The request was invalid.');
     assert

--- a/ui/admin/tests/acceptance/storage-buckets/update-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/update-test.js
@@ -54,7 +54,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     await visit(urls.storageBuckets);
 
     await click(`[href="${urls.storageBucket}"]`);
-    await click(selectors.EDIT_BTN, 'Click edit mode');
+    await click(commonSelectors.EDIT_BTN, 'Click edit mode');
     await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
     await click(commonSelectors.SAVE_BTN, 'Click save');
 
@@ -71,7 +71,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     await visit(urls.storageBuckets);
 
     await click(`[href="${urls.storageBucket}"]`);
-    await click(selectors.EDIT_BTN, 'Click edit mode');
+    await click(commonSelectors.EDIT_BTN, 'Click edit mode');
     await fillIn(selectors.FIELD_NAME, selectors.FIELD_NAME_VALUE);
     await click(commonSelectors.CANCEL_BTN, 'Click cancel');
 
@@ -89,7 +89,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     assert.dom(selectors.FIELD_ACCESS_KEY_EDIT_BTN).isDisabled();
     assert.dom(selectors.FIELD_SECRET_KEY_EDIT_BTN).isDisabled();
 
-    await click(selectors.EDIT_BTN, 'Click edit mode');
+    await click(commonSelectors.EDIT_BTN, 'Click edit mode');
 
     assert.dom(selectors.FIELD_ACCESS_KEY_EDIT_BTN).isEnabled();
     assert.dom(selectors.FIELD_SECRET_KEY_EDIT_BTN).isEnabled();
@@ -118,7 +118,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     await visit(urls.storageBuckets);
 
     await click(`[href="${urls.storageBucket}"]`);
-    await click(selectors.EDIT_BTN, 'Click edit mode');
+    await click(commonSelectors.EDIT_BTN, 'Click edit mode');
     await click(selectors.FIELD_ACCESS_KEY_EDIT_BTN);
     await click(selectors.FIELD_SECRET_KEY_EDIT_BTN);
 
@@ -164,7 +164,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     });
 
     await click(`[href="${urls.storageBucket}"]`);
-    await click(selectors.EDIT_BTN, 'Activate edit mode');
+    await click(commonSelectors.EDIT_BTN, 'Activate edit mode');
     await fillIn(selectors.FIELD_WORKER_FILTER, 'random string');
     await click(commonSelectors.SAVE_BTN);
 
@@ -185,7 +185,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     assert.dom(selectors.FIELD_BUCKET_NAME).isDisabled();
     assert.dom(selectors.FIELD_BUCKET_PREFIX).isDisabled();
 
-    await click(selectors.EDIT_BTN, 'Click edit mode');
+    await click(commonSelectors.EDIT_BTN, 'Click edit mode');
 
     assert.dom(selectors.FIELD_SCOPE).doesNotExist();
     assert.dom(selectors.FIELD_PLUGIN_TYPE).isDisabled();
@@ -204,7 +204,7 @@ module('Acceptance | storage-buckets | update', function (hooks) {
 
     assert.dom(selectors.FIELD_BUCKET_NAME).isDisabled();
 
-    await click(selectors.EDIT_BTN, 'Click edit mode');
+    await click(commonSelectors.EDIT_BTN, 'Click edit mode');
 
     assert.dom(selectors.FIELD_SCOPE).doesNotExist();
     assert.dom(selectors.FIELD_PLUGIN_TYPE).isDisabled();


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
follow up to address TODO from this [PR](https://github.com/hashicorp/boundary-ui/pull/2414)
remove duplicate selectors from storage buckets and use common selectors in their place

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
