### PR TITLE
refactor: 💡 remove route-action usage for session recordings

### DIFF
--- a/ui/admin/app/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index.js
@@ -4,12 +4,23 @@
  */
 
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { loading } from 'ember-loading';
+import { confirm } from 'core/decorators/confirm';
+import { notifySuccess, notifyError } from 'core/decorators/notify';
 import {
   STATE_SESSION_RECORDING_STARTED,
   STATE_SESSION_RECORDING_UNKNOWN,
 } from 'api/models/session-recording';
 
 export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConnectionIndexController extends Controller {
+  // =services
+
+  @service router;
+
+  // =attributes
+
   /**
    * Returns true if the session recording has started
    * but has not started any connections
@@ -32,5 +43,43 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
       this.model?.sessionRecording?.connection_recordings?.length === 0 &&
       this.model?.sessionRecording?.state === STATE_SESSION_RECORDING_UNKNOWN
     );
+  }
+
+  // =actions
+
+  /**
+   * Reapplies storage policy dates to session recording
+   * @param {SessionRecordingModel}
+   */
+  @action
+  @notifyError(({ message }) => message, { catch: true })
+  @notifySuccess(({ end_time }) =>
+    !end_time
+      ? 'resources.policy.messages.later'
+      : 'resources.policy.messages.reapply',
+  )
+  async reapplyStoragePolicy(sessionRecording) {
+    try {
+      await sessionRecording.reapplyStoragePolicy();
+    } catch (e) {
+      await this.router.replaceWith('scopes.scope.session-recordings');
+      this.router.refresh();
+      throw new Error(e);
+    }
+  }
+
+  /**
+   * Deletes the session recording
+   * @param {SessionRecording} recording
+   */
+  @action
+  @loading
+  @confirm('resources.session-recording.questions.delete')
+  @notifyError(({ message }) => message, { catch: true })
+  @notifySuccess('notifications.delete-success')
+  async delete(recording) {
+    await recording.destroyRecord();
+    await this.router.replaceWith('scopes.scope.session-recordings');
+    this.router.refresh();
   }
 }

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index.js
@@ -69,7 +69,7 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
   }
 
   /**
-   * Deletes the session recording
+   * Deletes the session recording.
    * @param {SessionRecording} recording
    */
   @action

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index.js
@@ -23,7 +23,7 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
 
   /**
    * Returns true if the session recording has started
-   * but has not started any connections
+   * but has not started any connections.
    * @type {boolean}
    */
   get isSessionInprogressWithNoConnections() {
@@ -35,7 +35,7 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
 
   /**
    * Returns true if the session recording state is unknown
-   * and has no connections
+   * and has no connections.
    * @type {boolean}
    */
   get isSessionUnknownWithNoConnections() {
@@ -48,7 +48,7 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
   // =actions
 
   /**
-   * Reapplies storage policy dates to session recording
+   * Reapplies storage policy dates to session recording.
    * @param {SessionRecordingModel}
    */
   @action
@@ -77,8 +77,8 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
   @confirm('resources.session-recording.questions.delete')
   @notifyError(({ message }) => message, { catch: true })
   @notifySuccess('notifications.delete-success')
-  async delete(recording) {
-    await recording.destroyRecord();
+  async delete(sessionRecording) {
+    await sessionRecording.destroyRecord();
     await this.router.replaceWith('scopes.scope.session-recordings');
     this.router.refresh();
   }

--- a/ui/admin/app/routes/scopes/scope/session-recordings.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings.js
@@ -6,10 +6,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import orderBy from 'lodash/orderBy';
-import { loading } from 'ember-loading';
-import { confirm } from 'core/decorators/confirm';
-import { action } from '@ember/object';
-import { notifySuccess, notifyError } from 'core/decorators/notify';
 
 export default class ScopesScopeSessionRecordingsRoute extends Route {
   // =services
@@ -71,20 +67,5 @@ export default class ScopesScopeSessionRecordingsRoute extends Route {
         storageBuckets,
       };
     }
-  }
-
-  /**
-   * Deletes the session recording
-   * @param {SessionRecording} recording
-   */
-  @action
-  @loading
-  @confirm('resources.session-recording.questions.delete')
-  @notifyError(({ message }) => message, { catch: true })
-  @notifySuccess('notifications.delete-success')
-  async delete(recording) {
-    await recording.destroyRecord();
-    await this.router.replaceWith('scopes.scope.session-recordings');
-    this.router.refresh();
   }
 }

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection.js
@@ -5,8 +5,6 @@
 
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { action } from '@ember/object';
-import { notifySuccess, notifyError } from 'core/decorators/notify';
 
 export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConnectionRoute extends Route {
   // =services
@@ -49,25 +47,5 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
       sessionRecording,
       storageBucket,
     };
-  }
-  /**
-   * Reapplies storage policy dates to session recording
-   * @param {SessionRecordingModel}
-   */
-  @action
-  @notifyError(({ message }) => message, { catch: true })
-  @notifySuccess(({ end_time }) =>
-    !end_time
-      ? 'resources.policy.messages.later'
-      : 'resources.policy.messages.reapply',
-  )
-  async reapplyStoragepolicy(sessionRecording) {
-    try {
-      await sessionRecording.reapplyStoragePolicy();
-    } catch (e) {
-      await this.router.replaceWith('scopes.scope.session-recordings');
-      this.router.refresh();
-      throw new Error(e);
-    }
   }
 }

--- a/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
@@ -25,10 +25,7 @@
 
         <dd.Interactive
           @text={{t 'resources.policy.actions.update'}}
-          {{on
-            'click'
-            (route-action 'reapplyStoragepolicy' @model.sessionRecording)
-          }}
+          {{on 'click' (fn this.reapplyStoragePolicy @model.sessionRecording)}}
         />
         {{#if (can 'delete session-recording' @model.sessionRecording)}}
           <dd.Separator />
@@ -36,7 +33,7 @@
             data-test-manage-dropdown-delete
             @color='critical'
             @text={{t 'resources.policy.actions.delete_recording'}}
-            {{on 'click' (route-action 'delete' @model.sessionRecording)}}
+            {{on 'click' (fn this.delete @model.sessionRecording)}}
           />
         {{/if}}
       </Hds::Dropdown>

--- a/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { setupTest } from 'admin/tests/helpers';
+import { setupTest } from 'ember-qunit';
 
 module(
   'Unit | Controller | scopes/scope/session-recordings/index',


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-12620

# Description
<!-- Add a brief description of changes here -->
Remove route-action usage for session recordings
<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

https://github.com/user-attachments/assets/6c64a83f-a7e2-4324-afa6-d05fcc8eb84a


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
1. Create a session recording using DC & ssh Target
2. Create a storage policy that allows deletion
3. Apply that storage policy to the global scope
4. Navigate to session-recording
5. Click "Manage" -> "Re-apply storage policy"
6. Card should update with correct time in "Delete after" row
7. Click "Manage" -> "Delete"
8. Session recording should be removed
## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
