### PR TITLE
fix: 🐛 Push associated targets in sessions to ember store

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects/sessions/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions/index.js
@@ -136,27 +136,21 @@ export default class ScopesScopeProjectsSessionsIndexRoute extends Route {
     const chunkedTargetIds = chunk(uniqueTargetIds, 50);
 
     const associatedTargetsPromises = chunkedTargetIds.map((targetIds) =>
-      this.store.query(
-        'target',
-        {
-          scope_id: orgScope.id,
-          recursive: true,
-          force_refresh: true,
-          query: {
-            filters: {
-              id: {
-                logicalOperator: 'or',
-                values: targetIds.map((targetId) => ({
-                  equals: targetId,
-                })),
-              },
+      this.store.query('target', {
+        scope_id: orgScope.id,
+        recursive: true,
+        force_refresh: true,
+        query: {
+          filters: {
+            id: {
+              logicalOperator: 'or',
+              values: targetIds.map((targetId) => ({
+                equals: targetId,
+              })),
             },
           },
         },
-        {
-          pushToStore: false,
-        },
-      ),
+      }),
     );
 
     const targetsArray = await Promise.all(associatedTargetsPromises);


### PR DESCRIPTION
# Description
Fixes the bug here described in this slack [thread](https://hashicorp.slack.com/archives/C05EHAH84HE/p1728507679515329).

As users can now start sessions with transparent sessions, we aren't guaranteed that they have navigated to the target first in the DC so it may not yet be in the store.

## Screenshots (if appropriate)
Before:
<img width="982" alt="image" src="https://github.com/user-attachments/assets/7d34fa1e-8ee5-4b27-8394-3014ab39477a">

After:
<img width="984" alt="image" src="https://github.com/user-attachments/assets/4fa33636-1f33-4dc9-83eb-6d3d43c0aaa2">

## How to Test
Use the installer to install the client agent. Make sure you're using a cluster that has enough targets where it won't be able to load all targets on one page. (Use my [int cluster](https://27425825-515c-4d8c-beb6-aa91cbc20c5a.boundary.hcp.to) if you'd like). 

Connect to a generic TCP target (make sure it wasn't loaded on the first page) transparently and go to sessions (use www.hashicorp.com in your browser if using my int cluster). It should have the target name displayed. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
