### PR TITLE
Add CLI_SETUP and delete BYPASS_CLI_BUILD

### DIFF
--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -83,12 +83,12 @@ To run as a desktop app:
 
 - `yarn start:desktop`
 
-The Boundary CLI is NOT downloaded by default, to download and extract the CLI to `electron-app/cli` folder as part of the build, you need to set environment variable `CLI_SETUP` to true. Example: `CLI_SETUP=true yarn start:desktop`.
-CLI version is defined in `electron-app/config.cli.js`.
+The Boundary CLI is NOT downloaded by default, to download and extract the CLI to `electron-app/cli` folder as part of the build, you need to set the environment variable `CLI_SETUP` to true. Example: `CLI_SETUP=true yarn start:desktop`.
+The CLI version is defined in `electron-app/config/cli/VERSION`.
 
 ### Developing Using Non-Release Versions of Boundary
 
-To develop using a non-release version of Boundary, download the Boundary CLI version you want to use and extract it at `electron-app/cli` folder. You may need to create the directory or to cleaning it up beforehand.
+To develop using a non-release version of Boundary, download the Boundary CLI version you want to use and extract it to the `electron-app/cli` folder. You may need to create the directory or clean it up beforehand.
 
 ### Environment Variables (DEV)
 

--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -83,7 +83,7 @@ To run as a desktop app:
 
 - `yarn start:desktop`
 
-The Boundary CLI is NOT downloaded by default, to download and extract the CLI to `electron-app/cli` folder as part of the build, you need to set the environment variable `CLI_SETUP` to true. Example: `CLI_SETUP=true yarn start:desktop`.
+The Boundary CLI is NOT downloaded by default, to download and extract the CLI to `electron-app/cli` folder as part of the build, you need to set the environment variable `SETUP_CLI` to true. Example: `SETUP_CLI=true yarn start:desktop`.
 The CLI version is defined in `electron-app/config/cli/VERSION`.
 
 ### Developing Using Non-Release Versions of Boundary
@@ -100,7 +100,7 @@ These environment variables may be used to customized the build.
 | `APP_UPDATER_CURRENT_VERSION` | Version of client. |
 | `APP_UPDATER_LATEST_VERSION_TAG` | Next version for comparison with current version. |
 | `APP_UPDATER_LATEST_VERSION_LOCATION` | Location of app release to use for updating client. Can be a filepath or url. |
-| `CLI_SETUP` | Enable download and extraction of CLI. For development use only. |
+| `SETUP_CLI` | Enable download and extraction of CLI. |
 | `BYPASS_APP_UPDATER` | Disable app updater feature. For development use only. |
 | `DISABLE_WINDOW_CHROME` | Disable window chrome. For internal use only. |
 | `ENABLE_MIRAGE` | Enable (`true`) or disable (`false`) mirage. Default value is `true`. |
@@ -144,7 +144,7 @@ These environment variables may be used to customized the build.
 | -------- | ------------- | ----------- |
 | `APP_NAME` | Application Name | The user-facing name of the application, appearing in titles, etc. |
 | `BOUNDARY_DESKTOP_SIGNING_IDENTITY` | | The name of the certificate to use when signing (e.g. Developer ID Application: \* (*)). |
-| `BYPASS_CLI_SETUP` | Set to `true` to launch without bootstrapping the CLI (see above). ||
+| `SETUP_CLI` | Enable download and extraction of CLI. |
 
 ### Running Tests
 

--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -83,18 +83,12 @@ To run as a desktop app:
 
 - `yarn start:desktop`
 
-The Boundary CLI is downloaded and extracted to `electron-app/cli/` folder as part of
-build. CLI version is defined in `electron-app/config/cli.js`.
+The Boundary CLI is NOT downloaded by default, to download and extract the CLI to `electron-app/cli` folder as part of the build, you need to set environment variable `CLI_SETUP` to true. Example: `CLI_SETUP=true yarn start:desktop`.
+CLI version is defined in `electron-app/config.cli.js`.
 
 ### Developing Using Non-Release Versions of Boundary
 
