### PR TITLE
Icu 15181 add pagination to session recordings

### DIFF
--- a/addons/api/addon/services/indexed-db.js
+++ b/addons/api/addon/services/indexed-db.js
@@ -30,7 +30,7 @@ export const modelIndexes = {
   'auth-method':
     '&id, attributes.created_time, attributes.type, attributes.name, attributes.description, attributes.is_primary, attributes.scope.scope_id',
   'session-recording':
-    '&id, attributes.created_time, attributes.type, attributes.state, attributes.start_time, attributes.end_time, attributes.duration, attributes.scope.scope_id, attributes.create_time_values.user.id, attributes.create_time_values.user.name, attributes.create_time_values.host.id, attributes.create_time_values.target.id, attributes.create_time_values.target.name',
+    '&id, attributes.created_time, attributes.type, attributes.state, attributes.start_time, attributes.end_time, attributes.duration, attributes.scope.scope_id, attributes.create_time_values.user.id, attributes.create_time_values.user.name, attributes.create_time_values.target.id, attributes.create_time_values.target.name, attributes.create_time_values.target.scope.id, attributes.create_time_values.target.scope.name',
 };
 
 export const formatDbName = (userId, clusterUrl) =>

--- a/addons/api/addon/services/indexed-db.js
+++ b/addons/api/addon/services/indexed-db.js
@@ -29,6 +29,8 @@ export const modelIndexes = {
     '&id, attributes.created_time, attributes.type, attributes.name, attributes.description, attributes.scope.scope_id, attributes.plugin.name',
   'auth-method':
     '&id, attributes.created_time, attributes.type, attributes.name, attributes.description, attributes.is_primary, attributes.scope.scope_id',
+  'session-recording':
+    '&id, attributes.created_time, attributes.type, attributes.state, attributes.start_time, attributes.end_time, attributes.duration, attributes.scope.scope_id, attributes.create_time_values.user, attributes.create_time_values.host, attributes.create_time_values.target',
 };
 
 export const formatDbName = (userId, clusterUrl) =>

--- a/addons/api/addon/services/indexed-db.js
+++ b/addons/api/addon/services/indexed-db.js
@@ -30,7 +30,7 @@ export const modelIndexes = {
   'auth-method':
     '&id, attributes.created_time, attributes.type, attributes.name, attributes.description, attributes.is_primary, attributes.scope.scope_id',
   'session-recording':
-    '&id, attributes.created_time, attributes.type, attributes.state, attributes.start_time, attributes.end_time, attributes.duration, attributes.scope.scope_id, attributes.create_time_values.user, attributes.create_time_values.host, attributes.create_time_values.target',
+    '&id, attributes.created_time, attributes.type, attributes.state, attributes.start_time, attributes.end_time, attributes.duration, attributes.scope.scope_id, attributes.create_time_values.user.id, attributes.create_time_values.user.name, attributes.create_time_values.host.id, attributes.create_time_values.target.id, attributes.create_time_values.target.name',
 };
 
 export const formatDbName = (userId, clusterUrl) =>

--- a/addons/api/addon/services/indexed-db.js
+++ b/addons/api/addon/services/indexed-db.js
@@ -113,7 +113,7 @@ export default class IndexedDbService extends Service {
     }
 
     this.#db = new Dexie(dbName);
-    this.#db.version(1).stores(modelIndexes);
+    this.#db.version(2).stores(modelIndexes);
   }
 
   /**

--- a/addons/api/mirage/config.js
+++ b/addons/api/mirage/config.js
@@ -778,18 +778,7 @@ function routes() {
   });
 
   // session recordings
-  this.get(
-    '/session-recordings',
-    (
-      { sessionRecordings },
-      { queryParams: { scope_id: scopeId, recursive } },
-    ) => {
-      if (recursive && scopeId === 'global') {
-        return sessionRecordings.all();
-      }
-      return sessionRecordings.where({ scopeId });
-    },
-  );
+  this.get('/session-recordings');
   this.get(
     '/session-recordings/:idMethod',
     async ({ sessionRecordings }, { params: { idMethod } }) => {

--- a/addons/core/translations/actions/en-us.yaml
+++ b/addons/core/translations/actions/en-us.yaml
@@ -56,6 +56,7 @@ toggle-feature-edition: Toggle Feature Edition
 toggle-licensed-features: Toggle Licensed Features
 more: ', +{remainingItems} more'
 search: Search
+search-session-recording: Search recording ID
 yes: Yes
 no: No
 narrow-results: Narrow results

--- a/addons/core/translations/actions/en-us.yaml
+++ b/addons/core/translations/actions/en-us.yaml
@@ -58,7 +58,6 @@ toggle-feature-edition: Toggle Feature Edition
 toggle-licensed-features: Toggle Licensed Features
 more: ', +{remainingItems} more'
 search: Search
-search-session-recording: Search recording ID
 yes: Yes
 no: No
 narrow-results: Narrow results

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -357,6 +357,12 @@ session-recording:
   duration: '{time} duration'
   questions:
     delete: Are you sure you want to delete this recording?
+  filters:
+    time:
+      title: Time
+      today: Today
+      last-three-days: Last 3 days
+      last-seven-days: Last 7 days
   connection:
     title: Connection
     title_index: Connection {index}

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -360,7 +360,7 @@ session-recording:
   filters:
     time:
       title: Time
-      today: Today
+      last-twenty-four-hours: Last 24 hours
       last-three-days: Last 3 days
       last-seven-days: Last 7 days
   connection:

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
@@ -32,8 +32,8 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
   get filters() {
     return {
       allFilters: {
-        users: this.userOptions,
-        targets: this.targetOptions,
+        users: this.filterOptions('user'),
+        targets: this.filterOptions('target'),
       },
       selectedFilters: {
         users: this.users,
@@ -43,35 +43,17 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
   }
 
   /**
-   * Returns all users for session recordings
+   * Returns all filter options for key for session recordings
+   * @param {string} key
    * @returns {[object]}
    */
