### PR TITLE
fix: 🐛 remove connected label

### DIFF
--- a/addons/core/translations/en-us.yaml
+++ b/addons/core/translations/en-us.yaml
@@ -114,7 +114,6 @@ settings:
   provider: Provider
   hcp: HashiCorp Cloud Platform
   self-managed: Self-managed
-  connected: Connected
   server:
     title: Server
     description: Boundary connects you to targets using this server managed by your organization.

--- a/ui/desktop/app/components/settings-card/server/index.hbs
+++ b/ui/desktop/app/components/settings-card/server/index.hbs
@@ -8,15 +8,6 @@
   @icon='cloud'
   @description={{t 'settings.server.description'}}
 >
-  <:state>
-    {{#if @model.serverInformation}}
-      <Hds::Badge
-        @text={{t 'settings.connected'}}
-        @icon='check'
-        @color='success'
-      />
-    {{/if}}
-  </:state>
   <:body>
     <div>
       <Hds::Text::Display>


### PR DESCRIPTION
# Description
This pr removes the `connected` label to avoid confusion when the controller gets disconnected and the page isn't refreshed. see this slack [thread](https://hashicorp.slack.com/archives/C012GTH1C4E/p1724096649298689) 
https://hashicorp.atlassian.net/browse/ICU-14885
## Screenshots (if appropriate)
<img width="973" alt="Screenshot 2024-08-20 at 4 09 24 PM" src="https://github.com/user-attachments/assets/5925a12c-6173-48f9-9f07-377b54c57dc3">


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
