### PR TITLE
Enable storage bucket deletion 

### DIFF
--- a/ui/admin/app/abilities/storage-bucket.js
+++ b/ui/admin/app/abilities/storage-bucket.js
@@ -36,9 +36,8 @@ export default class OverrideStorageBucketAbility extends StorageBucketAbility {
    * For now a storage bucket cannot be deleted.
    */
   get canDelete() {
-    return false;
-    // return this.features.isEnabled('ssh-session-recording')
-    //   ? super.canDelete
-    //   : false;
+    return this.features.isEnabled('ssh-session-recording')
+      ? super.canDelete
+      : false;
   }
 }

--- a/ui/admin/app/abilities/storage-bucket.js
+++ b/ui/admin/app/abilities/storage-bucket.js
@@ -31,9 +31,8 @@ export default class OverrideStorageBucketAbility extends StorageBucketAbility {
   }
 
   /**
-   * TODO: Ensure that storage buckets may be deleted only if the
+   * This override ensures that storage buckets may be deleted only if the
    * session-recording feature flag is enabled.
-   * For now a storage bucket cannot be deleted.
    */
   get canDelete() {
     return this.features.isEnabled('ssh-session-recording')

--- a/ui/admin/app/controllers/scopes/scope/storage-buckets/index.js
+++ b/ui/admin/app/controllers/scopes/scope/storage-buckets/index.js
@@ -47,6 +47,8 @@ export default class ScopesScopeStorageBucketsIndexController extends Controller
   @notifySuccess('notifications.delete-success')
   async delete(storageBucket) {
     await storageBucket.destroyRecord();
+    await this.router.replaceWith('scopes.scope.storage-buckets');
+    await this.router.refresh();
   }
 
   /**

--- a/ui/admin/app/templates/scopes/scope/storage-buckets/storage-bucket/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/storage-buckets/storage-bucket/index.hbs
@@ -16,18 +16,18 @@
     <Hds::Copy::Snippet @textToCopy={{@model.id}} @color='secondary' />
   </page.header>
 
-  <page.actions>
-    <Hds::Dropdown as |dd|>
-      <dd.ToggleButton @text={{t 'actions.manage'}} @color='secondary' />
-      {{#if (can 'delete model' @model)}}
+  {{#if (can 'delete storage-bucket' @model)}}
+    <page.actions>
+      <Hds::Dropdown as |dd|>
+        <dd.ToggleButton @text={{t 'actions.manage'}} @color='secondary' />
         <dd.Interactive
           @text={{t 'actions.delete'}}
           @color='critical'
           {{on 'click' (fn this.storageBuckets.delete @model)}}
         />
-      {{/if}}
-    </Hds::Dropdown>
-  </page.actions>
+      </Hds::Dropdown>
+    </page.actions>
+  {{/if}}
 
   <page.navigation>
     <Rose::Nav::Tabs as |nav|>

--- a/ui/admin/app/templates/scopes/scope/storage-buckets/storage-bucket/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/storage-buckets/storage-bucket/index.hbs
@@ -16,6 +16,19 @@
     <Hds::Copy::Snippet @textToCopy={{@model.id}} @color='secondary' />
   </page.header>
 
+  <page.actions>
+    <Hds::Dropdown as |dd|>
+      <dd.ToggleButton @text={{t 'actions.manage'}} @color='secondary' />
+      {{#if (can 'delete model' @model)}}
+        <dd.Interactive
+          @text={{t 'actions.delete'}}
+          @color='critical'
+          {{on 'click' (fn this.storageBuckets.delete @model)}}
+        />
+      {{/if}}
+    </Hds::Dropdown>
+  </page.actions>
+
   <page.navigation>
     <Rose::Nav::Tabs as |nav|>
       <nav.link @route='scopes.scope.storage-buckets.storage-bucket.index'>

--- a/ui/admin/tests/acceptance/storage-buckets/delete-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/delete-test.js
@@ -62,17 +62,18 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
     features.enable('ssh-session-recording');
   });
 
-  skip('user can delete a storage bucket', async function (assert) {
-    const storageBucketCount = getStorageBucketCount();
-    await visit(urls.globalScope);
+  'user can delete a storage bucket',
+    async function (assert) {
+      const storageBucketCount = getStorageBucketCount();
+      await visit(urls.globalScope);
 
-    await click(`[href="${urls.storageBuckets}"]`);
-    await click(DROPDOWN_BUTTON_SELECTOR);
-    await click(DELETE_DROPDOWN_SELECTOR);
+      await click(`[href="${urls.storageBuckets}"]`);
+      await click(DROPDOWN_BUTTON_SELECTOR);
+      await click(DELETE_DROPDOWN_SELECTOR);
 
-    assert.strictEqual(currentURL(), urls.storageBuckets);
-    assert.strictEqual(getStorageBucketCount(), storageBucketCount - 1);
-  });
+      assert.strictEqual(currentURL(), urls.storageBuckets);
+      assert.strictEqual(getStorageBucketCount(), storageBucketCount - 1);
+    };
 
   skip('user can accept delete storage bucket via dialog', async function (assert) {
     const confirmService = this.owner.lookup('service:confirm');
@@ -95,68 +96,71 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
     assert.strictEqual(getStorageBucketCount(), storageBucketCount - 1);
   });
 
-  skip('user can cancel delete storage bucket via dialog', async function (assert) {
-    const confirmService = this.owner.lookup('service:confirm');
-    confirmService.enabled = true;
-    const storageBucketCount = getStorageBucketCount();
-    await visit(urls.globalScope);
+  'user can cancel delete storage bucket via dialog',
+    async function (assert) {
+      const confirmService = this.owner.lookup('service:confirm');
+      confirmService.enabled = true;
+      const storageBucketCount = getStorageBucketCount();
+      await visit(urls.globalScope);
 
-    await click(`[href="${urls.storageBuckets}"]`);
-    await click(DROPDOWN_BUTTON_SELECTOR);
-    await click(DELETE_DROPDOWN_SELECTOR);
+      await click(`[href="${urls.storageBuckets}"]`);
+      await click(DROPDOWN_BUTTON_SELECTOR);
+      await click(DELETE_DROPDOWN_SELECTOR);
 
-    assert
-      .dom(DIALOG_TITLE_SELECTOR)
-      .hasText(
-        intl.t(
-          'resources.storage-bucket.questions.delete-storage-bucket.title',
-        ),
-      );
-    assert
-      .dom(DIALOG_MESSAGE_SELECTOR)
-      .hasText(
-        intl.t(
-          'resources.storage-bucket.questions.delete-storage-bucket.message',
-        ),
-      );
+      assert
+        .dom(DIALOG_TITLE_SELECTOR)
+        .hasText(
+          intl.t(
+            'resources.storage-bucket.questions.delete-storage-bucket.title',
+          ),
+        );
+      assert
+        .dom(DIALOG_MESSAGE_SELECTOR)
+        .hasText(
+          intl.t(
+            'resources.storage-bucket.questions.delete-storage-bucket.message',
+          ),
+        );
 
-    await click(DIALOG_CANCEL_BTN_SELECTOR);
+      await click(DIALOG_CANCEL_BTN_SELECTOR);
 
-    assert.strictEqual(currentURL(), urls.storageBuckets);
-    assert.strictEqual(getStorageBucketCount(), storageBucketCount);
-  });
+      assert.strictEqual(currentURL(), urls.storageBuckets);
+      assert.strictEqual(getStorageBucketCount(), storageBucketCount);
+    };
 
-  skip('user cannot delete storage bucket without proper authorization', async function (assert) {
-    await visit(urls.globalScope);
-    instances.storageBucket.authorized_actions =
-      instances.storageBucket.authorized_actions.filter(
-        (item) => item !== 'delete',
-      );
+  'user cannot delete storage bucket without proper authorization',
+    async function (assert) {
+      await visit(urls.globalScope);
+      instances.storageBucket.authorized_actions =
+        instances.storageBucket.authorized_actions.filter(
+          (item) => item !== 'delete',
+        );
 
-    await click(`[href="${urls.storageBuckets}"]`);
-    await click(DROPDOWN_BUTTON_SELECTOR);
+      await click(`[href="${urls.storageBuckets}"]`);
+      await click(DROPDOWN_BUTTON_SELECTOR);
 
-    assert.dom(DELETE_DROPDOWN_SELECTOR).doesNotExist();
-  });
+      assert.dom(DELETE_DROPDOWN_SELECTOR).doesNotExist();
+    };
 
-  skip('deleting a storage bucket which errors displays error messages', async function (assert) {
-    await visit(urls.globalScope);
-    this.server.del('/storage-buckets/:id', () => {
-      return new Response(
-        490,
-        {},
-        {
-          status: 490,
-          code: 'error',
-          message: 'Oops.',
-        },
-      );
-    });
+  'deleting a storage bucket which errors displays error messages',
+    async function (assert) {
+      await visit(urls.globalScope);
+      this.server.del('/storage-buckets/:id', () => {
+        return new Response(
+          490,
+          {},
+          {
+            status: 490,
+            code: 'error',
+            message: 'Oops.',
+          },
+        );
+      });
 
-    await click(`[href="${urls.storageBuckets}"]`);
-    await click(DROPDOWN_BUTTON_SELECTOR);
-    await click(DELETE_DROPDOWN_SELECTOR);
+      await click(`[href="${urls.storageBuckets}"]`);
+      await click(DROPDOWN_BUTTON_SELECTOR);
+      await click(DELETE_DROPDOWN_SELECTOR);
 
-    assert.dom(NOTIFICATION_MSG_SELECTOR).hasText('Oops.');
-  });
+      assert.dom(NOTIFICATION_MSG_SELECTOR).hasText('Oops.');
+    };
 });

--- a/ui/admin/tests/acceptance/storage-buckets/delete-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/delete-test.js
@@ -64,7 +64,7 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
   test('user can delete a storage bucket', async function (assert) {
     const storageBucketCount = getStorageBucketCount();
     await visit(urls.globalScope);
-
+    assert.true(instances.storageBucket.authorized_actions.includes('delete'));
     await click(`[href="${urls.storageBuckets}"]`);
     await click(DROPDOWN_BUTTON_SELECTOR);
     await click(DELETE_DROPDOWN_SELECTOR);

--- a/ui/admin/tests/acceptance/storage-buckets/delete-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/delete-test.js
@@ -5,7 +5,7 @@
 
 // TODO: Un-skip tests once delete storage bucket action is enabled.
 
-import { module, skip } from 'qunit';
+import { module } from 'qunit';
 import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -75,26 +75,27 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
       assert.strictEqual(getStorageBucketCount(), storageBucketCount - 1);
     };
 
-  skip('user can accept delete storage bucket via dialog', async function (assert) {
-    const confirmService = this.owner.lookup('service:confirm');
-    confirmService.enabled = true;
-    const storageBucketCount = getStorageBucketCount();
-    await visit(urls.globalScope);
+  'user can accept delete storage bucket via dialog',
+    async function (assert) {
+      const confirmService = this.owner.lookup('service:confirm');
+      confirmService.enabled = true;
+      const storageBucketCount = getStorageBucketCount();
+      await visit(urls.globalScope);
 
-    await click(`[href="${urls.storageBuckets}"]`);
-    await click(DROPDOWN_BUTTON_SELECTOR);
-    await click(DELETE_DROPDOWN_SELECTOR);
+      await click(`[href="${urls.storageBuckets}"]`);
+      await click(DROPDOWN_BUTTON_SELECTOR);
+      await click(DELETE_DROPDOWN_SELECTOR);
 
-    assert
-      .dom(DIALOG_DELETE_BTN_SELECTOR)
-      .hasText(intl.t('resources.storage-bucket.actions.delete'));
+      assert
+        .dom(DIALOG_DELETE_BTN_SELECTOR)
+        .hasText(intl.t('resources.storage-bucket.actions.delete'));
 
-    await click(DIALOG_DELETE_BTN_SELECTOR);
+      await click(DIALOG_DELETE_BTN_SELECTOR);
 
-    assert.dom(NOTIFICATION_MSG_SELECTOR).hasText(NOTIFICATION_MSG_TEXT);
-    assert.strictEqual(currentURL(), urls.storageBuckets);
-    assert.strictEqual(getStorageBucketCount(), storageBucketCount - 1);
-  });
+      assert.dom(NOTIFICATION_MSG_SELECTOR).hasText(NOTIFICATION_MSG_TEXT);
+      assert.strictEqual(currentURL(), urls.storageBuckets);
+      assert.strictEqual(getStorageBucketCount(), storageBucketCount - 1);
+    };
 
   'user can cancel delete storage bucket via dialog',
     async function (assert) {

--- a/ui/admin/tests/acceptance/storage-buckets/delete-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/delete-test.js
@@ -2,19 +2,18 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: BUSL-1.1
  */
-
-// TODO: Un-skip tests once delete storage bucket action is enabled.
-
-import { module } from 'qunit';
+import { module, test } from 'qunit';
 import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 
 module('Acceptance | storage-buckets | delete', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIndexedDb(hooks);
 
   let intl;
   let features;
@@ -62,106 +61,101 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
     features.enable('ssh-session-recording');
   });
 