-  get userOptions() {
+  @action
+  filterOptions(key) {
     const uniqueMap = new Map();
     this.model.allSessionRecordings.forEach(
       ({
         create_time_values: {
-          user: { id, name },
-        },
-      }) => {
-        if (!uniqueMap.has(id)) {
-          uniqueMap.set(id, { id, name });
-        }
-      },
-    );
-    return Array.from(uniqueMap.values());
-  }
-
-  /**
-   * Returns all targets for session recordings
-   * @returns {[object]}
-   */
-  get targetOptions() {
-    const uniqueMap = new Map();
-    this.model.allSessionRecordings.forEach(
-      ({
-        create_time_values: {
-          target: { id, name },
+          [key]: { id, name },
         },
       }) => {
         if (!uniqueMap.has(id)) {

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
@@ -19,7 +19,7 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
    * @type {boolean}
    */
   get hasSessionRecordings() {
-    return this.model?.sessionRecordings?.length;
+    return !!this.model?.sessionRecordings?.length;
   }
 
   /**
@@ -27,6 +27,6 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
    * @type {boolean}
    */
   get hasSessionRecordingsConfigured() {
-    return this.model?.storageBuckets?.length;
+    return !!this.model?.storageBuckets?.length;
   }
 }

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
@@ -19,7 +19,7 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
 
   queryParams = [
     'search',
-    { times: { type: 'array' } },
+    'time',
     { users: { type: 'array' } },
     { scopes: { type: 'array' } },
     { targets: { type: 'array' } },
@@ -28,7 +28,7 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
   ];
 
   @tracked search = '';
-  @tracked times = [];
+  @tracked time = null;
   @tracked users = [];
   @tracked scopes = [];
   @tracked targets = [];
@@ -42,13 +42,13 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
   get filters() {
     return {
       allFilters: {
-        times: this.timeOptions,
+        time: this.timeOptions,
         users: this.filterOptions('user'),
         scopes: this.projectScopes,
         targets: this.filterOptions('target'),
       },
       selectedFilters: {
-        times: this.times,
+        time: [this.time],
         users: this.users,
         scopes: this.scopes,
         targets: this.targets,
@@ -172,12 +172,12 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
 
   /**
    * Sets the time filter, sets the page to 1, and closes the filter dropdown
-   * @param {string} timeId
+   * @param {object} timeId
    * @param {func} onClose
    */
   @action
   changeTimeFilter(timeId, onClose) {
-    this.times = [timeId];
+    this.time = timeId;
     this.page = 1;
     onClose();
   }

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
@@ -122,7 +122,7 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
   @action
   orgName(orgID) {
     const org = this.store.peekRecord('scope', orgID);
-    return org.name;
+    return org.displayName;
   }
 
   /**

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
@@ -5,28 +5,29 @@
 
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { debounce } from 'core/decorators/debounce';
 
 export default class ScopesScopeSessionRecordingsIndexController extends Controller {
   // =attributes
 
-  queryParams = ['page', 'pageSize'];
+  queryParams = ['search', 'page', 'pageSize'];
 
+  @tracked search = '';
   @tracked page = 1;
   @tracked pageSize = 10;
 
-  /**
-   * Returns true if any session recordings exist
-   * @type {boolean}
-   */
-  get hasSessionRecordings() {
-    return !!this.model?.sessionRecordings?.length;
-  }
+  // =actions
 
   /**
-   * Returns true if any storage buckets exist
-   * @type {boolean}
+   * Handles input on each keystroke and the search queryParam
+   * @param {object} event
    */
-  get hasSessionRecordingsConfigured() {
-    return !!this.model?.storageBuckets?.length;
+  @action
+  @debounce(250)
+  handleSearchInput(event) {
+    const { value } = event.target;
+    this.search = value;
+    this.page = 1;
   }
 }

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
@@ -27,6 +27,8 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
     'pageSize',
   ];
 
+  now = new Date();
+
   @tracked search = '';
   @tracked time = null;
   @tracked users = [];
@@ -61,26 +63,27 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
    * @returns {[object]}
    */
   get timeOptions() {
-    const now = new Date();
-    const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-    const threeDaysPast = new Date(midnight);
-    threeDaysPast.setDate(midnight.getDate() - 3);
-    const sevenDaysPast = new Date(midnight);
-    sevenDaysPast.setDate(midnight.getDate() - 7);
+    const last24Hours = new Date(this.now.getTime() - 24 * 60 * 60 * 1000);
+    const last3Days = new Date(this.now);
+    last3Days.setDate(this.now.getDate() - 3);
+    const last7Days = new Date(this.now);
+    last7Days.setDate(this.now.getDate() - 7);
 
     return [
       {
-        id: midnight.toISOString(),
-        name: this.intl.t('resources.session-recording.filters.time.today'),
+        id: last24Hours.toISOString(),
+        name: this.intl.t(
+          'resources.session-recording.filters.time.last-twenty-four-hours',
+        ),
       },
       {
-        id: threeDaysPast.toISOString(),
+        id: last3Days.toISOString(),
         name: this.intl.t(
           'resources.session-recording.filters.time.last-three-days',
         ),
       },
       {
-        id: sevenDaysPast.toISOString(),
+        id: last7Days.toISOString(),
         name: this.intl.t(
           'resources.session-recording.filters.time.last-seven-days',
         ),

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
@@ -11,10 +11,17 @@ import { debounce } from 'core/decorators/debounce';
 export default class ScopesScopeSessionRecordingsIndexController extends Controller {
   // =attributes
 
-  queryParams = ['search', { users: { type: 'array' } }, 'page', 'pageSize'];
+  queryParams = [
+    'search',
+    { users: { type: 'array' } },
+    { targets: { type: 'array' } },
+    'page',
+    'pageSize',
+  ];
 
   @tracked search = '';
   @tracked users = [];
+  @tracked targets = [];
   @tracked page = 1;
   @tracked pageSize = 10;
 
@@ -26,9 +33,11 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
     return {
       allFilters: {
         users: this.userOptions,
+        targets: this.targetOptions,
       },
       selectedFilters: {
         users: this.users,
+        targets: this.targets,
       },
     };
   }
@@ -43,6 +52,26 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
       ({
         create_time_values: {
           user: { id, name },
+        },
+      }) => {
+        if (!uniqueMap.has(id)) {
+          uniqueMap.set(id, { id, name });
+        }
+      },
+    );
+    return Array.from(uniqueMap.values());
+  }
+
+  /**
+   * Returns all targets for session recordings
+   * @returns {[object]}
+   */
+  get targetOptions() {
+    const uniqueMap = new Map();
+    this.model.allSessionRecordings.forEach(
+      ({
+        create_time_values: {
+          target: { id, name },
         },
       }) => {
         if (!uniqueMap.has(id)) {

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
@@ -11,11 +11,47 @@ import { debounce } from 'core/decorators/debounce';
 export default class ScopesScopeSessionRecordingsIndexController extends Controller {
   // =attributes
 
-  queryParams = ['search', 'page', 'pageSize'];
+  queryParams = ['search', { users: { type: 'array' } }, 'page', 'pageSize'];
 
   @tracked search = '';
+  @tracked users = [];
   @tracked page = 1;
   @tracked pageSize = 10;
+
+  /**
+   * Returns object of filters to be used for displaying selected filters
+   * @returns {object}
+   */
+  get filters() {
+    return {
+      allFilters: {
+        users: this.userOptions,
+      },
+      selectedFilters: {
+        users: this.users,
+      },
+    };
+  }
+
+  /**
+   * Returns all users for session recordings
+   * @returns {[object]}
+   */
+  get userOptions() {
+    const uniqueMap = new Map();
+    this.model.allSessionRecordings.forEach(
+      ({
+        create_time_values: {
+          user: { id, name },
+        },
+      }) => {
+        if (!uniqueMap.has(id)) {
+          uniqueMap.set(id, { id, name });
+        }
+      },
+    );
+    return Array.from(uniqueMap.values());
+  }
 
   // =actions
 
@@ -29,5 +65,24 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
     const { value } = event.target;
     this.search = value;
     this.page = 1;
+  }
+
+  /**
+   * Sets the selected items for the given paramKey and sets the page to 1
+   * @param {string} paramKey
+   * @param {[string]} selectedItems
+   */
+  @action
+  applyFilter(paramKey, selectedItems) {
+    this[paramKey] = [...selectedItems];
+    this.page = 1;
+  }
+
+  /**
+   * Refreshes the all data for the current page
+   */
+  @action
+  refresh() {
+    this.send('refreshAll');
   }
 }

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
@@ -7,13 +7,19 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { debounce } from 'core/decorators/debounce';
+import { inject as service } from '@ember/service';
 
 export default class ScopesScopeSessionRecordingsIndexController extends Controller {
+  // =services
+
+  @service store;
+
   // =attributes
 
   queryParams = [
     'search',
     { users: { type: 'array' } },
+    { scopes: { type: 'array' } },
     { targets: { type: 'array' } },
     'page',
     'pageSize',
@@ -21,6 +27,7 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
 
   @tracked search = '';
   @tracked users = [];
+  @tracked scopes = [];
   @tracked targets = [];
   @tracked page = 1;
   @tracked pageSize = 10;
@@ -33,13 +40,50 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
     return {
       allFilters: {
         users: this.filterOptions('user'),
+        scopes: this.projectScopes,
         targets: this.filterOptions('target'),
       },
       selectedFilters: {
         users: this.users,
+        scopes: this.scopes,
         targets: this.targets,
       },
     };
+  }
+
+  /**
+   * Returns unique project scopes from targets
+   * linked to the session recordings
+   * @returns {[object]}
+   */
+  get projectScopes() {
+    const uniqueMap = new Map();
+    this.model.allSessionRecordings.forEach(
+      ({
+        create_time_values: {
+          target: {
+            scope: { id, name, parent_scope_id },
+          },
+        },
+      }) => {
+        if (!uniqueMap.has(id)) {
+          const projectName = name || id;
+          uniqueMap.set(id, { id, name: projectName, parent_scope_id });
+        }
+      },
+    );
+    return Array.from(uniqueMap.values());
+  }
+
+  /**
+   * Looks up org by ID and returns the org name
+   * @param {string} orgID
+   * @returns {string}
+   */
+  @action
+  orgName(orgID) {
+    const org = this.store.peekRecord('scope', orgID);
+    return org.name;
   }
 
   /**

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
@@ -4,8 +4,16 @@
  */
 
 import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
 
 export default class ScopesScopeSessionRecordingsIndexController extends Controller {
+  // =attributes
+
+  queryParams = ['page', 'pageSize'];
+
+  @tracked page = 1;
+  @tracked pageSize = 10;
+
   /**
    * Returns true if any session recordings exist
    * @type {boolean}

--- a/ui/admin/app/routes/scopes/scope/session-recordings.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings.js
@@ -5,15 +5,12 @@
 
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import orderBy from 'lodash/orderBy';
 
 export default class ScopesScopeSessionRecordingsRoute extends Route {
   // =services
 
-  @service store;
-  @service can;
-  @service session;
   @service router;
+  @service session;
 
   // =methods
 
@@ -22,50 +19,5 @@ export default class ScopesScopeSessionRecordingsRoute extends Route {
    */
   beforeModel() {
     if (!this.session.isAuthenticated) this.router.transitionTo('index');
-  }
-
-  /**
-   * Load all session recordings.
-   * @return {{sessionRecordings: Array, storageBuckets: Array}}
-   */
-  async model() {
-    let storageBuckets;
-
-    const scope = this.modelFor('scopes.scope');
-    const { id: scope_id } = scope;
-
-    if (
-      this.can.can('list scope', scope, {
-        collection: 'session-recordings',
-      })
-    ) {
-      const sessionRecordings = await this.store.query('session-recording', {
-        scope_id,
-        recursive: true,
-      });
-
-      // Sort sessions by created time descending (newest on top)
-      const sortedSessionRecordings = orderBy(
-        sessionRecordings,
-        'created_time',
-        'desc',
-      );
-
-      // Storage buckets could fail for a number of reasons, including that
-      // the user isn't authorized to access them.
-      try {
-        storageBuckets = await this.store.query('storage-bucket', {
-          scope_id,
-          recursive: true,
-        });
-      } catch (e) {
-        // no op
-      }
-
-      return {
-        sessionRecordings: sortedSessionRecordings,
-        storageBuckets,
-      };
-    }
   }
 }

--- a/ui/admin/app/routes/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/index.js
@@ -20,6 +20,10 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
       refreshModel: true,
       replace: true,
     },
+    times: {
+      refreshModel: true,
+      replace: true,
+    },
     users: {
       refreshModel: true,
       replace: true,
@@ -46,7 +50,7 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
    * Load all session recordings.
    * @return {Promise<{ totalItems: number, sessionRecordings: [SessionRecordingModel], sessionRecordingsExist: boolean, storageBucketsExist: boolean }>}
    */
-  async model({ search, users, scopes, targets, page, pageSize }) {
+  async model({ search, times, users, scopes, targets, page, pageSize }) {
     const scope = this.modelFor('scopes.scope');
     const { id: scope_id } = scope;
     let sessionRecordings;
@@ -55,10 +59,14 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
     let storageBucketsExist = false;
     const filters = {
       scope_id: [{ equals: scope_id }],
+      created_time: [],
       'create_time_values.user.id': [],
       'create_time_values.target.scope.id': [],
       'create_time_values.target.id': [],
     };
+    times.forEach((time) => {
+      filters.created_time.push({ gte: new Date(time) });
+    });
     users.forEach((user) => {
       filters['create_time_values.user.id'].push({ equals: user });
     });

--- a/ui/admin/app/routes/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/index.js
@@ -84,6 +84,7 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
     ) {
       const queryOptions = {
         scope_id,
+        recursive: true,
         query: { search, filters },
         page,
         pageSize,
@@ -98,7 +99,7 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
       if (!this.allSessionRecordings) {
         await this.getAllSessionRecordings(scope_id);
       }
-      doSessionRecordingsExist = !!this.allSessionRecordings.length;
+      doSessionRecordingsExist = Boolean(this.allSessionRecordings.length);
 
       doStorageBucketsExist = await this.getDoStorageBucketsExist(scope_id);
 
@@ -117,6 +118,8 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
     this.allSessionRecordings = await this.store.query(
       'session-recording',
       {
+        scope_id,
+        recursive: true,
         query: {
           filters: {
             scope_id: [{ equals: scope_id }],
@@ -140,7 +143,7 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
         scope_id,
         recursive: true,
       });
-      return !!storageBuckets.length;
+      return Boolean(storageBuckets.length);
     } catch (e) {
       // no op
       return false;

--- a/ui/admin/app/routes/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/index.js
@@ -58,7 +58,6 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
     let doSessionRecordingsExist = false;
     let doStorageBucketsExist = false;
     const filters = {
-      scope_id: [{ equals: scope_id }],
       created_time: [],
       'create_time_values.user.id': [],
       'create_time_values.target.scope.id': [],
@@ -100,7 +99,6 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
         await this.getAllSessionRecordings(scope_id);
       }
       doSessionRecordingsExist = Boolean(this.allSessionRecordings.length);
-
       doStorageBucketsExist = await this.getDoStorageBucketsExist(scope_id);
 
       return {
@@ -120,11 +118,6 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
       {
         scope_id,
         recursive: true,
-        query: {
-          filters: {
-            scope_id: [{ equals: scope_id }],
-          },
-        },
       },
       options,
     );

--- a/ui/admin/app/routes/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/index.js
@@ -4,5 +4,68 @@
  */
 
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import orderBy from 'lodash/orderBy';
 
-export default class ScopesScopeSessionRecordingsIndexRoute extends Route {}
+export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
+  // =services
+  @service store;
+  @service router;
+  @service can;
+
+  // =attributes
+
+  queryParams = {
+    page: {
+      refreshModel: true,
+    },
+    pageSize: {
+      refreshModel: true,
+    },
+  };
+
+  /**
+   * Load all session recordings.
+   * @return {{sessionRecordings: Array, storageBuckets: Array}}
+   */
+  async model() {
+    let storageBuckets;
+
+    const scope = this.modelFor('scopes.scope');
+    const { id: scope_id } = scope;
+
+    if (
+      this.can.can('list scope', scope, {
+        collection: 'session-recordings',
+      })
+    ) {
+      const sessionRecordings = await this.store.query('session-recording', {
+        scope_id,
+        recursive: true,
+      });
+
+      // Sort sessions by created time descending (newest on top)
+      const sortedSessionRecordings = orderBy(
+        sessionRecordings,
+        'created_time',
+        'desc',
+      );
+
+      // Storage buckets could fail for a number of reasons, including that
+      // the user isn't authorized to access them.
+      try {
+        storageBuckets = await this.store.query('storage-bucket', {
+          scope_id,
+          recursive: true,
+        });
+      } catch (e) {
+        // no op
+      }
+
+      return {
+        sessionRecordings: sortedSessionRecordings,
+        storageBuckets,
+      };
+    }
+  }
+}

--- a/ui/admin/app/routes/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/index.js
@@ -20,7 +20,7 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
       refreshModel: true,
       replace: true,
     },
-    times: {
+    time: {
       refreshModel: true,
       replace: true,
     },
@@ -50,7 +50,7 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
    * Load all session recordings.
    * @return {Promise<{ totalItems: number, sessionRecordings: [SessionRecordingModel], doSessionRecordingsExist: boolean, doStorageBucketsExist: boolean }>}
    */
-  async model({ search, times, users, scopes, targets, page, pageSize }) {
+  async model({ search, time, users, scopes, targets, page, pageSize }) {
     const scope = this.modelFor('scopes.scope');
     const { id: scope_id } = scope;
     let sessionRecordings;
@@ -63,9 +63,7 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
       'create_time_values.target.scope.id': [],
       'create_time_values.target.id': [],
     };
-    times.forEach((time) => {
-      filters.created_time.push({ gte: new Date(time) });
-    });
+    if (time) filters.created_time.push({ gte: new Date(time) });
     users.forEach((user) => {
       filters['create_time_values.user.id'].push({ equals: user });
     });

--- a/ui/admin/app/routes/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/index.js
@@ -5,6 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
   // =services
@@ -19,6 +20,10 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
       refreshModel: true,
       replace: true,
     },
+    users: {
+      refreshModel: true,
+      replace: true,
+    },
     page: {
       refreshModel: true,
     },
@@ -27,20 +32,26 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
     },
   };
 
+  allSessionRecordings;
+
   /**
    * Load all session recordings.
    * @return {Promise<{ totalItems: number, sessionRecordings: [SessionRecordingModel], sessionRecordingsExist: boolean, storageBucketsExist: boolean }>}
    */
-  async model({ search, page, pageSize }) {
+  async model({ search, users, page, pageSize }) {
     const scope = this.modelFor('scopes.scope');
     const { id: scope_id } = scope;
-    const filters = {
-      scope_id: [{ equals: scope_id }],
-    };
     let sessionRecordings;
     let totalItems = 0;
     let sessionRecordingsExist = false;
     let storageBucketsExist = false;
+    const filters = {
+      scope_id: [{ equals: scope_id }],
+      'create_time_values.user.id': [],
+    };
+    users.forEach((user) => {
+      filters['create_time_values.user.id'].push({ equals: user });
+    });
 
     if (
       this.can.can('list scope', scope, {
@@ -59,41 +70,37 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
         queryOptions,
       );
       totalItems = sessionRecordings.meta?.totalItems;
-      sessionRecordingsExist = await this.getSessionRecordingsExist(
-        scope_id,
-        totalItems,
-      );
+      // Query all session reocordings for filtering values if entering route for the first time
+      if (!this.allSessionRecordings) {
+        await this.getAllSessionRecordings(scope_id);
+      }
+      sessionRecordingsExist = !!this.allSessionRecordings.length;
+
       storageBucketsExist = await this.getStorageBucketsExist(scope_id);
 
       return {
         sessionRecordings,
         sessionRecordingsExist,
+        allSessionRecordings: this.allSessionRecordings,
         totalItems,
         storageBucketsExist,
       };
     }
   }
 
-  async getSessionRecordingsExist(scope_id, totalItems) {
-    if (totalItems > 0) {
-      return true;
-    }
+  async getAllSessionRecordings(scope_id) {
     const options = { pushToStore: false, peekIndexedDB: true };
-    const sessionRecording = await this.store.query(
+    this.allSessionRecordings = await this.store.query(
       'session-recording',
       {
-        scope_id,
         query: {
           filters: {
             scope_id: [{ equals: scope_id }],
           },
         },
-        page: 1,
-        pageSize: 1,
       },
       options,
     );
-    return sessionRecording.length > 0;
   }
 
   /**
@@ -109,10 +116,24 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
         scope_id,
         recursive: true,
       });
-      return storageBuckets.length > 0;
+      return !!storageBuckets.length;
     } catch (e) {
       // no op
       return false;
     }
+  }
+
+  // =actions
+
+  /**
+   * refreshes all session recording route data.
+   */
+  @action
+  async refreshAll() {
+    const scope = this.modelFor('scopes.scope');
+
+    await this.getAllSessionRecordings(scope.id);
+
+    return super.refresh(...arguments);
   }
 }

--- a/ui/admin/app/routes/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/index.js
@@ -48,15 +48,15 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
 
   /**
    * Load all session recordings.
-   * @return {Promise<{ totalItems: number, sessionRecordings: [SessionRecordingModel], sessionRecordingsExist: boolean, storageBucketsExist: boolean }>}
+   * @return {Promise<{ totalItems: number, sessionRecordings: [SessionRecordingModel], doSessionRecordingsExist: boolean, doStorageBucketsExist: boolean }>}
    */
   async model({ search, times, users, scopes, targets, page, pageSize }) {
     const scope = this.modelFor('scopes.scope');
     const { id: scope_id } = scope;
     let sessionRecordings;
     let totalItems = 0;
-    let sessionRecordingsExist = false;
-    let storageBucketsExist = false;
+    let doSessionRecordingsExist = false;
+    let doStorageBucketsExist = false;
     const filters = {
       scope_id: [{ equals: scope_id }],
       created_time: [],
@@ -98,16 +98,16 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
       if (!this.allSessionRecordings) {
         await this.getAllSessionRecordings(scope_id);
       }
-      sessionRecordingsExist = !!this.allSessionRecordings.length;
+      doSessionRecordingsExist = !!this.allSessionRecordings.length;
 
-      storageBucketsExist = await this.getStorageBucketsExist(scope_id);
+      doStorageBucketsExist = await this.getDoStorageBucketsExist(scope_id);
 
       return {
         sessionRecordings,
-        sessionRecordingsExist,
+        doSessionRecordingsExist: doSessionRecordingsExist,
         allSessionRecordings: this.allSessionRecordings,
         totalItems,
-        storageBucketsExist,
+        doStorageBucketsExist: doStorageBucketsExist,
       };
     }
   }
@@ -132,7 +132,7 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
    * @param {string} scope_id
    * @returns {Promise<boolean>}
    */
-  async getStorageBucketsExist(scope_id) {
+  async getDoStorageBucketsExist(scope_id) {
     // Storage buckets could fail for a number of reasons, including that
     // the user isn't authorized to access them.
     try {

--- a/ui/admin/app/routes/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/index.js
@@ -24,6 +24,10 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
       refreshModel: true,
       replace: true,
     },
+    targets: {
+      refreshModel: true,
+      replace: true,
+    },
     page: {
       refreshModel: true,
     },
@@ -38,7 +42,7 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
    * Load all session recordings.
    * @return {Promise<{ totalItems: number, sessionRecordings: [SessionRecordingModel], sessionRecordingsExist: boolean, storageBucketsExist: boolean }>}
    */
-  async model({ search, users, page, pageSize }) {
+  async model({ search, users, targets, page, pageSize }) {
     const scope = this.modelFor('scopes.scope');
     const { id: scope_id } = scope;
     let sessionRecordings;
@@ -48,9 +52,13 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
     const filters = {
       scope_id: [{ equals: scope_id }],
       'create_time_values.user.id': [],
+      'create_time_values.target.id': [],
     };
     users.forEach((user) => {
       filters['create_time_values.user.id'].push({ equals: user });
+    });
+    targets.forEach((target) => {
+      filters['create_time_values.target.id'].push({ equals: target });
     });
 
     if (

--- a/ui/admin/app/routes/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/index.js
@@ -94,7 +94,7 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
         queryOptions,
       );
       totalItems = sessionRecordings.meta?.totalItems;
-      // Query all session reocordings for filtering values if entering route for the first time
+      // Query all session recordings for filtering values if entering route for the first time
       if (!this.allSessionRecordings) {
         await this.getAllSessionRecordings(scope_id);
       }
@@ -111,6 +111,10 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
     }
   }
 
+  /**
+   * Sets allSessionRecordings to all session recordings for filters
+   * @param {string} scope_id
+   */
   async getAllSessionRecordings(scope_id) {
     const options = { pushToStore: false, peekIndexedDB: true };
     this.allSessionRecordings = await this.store.query(

--- a/ui/admin/app/routes/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/index.js
@@ -24,6 +24,10 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
       refreshModel: true,
       replace: true,
     },
+    scopes: {
+      refreshModel: true,
+      replace: true,
+    },
     targets: {
       refreshModel: true,
       replace: true,
@@ -42,7 +46,7 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
    * Load all session recordings.
    * @return {Promise<{ totalItems: number, sessionRecordings: [SessionRecordingModel], sessionRecordingsExist: boolean, storageBucketsExist: boolean }>}
    */
-  async model({ search, users, targets, page, pageSize }) {
+  async model({ search, users, scopes, targets, page, pageSize }) {
     const scope = this.modelFor('scopes.scope');
     const { id: scope_id } = scope;
     let sessionRecordings;
@@ -52,10 +56,14 @@ export default class ScopesScopeSessionRecordingsIndexRoute extends Route {
     const filters = {
       scope_id: [{ equals: scope_id }],
       'create_time_values.user.id': [],
+      'create_time_values.target.scope.id': [],
       'create_time_values.target.id': [],
     };
     users.forEach((user) => {
       filters['create_time_values.user.id'].push({ equals: user });
+    });
+    scopes.forEach((scope) => {
+      filters['create_time_values.target.scope.id'].push({ equals: scope });
     });
     targets.forEach((target) => {
       filters['create_time_values.target.id'].push({ equals: target });

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel.js
@@ -11,6 +11,8 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
   @service store;
   @service can;
   @service router;
+  @service flashMessages;
+  @service intl;
 
   // =methods
   /**
@@ -35,19 +37,30 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
   }
 
   /**
-   * Redirects to route with correct session-recording id if incorrect.
+   * Redirects to route with correct session-recording id if incorrect. If
+   * the channelRecording is undefined we redirect the user back to
+   * the session recordings list page.
    * @param {channelRecording: Object, sessionRecording: Object, storageBucket: Object} model
    */
   redirect(model) {
     const { channelRecording, sessionRecording } = model;
-    const session_recording_id =
-      channelRecording.connection_recording.session_recording.id;
-    if (session_recording_id !== sessionRecording.id) {
-      this.router.replaceWith(
-        'scopes.scope.session-recordings.session-recording.channels-by-connection.channel',
-        session_recording_id,
-        channelRecording.id,
-      );
+    if (channelRecording) {
+      const session_recording_id =
+        channelRecording.connection_recording.session_recording.id;
+      if (session_recording_id !== sessionRecording.id) {
+        this.router.replaceWith(
+          'scopes.scope.session-recordings.session-recording.channels-by-connection.channel',
+          session_recording_id,
+          channelRecording.id,
+        );
+      }
+    } else {
+      this.flashMessages.danger(this.intl.t('errors.404.title'), {
+        notificationType: 'error',
+        sticky: true,
+        dismiss: (flash) => flash.destroyMessage(),
+      });
+      this.router.transitionTo('scopes.scope.session-recordings');
     }
   }
 }

--- a/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
@@ -22,8 +22,8 @@
           <S.TextInput
             @value={{this.search}}
             @type='search'
-            placeholder={{t 'actions.search-session-recording'}}
-            aria-label={{t 'actions.search-session-recording'}}
+            placeholder={{t 'actions.search'}}
+            aria-label={{t 'actions.search'}}
             {{on 'input' this.handleSearchInput}}
           />
           <S.Dropdown name='time' as |D|>

--- a/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
@@ -50,6 +50,36 @@
             </S.Generic>
             <S.Generic>
               <Dropdown
+                name='scope'
+                @toggleText={{t 'resources.scope.title'}}
+                @itemOptions={{this.projectScopes}}
+                @checkedItems={{this.scopes}}
+                @applyFilter={{fn this.applyFilter 'scopes'}}
+                @isSearchable={{true}}
+                as |FD selectItem itemOptions|
+              >
+                {{#each-in
+                  (group-by 'parent_scope_id' itemOptions)
+                  as |orgId items|
+                }}
+                  <FD.Generic>
+                    <FlightIcon @name='org' />
+                    {{this.orgName orgId}}
+                  </FD.Generic>
+                  {{#each items as |project|}}
+                    <FD.Checkbox
+                      @value={{project.id}}
+                      checked={{includes project.id this.scopes}}
+                      {{on 'change' selectItem}}
+                    >
+                      {{project.name}}
+                    </FD.Checkbox>
+                  {{/each}}
+                {{/each-in}}
+              </Dropdown>
+            </S.Generic>
+            <S.Generic>
+              <Dropdown
                 name='target'
                 @toggleText={{t 'resources.target.title'}}
                 @itemOptions={{this.filterOptions 'target'}}

--- a/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
@@ -33,7 +33,7 @@
             />
             {{#each this.timeOptions as |time|}}
               <D.Checkmark
-                @selected={{includes time.id this.times}}
+                @selected={{eq time.id this.time}}
                 {{on 'click' (fn this.changeTimeFilter time.id D.close)}}
               >
                 {{time.name}}

--- a/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
@@ -26,80 +26,92 @@
             aria-label={{t 'actions.search-session-recording'}}
             {{on 'input' this.handleSearchInput}}
           />
-          {{#if @model.allSessionRecordings}}
-            <S.Generic>
-              <Dropdown
-                name='user'
-                @toggleText={{t 'resources.user.title'}}
-                @itemOptions={{this.filterOptions 'user'}}
-                @checkedItems={{this.users}}
-                @applyFilter={{fn this.applyFilter 'users'}}
-                @isSearchable={{true}}
-                as |FD selectItem itemOptions|
+          <S.Dropdown name='time' as |D|>
+            <D.ToggleButton
+              @text={{t 'resources.session-recording.filters.time.title'}}
+              @color='secondary'
+            />
+            {{#each this.timeOptions as |time|}}
+              <D.Checkmark
+                @selected={{includes time.id this.times}}
+                {{on 'click' (fn this.changeTimeFilter time.id D.close)}}
               >
-                {{#each itemOptions as |itemOption|}}
+                {{time.name}}
+              </D.Checkmark>
+            {{/each}}
+          </S.Dropdown>
+          <S.Generic>
+            <Dropdown
+              name='user'
+              @toggleText={{t 'resources.user.title'}}
+              @itemOptions={{this.filterOptions 'user'}}
+              @checkedItems={{this.users}}
+              @applyFilter={{fn this.applyFilter 'users'}}
+              @isSearchable={{true}}
+              as |FD selectItem itemOptions|
+            >
+              {{#each itemOptions as |itemOption|}}
+                <FD.Checkbox
+                  @value={{itemOption.id}}
+                  checked={{includes itemOption.id this.users}}
+                  {{on 'change' selectItem}}
+                >
+                  {{itemOption.name}}
+                </FD.Checkbox>
+              {{/each}}
+            </Dropdown>
+          </S.Generic>
+          <S.Generic>
+            <Dropdown
+              name='scope'
+              @toggleText={{t 'resources.scope.title'}}
+              @itemOptions={{this.projectScopes}}
+              @checkedItems={{this.scopes}}
+              @applyFilter={{fn this.applyFilter 'scopes'}}
+              @isSearchable={{true}}
+              as |FD selectItem itemOptions|
+            >
+              {{#each-in
+                (group-by 'parent_scope_id' itemOptions)
+                as |orgId items|
+              }}
+                <FD.Generic>
+                  <FlightIcon @name='org' />
+                  {{this.orgName orgId}}
+                </FD.Generic>
+                {{#each items as |project|}}
                   <FD.Checkbox
-                    @value={{itemOption.id}}
-                    checked={{includes itemOption.id this.users}}
+                    @value={{project.id}}
+                    checked={{includes project.id this.scopes}}
                     {{on 'change' selectItem}}
                   >
-                    {{itemOption.name}}
+                    {{project.name}}
                   </FD.Checkbox>
                 {{/each}}
-              </Dropdown>
-            </S.Generic>
-            <S.Generic>
-              <Dropdown
-                name='scope'
-                @toggleText={{t 'resources.scope.title'}}
-                @itemOptions={{this.projectScopes}}
-                @checkedItems={{this.scopes}}
-                @applyFilter={{fn this.applyFilter 'scopes'}}
-                @isSearchable={{true}}
-                as |FD selectItem itemOptions|
-              >
-                {{#each-in
-                  (group-by 'parent_scope_id' itemOptions)
-                  as |orgId items|
-                }}
-                  <FD.Generic>
-                    <FlightIcon @name='org' />
-                    {{this.orgName orgId}}
-                  </FD.Generic>
-                  {{#each items as |project|}}
-                    <FD.Checkbox
-                      @value={{project.id}}
-                      checked={{includes project.id this.scopes}}
-                      {{on 'change' selectItem}}
-                    >
-                      {{project.name}}
-                    </FD.Checkbox>
-                  {{/each}}
-                {{/each-in}}
-              </Dropdown>
-            </S.Generic>
-            <S.Generic>
-              <Dropdown
-                name='target'
-                @toggleText={{t 'resources.target.title'}}
-                @itemOptions={{this.filterOptions 'target'}}
-                @checkedItems={{this.targets}}
-                @applyFilter={{fn this.applyFilter 'targets'}}
-                @isSearchable={{true}}
-                as |FD selectItem itemOptions|
-              >
-                {{#each itemOptions as |itemOption|}}
-                  <FD.Checkbox
-                    @value={{itemOption.id}}
-                    checked={{includes itemOption.id this.targets}}
-                    {{on 'change' selectItem}}
-                  >
-                    {{itemOption.name}}
-                  </FD.Checkbox>
-                {{/each}}
-              </Dropdown>
-            </S.Generic>
-          {{/if}}
+              {{/each-in}}
+            </Dropdown>
+          </S.Generic>
+          <S.Generic>
+            <Dropdown
+              name='target'
+              @toggleText={{t 'resources.target.title'}}
+              @itemOptions={{this.filterOptions 'target'}}
+              @checkedItems={{this.targets}}
+              @applyFilter={{fn this.applyFilter 'targets'}}
+              @isSearchable={{true}}
+              as |FD selectItem itemOptions|
+            >
+              {{#each itemOptions as |itemOption|}}
+                <FD.Checkbox
+                  @value={{itemOption.id}}
+                  checked={{includes itemOption.id this.targets}}
+                  {{on 'change' selectItem}}
+                >
+                  {{itemOption.name}}
+                </FD.Checkbox>
+              {{/each}}
+            </Dropdown>
+          </S.Generic>
         </Hds::SegmentedGroup>
         <span>
           <ToolbarRefresher @onClick={{this.refresh}} />

--- a/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
@@ -214,7 +214,11 @@
           <A.Header @title={{t 'titles.no-results-found'}} />
           <A.Body
             @text={{t
-              'descriptions.no-search-results'
+              (if
+                this.search
+                'descriptions.no-search-results'
+                'descriptions.no-filter-results'
+              )
               query=this.search
               resource=(t 'resources.session-recording.title_plural')
             }}

--- a/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
@@ -15,118 +15,142 @@
     <p>{{t 'resources.session-recording.description'}}</p>
   </page.header>
 
-  <page.body>
-    {{#if this.hasSessionRecordings}}
-      <Hds::Table
-        @model={{@model.sessionRecordings}}
-        @density='tall'
-        @columns={{array
-          (hash label=(t 'resources.session-recording.form.time.label'))
-          (hash label=(t 'resources.session-recording.form.status.label'))
-          (hash label=(t 'resources.session-recording.form.user.label'))
-          (hash label=(t 'resources.session-recording.form.target.label'))
-          (hash label=(t 'resources.session-recording.form.duration.label'))
-          (hash label=(t 'actions.view') isVisuallyHidden=true align='right')
-        }}
-        @valign='middle'
-      >
-        <:body as |B|>
-          <B.Tr>
-            {{! Created Time }}
-            <B.Td>
-              {{#if B.data.created_time}}
-                <span class='hds-foreground-faint'>
-                  <time datetime={{format-date-iso B.data.created_time}}>
-                    {{format-date-iso B.data.created_time}}
-                  </time>
-                </span>
-              {{/if}}
-            </B.Td>
-            {{! Status }}
-            <B.Td>
-              <SessionRecording::Status @status={{B.data.state}} />
-            </B.Td>
-            {{! User }}
-            <B.Td>
-              <div
-                class='session-recording-list-cell-item hds-font-weight-semibold'
-              >
-                <span><FlightIcon @name='user' /></span>
-                <span>{{B.data.userDisplayName}}</span>
-              </div>
-            </B.Td>
-            {{! Target }}
-            <B.Td>
-              <div
-                class='session-recording-list-cell-item target-column hds-font-weight-semibold'
-              >
-                <span>
-                  <FlightIcon @name='target' />
-                  {{B.data.create_time_values.target.name}}
-                </span>
-                <span>
-                  <Hds::Badge
-                    @text={{B.data.targetScopeDisplayName}}
-                    @icon='grid'
-                  />
-                </span>
-              </div>
-            </B.Td>
-            {{! Duration }}
-            <B.Td>
-              {{#if B.data.duration}}
+  <page.body class='search-filtering'>
+    {{#if @model.sessionRecordingsExist}}
+      <Hds::SegmentedGroup as |S|>
+        <S.TextInput
+          @value={{this.search}}
+          @type='search'
+          placeholder={{t 'actions.search-session-recording'}}
+          aria-label={{t 'actions.search-session-recording'}}
+          {{on 'input' this.handleSearchInput}}
+        />
+      </Hds::SegmentedGroup>
+      {{#if @model.sessionRecordings}}
+        <Hds::Table
+          @model={{@model.sessionRecordings}}
+          @density='tall'
+          @columns={{array
+            (hash label=(t 'resources.session-recording.form.time.label'))
+            (hash label=(t 'resources.session-recording.form.status.label'))
+            (hash label=(t 'resources.session-recording.form.user.label'))
+            (hash label=(t 'resources.session-recording.form.target.label'))
+            (hash label=(t 'resources.session-recording.form.duration.label'))
+            (hash label=(t 'actions.view') isVisuallyHidden=true align='right')
+          }}
+          @valign='middle'
+        >
+          <:body as |B|>
+            <B.Tr>
+              {{! Created Time }}
+              <B.Td>
+                {{#if B.data.created_time}}
+                  <span class='hds-foreground-faint'>
+                    <time datetime={{format-date-iso B.data.created_time}}>
+                      {{format-date-iso B.data.created_time}}
+                    </time>
+                  </span>
+                {{/if}}
+              </B.Td>
+              {{! Status }}
+              <B.Td>
+                <SessionRecording::Status @status={{B.data.state}} />
+              </B.Td>
+              {{! User }}
+              <B.Td>
                 <div
-                  class='session-recording-list-cell-item hds-foreground-faint'
+                  class='session-recording-list-cell-item hds-font-weight-semibold'
                 >
-                  <span><FlightIcon @name='clock' /></span>
+                  <span><FlightIcon @name='user' /></span>
+                  <span>{{B.data.userDisplayName}}</span>
+                </div>
+              </B.Td>
+              {{! Target }}
+              <B.Td>
+                <div
+                  class='session-recording-list-cell-item target-column hds-font-weight-semibold'
+                >
                   <span>
-                    {{format-time-duration B.data.duration}}
+                    <FlightIcon @name='target' />
+                    {{B.data.create_time_values.target.name}}
+                  </span>
+                  <span>
+                    <Hds::Badge
+                      @text={{B.data.targetScopeDisplayName}}
+                      @icon='grid'
+                    />
                   </span>
                 </div>
-              {{/if}}
-            </B.Td>
-            <B.Td align='right'>
-              {{#if (can 'read session-recording' B.data)}}
-                <Hds::Button
-                  @icon='arrow-right'
-                  @iconPosition='trailing'
-                  @color='secondary'
-                  @text={{t 'actions.view'}}
-                  @route='scopes.scope.session-recordings.session-recording.channels-by-connection'
-                  @model={{B.data.id}}
-                />
-              {{/if}}
-            </B.Td>
-          </B.Tr>
-        </:body>
-      </Hds::Table>
+              </B.Td>
+              {{! Duration }}
+              <B.Td>
+                {{#if B.data.duration}}
+                  <div
+                    class='session-recording-list-cell-item hds-foreground-faint'
+                  >
+                    <span><FlightIcon @name='clock' /></span>
+                    <span>
+                      {{format-time-duration B.data.duration}}
+                    </span>
+                  </div>
+                {{/if}}
+              </B.Td>
+              <B.Td align='right'>
+                {{#if (can 'read session-recording' B.data)}}
+                  <Hds::Button
+                    @icon='arrow-right'
+                    @iconPosition='trailing'
+                    @color='secondary'
+                    @text={{t 'actions.view'}}
+                    @route='scopes.scope.session-recordings.session-recording.channels-by-connection'
+                    @model={{B.data.id}}
+                  />
+                {{/if}}
+              </B.Td>
+            </B.Tr>
+          </:body>
+        </Hds::Table>
+        <Rose::Pagination
+          @totalItems={{@model.totalItems}}
+          @currentPage={{this.page}}
+          @currentPageSize={{this.pageSize}}
+        />
+      {{else}}
+        <Hds::ApplicationState data-test-no-session-recording-results as |A|>
+          <A.Header @title={{t 'titles.no-results-found'}} />
+          <A.Body
+            @text={{t
+              'descriptions.no-search-results'
+              query=this.search
+              resource=(t 'resources.session-recording.title_plural')
+            }}
+          />
+        </Hds::ApplicationState>
+      {{/if}}
     {{else}}
-      <Rose::Layout::Centered>
-        <Rose::Message
+      <Hds::ApplicationState as |A|>
+        <A.Header
           @title={{t 'resources.session-recording.messages.none.title'}}
-          as |message|
-        >
-          <message.description>
-            {{#if this.hasSessionRecordingsConfigured}}
-              {{! storage buckets exist but no recordings }}
-              {{t 'resources.session-recording.messages.none.description'}}
-            {{else}}
-              {{! No storage buckets exist }}
-              {{t
-                'resources.session-recording.messages.none.no-storage-bucket-description'
-              }}
-            {{/if}}
-          </message.description>
-          {{#unless this.hasSessionRecordingsConfigured}}
-            <Hds::Link::Standalone
+        />
+        <A.Body
+          @text={{t
+            (if
+              @model.storageBucketsExist
+              'resources.session-recording.messages.none.description'
+              'resources.session-recording.messages.none.no-storage-bucket-description'
+            )
+          }}
+        />
+        {{#unless @model.storageBucketsExist}}
+          <A.Footer as |F|>
+            <F.LinkStandalone
               @icon='plus-circle'
-              @iconPosition='leading'
-              @route='scopes.scope.storage-buckets.new'
               @text={{t 'resources.storage-bucket.messages.none.link'}}
+              @route='scopes.scope.storage-buckets.new'
             />
-          {{/unless}}
-        </Rose::Message>
-      </Rose::Layout::Centered>
+          </A.Footer>
+        {{/unless}}
+      </Hds::ApplicationState>
     {{/if}}
   </page.body>
 </Rose::Layout::Page>

--- a/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
@@ -31,7 +31,7 @@
               <Dropdown
                 name='user'
                 @toggleText={{t 'resources.user.title'}}
-                @itemOptions={{this.userOptions}}
+                @itemOptions={{this.filterOptions 'user'}}
                 @checkedItems={{this.users}}
                 @applyFilter={{fn this.applyFilter 'users'}}
                 @isSearchable={{true}}
@@ -52,7 +52,7 @@
               <Dropdown
                 name='target'
                 @toggleText={{t 'resources.target.title'}}
-                @itemOptions={{this.targetOptions}}
+                @itemOptions={{this.filterOptions 'target'}}
                 @checkedItems={{this.targets}}
                 @applyFilter={{fn this.applyFilter 'targets'}}
                 @isSearchable={{true}}

--- a/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
@@ -16,7 +16,7 @@
   </page.header>
 
   <page.body class='search-filtering'>
-    {{#if @model.sessionRecordingsExist}}
+    {{#if @model.doSessionRecordingsExist}}
       <div class='search-filtering-toolbar'>
         <Hds::SegmentedGroup data-test-session-recordings-bar as |S|>
           <S.TextInput
@@ -233,13 +233,13 @@
         <A.Body
           @text={{t
             (if
-              @model.storageBucketsExist
+              @model.doStorageBucketsExist
               'resources.session-recording.messages.none.description'
               'resources.session-recording.messages.none.no-storage-bucket-description'
             )
           }}
         />
-        {{#unless @model.storageBucketsExist}}
+        {{#unless @model.doStorageBucketsExist}}
           <A.Footer as |F|>
             <F.LinkStandalone
               @icon='plus-circle'

--- a/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
@@ -48,6 +48,27 @@
                 {{/each}}
               </Dropdown>
             </S.Generic>
+            <S.Generic>
+              <Dropdown
+                name='target'
+                @toggleText={{t 'resources.target.title'}}
+                @itemOptions={{this.targetOptions}}
+                @checkedItems={{this.targets}}
+                @applyFilter={{fn this.applyFilter 'targets'}}
+                @isSearchable={{true}}
+                as |FD selectItem itemOptions|
+              >
+                {{#each itemOptions as |itemOption|}}
+                  <FD.Checkbox
+                    @value={{itemOption.id}}
+                    checked={{includes itemOption.id this.targets}}
+                    {{on 'change' selectItem}}
+                  >
+                    {{itemOption.name}}
+                  </FD.Checkbox>
+                {{/each}}
+              </Dropdown>
+            </S.Generic>
           {{/if}}
         </Hds::SegmentedGroup>
         <span>

--- a/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/index.hbs
@@ -17,15 +17,46 @@
 
   <page.body class='search-filtering'>
     {{#if @model.sessionRecordingsExist}}
-      <Hds::SegmentedGroup as |S|>
-        <S.TextInput
-          @value={{this.search}}
-          @type='search'
-          placeholder={{t 'actions.search-session-recording'}}
-          aria-label={{t 'actions.search-session-recording'}}
-          {{on 'input' this.handleSearchInput}}
-        />
-      </Hds::SegmentedGroup>
+      <div class='search-filtering-toolbar'>
+        <Hds::SegmentedGroup data-test-session-recordings-bar as |S|>
+          <S.TextInput
+            @value={{this.search}}
+            @type='search'
+            placeholder={{t 'actions.search-session-recording'}}
+            aria-label={{t 'actions.search-session-recording'}}
+            {{on 'input' this.handleSearchInput}}
+          />
+          {{#if @model.allSessionRecordings}}
+            <S.Generic>
+              <Dropdown
+                name='user'
+                @toggleText={{t 'resources.user.title'}}
+                @itemOptions={{this.userOptions}}
+                @checkedItems={{this.users}}
+                @applyFilter={{fn this.applyFilter 'users'}}
+                @isSearchable={{true}}
+                as |FD selectItem itemOptions|
+              >
+                {{#each itemOptions as |itemOption|}}
+                  <FD.Checkbox
+                    @value={{itemOption.id}}
+                    checked={{includes itemOption.id this.users}}
+                    {{on 'change' selectItem}}
+                  >
+                    {{itemOption.name}}
+                  </FD.Checkbox>
+                {{/each}}
+              </Dropdown>
+            </S.Generic>
+          {{/if}}
+        </Hds::SegmentedGroup>
+        <span>
+          <ToolbarRefresher @onClick={{this.refresh}} />
+        </span>
+      </div>
+
+      <FilterTags @filters={{this.filters}} />
+
       {{#if @model.sessionRecordings}}
         <Hds::Table
           @model={{@model.sessionRecordings}}

--- a/ui/admin/tests/acceptance/session-recordings/list-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/list-test.js
@@ -29,6 +29,10 @@ module('Acceptance | session recordings | list', function (hooks) {
   const SESSION_RECORDING_TITLE = 'Session Recordings';
   const SEARCH_INPUT_SELECTOR = '.search-filtering [type="search"]';
   const NO_RESULTS_MSG_SELECTOR = '[data-test-no-session-recording-results]';
+  const FILTER_TOGGLE_SELECTOR = (name) =>
+    `[data-test-session-recordings-bar] div[name="${name}"] button`;
+  const FILTER_APPLY_BUTTON = (name) =>
+    `[data-test-session-recordings-bar] div[name="${name}"] div div:last-child button[type="button"]`;
 
   // Instances
   const instances = {
@@ -38,6 +42,7 @@ module('Acceptance | session recordings | list', function (hooks) {
     },
     target: null,
     user: null,
+    user2: null,
     sessionRecording: null,
     sessionRecording2: null,
   };
@@ -60,6 +65,7 @@ module('Acceptance | session recordings | list', function (hooks) {
       scope: instances.scopes.global,
     });
     instances.user = this.server.create('user');
+    instances.user2 = this.server.create('user');
     instances.sessionRecording = this.server.create('session-recording', {
       scope: instances.scopes.global,
       create_time_values: {
@@ -71,7 +77,7 @@ module('Acceptance | session recordings | list', function (hooks) {
       scope: instances.scopes.global,
       create_time_values: {
         target: instances.target.attrs,
-        user: instances.user.attrs,
+        user: instances.user2.attrs,
       },
     });
     urls.globalScope = `/scopes/global`;
@@ -144,5 +150,17 @@ module('Acceptance | session recordings | list', function (hooks) {
     assert.dom(commonSelectors.HREF(urls.sessionRecording)).doesNotExist();
     assert.dom(commonSelectors.HREF(urls.sessionRecording2)).doesNotExist();
     assert.dom(NO_RESULTS_MSG_SELECTOR).includesText('No results found');
+  });
+
+  test('user can filter session recordings by user', async function (assert) {
+    await visit(urls.sessionRecordings);
+
+    assert.dom('tbody tr').exists({ count: 2 });
+
+    await click(FILTER_TOGGLE_SELECTOR('user'));
+    await click(`input[value="${instances.user.id}"]`);
+    await click(FILTER_APPLY_BUTTON('user'));
+
+    assert.dom('tbody tr').exists({ count: 1 });
   });
 });

--- a/ui/admin/tests/acceptance/session-recordings/list-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/list-test.js
@@ -17,6 +17,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
+import { faker } from '@faker-js/faker';
 
 module('Acceptance | session recordings | list', function (hooks) {
   setupApplicationTest(hooks);
@@ -33,6 +34,8 @@ module('Acceptance | session recordings | list', function (hooks) {
     `[data-test-session-recordings-bar] div[name="${name}"] button`;
   const FILTER_APPLY_BUTTON = (name) =>
     `[data-test-session-recordings-bar] div[name="${name}"] div div:last-child button[type="button"]`;
+  const LAST_3_DAYS_OPTION =
+    '[data-test-session-recordings-bar] div[name="time"] li:nth-child(2) button';
 
   // Instances
   const instances = {
@@ -97,6 +100,7 @@ module('Acceptance | session recordings | list', function (hooks) {
     });
     instances.sessionRecording2 = this.server.create('session-recording', {
       scope: instances.scopes.global,
+      created_time: faker.date.past(),
       create_time_values: {
         target: {
           id: instances.target2.id,
@@ -214,6 +218,17 @@ module('Acceptance | session recordings | list', function (hooks) {
     await click(FILTER_TOGGLE_SELECTOR('scope'));
     await click(`input[value="${instances.target.scope.id}"]`);
     await click(FILTER_APPLY_BUTTON('scope'));
+
+    assert.dom('tbody tr').exists({ count: 1 });
+  });
+
+  test('user can filter session recordings by time', async function (assert) {
+    await visit(urls.sessionRecordings);
+
+    assert.dom('tbody tr').exists({ count: 2 });
+
+    await click(FILTER_TOGGLE_SELECTOR('time'));
+    await click(LAST_3_DAYS_OPTION);
 
     assert.dom('tbody tr').exists({ count: 1 });
   });

--- a/ui/admin/tests/acceptance/session-recordings/list-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/list-test.js
@@ -39,6 +39,8 @@ module('Acceptance | session recordings | list', function (hooks) {
     scopes: {
       global: null,
       org: null,
+      project: null,
+      project2: null,
     },
     target: null,
     target2: null,
@@ -62,25 +64,49 @@ module('Acceptance | session recordings | list', function (hooks) {
       type: 'org',
       scope: { id: 'global', type: 'global' },
     });
+    instances.scopes.project = this.server.create('scope', {
+      type: 'project',
+      scope: { id: instances.scopes.org.id, type: 'org' },
+    });
+    instances.scopes.project2 = this.server.create('scope', {
+      type: 'project',
+      scope: { id: instances.scopes.org.id, type: 'org' },
+    });
     instances.target = this.server.create('target', {
-      scope: instances.scopes.global,
+      scope: instances.scopes.project,
     });
     instances.target2 = this.server.create('target', {
-      scope: instances.scopes.global,
+      scope: instances.scopes.project2,
     });
     instances.user = this.server.create('user');
     instances.user2 = this.server.create('user');
     instances.sessionRecording = this.server.create('session-recording', {
       scope: instances.scopes.global,
       create_time_values: {
-        target: instances.target.attrs,
+        target: {
+          id: instances.target.id,
+          name: instances.target.name,
+          scope: {
+            id: instances.scopes.project.id,
+            name: instances.scopes.project.name,
+            parent_scope_id: instances.scopes.org.id,
+          },
+        },
         user: instances.user.attrs,
       },
     });
     instances.sessionRecording2 = this.server.create('session-recording', {
       scope: instances.scopes.global,
       create_time_values: {
-        target: instances.target2.attrs,
+        target: {
+          id: instances.target2.id,
+          name: instances.target2.name,
+          scope: {
+            id: instances.scopes.project2.id,
+            name: instances.scopes.project2.name,
+            parent_scope_id: instances.scopes.org.id,
+          },
+        },
         user: instances.user2.attrs,
       },
     });
@@ -168,7 +194,7 @@ module('Acceptance | session recordings | list', function (hooks) {
     assert.dom('tbody tr').exists({ count: 1 });
   });
 
-  test('user can filter session recordings by target', async function (assert) {
+  test('user can filter session recordings by scope', async function (assert) {
     await visit(urls.sessionRecordings);
 
     assert.dom('tbody tr').exists({ count: 2 });
@@ -176,6 +202,18 @@ module('Acceptance | session recordings | list', function (hooks) {
     await click(FILTER_TOGGLE_SELECTOR('target'));
     await click(`input[value="${instances.target.id}"]`);
     await click(FILTER_APPLY_BUTTON('target'));
+
+    assert.dom('tbody tr').exists({ count: 1 });
+  });
+
+  test('user can filter session recordings by target', async function (assert) {
+    await visit(urls.sessionRecordings);
+
+    assert.dom('tbody tr').exists({ count: 2 });
+
+    await click(FILTER_TOGGLE_SELECTOR('scope'));
+    await click(`input[value="${instances.target.scope.id}"]`);
+    await click(FILTER_APPLY_BUTTON('scope'));
 
     assert.dom('tbody tr').exists({ count: 1 });
   });

--- a/ui/admin/tests/acceptance/session-recordings/list-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/list-test.js
@@ -41,6 +41,7 @@ module('Acceptance | session recordings | list', function (hooks) {
       org: null,
     },
     target: null,
+    target2: null,
     user: null,
     user2: null,
     sessionRecording: null,
@@ -64,6 +65,9 @@ module('Acceptance | session recordings | list', function (hooks) {
     instances.target = this.server.create('target', {
       scope: instances.scopes.global,
     });
+    instances.target2 = this.server.create('target', {
+      scope: instances.scopes.global,
+    });
     instances.user = this.server.create('user');
     instances.user2 = this.server.create('user');
     instances.sessionRecording = this.server.create('session-recording', {
@@ -76,7 +80,7 @@ module('Acceptance | session recordings | list', function (hooks) {
     instances.sessionRecording2 = this.server.create('session-recording', {
       scope: instances.scopes.global,
       create_time_values: {
-        target: instances.target.attrs,
+        target: instances.target2.attrs,
         user: instances.user2.attrs,
       },
     });
@@ -160,6 +164,18 @@ module('Acceptance | session recordings | list', function (hooks) {
     await click(FILTER_TOGGLE_SELECTOR('user'));
     await click(`input[value="${instances.user.id}"]`);
     await click(FILTER_APPLY_BUTTON('user'));
+
+    assert.dom('tbody tr').exists({ count: 1 });
+  });
+
+  test('user can filter session recordings by target', async function (assert) {
+    await visit(urls.sessionRecordings);
+
+    assert.dom('tbody tr').exists({ count: 2 });
+
+    await click(FILTER_TOGGLE_SELECTOR('target'));
+    await click(`input[value="${instances.target.id}"]`);
+    await click(FILTER_APPLY_BUTTON('target'));
 
     assert.dom('tbody tr').exists({ count: 1 });
   });

--- a/ui/admin/tests/acceptance/session-recordings/read-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/read-test.js
@@ -9,10 +9,12 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 
 module('Acceptance | session-recordings | read', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIndexedDb(hooks);
 
   let featuresService;
 
@@ -28,6 +30,8 @@ module('Acceptance | session-recordings | read', function (hooks) {
       global: null,
       org: null,
     },
+    target: null,
+    user: null,
     sessionRecording: null,
   };
   // Urls
@@ -47,10 +51,12 @@ module('Acceptance | session-recordings | read', function (hooks) {
     instances.target = this.server.create('target', {
       scope: instances.scopes.global,
     });
+    instances.user = this.server.create('user');
     instances.sessionRecording = this.server.create('session-recording', {
       scope: instances.scopes.global,
       create_time_values: {
         target: instances.target.attrs,
+        user: instances.user.attrs,
       },
     });
     instances.connectionRecording = this.server.create('connection-recording', {

--- a/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
@@ -9,24 +9,30 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { Response } from 'miragejs';
+import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 
 module(
   'Acceptance | session-recordings | session-recording | channels-by-connection | channel',
   function (hooks) {
     setupApplicationTest(hooks);
     setupMirage(hooks);
+    setupIndexedDb(hooks);
 
     let featuresService;
     let getRecordingCount;
 
     const DELETE_DROPDOWN_SELECTOR = '[data-test-manage-dropdown-delete]';
     const DROPDOWN_SELECTOR = '[data-test-manage-dropdown]';
+    const ERROR_MSG_SELECTOR = '.rose-notification-body';
+
     // Instances
     const instances = {
       scopes: {
         global: null,
         org: null,
       },
+      target: null,
+      user: null,
       sessionRecording: null,
       connectionRecording: null,
       channelRecording: null,
@@ -46,13 +52,15 @@ module(
         type: 'org',
         scope: { id: 'global', type: 'global' },
       });
-      instances.scopes.targetModel = this.server.create('target', {
+      instances.target = this.server.create('target', {
         scope: instances.scopes.global,
       });
+      instances.user = this.server.create('user');
       instances.sessionRecording = this.server.create('session-recording', {
         scope: instances.scopes.global,
         create_time_values: {
-          target: instances.scopes.targetModel.attrs,
+          target: instances.target.attrs,
+          user: instances.user.attrs,
         },
       });
       instances.connectionRecording = this.server.create(
@@ -153,11 +161,29 @@ module(
         scope: instances.scopes.global,
       });
       const incorrectUrl = `${urls.sessionRecordings}/${sessionRecording.id}/channels-by-connection/${instances.channelRecording.id}`;
+      await visit(urls.sessionRecording);
 
       await visit(incorrectUrl);
 
       assert.notEqual(currentURL(), incorrectUrl);
       assert.strictEqual(currentURL(), urls.channelRecording);
+    });
+
+    test('users are redirected to session-recordings list with incorrect url', async function (assert) {
+      featuresService.enable('ssh-session-recording');
+      const sessionRecording = this.server.create('session-recording', {
+        scope: instances.scopes.global,
+        create_time_values: {
+          target: instances.target.attrs,
+          user: instances.user.attrs,
+        },
+      });
+      const incorrectUrl = `${urls.sessionRecordings}/${sessionRecording.id}/channels-by-connection/${instances.channelRecording.id}`;
+
+      await visit(incorrectUrl);
+
+      assert.strictEqual(currentURL(), urls.sessionRecordings);
+      assert.dom(ERROR_MSG_SELECTOR).hasText('Resource not found');
     });
 
     test('user cannot view manage dropdown without proper authorization', async function (assert) {

--- a/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
@@ -76,10 +76,10 @@ module(
       });
       model = {
         sessionRecordings: [instances.sessionRecording],
-        sessionRecordingsExist: true,
+        doSessionRecordingsExist: true,
         allSessionRecordings: [instances.sessionRecording],
         totalItems: 1,
-        storageBucketsExist: true,
+        doStorageBucketsExist: true,
       };
       controller.set('model', model);
     });

--- a/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
@@ -19,7 +19,7 @@ module(
 
     let controller;
     let model;
-    const originalDateNow = Date.now;
+    let date;
     let last24Hours, last3Days, last7Days;
 
     const instances = {
@@ -35,8 +35,7 @@ module(
     };
 
     hooks.beforeEach(function () {
-      const timeStamp = 1726760348000; // Thursday, September 19, 2024 3:39:08 PM (GMT)
-      sinon.stub(Date, 'now').returns(timeStamp);
+      date = sinon.useFakeTimers(new Date(2024, 9, 19).getTime());
       const now = new Date();
       last24Hours = new Date(now.getTime() - 24 * 60 * 60 * 1000);
       last3Days = new Date(now);
@@ -91,7 +90,7 @@ module(
     });
 
     hooks.afterEach(function () {
-      Date.now = originalDateNow;
+      date.restore();
     });
 
     test('it exists', function (assert) {
@@ -160,9 +159,9 @@ module(
     });
 
     test('handleSearchInput action sets expected values correctly', async function (assert) {
-      // Date.now mock in beforeEach is causing waitUntil to fail so I set it
-      // back to the originalDateNow before running this test
-      Date.now = originalDateNow;
+      // Date mock in beforeEach is causing waitUntil to fail so I restore it
+      // back before running this test
+      date.restore();
       const searchValue = 'test';
       controller.handleSearchInput({ target: { value: searchValue } });
       await waitUntil(() => controller.search === searchValue);

--- a/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
@@ -5,6 +5,7 @@
 
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { waitUntil } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module(
@@ -41,26 +42,13 @@ module(
       assert.ok(controller);
     });
 
-    test('hasSessionRecordings returns true if session recordings exist', function (assert) {
-      controller.set('model', {
-        sessionRecordings: [instances.sessionRecording],
-      });
-      assert.true(controller.hasSessionRecordings);
-    });
+    test('handleSearchInput action sets expected values correctly', async function (assert) {
+      const searchValue = 'test';
+      controller.handleSearchInput({ target: { value: searchValue } });
+      await waitUntil(() => controller.search === searchValue);
 
-    test('hasSessionRecordings returns false if no session recordings exist', function (assert) {
-      controller.set('model', { sessionRecordings: [] });
-      assert.false(controller.hasSessionRecordings);
-    });
-
-    test('hasSessionRecordingsConfigured returns true if storage buckets exist', function (assert) {
-      controller.set('model', { storageBuckets: [instances.storageBucket] });
-      assert.true(controller.hasSessionRecordingsConfigured);
-    });
-
-    test('hasSessionRecordingsConfigured returns false if no storage buckets exist', function (assert) {
-      controller.set('model', { storageBuckets: [] });
-      assert.false(controller.hasSessionRecordingsConfigured);
+      assert.strictEqual(controller.page, 1);
+      assert.strictEqual(controller.search, searchValue);
     });
   },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
@@ -5,17 +5,62 @@
 
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module(
   'Unit | Controller | scopes/scope/session-recordings/index',
   function (hooks) {
     setupTest(hooks);
+    setupMirage(hooks);
 
-    test('it exists', function (assert) {
-      let controller = this.owner.lookup(
+    let controller;
+
+    const instances = {
+      scopes: {
+        global: null,
+      },
+      sessionRecording: null,
+      storageBucket: null,
+    };
+
+    hooks.beforeEach(function () {
+      controller = this.owner.lookup(
         'controller:scopes/scope/session-recordings/index',
       );
+
+      instances.scopes.global = this.server.create('scope', { id: 'global' });
+      instances.sessionRecording = this.server.create('session-recording', {
+        scope: instances.scopes.global,
+      });
+      instances.storageBucket = this.server.create('storage-bucket', {
+        scope: instances.scopes.global,
+      });
+    });
+
+    test('it exists', function (assert) {
       assert.ok(controller);
+    });
+
+    test('hasSessionRecordings returns true if session recordings exist', function (assert) {
+      controller.set('model', {
+        sessionRecordings: [instances.sessionRecording],
+      });
+      assert.true(controller.hasSessionRecordings);
+    });
+
+    test('hasSessionRecordings returns false if no session recordings exist', function (assert) {
+      controller.set('model', { sessionRecordings: [] });
+      assert.false(controller.hasSessionRecordings);
+    });
+
+    test('hasSessionRecordingsConfigured returns true if storage buckets exist', function (assert) {
+      controller.set('model', { storageBuckets: [instances.storageBucket] });
+      assert.true(controller.hasSessionRecordingsConfigured);
+    });
+
+    test('hasSessionRecordingsConfigured returns false if no storage buckets exist', function (assert) {
+      controller.set('model', { storageBuckets: [] });
+      assert.false(controller.hasSessionRecordingsConfigured);
     });
   },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
@@ -7,19 +7,32 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { waitUntil } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupIntl } from 'ember-intl/test-support';
 
 module(
   'Unit | Controller | scopes/scope/session-recordings/index',
   function (hooks) {
     setupTest(hooks);
     setupMirage(hooks);
+    setupIntl(hooks, 'en-us');
 
     let controller;
+    let model;
+    const now = new Date();
+    const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const threeDaysPast = new Date(midnight);
+    threeDaysPast.setDate(midnight.getDate() - 3);
+    const sevenDaysPast = new Date(midnight);
+    sevenDaysPast.setDate(midnight.getDate() - 7);
 
     const instances = {
       scopes: {
         global: null,
+        org: null,
+        project: null,
       },
+      target: null,
+      user: null,
       sessionRecording: null,
       storageBucket: null,
     };
@@ -30,16 +43,110 @@ module(
       );
 
       instances.scopes.global = this.server.create('scope', { id: 'global' });
+      instances.scopes.org = this.server.create('scope', {
+        type: 'org',
+        scope: { id: 'global', type: 'global' },
+      });
+      instances.scopes.project = this.server.create('scope', {
+        type: 'project',
+        parent_scope_id: instances.scopes.org.id,
+        scope: { id: instances.scopes.org.id, type: 'org' },
+      });
+      instances.target = this.server.create('target', {
+        scope: instances.scopes.project,
+      });
+      instances.user = this.server.create('user');
       instances.sessionRecording = this.server.create('session-recording', {
         scope: instances.scopes.global,
+        create_time_values: {
+          target: {
+            id: instances.target.id,
+            name: instances.target.name,
+            scope: {
+              id: instances.scopes.project.id,
+              name: instances.scopes.project.name,
+              parent_scope_id: instances.scopes.org.id,
+            },
+          },
+          user: instances.user.attrs,
+        },
       });
       instances.storageBucket = this.server.create('storage-bucket', {
         scope: instances.scopes.global,
       });
+      model = {
+        sessionRecordings: [instances.sessionRecording],
+        sessionRecordingsExist: true,
+        allSessionRecordings: [instances.sessionRecording],
+        totalItems: 1,
+        storageBucketsExist: true,
+      };
+      controller.set('model', model);
     });
 
     test('it exists', function (assert) {
       assert.ok(controller);
+    });
+
+    test('filters returns expected entries', function (assert) {
+      assert.deepEqual(controller.filters.allFilters, {
+        times: [
+          {
+            id: midnight.toISOString(),
+            name: 'Today',
+          },
+          {
+            id: threeDaysPast.toISOString(),
+            name: 'Last 3 days',
+          },
+          {
+            id: sevenDaysPast.toISOString(),
+            name: 'Last 7 days',
+          },
+        ],
+        users: [{ id: instances.user.id, name: instances.user.name }],
+        scopes: [
+          {
+            id: instances.scopes.project.id,
+            name: instances.scopes.project.name,
+            parent_scope_id: instances.scopes.project.parent_scope_id,
+          },
+        ],
+        targets: [{ id: instances.target.id, name: instances.target.name }],
+      });
+      assert.deepEqual(controller.filters.selectedFilters, {
+        times: [],
+        users: [],
+        scopes: [],
+        targets: [],
+      });
+    });
+
+    test('timeOptions returns expected filter options', function (assert) {
+      assert.deepEqual(controller.timeOptions, [
+        {
+          id: midnight.toISOString(),
+          name: 'Today',
+        },
+        {
+          id: threeDaysPast.toISOString(),
+          name: 'Last 3 days',
+        },
+        {
+          id: sevenDaysPast.toISOString(),
+          name: 'Last 7 days',
+        },
+      ]);
+    });
+
+    test('projectScopes returns an array of unique projects', function (assert) {
+      assert.deepEqual(controller.projectScopes, [
+        {
+          id: instances.scopes.project.id,
+          name: instances.scopes.project.name,
+          parent_scope_id: instances.scopes.project.parent_scope_id,
+        },
+      ]);
     });
 
     test('handleSearchInput action sets expected values correctly', async function (assert) {
@@ -49,6 +156,39 @@ module(
 
       assert.strictEqual(controller.page, 1);
       assert.strictEqual(controller.search, searchValue);
+    });
+
+    test('applyFilter action sets expected values correctly', function (assert) {
+      const selectedItems = ['admin'];
+      controller.applyFilter('users', selectedItems);
+
+      assert.strictEqual(controller.page, 1);
+      assert.deepEqual(controller.users, selectedItems);
+    });
+
+    test('changeTimeFilter action sets the time filter', function (assert) {
+      assert.expect(3);
+      this.onClose = () => assert.ok(true, 'onClose was called');
+      controller.changeTimeFilter(midnight.toISOString(), this.onClose);
+
+      assert.strictEqual(controller.page, 1);
+      assert.deepEqual(controller.times, [midnight.toISOString()]);
+    });
+
+    test('refresh action calls refreshAll', async function (assert) {
+      assert.expect(2);
+      controller.set('target', {
+        send(actionName, ...args) {
+          assert.strictEqual(actionName, 'refreshAll');
+          assert.deepEqual(
+            args,
+            [],
+            'refreshAll was called with the correct arguments',
+          );
+        },
+      });
+
+      await controller.refresh();
     });
   },
 );

--- a/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/index-test.js
@@ -90,7 +90,7 @@ module(
 
     test('filters returns expected entries', function (assert) {
       assert.deepEqual(controller.filters.allFilters, {
-        times: [
+        time: [
           {
             id: midnight.toISOString(),
             name: 'Today',
@@ -115,7 +115,7 @@ module(
         targets: [{ id: instances.target.id, name: instances.target.name }],
       });
       assert.deepEqual(controller.filters.selectedFilters, {
-        times: [],
+        time: [null],
         users: [],
         scopes: [],
         targets: [],
@@ -172,7 +172,7 @@ module(
       controller.changeTimeFilter(midnight.toISOString(), this.onClose);
 
       assert.strictEqual(controller.page, 1);
-      assert.deepEqual(controller.times, [midnight.toISOString()]);
+      assert.deepEqual(controller.time, midnight.toISOString());
     });
 
     test('refresh action calls refreshAll', async function (assert) {


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
This adds pagination support for Session Recordings along with search for `session-recording.id` and filters for user and target.

Another change that is made in this PR is how we handle redirects for the `scopes.scope.session-recordings.session-recording.channels-by-connection.channel` route. If the user has entered a URL where the session recording ID is wrong, we redirect the user back to the list view and display a toast message.

<!-- Uncomment line below to manually add link to JIRA ticket -->
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-15181)

## Screenshots (if appropriate)
Search and filter:

https://github.com/user-attachments/assets/8c748e27-898f-4443-a978-e01f571824c7


Redirect change:

https://github.com/user-attachments/assets/41eb6cde-7e64-4c94-96dc-619da173683a

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
Create sessions with targets that have recording enabled. After creating a few, you should see the table of session recordings with new filters above.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
