### PR TITLE
style: 💄 Fix text description

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -883,7 +883,7 @@ credential-library:
       help: The body of the HTTP request the library sends to Vault when requesting credentials. Only allowed when HTTP method is set to POST.
     username:
       label: Username
-      help: The username to use when making an SSH connection. This can be templated to use the requesting user's name. This will be included in the valid_principles when making the request to Vault.
+      help: The username to use when making an SSH connection. This can be templated to use the requesting user's name. This will be included in the valid_principals when making the request to Vault.
     key_type:
       label: Key Type
       help: Specifies the desired key type to use when generating a private key.


### PR DESCRIPTION
# Description
Jeff noticed a typo in our description for vault ssh certificates cred library page. 

## Screenshots (if appropriate)
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/ec4c8883-c6b1-448a-97db-91ffbac6d605">


## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