-You can also develop using a non-release version of Boundary - bypassing the
-above CLI download behavior - by manually placing the version of Boundary that
-you want to develop with in the `electron-app/cli/` directly (you may need to
-create the directory).
-
-After doing this, run yarn with `BYPASS_CLI_SETUP=true`; example:
-`BYPASS_CLI_SETUP=true yarn start:desktop`.
+To develop using a non-release version of Boundary, download the Boundary CLI version you want to use and extract it at `electron-app/cli` folder. You may need to create the directory or to cleaning it up beforehand.
 
 ### Environment Variables (DEV)
 
@@ -106,7 +100,7 @@ These environment variables may be used to customized the build.
 | `APP_UPDATER_CURRENT_VERSION` | Version of client. |
 | `APP_UPDATER_LATEST_VERSION_TAG` | Next version for comparison with current version. |
 | `APP_UPDATER_LATEST_VERSION_LOCATION` | Location of app release to use for updating client. Can be a filepath or url. |
-| `BYPASS_CLI_SETUP` | Disable download and extraction of cli. For development use only. |
+| `CLI_SETUP` | Enable download and extraction of CLI. For development use only. |
 | `BYPASS_APP_UPDATER` | Disable app updater feature. For development use only. |
 | `DISABLE_WINDOW_CHROME` | Disable window chrome. For internal use only. |
 | `ENABLE_MIRAGE` | Enable (`true`) or disable (`false`) mirage. Default value is `true`. |

--- a/ui/desktop/electron-app/config/cli.js
+++ b/ui/desktop/electron-app/config/cli.js
@@ -95,7 +95,7 @@ const extract = async (artifactPath, destination) => {
 
 module.exports = {
   setup: async () => {
-    if (process.env.CLI_SETUP) {
+    if (process.env.CLI_SETUP === 'true') {
       try {
         const artifactVersion = await fs.promises.readFile(
           path.resolve(__dirname, 'cli', 'VERSION'),

--- a/ui/desktop/electron-app/config/cli.js
+++ b/ui/desktop/electron-app/config/cli.js
@@ -95,20 +95,20 @@ const extract = async (artifactPath, destination) => {
 
 module.exports = {
   setup: async () => {
-    if (process.env.BYPASS_CLI_SETUP) {
+    if (process.env.CLI_SETUP) {
+      try {
+        const artifactVersion = await fs.promises.readFile(
+          path.resolve(__dirname, 'cli', 'VERSION'),
+          'utf8',
+        );
+        const artifactPath = await downloadArtifact(artifactVersion.trim());
+        await extract(artifactPath, artifactDestination);
+      } catch (e) {
+        console.error('ERROR: Failed setting up CLI.', e);
+        process.exit(1);
+      }
+    } else {
       console.warn('WARNING: Bypassing cli setup');
-      return;
-    }
-    try {
-      const artifactVersion = await fs.promises.readFile(
-        path.resolve(__dirname, 'cli', 'VERSION'),
-        'utf8',
-      );
-      const artifactPath = await downloadArtifact(artifactVersion.trim());
-      await extract(artifactPath, artifactDestination);
-    } catch (e) {
-      console.error('ERROR: Failed setting up CLI.', e);
-      process.exit(1);
     }
   },
 };

--- a/ui/desktop/electron-app/config/cli.js
+++ b/ui/desktop/electron-app/config/cli.js
@@ -95,7 +95,7 @@ const extract = async (artifactPath, destination) => {
 
 module.exports = {
   setup: async () => {
-    if (process.env.CLI_SETUP === 'true') {
+    if (process.env.SETUP_CLI === 'true') {
       try {
         const artifactVersion = await fs.promises.readFile(
           path.resolve(__dirname, 'cli', 'VERSION'),


### PR DESCRIPTION
# Description

Add CLI_SETUP and delete BYPASS_CLI_BUILD.

Note: This PR needs to be sync [with a counterpart within boundary-ui-releases](https://github.com/hashicorp/boundary-ui-releases/pull/107), since the BYPASS_CLI_BUILD is use there.

Note 2: This is merging to a LLB which will contain all the changes to achieve Desktop Client with no CLI

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-14904)

## How to Test
- Navigate to `electron-app/cli` and clean up the directory.
- Run `SETUP_CLI=true`
- Desktop client should download the CLI and start.
- To validate CLI has been downloaded, navigate to `electron-app/cli` and confirm the CLI is present.
- Run `yarn start:desktop`, in the terminal you should see a warning: `WARNING: Bypassing cli setup`.
- Desktop client should start no problem.
