### PR TITLE
fix: show username first and then password when credentials are listed

### DIFF
--- a/ui/desktop/app/components/credentials-panel/index.hbs
+++ b/ui/desktop/app/components/credentials-panel/index.hbs
@@ -33,6 +33,7 @@
         as |CB|
       >
         <CB.Title>
+
           {{#if credential.source.name}}
             {{credential.source.name}}
           {{else}}
@@ -61,7 +62,7 @@
 
       <ul class='credential-secret'>
         {{#if credential.secrets}}
-          {{#each credential.secrets as |secret|}}
+          {{#each (order-by credential.secrets 'username') as |secret|}}
             <li class='secret-container'>
               <span class='secret-key'>{{secret.key}}</span>
               <HiddenSecret @secret={{secret.value}} />

--- a/ui/desktop/app/components/credentials-panel/index.hbs
+++ b/ui/desktop/app/components/credentials-panel/index.hbs
@@ -62,7 +62,7 @@
 
       <ul class='credential-secret'>
         {{#if credential.secrets}}
-          {{#each (order-by credential.secrets 'username') as |secret|}}
+          {{#each (order-by credential.secrets this.customOrder) as |secret|}}
             <li class='secret-container'>
               <span class='secret-key'>{{secret.key}}</span>
               <HiddenSecret @secret={{secret.value}} />

--- a/ui/desktop/app/components/credentials-panel/index.js
+++ b/ui/desktop/app/components/credentials-panel/index.js
@@ -8,6 +8,8 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class CredentialsPanelIndexComponent extends Component {
+  customOrder = ['username', 'password'];
+
   @tracked isRawApiVisible = false;
 
   @action

--- a/ui/desktop/app/helpers/order-by.js
+++ b/ui/desktop/app/helpers/order-by.js
@@ -8,18 +8,22 @@ import { helper } from '@ember/component/helper';
 /**
  * This helper accepts an array of objects and orders them by a specified key.
  * @param {object[]} arr - The array of objects to be ordered
- * @param {string} keyToShowFirst - The key to be shown first in the order
+ * @param {string[]} customOrder - The order of keys to be used for sorting
  * @returns {object[]} - New order of array of objects
  */
-
-export default helper(function orderBy([arr, keyToShowFirst]) {
+export default helper(function orderBy([arr, customOrder]) {
   return arr.sort((a, b) => {
-    if (a.key === keyToShowFirst && b.key !== keyToShowFirst) {
-      return -1;
+    const indexA = customOrder.indexOf(a.key);
+    const indexB = customOrder.indexOf(b.key);
+
+    if (indexA === -1 && indexB === -1) {
+      return 0; // Maintain original order if both keys are not in the customOrder arr
+    } else if (indexA === -1) {
+      return 1; // Move b to a higher index if a is not in the customOrder arr
+    } else if (indexB === -1) {
+      return -1; // Move a to a higher index if b is not in the customOrder arr
+    } else {
+      return indexA - indexB; // Sort based on the index in the customOrder arr
     }
-    if (a.key !== keyToShowFirst && b.key === keyToShowFirst) {
-      return 1;
-    }
-    return 0; // Maintain original order if both values are the same or neither matches
   });
 });

--- a/ui/desktop/app/helpers/order-by.js
+++ b/ui/desktop/app/helpers/order-by.js
@@ -7,9 +7,9 @@ import { helper } from '@ember/component/helper';
 
 /**
  * This helper accepts an array of objects and orders them by a specified key.
- * @param {object[]} arr - The array of objects to be sorted
- * @param {string} keyToShowFirst - The key to be shown first in the sorting order
- * @returns {object[]} - The sorted array of objects
+ * @param {object[]} arr - The array of objects to be ordered
+ * @param {string} keyToShowFirst - The key to be shown first in the order
+ * @returns {object[]} - New order of array of objects
  */
 
 export default helper(function orderBy([arr, keyToShowFirst]) {

--- a/ui/desktop/app/helpers/order-by.js
+++ b/ui/desktop/app/helpers/order-by.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { helper } from '@ember/component/helper';
+
+/**
+ * This helper accepts an array of objects and orders them by a specified key.
+ * @param {object[]} arr - The array of objects to be sorted
+ * @param {string} keyToShowFirst - The key to be shown first in the sorting order
+ * @returns {object[]} - The sorted array of objects
+ */
+
+export default helper(function orderBy([arr, keyToShowFirst]) {
+  return arr.sort((a, b) => {
+    if (a.key === keyToShowFirst && b.key !== keyToShowFirst) {
+      return -1;
+    }
+    if (a.key !== keyToShowFirst && b.key === keyToShowFirst) {
+      return 1;
+    }
+    return 0; // Maintain original order if both values are the same or neither matches
+  });
+});

--- a/ui/desktop/tests/integration/helpers/order-by-test.js
+++ b/ui/desktop/tests/integration/helpers/order-by-test.js
@@ -26,7 +26,7 @@ module('Integration | Helper | order-by', function (hooks) {
       </ul>
     `);
 
-    assert.strictEqual(findAll('li').length, 3);
+    assert.dom('li').exists({ count: 3 });
     assert.strictEqual(
       this.element.textContent.replace(/\s+/g, ' ').trim(),
       'none username password',

--- a/ui/desktop/tests/integration/helpers/order-by-test.js
+++ b/ui/desktop/tests/integration/helpers/order-by-test.js
@@ -18,9 +18,11 @@ module('Integration | Helper | order-by', function (hooks) {
       { key: 'none', value: 3 },
     ]);
 
+    this.set('customOrder', ['username', 'none', 'password']);
+
     await render(hbs`
       <ul>
-        {{#each (order-by this.inputValue 'none') as |secret|}}
+        {{#each (order-by this.inputValue this.customOrder) as |secret|}}
           <li>{{secret.key}}</li>
         {{/each}}
       </ul>
@@ -29,7 +31,7 @@ module('Integration | Helper | order-by', function (hooks) {
     assert.dom('li').exists({ count: 3 });
     assert.strictEqual(
       this.element.textContent.replace(/\s+/g, ' ').trim(),
-      'none username password',
+      'username none password',
     );
   });
 });

--- a/ui/desktop/tests/integration/helpers/order-by-test.js
+++ b/ui/desktop/tests/integration/helpers/order-by-test.js
@@ -34,4 +34,53 @@ module('Integration | Helper | order-by', function (hooks) {
       'username none password',
     );
   });
+
+  test('maintains order if there are no matching keys in the list', async function (assert) {
+    this.set('inputValue', [
+      { key: 'username', value: 1 },
+      { key: 'password', value: 2 },
+      { key: 'none', value: 3 },
+    ]);
+
+    this.set('customOrder', ['one', 'two', 'three']);
+
+    await render(hbs`
+      <ul>
+        {{#each (order-by this.inputValue this.customOrder) as |secret|}}
+          <li>{{secret.key}}</li>
+        {{/each}}
+      </ul>
+    `);
+
+    assert.dom('li').exists({ count: 3 });
+    assert.strictEqual(
+      this.element.textContent.replace(/\s+/g, ' ').trim(),
+      'username password none',
+    );
+  });
+
+  test('maintains order if there are only some matching keys in the list', async function (assert) {
+    this.set('inputValue', [
+      { key: 'username', value: 1 },
+      { key: 'password', value: 2 },
+      { key: 'email', value: 3 },
+      { key: 'none', value: 3 },
+    ]);
+
+    this.set('customOrder', ['none', 'email']);
+
+    await render(hbs`
+      <ul>
+        {{#each (order-by this.inputValue this.customOrder) as |secret|}}
+          <li>{{secret.key}}</li>
+        {{/each}}
+      </ul>
+    `);
+
+    assert.dom('li').exists({ count: 4 });
+    assert.strictEqual(
+      this.element.textContent.replace(/\s+/g, ' ').trim(),
+      'none email username password',
+    );
+  });
 });

--- a/ui/desktop/tests/integration/helpers/order-by-test.js
+++ b/ui/desktop/tests/integration/helpers/order-by-test.js
@@ -11,7 +11,6 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Helper | order-by', function (hooks) {
   setupRenderingTest(hooks);
 
-  // TODO: Replace this with your real tests.
   test('it renders', async function (assert) {
     this.set('inputValue', [
       { key: 'username', value: 1 },

--- a/ui/desktop/tests/integration/helpers/order-by-test.js
+++ b/ui/desktop/tests/integration/helpers/order-by-test.js
@@ -5,7 +5,7 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, findAll } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Helper | order-by', function (hooks) {

--- a/ui/desktop/tests/integration/helpers/order-by-test.js
+++ b/ui/desktop/tests/integration/helpers/order-by-test.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, findAll } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | order-by', function (hooks) {
+  setupRenderingTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it renders', async function (assert) {
+    this.set('inputValue', [
+      { key: 'username', value: 1 },
+      { key: 'password', value: 2 },
+      { key: 'none', value: 3 },
+    ]);
+
+    await render(hbs`
+      <ul>
+        {{#each (order-by this.inputValue 'none') as |secret|}}
+          <li>{{secret.key}}</li>
+        {{/each}}
+      </ul>
+    `);
+
+    assert.strictEqual(findAll('li').length, 3);
+    assert.strictEqual(
+      this.element.textContent.replace(/\s+/g, ' ').trim(),
+      'none username password',
+    );
+  });
+});


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-15105

# Description

This PR moves up `username` field  

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

before:

<img width="1018" alt="Screenshot 2024-09-17 at 6 37 46 PM" src="https://github.com/user-attachments/assets/bd1733b0-30e9-4c6a-8f31-e3d740a5476b">

after:
<img width="910" alt="Screenshot 2024-09-17 at 6 31 53 PM" src="https://github.com/user-attachments/assets/c2347311-8af5-49d6-9679-d81d48be1d4e">


with a JSON blob: 
<img width="682" alt="Screenshot 2024-09-18 at 6 22 21 PM" src="https://github.com/user-attachments/assets/8df1f678-58c1-4e85-9d89-7ef1e5b088ff">


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
