### PR TITLE
refactor: 💡 change channel app state title & add alert msg

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -386,7 +386,7 @@ session-recording:
         title: Channel Playback
       error:
         title: Playback error
-        description: This likely means the connected storage bucket is misconfigured or the file was deleted.
+        description: This may mean the connected storage bucket is misconfigured, the file was deleted, or integrity validation failed.
         link: Retrieving lost session recordings
       not-supported:
         title: Playback is not supported for this channel

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -384,8 +384,8 @@ session-recording:
     messages:
       none:
         title: Channel Playback
-      missing:
-        title: We can't play back this channel because the file is missing
+      error:
+        title: Playback error
         description: This likely means the connected storage bucket is misconfigured or the file was deleted.
         link: Retrieving lost session recordings
       not-supported:

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index.js
@@ -9,6 +9,7 @@ import { inject as service } from '@ember/service';
 export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConnectionChannelIndexRoute extends Route {
   // =services
   @service can;
+  @service flashMessages;
 
   // =methods
   /**
@@ -24,7 +25,14 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
       try {
         asciicast = await channelRecording.getAsciicast();
       } catch (e) {
-        // no op
+        // Alert user of any error messages.
+        e.errors?.forEach((error) => {
+          this.flashMessages.danger(error.detail, {
+            notificationType: 'error',
+            sticky: true,
+            dismiss: (flash) => flash.destroyMessage(),
+          });
+        });
       }
     }
 

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index.js
@@ -25,13 +25,12 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
       try {
         asciicast = await channelRecording.getAsciicast();
       } catch (e) {
-        // Alert user of any error messages.
-        e.errors?.forEach((error) => {
-          this.flashMessages.danger(error.detail, {
-            notificationType: 'error',
-            sticky: true,
-            dismiss: (flash) => flash.destroyMessage(),
-          });
+        // Alert user of error occurred during download.
+        const error = e.errors[0];
+        this.flashMessages.danger(error.detail, {
+          notificationType: 'error',
+          sticky: true,
+          dismiss: (flash) => flash.destroyMessage(),
         });
       }
     }

--- a/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index.hbs
@@ -14,21 +14,17 @@
     {{#if (can 'getAsciicast channel-recording' @model.channelRecording)}}
       {{! Was not able to download asciicast }}
       <A.Header
-        @title={{t
-          'resources.session-recording.channel.messages.missing.title'
-        }}
+        @title={{t 'resources.session-recording.channel.messages.error.title'}}
       />
       <A.Body
         @text={{t
-          'resources.session-recording.channel.messages.missing.description'
+          'resources.session-recording.channel.messages.error.description'
         }}
       />
       <A.Footer as |F|>
         <F.LinkStandalone
           @icon='learn-link'
-          @text={{t
-            'resources.session-recording.channel.messages.missing.link'
-          }}
+          @text={{t 'resources.session-recording.channel.messages.error.link'}}
           @href={{doc-url 'session-recording.retrieve-lost-session-recordings'}}
         />
       </A.Footer>

--- a/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
@@ -132,9 +132,10 @@ module(
 
       // if there was an error player will not render
       assert.dom('.session-recording-player').doesNotExist();
+      assert.dom('.hds-application-state__title').hasText('Playback error');
       assert
-        .dom('.hds-application-state__title')
-        .hasText("We can't play back this channel because the file is missing");
+        .dom('.rose-notification-body')
+        .includesText('rpc error: code = Unknown');
     });
 
     test('user can navigate back to session recording screen', async function (assert) {
@@ -146,7 +147,7 @@ module(
       assert.strictEqual(currentURL(), urls.sessionRecording);
     });
 
-    test('users can navigate to channel recording and incorrect url autocorrects', async function (assert) {
+    test('users can navigate to channel recording and incorrect url auto corrects', async function (assert) {
       featuresService.enable('ssh-session-recording');
       const sessionRecording = this.server.create('session-recording', {
         scope: instances.scopes.global,


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-11148

# Description
<!-- Add a brief description of changes here -->
[slack thread for context](https://hashicorp.slack.com/archives/C012GTH1C4E/p1726092296630819)
Add alert messages for api errors when failing to download recording.
Update app state title to be more generic.

## Screenshots (if appropriate)

https://github.com/user-attachments/assets/daa10214-b2fb-4362-88f9-017cb8fe7c15


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
1. Create a session-recording
2. Modify any one of the session-recording files in the aws s3 storage bucket
3. Navigate to the session-recording channel
4. Attempt to play the recording and observe the error being displayed as an alert.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [X] I have added steps to reproduce and test for bug fixes in the description
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
