### PR TITLE
appupdater cli check

### DIFF
--- a/ui/desktop/electron-app/src/cli/index.js
+++ b/ui/desktop/electron-app/src/cli/index.js
@@ -4,7 +4,7 @@
  */
 
 const { spawnSync } = require('../helpers/spawn-promise.js');
-const { path } = require('./path.js');
+const { path, isBuiltInCli } = require('./path.js');
 const pathPosix = require('path');
 const pathWin = require('path/win32');
 const { isWindows } = require('../helpers/platform.js');
@@ -13,18 +13,7 @@ module.exports = {
   // Check boundary cli existence
   exists: () => Boolean(path()),
 
-  // Return true if the CLI in usage is the built in. False if relies on system CLI.
-  isBuiltInCli: () => {
-    const pathToParse = path();
-    const pathParsed = isWindows()
-      ? pathWin.parse(pathToParse)
-      : pathPosix.parse(pathToParse);
-
-    if (pathParsed.dir === '' && pathParsed.root === '') {
-      return false;
-    }
-    return true;
-  },
+  isBuiltInCli,
 
   // Returns JSON-formatted version information from the CLI
   version: () => {

--- a/ui/desktop/electron-app/src/cli/index.js
+++ b/ui/desktop/electron-app/src/cli/index.js
@@ -5,9 +5,6 @@
 
 const { spawnSync } = require('../helpers/spawn-promise.js');
 const { path, isBuiltInCli } = require('./path.js');
-const pathPosix = require('path');
-const pathWin = require('path/win32');
-const { isWindows } = require('../helpers/platform.js');
 
 module.exports = {
   // Check boundary cli existence

--- a/ui/desktop/electron-app/src/cli/index.js
+++ b/ui/desktop/electron-app/src/cli/index.js
@@ -5,10 +5,26 @@
 
 const { spawnSync } = require('../helpers/spawn-promise.js');
 const { path } = require('./path.js');
+const pathPosix = require('path');
+const pathWin = require('path/win32');
+const { isWindows } = require('../helpers/platform.js');
 
 module.exports = {
   // Check boundary cli existence
   exists: () => Boolean(path()),
+
+  // Return true if the CLI in usage is the built in. False if relies on system CLI.
+  isBuiltInCli: () => {
+    const pathToParse = path();
+    const pathParsed = isWindows()
+      ? pathWin.parse(pathToParse)
+      : pathPosix.parse(pathToParse);
+
+    if (pathParsed.dir === '' && pathParsed.root === '') {
+      return false;
+    }
+    return true;
+  },
 
   // Returns JSON-formatted version information from the CLI
   version: () => {

--- a/ui/desktop/electron-app/src/cli/index.js
+++ b/ui/desktop/electron-app/src/cli/index.js
@@ -8,7 +8,7 @@ const { path, isBuiltInCli } = require('./path.js');
 
 module.exports = {
   // Check boundary cli existence
-  exists: () => Boolean(path()),
+  exists: () => Boolean(path),
 
   isBuiltInCli,
 

--- a/ui/desktop/electron-app/src/cli/path.js
+++ b/ui/desktop/electron-app/src/cli/path.js
@@ -16,13 +16,13 @@ const builtInCliPath = isDev
 // Return true if the CLI in usage is the built in. False if relies on system CLI.
 const isBuiltInCli = existsSync(builtInCliPath);
 
+/**
+ * Returns Boundary CLI path if the CLI is built in or the Boundary binary name
+ * if not, so we assume boundary is available within user $PATH.
+ */
+const pathBoundary = isBuiltInCli ? builtInCliPath : binaryName;
+
 module.exports = {
-  /**
-   * Returns Boundary CLI path if the CLI is built in or the Boundary binary name
-   * if not, so we assume boundary is available within user $PATH.
-   */
-  path: () => {
-    return isBuiltInCli ? builtInCliPath : binaryName;
-  },
+  path: pathBoundary,
   isBuiltInCli,
 };

--- a/ui/desktop/electron-app/src/cli/path.js
+++ b/ui/desktop/electron-app/src/cli/path.js
@@ -8,18 +8,21 @@ const { isWindows } = require('../helpers/platform.js');
 const isDev = require('electron-is-dev');
 const { existsSync } = require('node:fs');
 
+const binaryName = isWindows() ? 'boundary.exe' : 'boundary';
+const builtInCliPath = isDev
+  ? path.resolve(__dirname, '..', '..', 'cli', binaryName)
+  : path.resolve(process.resourcesPath, 'cli', binaryName);
+
+// Return true if the CLI in usage is the built in. False if relies on system CLI.
+const isBuiltInCli = existsSync(builtInCliPath);
+
 module.exports = {
   /**
    * Returns Boundary CLI path if the CLI is built in or the Boundary binary name
    * if not, so we assume boundary is available within user $PATH.
    */
   path: () => {
-    const binaryName = isWindows() ? 'boundary.exe' : 'boundary';
-    const builtInCliPath = isDev
-      ? path.resolve(__dirname, '..', '..', 'cli', binaryName)
-      : path.resolve(process.resourcesPath, 'cli', binaryName);
-    const isBuiltInCli = existsSync(builtInCliPath);
-
     return isBuiltInCli ? builtInCliPath : binaryName;
   },
+  isBuiltInCli,
 };

--- a/ui/desktop/electron-app/src/helpers/app-updater.js
+++ b/ui/desktop/electron-app/src/helpers/app-updater.js
@@ -164,13 +164,17 @@ module.exports = {
      * Ignore app updater prompts.
      */
     if (process.env.BYPASS_APP_UPDATER) return;
-    if (boundaryCli.isBuiltInCli()) return;
 
     /**
      * Disable app updater check for linux as update is unsupported.
      * TODO: Enable for windows pending feature dev. Windows is supported.
      */
     if (isWindows() || isLinux()) return;
+
+    /**
+     * Skip the app updater if we are NOT using the built in CLI
+     */
+    if (!boundaryCli.isBuiltInCli()) return;
 
     let latestVersion;
     if (debug) {

--- a/ui/desktop/electron-app/src/helpers/app-updater.js
+++ b/ui/desktop/electron-app/src/helpers/app-updater.js
@@ -164,6 +164,7 @@ module.exports = {
      * Ignore app updater prompts.
      */
     if (process.env.BYPASS_APP_UPDATER) return;
+    if (boundaryCli.isBuiltInCli()) return;
 
     /**
      * Disable app updater check for linux as update is unsupported.

--- a/ui/desktop/electron-app/src/helpers/app-updater.js
+++ b/ui/desktop/electron-app/src/helpers/app-updater.js
@@ -174,7 +174,7 @@ module.exports = {
     /**
      * Skip the app updater if we are NOT using the built in CLI
      */
-    if (!boundaryCli.isBuiltInCli()) return;
+    if (!boundaryCli.isBuiltInCli) return;
 
     let latestVersion;
     if (debug) {

--- a/ui/desktop/electron-app/src/helpers/spawn-promise.js
+++ b/ui/desktop/electron-app/src/helpers/spawn-promise.js
@@ -32,7 +32,7 @@ module.exports = {
    */
   spawnAsyncJSONPromise(command, token) {
     return new Promise((resolve, reject) => {
-      const childProcess = spawn(path(), command, {
+      const childProcess = spawn(path, command, {
         env: {
           ...process.env,
           BOUNDARY_TOKEN: token,
@@ -77,7 +77,7 @@ module.exports = {
    * @param {object} envVars
    * @returns {{stdout: string | undefined, stderr: string | undefined}}   */
   spawnSync(args, envVars = {}) {
-    const childProcess = spawnSync(path(), args, {
+    const childProcess = spawnSync(path, args, {
       // Some of our outputs (namely cache daemon searching) can be very large.
       // This an undocumented hack to allow for an unlimited buffer size which
       // could change at any time. If it does, we should just set an arbitrarily
@@ -103,7 +103,7 @@ module.exports = {
    */
   spawn(command, options) {
     return new Promise((resolve, reject) => {
-      const childProcess = spawn(path(), command, options);
+      const childProcess = spawn(path, command, options);
       childProcess.stdout.on('data', (data) => {
         resolve({ childProcess, stdout: data.toString() });
       });


### PR DESCRIPTION
# Description

[ICU-15109](https://hashicorp.atlassian.net/browse/ICU-15109)

Add check on the appUpdater to skip it if the Desktop client is NOT using the built in CLI.

**IMPORTANT**
The first approach I tried was to use node [fs.lstatSync](https://nodejs.org/api/fs.html#fslstatsyncpath-options). The issue I encounter is that the lstat object returned, in POSIX systems, the key `file` always `false` value.
This happens because on POSIX system, the binary name we return is `boundary` without file extension, therefore the lstat object mark it as directory, whatever we were passing `boundary` or `electron-app/cli/boundary`.

Decided to rely on [parsing the path](https://nodejs.org/api/path.html#pathparsepath). If the parsed object returns values for the keys `dir` and `root`, means it is indeed the CLI built in the desktop client.

Happy to discuss other approaches.

## How to Test

For Mac:

Use the built in CLI:
- Set `SETUP_CLI=true` and run `yarn start:desktop`.
- The desktop client should prompt the app updater.

Use system CLI:
- Set `SETUP_CLI=false` and run `yarn start:desktop`.
- The desktop client should NOT prompt the app updater.

For Windows:

Notice in windows, we have the appUpdater disabled, so it will not be possible to test without code modifications.

Code modifications:
- Above [this line](https://github.com/hashicorp/boundary-ui/blob/feat-ICU-15109-appupdater-cli-check/ui/desktop/electron-app/src/helpers/app-updater.js#L177) add a `console.log(`isBuiltInCli: `, boundaryCli.isBuiltInCli())`.

Test procedure:
- Set `SETUP_CLI=true` and run `yarn start:desktop`. The `console.log` should show TRUE.
- Set `SETUP_CLI=false` and run `yarn start:desktop`. The `console.log` should show FALSE.


[ICU-15109]: https://hashicorp.atlassian.net/browse/ICU-15109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