### PR TITLE
feat: 🎸 Hide daemon errors initially

### DIFF
--- a/addons/core/translations/actions/en-us.yaml
+++ b/addons/core/translations/actions/en-us.yaml
@@ -62,3 +62,5 @@ yes: Yes
 no: No
 narrow-results: Narrow results
 overflow-options: Overflow Options
+show-errors: Show Errors
+hide-errors: Hide Errors

--- a/ui/desktop/app/components/settings-card/application/index.hbs
+++ b/ui/desktop/app/components/settings-card/application/index.hbs
@@ -44,13 +44,13 @@
       </Hds::Text::Body>
     </div>
     {{#if @model.cacheDaemonStatus.errors}}
-      <Hds::Reveal
-        @text={{t 'actions.show-errors'}}
-        @textWhenOpen={{t 'actions.hide-errors'}}
-      >
-        <Hds::Alert @type='inline' @color='warning' as |A|>
-          <A.Title>{{t 'settings.alerts.cache-daemon'}}</A.Title>
-          <A.Description>
+      <Hds::Alert @type='inline' @color='warning' as |A|>
+        <A.Title>{{t 'settings.alerts.cache-daemon'}}</A.Title>
+        <A.Description>
+          <Hds::Reveal
+            @text={{t 'actions.show-errors'}}
+            @textWhenOpen={{t 'actions.hide-errors'}}
+          >
             {{#each @model.cacheDaemonStatus.errors as |error|}}
               <Hds::Text::Body @tag='p'>
                 {{#if error.name}}
@@ -59,9 +59,9 @@
                 {{error.message}}
               </Hds::Text::Body>
             {{/each}}
-          </A.Description>
-        </Hds::Alert>
-      </Hds::Reveal>
+          </Hds::Reveal>
+        </A.Description>
+      </Hds::Alert>
     {{/if}}
 
     <Hds::Form::Select::Field

--- a/ui/desktop/app/components/settings-card/application/index.hbs
+++ b/ui/desktop/app/components/settings-card/application/index.hbs
@@ -44,19 +44,24 @@
       </Hds::Text::Body>
     </div>
     {{#if @model.cacheDaemonStatus.errors}}
-      <Hds::Alert @type='inline' @color='warning' as |A|>
-        <A.Title>{{t 'settings.alerts.cache-daemon'}}</A.Title>
-        <A.Description>
-          {{#each @model.cacheDaemonStatus.errors as |error|}}
-            <Hds::Text::Body @tag='p'>
-              {{#if error.name}}
-                <strong>{{error.name}}: </strong>
-              {{/if}}
-              {{error.message}}
-            </Hds::Text::Body>
-          {{/each}}
-        </A.Description>
-      </Hds::Alert>
+      <Hds::Reveal
+        @text={{t 'actions.show-errors'}}
+        @textWhenOpen={{t 'actions.hide-errors'}}
+      >
+        <Hds::Alert @type='inline' @color='warning' as |A|>
+          <A.Title>{{t 'settings.alerts.cache-daemon'}}</A.Title>
+          <A.Description>
+            {{#each @model.cacheDaemonStatus.errors as |error|}}
+              <Hds::Text::Body @tag='p'>
+                {{#if error.name}}
+                  <strong>{{error.name}}: </strong>
+                {{/if}}
+                {{error.message}}
+              </Hds::Text::Body>
+            {{/each}}
+          </A.Description>
+        </Hds::Alert>
+      </Hds::Reveal>
     {{/if}}
 
     <Hds::Form::Select::Field

--- a/ui/desktop/app/components/settings-card/client-agent/index.hbs
+++ b/ui/desktop/app/components/settings-card/client-agent/index.hbs
@@ -34,21 +34,21 @@
         </Hds::Text::Body>
       </div>
       {{#if @model.clientAgentStatus.errors}}
-        <Hds::Reveal
-          @text={{t 'actions.show-errors'}}
-          @textWhenOpen={{t 'actions.hide-errors'}}
-        >
-          <Hds::Alert @type='inline' @color='warning' as |A|>
-            <A.Title>{{t 'settings.alerts.client-agent'}}</A.Title>
-            <A.Description>
+        <Hds::Alert @type='inline' @color='warning' as |A|>
+          <A.Title>{{t 'settings.alerts.client-agent'}}</A.Title>
+          <A.Description>
+            <Hds::Reveal
+              @text={{t 'actions.show-errors'}}
+              @textWhenOpen={{t 'actions.hide-errors'}}
+            >
               {{#each @model.clientAgentStatus.errors as |error|}}
                 <Hds::Text::Body @tag='p'>
                   {{error.message}}
                 </Hds::Text::Body>
               {{/each}}
-            </A.Description>
-          </Hds::Alert>
-        </Hds::Reveal>
+            </Hds::Reveal>
+          </A.Description>
+        </Hds::Alert>
       {{/if}}
 
     </:body>

--- a/ui/desktop/app/components/settings-card/client-agent/index.hbs
+++ b/ui/desktop/app/components/settings-card/client-agent/index.hbs
@@ -34,16 +34,21 @@
         </Hds::Text::Body>
       </div>
       {{#if @model.clientAgentStatus.errors}}
-        <Hds::Alert @type='inline' @color='warning' as |A|>
-          <A.Title>{{t 'settings.alerts.client-agent'}}</A.Title>
-          <A.Description>
-            {{#each @model.clientAgentStatus.errors as |error|}}
-              <Hds::Text::Body @tag='p'>
-                {{error.message}}
-              </Hds::Text::Body>
-            {{/each}}
-          </A.Description>
-        </Hds::Alert>
+        <Hds::Reveal
+          @text={{t 'actions.show-errors'}}
+          @textWhenOpen={{t 'actions.hide-errors'}}
+        >
+          <Hds::Alert @type='inline' @color='warning' as |A|>
+            <A.Title>{{t 'settings.alerts.client-agent'}}</A.Title>
+            <A.Description>
+              {{#each @model.clientAgentStatus.errors as |error|}}
+                <Hds::Text::Body @tag='p'>
+                  {{error.message}}
+                </Hds::Text::Body>
+              {{/each}}
+            </A.Description>
+          </Hds::Alert>
+        </Hds::Reveal>
       {{/if}}
 
     </:body>

--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -698,7 +698,7 @@ $chevron-down: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%231
       flex-grow: 1;
     }
 
-    .hds-reveal {
+    .hds-alert {
       flex-basis: 100%;
     }
   }

--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -698,7 +698,7 @@ $chevron-down: url("data:image/svg+xml;utf-8,<svg viewBox='0 0 24 24' fill='%231
       flex-grow: 1;
     }
 
-    .hds-alert {
+    .hds-reveal {
       flex-basis: 100%;
     }
   }

--- a/ui/desktop/app/templates/scopes/scope/projects/settings/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/settings/index.hbs
@@ -3,8 +3,8 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<SettingsCard::Application @model={{@model}} @toggle={{this.toggleTheme}} />
-<SettingsCard::ClientAgent @model={{@model}} />
 <SettingsCard::User />
 <SettingsCard::Server @model={{@model}} />
+<SettingsCard::Application @model={{@model}} @toggle={{this.toggleTheme}} />
+<SettingsCard::ClientAgent @model={{@model}} />
 <SettingsCard::Logs @model={{@model}} />

--- a/ui/desktop/tests/integration/components/settings-card/application-test.js
+++ b/ui/desktop/tests/integration/components/settings-card/application-test.js
@@ -10,10 +10,10 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 
 const CACHE_DAEMON_VERSION = '[data-test-cache-version]';
-const ERROR_MESSAGES = '.hds-alert__description > p';
+const ERROR_MESSAGES = '.hds-reveal__content > p';
 const REVEAL_BUTTON = '.hds-reveal button';
-const FIRST_ERROR_MESSAGE = '.hds-alert__description > p:first-child';
-const LAST_ERROR_MESSAGE = '.hds-alert__description > p:last-child';
+const FIRST_ERROR_MESSAGE = '.hds-reveal__content > p:first-child';
+const LAST_ERROR_MESSAGE = '.hds-reveal__content > p:last-child';
 
 module('Integration | Component | settings-card/application', function (hooks) {
   setupRenderingTest(hooks);

--- a/ui/desktop/tests/integration/components/settings-card/application-test.js
+++ b/ui/desktop/tests/integration/components/settings-card/application-test.js
@@ -5,12 +5,13 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 
 const CACHE_DAEMON_VERSION = '[data-test-cache-version]';
 const ERROR_MESSAGES = '.hds-alert__description > p';
+const REVEAL_BUTTON = '.hds-reveal button';
 const FIRST_ERROR_MESSAGE = '.hds-alert__description > p:first-child';
 const LAST_ERROR_MESSAGE = '.hds-alert__description > p:last-child';
 
@@ -58,6 +59,10 @@ module('Integration | Component | settings-card/application', function (hooks) {
     await render(
       hbs`<SettingsCard::Application @model={{this.model}} @toggle={{this.toggleTheme}}/>`,
     );
+
+    assert.dom(ERROR_MESSAGES).doesNotExist();
+
+    await click(REVEAL_BUTTON);
 
     assert.dom(ERROR_MESSAGES).isVisible({ count: 2 });
     assert

--- a/ui/desktop/tests/integration/components/settings-card/client-agent-test.js
+++ b/ui/desktop/tests/integration/components/settings-card/client-agent-test.js
@@ -13,8 +13,8 @@ const STATUS_BADGE = '.hds-badge';
 const ACTION_BUTTON = 'button';
 const REVEAL_BUTTON = '.hds-reveal button';
 const CARD_CONTAINER = 'hds-card__container';
-const ERROR_MESSAGES = '.hds-alert__description > p';
-const LAST_ERROR_MESSAGE = '.hds-alert__description > p:last-child';
+const ERROR_MESSAGES = '.hds-reveal__content > p';
+const LAST_ERROR_MESSAGE = '.hds-reveal__content > p:last-child';
 
 module(
   'Integration | Component | settings-card/client-agent',

--- a/ui/desktop/tests/integration/components/settings-card/client-agent-test.js
+++ b/ui/desktop/tests/integration/components/settings-card/client-agent-test.js
@@ -5,12 +5,13 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 
 const STATUS_BADGE = '.hds-badge';
 const ACTION_BUTTON = 'button';
+const REVEAL_BUTTON = '.hds-reveal button';
 const CARD_CONTAINER = 'hds-card__container';
 const ERROR_MESSAGES = '.hds-alert__description > p';
 const LAST_ERROR_MESSAGE = '.hds-alert__description > p:last-child';
@@ -76,6 +77,10 @@ module(
       });
 
       await render(hbs`<SettingsCard::ClientAgent @model={{this.model}}/>`);
+
+      assert.dom(ERROR_MESSAGES).doesNotExist();
+
+      await click(REVEAL_BUTTON);
 
       assert.dom(ERROR_MESSAGES).isVisible({ count: 3 });
       assert.dom(LAST_ERROR_MESSAGE).hasText('big oof');


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-14961
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-14962

# Description
Hide the initial errors behind a `reveal` so they don't distract the user if they don't care about them. Also moved the user and server cards up.

## Screenshots (if appropriate)
<img width="947" alt="image" src="https://github.com/user-attachments/assets/11a49862-cede-4bf6-aa59-eac8fbf4fec6">

## How to Test
Use this [50k cluster](https://27425825-515c-4d8c-beb6-aa91cbc20c5a.boundary.hcp.to) which should time out loading the cache daemon initially or use a CE boundary edition to generate errors for the client agent daemon. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
