### PR TITLE
chore: 🤖 Clean up Desktop out directory

### DIFF
--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -14,7 +14,7 @@
     "build": "yarn build:production && yarn build:desktop",
     "build:production": "cross-env EMBER_CLI_ELECTRON=true ember build --environment=production",
     "build:development": "ember build",
-    "prebuild:desktop": "shx rm -rf electron-app/ember-dist && shx cp -r dist/ electron-app/ember-dist/ && shx rm -rf electron-app/out",
+    "prebuild:desktop": "shx rm -rf electron-app/ember-dist electron-app/out && shx cp -r dist/ electron-app/ember-dist/",
     "build:desktop": "yarn build:desktop:install && yarn --cwd electron-app make",
     "build:desktop:debianOnMacOS": "yarn build:desktop:install && BUILD_DEBIAN=true yarn --cwd electron-app make --platform linux --arch x64",
     "build:desktop:install": "yarn install --cwd electron-app",

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -14,7 +14,7 @@
     "build": "yarn build:production && yarn build:desktop",
     "build:production": "cross-env EMBER_CLI_ELECTRON=true ember build --environment=production",
     "build:development": "ember build",
-    "prebuild:desktop": "shx rm -rf electron-app/ember-dist && shx cp -r dist/ electron-app/ember-dist/",
+    "prebuild:desktop": "shx rm -rf electron-app/ember-dist && shx cp -r dist/ electron-app/ember-dist/ && shx rm -rf electron-app/out",
     "build:desktop": "yarn build:desktop:install && yarn --cwd electron-app make",
     "build:desktop:debianOnMacOS": "yarn build:desktop:install && BUILD_DEBIAN=true yarn --cwd electron-app make --platform linux --arch x64",
     "build:desktop:install": "yarn install --cwd electron-app",


### PR DESCRIPTION
# Description

Clean up Desktop out directory before perform a build.

## How to test:

- Have the `electron-app/out` directory fill with a test.txt file (or any other file none related to the build).
- Perform a `yarn build` from `boundary-ui/ui/desktop` and validate the `out` directory just contains build output. 