-  'user can delete a storage bucket',
-    async function (assert) {
-      const storageBucketCount = getStorageBucketCount();
-      await visit(urls.globalScope);
+  test('user can delete a storage bucket', async function (assert) {
+    const storageBucketCount = getStorageBucketCount();
+    await visit(urls.globalScope);
 
-      await click(`[href="${urls.storageBuckets}"]`);
-      await click(DROPDOWN_BUTTON_SELECTOR);
-      await click(DELETE_DROPDOWN_SELECTOR);
+    await click(`[href="${urls.storageBuckets}"]`);
+    await click(DROPDOWN_BUTTON_SELECTOR);
+    await click(DELETE_DROPDOWN_SELECTOR);
 
-      assert.strictEqual(currentURL(), urls.storageBuckets);
-      assert.strictEqual(getStorageBucketCount(), storageBucketCount - 1);
-    };
+    assert.strictEqual(currentURL(), urls.storageBuckets);
+    assert.strictEqual(getStorageBucketCount(), storageBucketCount - 1);
+  });
 
-  'user can accept delete storage bucket via dialog',
-    async function (assert) {
-      const confirmService = this.owner.lookup('service:confirm');
-      confirmService.enabled = true;
-      const storageBucketCount = getStorageBucketCount();
-      await visit(urls.globalScope);
+  test('user can accept delete storage bucket via dialog', async function (assert) {
+    const confirmService = this.owner.lookup('service:confirm');
+    confirmService.enabled = true;
+    const storageBucketCount = getStorageBucketCount();
+    await visit(urls.globalScope);
 
-      await click(`[href="${urls.storageBuckets}"]`);
-      await click(DROPDOWN_BUTTON_SELECTOR);
-      await click(DELETE_DROPDOWN_SELECTOR);
+    await click(`[href="${urls.storageBuckets}"]`);
+    await click(DROPDOWN_BUTTON_SELECTOR);
+    await click(DELETE_DROPDOWN_SELECTOR);
 
-      assert
-        .dom(DIALOG_DELETE_BTN_SELECTOR)
-        .hasText(intl.t('resources.storage-bucket.actions.delete'));
+    assert
+      .dom(DIALOG_DELETE_BTN_SELECTOR)
+      .hasText(intl.t('resources.storage-bucket.actions.delete'));
 
-      await click(DIALOG_DELETE_BTN_SELECTOR);
+    await click(DIALOG_DELETE_BTN_SELECTOR);
 
-      assert.dom(NOTIFICATION_MSG_SELECTOR).hasText(NOTIFICATION_MSG_TEXT);
-      assert.strictEqual(currentURL(), urls.storageBuckets);
-      assert.strictEqual(getStorageBucketCount(), storageBucketCount - 1);
-    };
+    assert.dom(NOTIFICATION_MSG_SELECTOR).hasText(NOTIFICATION_MSG_TEXT);
+    assert.strictEqual(currentURL(), urls.storageBuckets);
+    assert.strictEqual(getStorageBucketCount(), storageBucketCount - 1);
+  });
 
