### PR TITLE
fix: 🐛 Fix theme selector not properly selecting option

### DIFF
--- a/ui/desktop/app/components/settings-card/application/index.js
+++ b/ui/desktop/app/components/settings-card/application/index.js
@@ -4,6 +4,7 @@
  */
 
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 const THEMES = [
   {
@@ -21,6 +22,9 @@ const THEMES = [
 ];
 
 export default class SettingsApplicationComponent extends Component {
+  // =services
+  @service session;
+
   /**
    * Returns available themes
    */

--- a/ui/desktop/tests/integration/components/settings-card/application-test.js
+++ b/ui/desktop/tests/integration/components/settings-card/application-test.js
@@ -17,7 +17,7 @@ const LAST_ERROR_MESSAGE = '.hds-reveal__content > p:last-child';
 
 module('Integration | Component | settings-card/application', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, 'en-us');
 
   let model;
 

--- a/ui/desktop/tests/integration/components/settings-card/client-agent-test.js
+++ b/ui/desktop/tests/integration/components/settings-card/client-agent-test.js
@@ -20,7 +20,7 @@ module(
   'Integration | Component | settings-card/client-agent',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks);
+    setupIntl(hooks, 'en-us');
 
     test('it renders running badge and pause button', async function (assert) {
       this.set('model', {

--- a/ui/desktop/tests/integration/components/settings-card/logs-test.js
+++ b/ui/desktop/tests/integration/components/settings-card/logs-test.js
@@ -11,7 +11,7 @@ import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | settings-card/logs', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, 'en-us');
 
   const SELECTED_OPTION = 'select option:checked';
   const COPY_BUTTON_TEXT = '.hds-copy-snippet__text';

--- a/ui/desktop/tests/integration/components/settings-card/server-test.js
+++ b/ui/desktop/tests/integration/components/settings-card/server-test.js
@@ -14,7 +14,7 @@ const SERVER_URL = '[data-test-server-url]';
 
 module('Integration | Component | settings-card/server', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, 'en-us');
 
   const setDefaultClusterUrl = (test) => {
     const windowOrigin = 'hashicorp.cloud';

--- a/ui/desktop/tests/integration/components/settings-card/user-test.js
+++ b/ui/desktop/tests/integration/components/settings-card/user-test.js
@@ -23,7 +23,7 @@ const AUTHENTICATION_BADGE = '.hds-badge__text';
 
 module('Integration | Component | settings-card/user', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, 'en-us');
 
   test('it renders password correctly', async function (assert) {
     this.owner.register(


### PR DESCRIPTION
# Description
I found a bug where the theme selector dropdown wasn't properly selecting the saved theme when revisiting the page. The issue was this line:
https://github.com/hashicorp/boundary-ui/blob/ba2b62ba5fa7977393f244c5780339b0bc84fb0c/ui/desktop/app/components/settings-card/application/index.hbs#L78
didn't have access to the session service.

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
