### PR TITLE
test(e2e): Updates from 0.18.0 testing

### DIFF
--- a/ui/admin/tests/e2e/pages/auth-methods.mjs
+++ b/ui/admin/tests/e2e/pages/auth-methods.mjs
@@ -42,8 +42,8 @@ export class AuthMethodsPage extends BaseResourcePage {
       .getByRole('navigation', { name: 'IAM' })
       .getByRole('link', { name: 'Auth Methods' })
       .click();
-    await this.page.getByRole('button', { name: 'Manage' }).click();
-    await this.page.getByText('Make Primary', { exact: true }).click();
+    await this.page.getByLabel('Manage').click();
+    await this.page.getByRole('button', { name: 'Make Primary' }).click();
     await this.page.getByText('OK', { exact: true }).click();
     await this.dismissSuccessAlert();
   }
@@ -52,7 +52,7 @@ export class AuthMethodsPage extends BaseResourcePage {
    * Removes auth method as primary. Assume you have selected the desired auth method.
    */
   async removeAuthMethodAsPrimary() {
-    await this.page.getByTitle('Manage').click();
+    await this.page.getByRole('button', { name: 'Manage' }).click();
     await this.page.getByRole('button', { name: 'Remove as primary' }).click();
     await this.page.getByText('OK', { exact: true }).click();
     await this.dismissSuccessAlert();

--- a/ui/admin/tests/e2e/tests/alias-ent.spec.mjs
+++ b/ui/admin/tests/e2e/tests/alias-ent.spec.mjs
@@ -87,9 +87,12 @@ test.describe('Aliases (Enterprise)', async () => {
 
       // Clear destination from alias
       await page.getByRole('link', { name: alias }).click();
+      // Note: On the Target details page, there is a section with the header
+      // "Aliases". The extra check here is to ensure that we are on the Alias
+      // details page and not the Target details page.
       await expect(
         page.getByRole('heading', { name: 'Alias' }),
-      ).toBeVisible();
+      ).not.toHaveText('Aliases');
       await page.getByRole('button', { name: 'Manage' }).click();
       await page.getByText('Clear', { exact: true }).click();
       await page.getByText('OK', { exact: true }).click();

--- a/ui/admin/tests/e2e/tests/alias-ent.spec.mjs
+++ b/ui/admin/tests/e2e/tests/alias-ent.spec.mjs
@@ -87,6 +87,9 @@ test.describe('Aliases (Enterprise)', async () => {
 
       // Clear destination from alias
       await page.getByRole('link', { name: alias }).click();
+      await expect(
+        page.getByRole('heading', { name: 'Alias' }),
+      ).toBeVisible();
       await page.getByRole('button', { name: 'Manage' }).click();
       await page.getByText('Clear', { exact: true }).click();
       await page.getByText('OK', { exact: true }).click();

--- a/ui/admin/tests/e2e/tests/alias.spec.mjs
+++ b/ui/admin/tests/e2e/tests/alias.spec.mjs
@@ -75,6 +75,9 @@ test.describe('Aliases', async () => {
 
       // Clear destination from alias
       await page.getByRole('link', { name: alias }).click();
+      await expect(
+        page.getByRole('heading', { name: 'Alias' }),
+      ).toBeVisible();
       await page.getByRole('button', { name: 'Manage' }).click();
       await page.getByText('Clear', { exact: true }).click();
       await page.getByText('OK', { exact: true }).click();

--- a/ui/admin/tests/e2e/tests/alias.spec.mjs
+++ b/ui/admin/tests/e2e/tests/alias.spec.mjs
@@ -75,9 +75,12 @@ test.describe('Aliases', async () => {
 
       // Clear destination from alias
       await page.getByRole('link', { name: alias }).click();
+      // Note: On the Target details page, there is a section with the header
+      // "Aliases". The extra check here is to ensure that we are on the Alias
+      // details page and not the Target details page.
       await expect(
         page.getByRole('heading', { name: 'Alias' }),
-      ).toBeVisible();
+      ).not.toHaveText('Aliases');
       await page.getByRole('button', { name: 'Manage' }).click();
       await page.getByText('Clear', { exact: true }).click();
       await page.getByText('OK', { exact: true }).click();


### PR DESCRIPTION
This PR updates some Admin UI e2e tests based on testing it against Boundary 0.18.0. There were two changes here
- On the Auth Methods page, the `Manage` button and some of its options were not being found by the current selectors. Those selectors were updated.
- On the Alias test, for some reason, it was starting to fail more often due to what seems like a timing issue. The test's intention is to navigate from the Target details page to the associated Alias details page in order to clear its value. What seems like is happening...
  - Test is on Target details page
  - Test clicks on associated Alias to go to Alias details page
  - Test clicks Manage button
    - It seems like the test is clicking the Manage button on the Target details page (before the Alias page finishes loading)
  - The PR now adds a check to ensure that the Alias details page has loaded

## Testing
Tests against CE and ENT on both docker and aws infra were updated
```
# boundary
enos scenario launch e2e_ui_docker builder:local
yarn run e2e:ce:docker

enos scenario launch e2e_ui_aws builder:local
yarn run e2e:ce:aws

# boundary-enterprise
enos scenario launch e2e_ui_docker_ent builder:local
yarn run e2e:ent:docker

enos scenario launch e2e_ui_aws_ent builder:local
yarn run e2e:ent:aws
```

https://hashicorp.atlassian.net/browse/ICU-15234