### PR TITLE
fix: 🐛 Fix daemon getting killed if started before DC

### DIFF
--- a/ui/desktop/electron-app/src/services/cache-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/cache-daemon-manager.js
@@ -52,9 +52,9 @@ class CacheDaemonManager {
     this.#cacheDaemonProcess = childProcess;
 
     // If we get a null/undefined, err on safe side and don't stop daemon when
-    // we close the desktop client as the absence of the "daemon is already running"
+    // we close the desktop client as the absence of the "cache is already running"
     // message doesn't necessarily guarantee it's running (but it likely should be)
-    if (stderr && !stderr.includes('The daemon is already running')) {
+    if (stderr && !stderr.includes('The cache is already running')) {
       this.#isCacheDaemonAlreadyRunning = false;
       log.info('Cache daemon started, status from daemon:\n', stderr);
     } else {


### PR DESCRIPTION
# Description
I missed a check when the client daemon was renamed to cache daemon. This accidentally caused us to kill a user started cache daemon. 

## How to Test
Start the daemon before the DC and close the DC after logging in. The daemon should still be running. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
