### PR TITLE
chore: 🤖 add resolution for send

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "**/ember-cli/testem/fireworm/async": "^2.6.4",
     "**/desktop/@doyensec/electronegativity/winston/async": "^2.6.4",
     "**/@hashicorp/design-system-components/ember-stargate": "^0.6.0",
-    "micromatch": "^4.0.8"
+    "micromatch": "^4.0.8",
+    "send": "^0.19.0"
   },
   "config": {
     "commitizen": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16511,26 +16511,7 @@ semver@^7.0.0, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semve
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
-send@0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
-  integrity sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==
-  dependencies:
-    debug "2.6.9"
-    depd "2.0.0"
-    destroy "1.2.0"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    fresh "0.5.2"
-    http-errors "2.0.0"
-    mime "1.6.0"
-    ms "2.1.3"
-    on-finished "2.4.1"
-    range-parser "~1.2.1"
-    statuses "2.0.1"
-
-send@0.19.0:
+send@0.18.0, send@0.19.0, send@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/send/-/send-0.19.0.tgz#bbc5a388c8ea6c048967049dbeac0e4a3f09d7f8"
   integrity sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
Fixes dependabot alert [#163](https://github.com/hashicorp/boundary-ui/security/dependabot/163)
We can probably get rid of the resolution on `send` once we upgrade `ember-cli`

`send@0.18.0 -> serve-static@1.16.0 -> express@^4.10.7 -> testem@^3.10.1 -> ember-cli@^4.12.2`
`send@0.18.0 -> serve-static@1.16.0 -> express@^4.18.1 -> ember-cli@^4.12.2`
* Exact versions of send are used so adding a resolution was only option. Attempting to force a resolution on the dependencies that use `send` didn't change anything.

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
1. `yarn start` in `ui/admin`
2. `yarn start:desktop` in `ui/desktop`
3. [boundary-ui-releases test run](https://github.com/hashicorp/boundary-ui-releases/actions/runs/10853523515) using branch `1.2.3-beta.send`

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
