### PR TITLE
fix: 🐛 pass current url to maintain session

### DIFF
--- a/ui/desktop/app/components/settings-card/client-agent/index.js
+++ b/ui/desktop/app/components/settings-card/client-agent/index.js
@@ -63,6 +63,6 @@ export default class SettingsCardClientAgentComponent extends Component {
     } else {
       await this.ipc.invoke('resumeClientAgent');
     }
-    await this.router.refresh();
+    await this.router.refresh('scopes.scope.projects.settings');
   }
 }


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-14963

# Description

The pr fixes session getting unauthorized on the route refresh, I noticed the session data becomes empty during the application route's beforemodel [hook](https://github.com/hashicorp/boundary-ui/blob/0cfa814cdd05e7ca83d05179d601887d4bcf9610/ui/desktop/app/initializers/cluster-url.js#L20) when an HCP cluster URL is used, causing an abrupt logout. 

Passing in the full route name fixes the issue. 

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)




https://github.com/user-attachments/assets/cd66f581-da98-4cc9-b477-f60edc3fd20d



## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
[Use the 0.20.0 installer](https://github.com/hashicorp/boundary-installer/actions/runs/10635747837). It contains DC 2.2.0-beta.ts.1, which has 0.17.0 CLI.

Open DC and connect to an HCP cluster. [let me know if you need one to test]

Wait until targets load.

Navigate to the settings page.

Click on the`pause` button,  it should say paused. 

Once paused, clicking on `resume` btn should not throw an error, you should be able to stay on the same page and perform other actions

 
## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
