### PR TITLE
fix: 🐛 cannot retry oidc authentication in desktop & admin

### DIFF
--- a/ui/admin/app/controllers/scopes/scope/authenticate/method/oidc.js
+++ b/ui/admin/app/controllers/scopes/scope/authenticate/method/oidc.js
@@ -3,12 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import Controller, { inject as controller } from '@ember/controller';
+import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 
 export default class ScopesScopeAuthenticateMethodOidcController extends Controller {
-  @controller('scopes/scope/authenticate/method/index') authMethod;
-
   // =services
 
   @service session;

--- a/ui/admin/app/templates/scopes/scope/authenticate/method/oidc.hbs
+++ b/ui/admin/app/templates/scopes/scope/authenticate/method/oidc.hbs
@@ -12,7 +12,7 @@
     <p>{{t 'resources.auth-method.messages.pending.description'}}</p>
     <p>
       {{t 'resources.auth-method.questions.no-see-window'}}
-      <a href='#' role='button' {{on 'click' this.authMethod.authenticate}}>
+      <a href={{this.authURL}} target='_blank' rel='noreferrer noopener'>
         {{t 'actions.retry'}}
       </a>
     </p>

--- a/ui/admin/tests/unit/controllers/scopes/scope/authenticate/method/oidc-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/authenticate/method/oidc-test.js
@@ -16,7 +16,6 @@ module(
         'controller:scopes/scope/authenticate/method/oidc',
       );
       assert.ok(controller);
-      assert.ok(controller.authMethod);
     });
   },
 );

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -34,6 +34,7 @@ const menu = require('./config/menu.js');
 const appUpdater = require('./helpers/app-updater.js');
 const { isMac, isLinux, isWindows } = require('./helpers/platform.js');
 const fixPath = require('./utils/fixPath');
+const isLocalhost = require('./utils/isLocalhost');
 const config = require('../config/config.js');
 const { version } = require('./cli/index.js');
 const isDev = require('electron-is-dev');
@@ -160,6 +161,7 @@ const createWindow = (partition, closeWindowCB) => {
   // link to the release page for the desktop app.
   browserWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (
+      isLocalhost(url) ||
       url.startsWith('https://developer.hashicorp.com/') ||
       url.startsWith('https://releases.hashicorp.com/boundary-desktop/')
     ) {
@@ -262,7 +264,7 @@ app.on('ready', async () => {
   appUpdater.run({ suppressNoUpdatePrompt: true });
 
   /**
-   * Need for Mac OS behaviour of closing the window but not the app.
+   * Need for Mac OS behavior of closing the window but not the app.
    * This allows to reopen the window if the user clicks Boundary icon in the dock
    * while the app is not close.
    * More info: https://www.electronjs.org/docs/latest/tutorial/quick-start#open-a-window-if-none-are-open-macos

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -10,6 +10,7 @@ const boundaryCli = require('../cli/index.js');
 const sessionManager = require('../services/session-manager.js');
 const runtimeSettings = require('../services/runtime-settings.js');
 const sanitizer = require('../utils/sanitizer.js');
+const isLocalhost = require('../utils/isLocalhost');
 const { isLinux, isMac, isWindows } = require('../helpers/platform.js');
 const os = require('node:os');
 const pty = require('node-pty');
@@ -46,11 +47,9 @@ handle('resetClusterUrl', async () => runtimeSettings.resetClusterUrl());
  * testing workflows).  Insecure URLs are allowed in dev mode.
  */
 handle('openExternal', async (href) => {
-  const localhostRegex = /^http:\/\/(localhost|127\.0\.0\.1):\d{1,5}(?:\/|$)/i;
-  const isLocalhost = localhostRegex.test(href);
   const isSecure = href.startsWith('https://');
 
-  if (isSecure || isLocalhost || isDev) {
+  if (isSecure || isLocalhost(href) || isDev) {
     /**
      * Launch browser to display documentation and to support arbitrary OIDC flows
      * using openExternal. The protocol is validated (see above).

--- a/ui/desktop/electron-app/src/utils/isLocalhost.js
+++ b/ui/desktop/electron-app/src/utils/isLocalhost.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+const isLocalhost = (url) => {
+  const localhostRegex = /^http:\/\/(localhost|127\.0\.0\.1):\d{1,5}(?:\/|$)/i;
+  return localhostRegex.test(url);
+};
+
+module.exports = isLocalhost;


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-15250

# Description
<!-- Add a brief description of changes here -->

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->
retry was broken for both admin & desktop.
Admin retry was broken due to this [refactor](https://github.com/hashicorp/boundary-ui/pull/2385)
Desktop retry has been broken for quite some time already.

## Screenshots (if appropriate)

Uploading Screen Recording 2024-10-07 at 4.46.03 PM.mov…

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
1. spin up local dev instance
2. use existing oidc auth method to sign in.
3. retry link should cause new browser to open.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
