### PR TITLE
feat: 🎸 Show cache daemon errors from status

### DIFF
--- a/addons/core/translations/errors/en-us.yaml
+++ b/addons/core/translations/errors/en-us.yaml
@@ -28,4 +28,4 @@ required-field: This is a required field.
 client-agent-failed:
   sessions: Unable to retrieve sessions from the client agent.
 settings-cache:
-  title: There is a problem with the cache daemon
+  title: There may be a problem with the cache daemon

--- a/ui/desktop/app/components/settings-card/application/index.hbs
+++ b/ui/desktop/app/components/settings-card/application/index.hbs
@@ -25,7 +25,7 @@
       <Hds::Text::Display>
         {{t 'settings.cache-daemon'}}
       </Hds::Text::Display>
-      <Hds::Text::Body @tag='p' @weight='medium'>
+      <Hds::Text::Body @tag='p' @weight='medium' data-test-cache-version>
         {{#if @model.formattedCacheVersion}}
           {{@model.formattedCacheVersion}}
           <Hds::Badge
@@ -43,12 +43,19 @@
 
       </Hds::Text::Body>
     </div>
-    {{#if @model.error}}
+    {{#if @model.cacheDaemonErrors}}
       <Hds::Alert @type='inline' @color='warning' as |A|>
         <A.Title>{{t 'errors.settings-cache.title'}}</A.Title>
-        {{#if @model.error.message}}
-          <A.Description>{{@model.error.message}}</A.Description>
-        {{/if}}
+        <A.Description>
+          {{#each @model.cacheDaemonErrors as |error|}}
+            <Hds::Text::Body @tag='p'>
+              {{#if error.name}}
+                <strong>{{error.name}}: </strong>
+              {{/if}}
+              {{error.message}}
+            </Hds::Text::Body>
+          {{/each}}
+        </A.Description>
       </Hds::Alert>
     {{/if}}
 

--- a/ui/desktop/app/routes/scopes/scope/projects/settings/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/settings/index.js
@@ -7,14 +7,17 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class ScopesScopeProjectsSettingsIndexRoute extends Route {
+  // =services
   @service ipc;
+  @service session;
 
+  // =methods
   async model() {
     let cacheDaemonStatus,
       formattedCacheVersion,
       formattedCliVersion,
       formattedDesktopVersion,
-      error;
+      cacheDaemonErrors = [];
 
     const { versionNumber: cliVersion } =
       await this.ipc.invoke('getCliVersion');
@@ -26,16 +29,28 @@ export default class ScopesScopeProjectsSettingsIndexRoute extends Route {
     try {
       cacheDaemonStatus = await this.ipc.invoke('cacheDaemonStatus');
     } catch (e) {
-      error = e;
+      cacheDaemonErrors.push(e);
     }
-    const { version } = cacheDaemonStatus ?? {};
+    const { version, users } = cacheDaemonStatus ?? {};
     formattedCacheVersion = version?.match(/v\d+\.\d+\.\d+/)?.[0];
+
+    // Grab the errors from each resource
+    const userId = this.session.data.authenticated.user_id;
+    const resourceErrors =
+      users
+        ?.find((user) => user.id === userId)
+        ?.resources.filter((resource) => resource?.last_error?.error)
+        ?.map((resource) => ({
+          message: resource.last_error.error,
+          name: resource.name,
+        })) ?? [];
+    cacheDaemonErrors = [...cacheDaemonErrors, ...resourceErrors];
 
     const logLevel = await this.ipc.invoke('getLogLevel');
     const logPath = await this.ipc.invoke('getLogPath');
 
     return {
-      error,
+      cacheDaemonErrors,
       formattedCliVersion,
       formattedCacheVersion,
       formattedDesktopVersion,

--- a/ui/desktop/electron-app/src/utils/generateErrorPromise.js
+++ b/ui/desktop/electron-app/src/utils/generateErrorPromise.js
@@ -12,7 +12,7 @@ const generateErrorPromise = async (stderr) => {
   if (parsedResponse?.status_code) {
     return Promise.reject({
       statusCode: parsedResponse?.status_code,
-      message: parsedResponse?.api_error,
+      ...parsedResponse?.api_error,
     });
   }
 

--- a/ui/desktop/tests/integration/components/settings-card/application-test.js
+++ b/ui/desktop/tests/integration/components/settings-card/application-test.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupIntl } from 'ember-intl/test-support';
+
+const CACHE_DAEMON_VERSION = '[data-test-cache-version]';
+const ERROR_MESSAGES = '.hds-alert__description > p';
+const FIRST_ERROR_MESSAGE = '.hds-alert__description > p:first-child';
+const LAST_ERROR_MESSAGE = '.hds-alert__description > p:last-child';
+
+module('Integration | Component | settings-card/application', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  test('it renders', async function (assert) {
+    this.set('model', {
+      cacheDaemonErrors: [],
+      formattedDesktopVersion: 'v2.0.0',
+      formattedCliVersion: 'v3.0.0',
+      formattedCacheVersion: 'v4.0.0',
+    });
+    this.set('toggleTheme', () => {});
+
+    await render(
+      hbs`<SettingsCard::Application @model={{this.model}} @toggle={{this.toggleTheme}}/>`,
+    );
+
+    assert.dom(this.element).includesText('v2.0.0');
+    assert.dom(this.element).includesText('v3.0.0');
+    assert.dom(this.element).includesText('v4.0.0');
+  });
+
+  test('it renders errors', async function (assert) {
+    this.set('model', {
+      cacheDaemonErrors: [
+        {
+          message: `this is a resolvable alias error`,
+          name: 'resolvable-alias',
+        },
+        {
+          message: `this is a target error`,
+          name: 'target',
+        },
+      ],
+      formattedDesktopVersion: 'v2.0.0',
+      formattedCliVersion: 'v3.0.0',
+      formattedCacheVersion: 'v4.0.0',
+    });
+    this.set('toggleTheme', () => {});
+
+    await render(
+      hbs`<SettingsCard::Application @model={{this.model}} @toggle={{this.toggleTheme}}/>`,
+    );
+
+    assert.dom(ERROR_MESSAGES).isVisible({ count: 2 });
+    assert
+      .dom(FIRST_ERROR_MESSAGE)
+      .hasText('resolvable-alias: this is a resolvable alias error');
+    assert.dom(LAST_ERROR_MESSAGE).hasText('target: this is a target error');
+  });
+
+  test('it indicates when cache daemon is running', async function (assert) {
+    this.set('model', {
+      cacheDaemonErrors: [],
+      formattedDesktopVersion: 'v2.0.0',
+      formattedCliVersion: 'v3.0.0',
+      formattedCacheVersion: 'v4.0.0',
+    });
+    this.set('toggleTheme', () => {});
+
+    await render(
+      hbs`<SettingsCard::Application @model={{this.model}} @toggle={{this.toggleTheme}}/>`,
+    );
+
+    assert.dom(CACHE_DAEMON_VERSION).hasText('v4.0.0 Running');
+
+    this.set('model', {
+      cacheDaemonErrors: [],
+      formattedDesktopVersion: 'v2.0.0',
+      formattedCliVersion: 'v3.0.0',
+      formattedCacheVersion: '',
+    });
+    assert.dom(CACHE_DAEMON_VERSION).hasText('Not Running');
+  });
+});


### PR DESCRIPTION
# Description
Displayed errors from cache daemon status for resources that aren't just from the actual status command erroring out. 


## Screenshots (if appropriate)
<img width="1580" alt="image" src="https://github.com/user-attachments/assets/31d71c30-c49a-4495-941d-3db6e7dab931">


## How to Test
I used an old version of the controller that doesn't support resolvable aliases (0.15.x) version and added enough targets where the initial load times out to generate two errors.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
