### PR TITLE
test(e2e): Add Admin UI test for vault credential libraries (enterprise)

### DIFF
--- a/ui/admin/tests/e2e/pages/credential-stores.mjs
+++ b/ui/admin/tests/e2e/pages/credential-stores.mjs
@@ -187,10 +187,11 @@ export class CredentialStoresPage extends BaseResourcePage {
    * Creates a vault-generic credential library. Assumes you have selected
    * the desired credential store.
    * @param {string} vaultPath path to secret in vault
-   * @param {string} credentialType type of credential for credential injection
+   * @param {string} credentialType type of credential for credential injection.
+   * Can be set to null if injection is not used
    * @returns Name of the credential library
    */
-  async createVaultGenericCredentialLibrary(vaultPath, credentialType) {
+  async createVaultGenericCredentialLibraryEnt(vaultPath, credentialType) {
     const credentialLibraryName = 'Credential Library ' + nanoid();
     await this.page.getByRole('link', { name: 'Credential Libraries' }).click();
     await this.page.getByRole('link', { name: 'New', exact: true }).click();
@@ -205,9 +206,12 @@ export class CredentialStoresPage extends BaseResourcePage {
       .getByLabel('Generic Secrets')
       .click();
     await this.page.getByLabel('Vault Path').fill(vaultPath);
-    await this.page
-      .getByRole('combobox', { name: 'Credential Type' })
-      .selectOption(credentialType);
+
+    if (credentialType) {
+      await this.page
+        .getByRole('combobox', { name: 'Credential Type' })
+        .selectOption(credentialType);
+    }
 
     await this.page.getByRole('button', { name: 'Save' }).click();
     await this.dismissSuccessAlert();
@@ -222,7 +226,7 @@ export class CredentialStoresPage extends BaseResourcePage {
    * @param {string} username username for the credential
    * @returns Name of the credential library
    */
-  async createVaultSshCertificateCredentialLibrary(vaultPath, username) {
+  async createVaultSshCertificateCredentialLibraryEnt(vaultPath, username) {
     const credentialLibraryName = 'Credential Library ' + nanoid();
 
     await this.page.getByRole('link', { name: 'Credential Libraries' }).click();

--- a/ui/admin/tests/e2e/tests/ssh-credential-injection-vault-ent.spec.mjs
+++ b/ui/admin/tests/e2e/tests/ssh-credential-injection-vault-ent.spec.mjs
@@ -102,7 +102,7 @@ test('SSH Credential Injection (Vault User & Key Pair) @ent @docker', async ({
     const credentialStoresPage = new CredentialStoresPage(page);
     await credentialStoresPage.createVaultCredentialStore(vaultAddr, clientToken);
     const credentialLibraryName =
-      await credentialStoresPage.createVaultGenericCredentialLibrary(
+      await credentialStoresPage.createVaultGenericCredentialLibraryEnt(
         `${secretsPath}/data/${secretName}`,
         'SSH Private Key',
       );


### PR DESCRIPTION
This PR adds a test to the Admin UI e2e test suite to check the creation of Vault credential libraries using `boundary-enterprise`. We already had a test for `boundary`, and this adds a similar check for the enterprise version, while accounting for the slight differences that this version has
- need to use the enterprise variant of creating targets (there's a selector for target type (i.e. tcp, ssh))
- need to use the enterprise variant of creating credential libraries (there's a selector for library type (i.e. generic secrets, ssh certificates))

## Testing
One test was added to enterprise
```
enos scenario launch e2e_ui_docker_ent builder:local
yarn run e2e:ent:docker
```

https://hashicorp.atlassian.net/browse/ICU-14761