### PR TITLE
chore: 🤖 Upgrade git-cz

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "cz-conventional-changelog": "^3.1.0",
     "doctoc": "^2.2.0",
-    "git-cz": "^4.8.0",
+    "git-cz": "^4.9.0",
     "husky": "^8.0.0",
     "license-checker": "^25.0.1",
     "lint-staged": "^13.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11305,10 +11305,10 @@ get-tsconfig@^4.7.0:
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
-git-cz@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/git-cz/-/git-cz-4.8.0.tgz#9dde589ce4e12d5aa4ee4fe54c6eef5f4635e6c3"
-  integrity sha512-2muVkIcT6cT/9eXuxztlKQSRiOy/oHhFldCySOi1xuRJ9T5yHlg3SRQhVLoY9BVu9kxSE3YcHYp0KgQW0vUf4A==
+git-cz@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/git-cz/-/git-cz-4.9.0.tgz#c0604ff85b37046d51fd85e265040032c9617bf2"
+  integrity sha512-cSRL8IIOXU7UFLdbziCYqg8f8InwLwqHezkiRHNSph7oZqGv0togId1kMTfKil6gzK0VaSXeVBb4oDl0fQCHiw==
 
 git-hooks-list@1.0.3:
   version "1.0.3"


### PR DESCRIPTION
# Description

Upgrade git-cz from 4.8.0 to 4.9.0. [As per git-cz changelog](https://github.com/streamich/git-cz/blob/master/CHANGELOG.md), there are no breaking changes

# How to test:

- This dependency is used when we commit, so no need for the boundary-ui-releases run.
- The test of this change is the PR itself. The committ has been performed under `4.9.0` without issues. The PR title and description were generated with it.