-  'user can cancel delete storage bucket via dialog',
-    async function (assert) {
-      const confirmService = this.owner.lookup('service:confirm');
-      confirmService.enabled = true;
-      const storageBucketCount = getStorageBucketCount();
-      await visit(urls.globalScope);
+  test('user can cancel delete storage bucket via dialog', async function (assert) {
+    const confirmService = this.owner.lookup('service:confirm');
+    confirmService.enabled = true;
+    const storageBucketCount = getStorageBucketCount();
+    await visit(urls.globalScope);
 
-      await click(`[href="${urls.storageBuckets}"]`);
-      await click(DROPDOWN_BUTTON_SELECTOR);
-      await click(DELETE_DROPDOWN_SELECTOR);
+    await click(`[href="${urls.storageBuckets}"]`);
+    await click(DROPDOWN_BUTTON_SELECTOR);
+    await click(DELETE_DROPDOWN_SELECTOR);
 
-      assert
-        .dom(DIALOG_TITLE_SELECTOR)
-        .hasText(
-          intl.t(
-            'resources.storage-bucket.questions.delete-storage-bucket.title',
-          ),
-        );
-      assert
-        .dom(DIALOG_MESSAGE_SELECTOR)
-        .hasText(
-          intl.t(
-            'resources.storage-bucket.questions.delete-storage-bucket.message',
-          ),
-        );
+    assert
+      .dom(DIALOG_TITLE_SELECTOR)
+      .hasText(
+        intl.t(
+          'resources.storage-bucket.questions.delete-storage-bucket.title',
+        ),
+      );
+    assert
+      .dom(DIALOG_MESSAGE_SELECTOR)
+      .hasText(
+        intl.t(
+          'resources.storage-bucket.questions.delete-storage-bucket.message',
+        ),
+      );
 
-      await click(DIALOG_CANCEL_BTN_SELECTOR);
+    await click(DIALOG_CANCEL_BTN_SELECTOR);
 
-      assert.strictEqual(currentURL(), urls.storageBuckets);
-      assert.strictEqual(getStorageBucketCount(), storageBucketCount);
-    };
+    assert.strictEqual(currentURL(), urls.storageBuckets);
+    assert.strictEqual(getStorageBucketCount(), storageBucketCount);
+  });
 
