### PR TITLE
fix: 🐛 add regex literal for isLocalHost check

### DIFF
--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -46,7 +46,8 @@ handle('resetClusterUrl', async () => runtimeSettings.resetClusterUrl());
 handle('openExternal', async (href) => {
   const isSecure = href.startsWith('https://');
   const isLocalhost =
-    href.startsWith('http://localhost') || href.startsWith('http://127.0.0.1');
+    href.startsWith('http://localhost:') ||
+    href.startsWith('http://127.0.0.1:');
   if (isSecure || isLocalhost || isDev) {
     /**
      * Launch browser to display documentation and to support arbitrary OIDC flows

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -44,10 +44,10 @@ handle('resetClusterUrl', async () => runtimeSettings.resetClusterUrl());
  * testing workflows).  Insecure URLs are allowed in dev mode.
  */
 handle('openExternal', async (href) => {
+  const localhostRegex = /^http:\/\/(localhost|127\.0\.0\.1):\d{1,5}(?:\/|$)/i;
+  const isLocalhost = localhostRegex.test(href);
   const isSecure = href.startsWith('https://');
-  const isLocalhost =
-    href.startsWith('http://localhost:') ||
-    href.startsWith('http://127.0.0.1:');
+
   if (isSecure || isLocalhost || isDev) {
     /**
      * Launch browser to display documentation and to support arbitrary OIDC flows


### PR DESCRIPTION
# Description

This is a fix for an issue found in a security audit. (see ticket for more details).
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-13242

My thinking here is we cannot check the whole `href` as the port is dynamic. However, adding a `:` at the end should prevent someone from using a clusterURL similar to these: `http://localhost.somedomain.com/`, `http://localhostdomain.com/`.

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
Using the Desktop Client, authenticate using an OIDC auth-method and it should still be able to trigger opening a window in your browser if using `http://localhost:xxxx`.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
