### PR TITLE
refact(e2e): Create HTTP methods and more page objects

### DIFF
--- a/ui/admin/tests/e2e/global-setup.mjs
+++ b/ui/admin/tests/e2e/global-setup.mjs
@@ -6,6 +6,8 @@
 import { chromium } from '@playwright/test';
 import { checkEnv } from './helpers/general.mjs';
 
+import { LoginPage } from './pages/login.mjs';
+
 async function globalSetup() {
   await checkEnv([
     'BOUNDARY_ADDR',
@@ -18,15 +20,12 @@ async function globalSetup() {
   const browser = await chromium.launch();
   const page = await browser.newPage();
   await page.goto(process.env.BOUNDARY_ADDR);
-  await page
-    .getByLabel('Login Name')
-    .fill(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
-  await page
-    .getByLabel('Password', { exact: true })
-    .fill(process.env.E2E_PASSWORD_ADMIN_PASSWORD);
-  await page.getByRole('button', { name: 'Sign In' }).click();
-  await page.getByRole('navigation', { name: 'General' }).waitFor();
-  await page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME).waitFor();
+
+  const loginPage = new LoginPage(page);
+  await loginPage.login(
+    process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+    process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+  );
   const storageState = await page
     .context()
     .storageState({ path: authenticatedState });

--- a/ui/admin/tests/e2e/helpers/boundary-http.mjs
+++ b/ui/admin/tests/e2e/helpers/boundary-http.mjs
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+export * from './boundary-http/scopes.mjs';
+export * from './boundary-http/targets.mjs';

--- a/ui/admin/tests/e2e/helpers/boundary-http/scopes.mjs
+++ b/ui/admin/tests/e2e/helpers/boundary-http/scopes.mjs
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { nanoid } from 'nanoid';
+
+/**
+ * Creates a new org
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @returns {Promise<Serializable>}
+ */
+export async function createOrgHttp(request) {
+  const org = await request.post(`/v1/scopes`, {
+    data: {
+      name: 'Org ' + nanoid(),
+      scope_id: 'global',
+    },
+  });
+  return await org.json();
+}
+
+/**
+ * Creates a new project
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} scopeId ID of the scope where target will be created
+ * @returns {Promise<Serializable>}
+ */
+export async function createProjectHttp(request, scopeId) {
+  const project = await request.post(`/v1/scopes`, {
+    data: {
+      name: 'Project ' + nanoid(),
+      scope_id: scopeId,
+    },
+  });
+  return await project.json();
+}

--- a/ui/admin/tests/e2e/helpers/boundary-http/targets.mjs
+++ b/ui/admin/tests/e2e/helpers/boundary-http/targets.mjs
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { nanoid } from 'nanoid';
+
+/**
+ * Creates a new target
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} scopeId ID of the scope where target will be created
+ * @param {string} type type of the target: 'tcp, 'ssh'
+ * @param {number} port default port of the target
+ * @returns {Promise<Serializable>}
+ */
+export async function createTargetHttp(request, scopeId, type, port) {
+  const target = await request.post(`/v1/targets`, {
+    data: {
+      name: 'Target ' + nanoid(),
+      scope_id: scopeId,
+      type: type,
+      attributes: {
+        default_port: port,
+      },
+    },
+  });
+
+  return await target.json();
+}

--- a/ui/admin/tests/e2e/pages/login.mjs
+++ b/ui/admin/tests/e2e/pages/login.mjs
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { expect } from '@playwright/test';
+
+import { BaseResourcePage } from './base-resource.mjs';
+
+export class LoginPage extends BaseResourcePage {
+  /**
+   * Logs in to the Admin UI
+   * @param {string} loginName Username to log in with
+   * @param {string} password Password to log in with
+   */
+  async login(loginName, password) {
+    await this.page.getByLabel('Login Name').fill(loginName);
+    await this.page.getByLabel('Password', { exact: true }).fill(password);
+    await this.page.getByRole('button', { name: 'Sign In' }).click();
+    await expect(this.page.getByRole('navigation', { name: 'General' })).toBeVisible();
+    await expect(this.page.getByText(loginName),).toBeEnabled();
+  }
+
+  /**
+   * Logs out of the Admin UI
+   * @param {string} loginName Username to log out
+   */
+  async logout(loginName) {
+    await this.page.getByText(loginName).click();
+    await this.page.getByRole('button', { name: 'Sign Out' }).click();
+    await expect(this.page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+  }
+}

--- a/ui/admin/tests/e2e/pages/roles.mjs
+++ b/ui/admin/tests/e2e/pages/roles.mjs
@@ -63,10 +63,7 @@ export class RolesPage extends BaseResourcePage {
     await this.page.getByRole('textbox', { name: 'New Grant' }).fill(grants);
     await this.page.getByRole('button', { name: 'Add', exact: true }).click();
     await this.page.getByRole('button', { name: 'Save', exact: true }).click();
-    await expect(
-      this.page.getByRole('alert').getByText('Success', { exact: true }),
-    ).toBeVisible();
-    await this.page.getByRole('button', { name: 'Dismiss' }).click();
+    await this.dismissSuccessAlert();
     await expect(
       this.page.getByRole('textbox', { name: 'Grant', exact: true }),
     ).toHaveValue(grants);

--- a/ui/admin/tests/e2e/pages/session-recordings.mjs
+++ b/ui/admin/tests/e2e/pages/session-recordings.mjs
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { BaseResourcePage } from './base-resource.mjs';
+
+export class SessionRecordingsPage extends BaseResourcePage {
+  async deleteResource() {
+    await this.page.getByText('Manage').click();
+    await this.page.getByRole('button', { name: 'Delete recording' }).click();
+    await this.page.getByText('OK', { exact: true }).click();
+    await this.dismissSuccessAlert();
+  }
+
+  /**
+   * Reapplies a storage policy to a session recording
+   */
+  async reapplyStoragePolicy() {
+    await this.page.getByText('Manage').click();
+    await this.page.getByRole('button', { name: 'Re-apply storage policy' }).click();
+    await this.dismissSuccessAlert();
+  }
+}

--- a/ui/admin/tests/e2e/pages/targets.mjs
+++ b/ui/admin/tests/e2e/pages/targets.mjs
@@ -276,6 +276,18 @@ export class TargetsPage extends BaseResourcePage {
     ).toBeVisible();
   }
 
+  async removeHostSourceFromTarget(hostSourceName) {
+    await this.page
+      .getByRole('link', { name: hostSourceName })
+      .locator('..')
+      .locator('..')
+      .getByRole('button', { name: 'Manage' })
+      .click();
+    await this.page.getByRole('button', { name: 'Remove' }).click();
+    await this.page.getByRole('button', { name: 'OK', exact: true }).click();
+    await this.dismissSuccessAlert();
+  }
+
   /**
    * Adds an egress worker filter to a target. Assume you have selected the desired target.
    * @param {string} filter Egress worker filter to be added to the target
@@ -440,5 +452,17 @@ export class TargetsPage extends BaseResourcePage {
     await expect(
       this.page.getByRole('listitem').getByText(storageBucketName),
     ).toBeVisible();
+  }
+
+  /**
+   * Detaches storage bucket from target. Assumes you have selected the desired target.
+   */
+  async detachStorageBucket() {
+    await this.page
+      .getByRole('link', { name: 'Session Recording settings' })
+      .click();
+    await this.page.getByLabel('Record sessions for this target').uncheck();
+    await this.page.getByRole('button', { name: 'Save' }).click();
+    await this.dismissSuccessAlert();
   }
 }

--- a/ui/admin/tests/e2e/tests/auth-method-ldap.spec.mjs
+++ b/ui/admin/tests/e2e/tests/auth-method-ldap.spec.mjs
@@ -14,6 +14,7 @@ import {
   getOrgIdFromNameCli,
 } from '../helpers/boundary-cli.mjs';
 import { AuthMethodsPage } from '../pages/auth-methods.mjs';
+import { LoginPage } from '../pages/login.mjs';
 import { OrgsPage } from '../pages/orgs.mjs';
 import { RolesPage } from '../pages/roles.mjs';
 import { UsersPage } from '../pages/users.mjs';
@@ -37,19 +38,11 @@ test('Set up LDAP auth method @ce @ent @docker', async ({ page }) => {
   let orgName;
   try {
     // Log in
-    await page
-      .getByLabel('Login Name')
-      .fill(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
-    await page
-      .getByLabel('Password', { exact: true })
-      .fill(process.env.E2E_PASSWORD_ADMIN_PASSWORD);
-    await page.getByRole('button', { name: 'Sign In' }).click();
-    await expect(
-      page.getByRole('navigation', { name: 'General' }),
-    ).toBeVisible();
-    await expect(
-      page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME),
-    ).toBeEnabled();
+    const loginPage = new LoginPage(page);
+    await loginPage.login(
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     await expect(
       page.getByRole('navigation', { name: 'breadcrumbs' }).getByText('Orgs'),
     ).toBeVisible();
@@ -178,49 +171,28 @@ test('Set up LDAP auth method @ce @ent @docker', async ({ page }) => {
     const authMethodsPage = new AuthMethodsPage(page);
     await authMethodsPage.createPasswordAuthMethod();
 
-    // Log out
-    await page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME).click();
-    await page.getByRole('button', { name: 'Sign Out' }).click();
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
-
     // Log in using ldap account
+    await loginPage.logout(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
+
     await page.getByText('Choose a different scope').click();
     await page.getByRole('link', { name: orgName }).click();
     await page.getByRole('link', { name: ldapAuthMethodName }).click();
-    await page.getByLabel('Login Name').fill(process.env.E2E_LDAP_USER_NAME);
-    await page
-      .getByLabel('Password', { exact: true })
-      .fill(process.env.E2E_LDAP_USER_PASSWORD);
-    await page.getByRole('button', { name: 'Sign In' }).click();
-    await expect(
-      page.getByRole('navigation', { name: 'General' }),
-    ).toBeVisible();
-    await expect(page.getByText(process.env.E2E_LDAP_USER_NAME)).toBeEnabled();
+    await loginPage.login(
+      process.env.E2E_LDAP_USER_NAME,
+      process.env.E2E_LDAP_USER_PASSWORD,
+    );
     await expect(
       page
         .getByRole('navigation', { name: 'breadcrumbs' })
         .getByText('Projects'),
     ).toBeVisible();
 
-    // Log out
-    await page.getByText(process.env.E2E_LDAP_USER_NAME).click();
-    await page.getByRole('button', { name: 'Sign Out' }).click();
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
-
     // Log back in as an admin
-    await page
-      .getByLabel('Login Name')
-      .fill(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
-    await page
-      .getByLabel('Password', { exact: true })
-      .fill(process.env.E2E_PASSWORD_ADMIN_PASSWORD);
-    await page.getByRole('button', { name: 'Sign In' }).click();
-    await expect(
-      page.getByRole('navigation', { name: 'General' }),
-    ).toBeVisible();
-    await expect(
-      page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME),
-    ).toBeEnabled();
+    await loginPage.logout(process.env.E2E_LDAP_USER_NAME);
+    await loginPage.login(
+      process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+      process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+    );
     await expect(
       page.getByRole('navigation', { name: 'breadcrumbs' }).getByText('Orgs'),
     ).toBeVisible();

--- a/ui/admin/tests/e2e/tests/login.spec.mjs
+++ b/ui/admin/tests/e2e/tests/login.spec.mjs
@@ -5,43 +5,35 @@
 
 import { test, expect } from '@playwright/test';
 
+import { LoginPage } from '../pages/login.mjs';
+
 test('Log in, log out, and then log back in @ce @ent @aws @docker', async ({
   page,
 }) => {
   await page.goto('/');
 
   // Log in
-  await page
-    .getByLabel('Login Name')
-    .fill(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
-  await page
-    .getByLabel('Password', { exact: true })
-    .fill(process.env.E2E_PASSWORD_ADMIN_PASSWORD);
-  await page.getByRole('button', { name: 'Sign In' }).click();
-  await expect(page.getByRole('navigation', { name: 'General' })).toBeVisible();
-  await expect(
-    page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME),
-  ).toBeEnabled();
+  const loginPage = new LoginPage(page);
+  await loginPage.login(
+    process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+    process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+  );
   await expect(
     page.getByRole('navigation', { name: 'breadcrumbs' }).getByText('Orgs'),
   ).toBeVisible();
 
   // Log out
-  await page.getByText(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME).click();
-  await page.getByRole('button', { name: 'Sign Out' }).click();
-  await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
-
+  await loginPage.logout(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
   await page.reload();
 
   // Log back in
-  await page
-    .getByLabel('Login Name')
-    .fill(process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME);
-  await page
-    .getByLabel('Password', { exact: true })
-    .fill(process.env.E2E_PASSWORD_ADMIN_PASSWORD);
-  await page.getByRole('button', { name: 'Sign In' }).click();
-  await expect(page.getByRole('navigation', { name: 'General' })).toBeVisible();
+  await loginPage.login(
+    process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+    process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+  );
+  await expect(
+    page.getByRole('navigation', { name: 'breadcrumbs' }).getByText('Orgs'),
+  ).toBeVisible();
 });
 
 test.describe('Failure Cases', async () => {

--- a/ui/admin/tests/e2e/tests/pagination.spec.mjs
+++ b/ui/admin/tests/e2e/tests/pagination.spec.mjs
@@ -4,9 +4,13 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { nanoid } from 'nanoid';
 
 import { authenticatedState } from '../global-setup.mjs';
+import {
+  createOrgHttp,
+  createProjectHttp,
+  createTargetHttp,
+} from '../helpers/boundary-http.mjs';
 
 test.use({ storageState: authenticatedState });
 
@@ -16,38 +20,15 @@ test('Search and Pagination (Targets) @ce @ent @aws @docker', async ({
 }) => {
   let org;
   try {
-    const newOrg = await request.post(`/v1/scopes`, {
-      data: {
-        name: 'Org ' + nanoid(),
-        scope_id: 'global',
-      },
-    });
-    org = await newOrg.json();
-
-    const newProject = await request.post(`/v1/scopes`, {
-      data: {
-        name: 'Project ' + nanoid(),
-        scope_id: org.id,
-      },
-    });
-    const project = await newProject.json();
+    org = await createOrgHttp(request);
+    const project = await createProjectHttp(request, org.id);
 
     // Create targets
     let targets = [];
     const targetCount = 15;
     for (let i = 0; i < targetCount; i++) {
-      const newTarget = await request.post(`/v1/targets`, {
-        data: {
-          name: 'Target ' + nanoid(),
-          scope_id: project.id,
-          type: 'tcp',
-          attributes: {
-            default_port: 22,
-          },
-        },
-      });
-
-      targets.push(await newTarget.json());
+      const target = await createTargetHttp(request, project.id, 'tcp', 22);
+      targets.push(target);
     }
 
     // Navigate to targets page

--- a/ui/admin/tests/e2e/tests/session-recording-aws-ent.spec.mjs
+++ b/ui/admin/tests/e2e/tests/session-recording-aws-ent.spec.mjs
@@ -24,6 +24,7 @@ import {
 import { CredentialStoresPage } from '../pages/credential-stores.mjs';
 import { OrgsPage } from '../pages/orgs.mjs';
 import { ProjectsPage } from '../pages/projects.mjs';
+import { SessionRecordingsPage } from '../pages/session-recordings.mjs';
 import { SessionsPage } from '../pages/sessions.mjs';
 import { StorageBucketsPage } from '../pages/storage-buckets.mjs';
 import { StoragePoliciesPage } from '../pages/storage-policies.mjs';
@@ -208,7 +209,7 @@ test('Session Recording Test (AWS) @ent @aws', async ({ page }) => {
     // temporary workaround.
     await page.reload();
 
-    // Re-apply storage policy to the session recording
+    // Re-apply storage policy to the session recording and delete
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
     await page
       .getByRole('link', { name: 'Session Recordings', exact: true })
@@ -217,21 +218,9 @@ test('Session Recording Test (AWS) @ent @aws', async ({ page }) => {
       .getByRole('row', { name: targetName })
       .getByRole('link', { name: 'View' })
       .click();
-    await page.getByText('Manage').click();
-    await page.getByRole('button', { name: 'Re-apply storage policy' }).click();
-    await expect(
-      page.getByRole('alert').getByText('Success', { exact: true }),
-    ).toBeVisible();
-    await page.getByRole('button', { name: 'Dismiss' }).click();
-
-    // Delete session recording
-    await page.getByText('Manage').click();
-    await page.getByRole('button', { name: 'Delete recording' }).click();
-    await page.getByRole('button', { name: 'OK', exact: true }).click();
-    await expect(
-      page.getByRole('alert').getByText('Success', { exact: true }),
-    ).toBeVisible();
-    await page.getByRole('button', { name: 'Dismiss' }).click();
+    const sessionRecordingsPage = new SessionRecordingsPage(page);
+    await sessionRecordingsPage.reapplyStoragePolicy();
+    await sessionRecordingsPage.deleteResource();
 
     // Detach storage bucket from target
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
@@ -240,15 +229,7 @@ test('Session Recording Test (AWS) @ent @aws', async ({ page }) => {
     await page.getByRole('link', { name: projectName }).click();
     await page.getByRole('link', { name: 'Targets', exact: true }).click();
     await page.getByRole('link', { name: targetName }).click();
-    await page
-      .getByRole('link', { name: 'Session Recording settings' })
-      .click();
-    await page.getByLabel('Record sessions for this target').uncheck();
-    await page.getByRole('button', { name: 'Save' }).click();
-    await expect(
-      page.getByRole('alert').getByText('Success', { exact: true }),
-    ).toBeVisible();
-    await page.getByRole('button', { name: 'Dismiss' }).click();
+    await targetsPage.detachStorageBucket();
   } finally {
     if (policyName) {
       const storagePolicyId = await getPolicyIdFromNameCli(orgId, policyName);

--- a/ui/admin/tests/e2e/tests/session-recording-minio-ent.spec.mjs
+++ b/ui/admin/tests/e2e/tests/session-recording-minio-ent.spec.mjs
@@ -24,6 +24,7 @@ import {
 import { CredentialStoresPage } from '../pages/credential-stores.mjs';
 import { OrgsPage } from '../pages/orgs.mjs';
 import { ProjectsPage } from '../pages/projects.mjs';
+import { SessionRecordingsPage } from '../pages/session-recordings.mjs';
 import { SessionsPage } from '../pages/sessions.mjs';
 import { StorageBucketsPage } from '../pages/storage-buckets.mjs';
 import { StoragePoliciesPage } from '../pages/storage-policies.mjs';
@@ -211,7 +212,7 @@ test('Session Recording Test (MinIO) @ent @docker', async ({ page }) => {
     // temporary workaround.
     await page.reload();
 
-    // Re-apply storage policy to the session recording
+    // Re-apply storage policy to the session recording and delete
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
     await page
       .getByRole('link', { name: 'Session Recordings', exact: true })
@@ -220,21 +221,9 @@ test('Session Recording Test (MinIO) @ent @docker', async ({ page }) => {
       .getByRole('row', { name: targetName })
       .getByRole('link', { name: 'View' })
       .click();
-    await page.getByText('Manage').click();
-    await page.getByRole('button', { name: 'Re-apply storage policy' }).click();
-    await expect(
-      page.getByRole('alert').getByText('Success', { exact: true }),
-    ).toBeVisible();
-    await page.getByRole('button', { name: 'Dismiss' }).click();
-
-    // Delete session recording
-    await page.getByText('Manage').click();
-    await page.getByRole('button', { name: 'Delete recording' }).click();
-    await page.getByRole('button', { name: 'OK', exact: true }).click();
-    await expect(
-      page.getByRole('alert').getByText('Success', { exact: true }),
-    ).toBeVisible();
-    await page.getByRole('button', { name: 'Dismiss' }).click();
+    const sessionRecordingsPage = new SessionRecordingsPage(page);
+    await sessionRecordingsPage.reapplyStoragePolicy();
+    await sessionRecordingsPage.deleteResource();
 
     // Detach storage bucket from target
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
@@ -243,15 +232,7 @@ test('Session Recording Test (MinIO) @ent @docker', async ({ page }) => {
     await page.getByRole('link', { name: projectName }).click();
     await page.getByRole('link', { name: 'Targets', exact: true }).click();
     await page.getByRole('link', { name: targetName }).click();
-    await page
-      .getByRole('link', { name: 'Session Recording settings' })
-      .click();
-    await page.getByLabel('Record sessions for this target').uncheck();
-    await page.getByRole('button', { name: 'Save' }).click();
-    await expect(
-      page.getByRole('alert').getByText('Success', { exact: true }),
-    ).toBeVisible();
-    await page.getByRole('button', { name: 'Dismiss' }).click();
+    await targetsPage.detachStorageBucket();
   } finally {
     if (policyName) {
       const storagePolicyId = await getPolicyIdFromNameCli(orgId, policyName);

--- a/ui/admin/tests/e2e/tests/target.spec.mjs
+++ b/ui/admin/tests/e2e/tests/target.spec.mjs
@@ -70,18 +70,7 @@ test('Verify session created to target with host, then cancel the session @ce @a
 
     // Add/Remove another host source
     await targetsPage.addHostSourceToTarget(hostSetName2);
-    await page
-      .getByRole('link', { name: hostSetName2 })
-      .locator('..')
-      .locator('..')
-      .getByRole('button', { name: 'Manage' })
-      .click();
-    await page.getByRole('button', { name: 'Remove' }).click();
-    await page.getByRole('button', { name: 'OK', exact: true }).click();
-    await expect(
-      page.getByRole('alert').getByText('Success', { exact: true }),
-    ).toBeVisible();
-    await page.getByRole('button', { name: 'Dismiss' }).click();
+    await targetsPage.removeHostSourceFromTarget(hostSetName2);
 
     // Connect to target
     await authenticateBoundaryCli(


### PR DESCRIPTION
This PR has some additional refactoring of the Admin UI e2e test suite
- HTTP API requests were moved to helper methods. The plan is for these methods to be shared with the Desktop e2e test suite
- Some additional page object methods were created

https://hashicorp.atlassian.net/browse/ICU-14776