-  'user cannot delete storage bucket without proper authorization',
-    async function (assert) {
-      await visit(urls.globalScope);
-      instances.storageBucket.authorized_actions =
-        instances.storageBucket.authorized_actions.filter(
-          (item) => item !== 'delete',
-        );
+  test('user cannot delete storage bucket without proper authorization', async function (assert) {
+    await visit(urls.globalScope);
+    instances.storageBucket.authorized_actions =
+      instances.storageBucket.authorized_actions.filter(
+        (item) => item !== 'delete',
+      );
 
-      await click(`[href="${urls.storageBuckets}"]`);
-      await click(DROPDOWN_BUTTON_SELECTOR);
+    await click(`[href="${urls.storageBuckets}"]`);
+    await click(DROPDOWN_BUTTON_SELECTOR);
 
-      assert.dom(DELETE_DROPDOWN_SELECTOR).doesNotExist();
-    };
+    assert.dom(DELETE_DROPDOWN_SELECTOR).doesNotExist();
+  });
 
-  'deleting a storage bucket which errors displays error messages',
-    async function (assert) {
-      await visit(urls.globalScope);
-      this.server.del('/storage-buckets/:id', () => {
-        return new Response(
-          490,
-          {},
-          {
-            status: 490,
-            code: 'error',
-            message: 'Oops.',
-          },
-        );
-      });
+  test('deleting a storage bucket which errors displays error messages', async function (assert) {
+    await visit(urls.globalScope);
+    this.server.del('/storage-buckets/:id', () => {
+      return new Response(
+        490,
+        {},
+        {
+          status: 490,
+          code: 'error',
+          message: 'Oops.',
+        },
+      );
+    });
 
-      await click(`[href="${urls.storageBuckets}"]`);
-      await click(DROPDOWN_BUTTON_SELECTOR);
-      await click(DELETE_DROPDOWN_SELECTOR);
+    await click(`[href="${urls.storageBuckets}"]`);
+    await click(DROPDOWN_BUTTON_SELECTOR);
+    await click(DELETE_DROPDOWN_SELECTOR);
 
-      assert.dom(NOTIFICATION_MSG_SELECTOR).hasText('Oops.');
-    };
+    assert.dom(NOTIFICATION_MSG_SELECTOR).hasText('Oops.');
+  });
 });


### PR DESCRIPTION
# Description
https://hashicorp.atlassian.net/browse/ICU-15625

this PR enables storage bucket deletion in the UI 

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
 
<img width="1603" alt="Screenshot 2024-10-29 at 11 23 14 AM" src="https://github.com/user-attachments/assets/f8d48c64-0130-48ff-8e60-1dd0f218d972">

<img width="1614" alt="Screenshot 2024-10-29 at 11 23 21 AM" src="https://github.com/user-attachments/assets/98ebc716-4118-4755-961c-4d1fbe65c511">
<img width="1460" alt="Screenshot 2024-10-29 at 11 23 36 AM" src="https://github.com/user-attachments/assets/241fddbe-ff11-405f-b498-543d0a58177c">




## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
- create a storage bucket either on mirage or using ent binary
- should be able to successfully delete the bucket that was created
## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
