### PR TITLE
Fix windows no cli crash

### DIFF
--- a/ui/desktop/electron-app/src/cli/path.js
+++ b/ui/desktop/electron-app/src/cli/path.js
@@ -7,6 +7,8 @@ const path = require('path');
 const { isWindows } = require('../helpers/platform.js');
 const isDev = require('electron-is-dev');
 const { existsSync } = require('node:fs');
+const which = require('which');
+const log = require('electron-log/main');
 
 const binaryName = isWindows() ? 'boundary.exe' : 'boundary';
 const builtInCliPath = isDev
@@ -19,8 +21,17 @@ const isBuiltInCli = existsSync(builtInCliPath);
 /**
  * Returns Boundary CLI path if the CLI is built in or the Boundary binary name
  * if not, so we assume boundary is available within user $PATH.
+ * For Windows, we filter out the path that is within the current working directory.
  */
-const pathBoundary = isBuiltInCli ? builtInCliPath : binaryName;
+const pathBoundary = isBuiltInCli
+  ? builtInCliPath
+  : isWindows()
+    ? which.sync(binaryName, { nothrow: true, all: true })
+      .filter((binary) => !binary.startsWith(process.cwd()))[0]
+    : binaryName;
+
+log.info('pathBoundary', pathBoundary)
+console.log(pathBoundary)
 
 module.exports = {
   path: pathBoundary,

--- a/ui/desktop/electron-app/src/cli/path.js
+++ b/ui/desktop/electron-app/src/cli/path.js
@@ -20,11 +20,14 @@ const isBuiltInCli = existsSync(builtInCliPath);
 /**
  * Returns Boundary CLI path if the CLI is built in or the Boundary binary name
  * if not, so we assume boundary is available within user $PATH.
- * For Windows, we filter out the path that is within the current working directory.
  */
 const pathBoundary = isBuiltInCli
   ? builtInCliPath
-  : isWindows()
+  : // On Windows, we need to filter out the path that is within the current working directory.
+  // This is necessary because the spawn methods may not always find the correct binary path.
+  // The `which` module returns an array of all available paths for the 'boundary' binary.
+  // We then filter out the path that is within the current working directory.
+  isWindows()
   ? which
       .sync(binaryName, { nothrow: true, all: true })
       .filter((binary) => !binary.startsWith(process.cwd()))[0]

--- a/ui/desktop/electron-app/src/cli/path.js
+++ b/ui/desktop/electron-app/src/cli/path.js
@@ -8,7 +8,6 @@ const { isWindows } = require('../helpers/platform.js');
 const isDev = require('electron-is-dev');
 const { existsSync } = require('node:fs');
 const which = require('which');
-const log = require('electron-log/main');
 
 const binaryName = isWindows() ? 'boundary.exe' : 'boundary';
 const builtInCliPath = isDev
@@ -26,12 +25,10 @@ const isBuiltInCli = existsSync(builtInCliPath);
 const pathBoundary = isBuiltInCli
   ? builtInCliPath
   : isWindows()
-    ? which.sync(binaryName, { nothrow: true, all: true })
+  ? which
+      .sync(binaryName, { nothrow: true, all: true })
       .filter((binary) => !binary.startsWith(process.cwd()))[0]
-    : binaryName;
-
-log.info('pathBoundary', pathBoundary)
-console.log(pathBoundary)
+  : binaryName;
 
 module.exports = {
   path: pathBoundary,


### PR DESCRIPTION
# Description
[ticket](https://hashicorp.atlassian.net/browse/ICU-15235) 
<!-- Add a brief description of changes here -->

This PR fixes the app crashing on launch in windows

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

- pull this branch to a Windows machine/parallels/ec2 instance
- install CLI locally using [this](https://github.com/hashicorp/boundary-installer/actions/runs/10966402384) click on the Windows build and follow the instructions to install
- delete `CLI` folder from `ui/desktop/electron-app` to make sure we don't package cli in our DC build 
- build it locally `yarn build` within ui/desktop
- go to the directory where the out/boundary binary is stored and click on boundary.exe app 
- the app should run as expected and not crash 

note: Plz reach out to me if you need a cluster for testing

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
