### PR TITLE
Update test selectors for create hosts

### DIFF
--- a/ui/admin/tests/acceptance/groups/delete-test.js
+++ b/ui/admin/tests/acceptance/groups/delete-test.js
@@ -19,8 +19,10 @@ module('Acceptance | groups | delete', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  const MANAGE_DROPDOWN_SELECTOR = "[data-test-manage-group-dropdown] div:first-child button"
-  const DELETE_ACTION_SELECTOR = "[data-test-manage-group-dropdown] ul li button"
+  const MANAGE_DROPDOWN_SELECTOR =
+    '[data-test-manage-group-dropdown] div:first-child button';
+  const DELETE_ACTION_SELECTOR =
+    '[data-test-manage-group-dropdown] ul li button';
 
   const instances = {
     scopes: {

--- a/ui/admin/tests/acceptance/host-catalogs/hosts/create-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/hosts/create-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { visit, currentURL, find, click, fillIn } from '@ember/test-helpers';
+import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
@@ -17,8 +17,6 @@ module('Acceptance | host-catalogs | hosts | create', function (hooks) {
   setupMirage(hooks);
 
   let getHostCount;
-  const MANAGE_DROPDOWN_SELECTOR =
-    '[data-test-manage-host-catalogs-dropdown] div:first-child button';
 
   const instances = {
     scopes: {
@@ -97,7 +95,8 @@ module('Acceptance | host-catalogs | hosts | create', function (hooks) {
         'create',
       ),
     );
-    assert.notOk(find(`.rose-layout-page-actions [href="${urls.newHost}"]`));
+
+    assert.dom(commonSelectors.HREF(urls.newHost)).doesNotExist();
   });
   test('Users can navigate to new host route with proper authorization', async function (assert) {
     await visit(urls.hosts);
@@ -106,7 +105,7 @@ module('Acceptance | host-catalogs | hosts | create', function (hooks) {
         'create',
       ),
     );
-    assert.dom(MANAGE_DROPDOWN_SELECTOR).exists();
+    assert.dom(selectors.MANAGE_DROPDOWN).exists();
   });
 
   test('Users cannot navigate to new host route without proper authorization', async function (assert) {
@@ -117,14 +116,15 @@ module('Acceptance | host-catalogs | hosts | create', function (hooks) {
         'create',
       ),
     );
-    assert.notOk(find(`[href="${urls.newHost}"]`));
+    assert.dom(commonSelectors.HREF(urls.newHost)).doesNotExist();
   });
 
   test('can cancel create new host', async function (assert) {
     const count = getHostCount();
     await visit(urls.newHost);
-    await fillIn('[name="name"]', 'random string');
-    await click('.rose-form-actions [type="button"]');
+    await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
+    await click(commonSelectors.CANCEL_BTN);
+
     assert.strictEqual(currentURL(), urls.hosts);
     assert.strictEqual(getHostCount(), count);
   });
@@ -150,15 +150,13 @@ module('Acceptance | host-catalogs | hosts | create', function (hooks) {
       );
     });
     await visit(urls.newHost);
-    await click('[type="submit"]');
-    assert.ok(
-      find('[role="alert"]').textContent.trim(),
-      'The request was invalid.',
-    );
-    assert.ok(
-      find('[data-test-error-message-name]').textContent.trim(),
-      'Name is required.',
-    );
+    await click(commonSelectors.SAVE_BTN);
+
+    assert
+      .dom(commonSelectors.ALERT_TOAST_BODY)
+      .hasText('The request was invalid.');
+
+    assert.dom(commonSelectors.FIELD_NAME_ERROR).hasText('Name is required.');
   });
 
   test('users cannot directly navigate to new host route without proper authorization', async function (assert) {

--- a/ui/admin/tests/acceptance/host-catalogs/hosts/create-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/hosts/create-test.js
@@ -8,12 +8,9 @@ import { visit, currentURL, find, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
-import {
-  authenticateSession,
-  // These are left here intentionally for future reference.
-  //currentSession,
-  //invalidateSession,
-} from 'ember-simple-auth/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as selectors from './selectors';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | host-catalogs | hosts | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -81,8 +78,14 @@ module('Acceptance | host-catalogs | hosts | create', function (hooks) {
   test('can create new host', async function (assert) {
     const count = getHostCount();
     await visit(urls.newHost);
-    await fillIn('[name="name"]', 'random string');
-    await click('[type="submit"]');
+
+    await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
+    await fillIn(
+      commonSelectors.FIELD_DESCRIPTION,
+      commonSelectors.FIELD_DESCRIPTION_VALUE,
+    );
+    await fillIn(selectors.FIELD_ADDRESS, selectors.FIELD_ADDRESS_VALUE);
+    await click(commonSelectors.SAVE_BTN);
     assert.strictEqual(getHostCount(), count + 1);
   });
 

--- a/ui/admin/tests/acceptance/host-catalogs/hosts/selectors.js
+++ b/ui/admin/tests/acceptance/host-catalogs/hosts/selectors.js
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+export const FIELD_ADDRESS = '[name=address]';
+export const FIELD_ADDRESS_VALUE = 'New address';

--- a/ui/admin/tests/acceptance/host-catalogs/hosts/selectors.js
+++ b/ui/admin/tests/acceptance/host-catalogs/hosts/selectors.js
@@ -3,5 +3,8 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+export const MANAGE_DROPDOWN =
+  '[data-test-manage-host-catalogs-dropdown] div:first-child button';
+
 export const FIELD_ADDRESS = '[name=address]';
 export const FIELD_ADDRESS_VALUE = 'New address';

--- a/ui/admin/tests/acceptance/roles/delete-test.js
+++ b/ui/admin/tests/acceptance/roles/delete-test.js
@@ -20,7 +20,8 @@ module('Acceptance | roles | delete', function (hooks) {
   setupMirage(hooks);
 
   const MANAGE_DROPDOWN_SELECTOR = '.hds-dropdown-toggle-button';
-  const DELETE_DROPDOWN_SELECTOR = '.hds-dropdown-list-item--color-critical button'
+  const DELETE_DROPDOWN_SELECTOR =
+    '.hds-dropdown-list-item--color-critical button';
 
   const instances = {
     scopes: {

--- a/ui/admin/tests/acceptance/users/delete-test.js
+++ b/ui/admin/tests/acceptance/users/delete-test.js
@@ -20,8 +20,10 @@ module('Acceptance | users | delete', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   setupIndexedDb(hooks);
-  const DELETE_ACTION_SELECTOR = "[data-test-manage-user-dropdown] ul li button"
-  const MANAGE_DROPDOWN_SELECTOR = "[data-test-manage-user-dropdown] div:first-child button"
+  const DELETE_ACTION_SELECTOR =
+    '[data-test-manage-user-dropdown] ul li button';
+  const MANAGE_DROPDOWN_SELECTOR =
+    '[data-test-manage-user-dropdown] div:first-child button';
   const instances = {
     scopes: {
       global: null,
@@ -68,13 +70,11 @@ module('Acceptance | users | delete', function (hooks) {
     instances.user.authorized_actions =
       instances.user.authorized_actions.filter((item) => item !== 'delete');
     await visit(urls.users);
-    
+
     await click(`[href="${urls.user}"]`);
-    
+
     await click(MANAGE_DROPDOWN_SELECTOR);
-    assert
-      .dom('[data-test-manage-user-dropdown] ul li button')
-      .doesNotExist();
+    assert.dom('[data-test-manage-user-dropdown] ul li button').doesNotExist();
   });
 
   test('can accept delete user via dialog', async function (assert) {
@@ -82,7 +82,6 @@ module('Acceptance | users | delete', function (hooks) {
     confirmService.enabled = true;
     const usersCount = this.server.db.users.length;
     await visit(urls.users);
-    
 
     await click(`[href="${urls.user}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);


### PR DESCRIPTION
# Description

- Update test selectors for host-catalog -> create host.
- A couple of files were missing the format, so add them within this PR after running `(ui/admin$): yarn format`

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-15497)

## Screenshots (if appropriate)

## How to Test

Run the test suite successfully within `ui/admin`: `(ui/admin)$: yarn test`
