### PR TITLE
chore: 🤖 Upgrade qunit-dom

### DIFF
--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -68,7 +68,7 @@
     "js-bexpr": "hashicorp/js-bexpr#9b4a4b54d85eba67fdfc0990133d1518d890b1e1",
     "loader.js": "^4.7.0",
     "prettier": "^3.0.0",
-    "qunit": "^2.19.4",
+    "qunit": "^2.22.0",
     "qunit-dom": "^3.2.1",
     "webpack": "^5.94.0"
   },

--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -69,7 +69,7 @@
     "loader.js": "^4.7.0",
     "prettier": "^3.0.0",
     "qunit": "^2.19.4",
-    "qunit-dom": "^2.0.0",
+    "qunit-dom": "^3.2.1",
     "webpack": "^5.94.0"
   },
   "peerDependencies": {

--- a/addons/auth/package.json
+++ b/addons/auth/package.json
@@ -63,7 +63,7 @@
     "pretender": "^3.4.3",
     "prettier": "^3.0.0",
     "qunit": "^2.19.4",
-    "qunit-dom": "^2.0.0",
+    "qunit-dom": "^3.2.1",
     "webpack": "^5.94.0"
   },
   "engines": {

--- a/addons/auth/package.json
+++ b/addons/auth/package.json
@@ -62,7 +62,7 @@
     "loader.js": "^4.7.0",
     "pretender": "^3.4.3",
     "prettier": "^3.0.0",
-    "qunit": "^2.19.4",
+    "qunit": "^2.22.0",
     "qunit-dom": "^3.2.1",
     "webpack": "^5.94.0"
   },

--- a/addons/core/package.json
+++ b/addons/core/package.json
@@ -81,7 +81,7 @@
     "js-bexpr": "hashicorp/js-bexpr#9b4a4b54d85eba67fdfc0990133d1518d890b1e1",
     "loader.js": "^4.7.0",
     "prettier": "^3.0.0",
-    "qunit": "^2.19.4",
+    "qunit": "^2.22.0",
     "qunit-dom": "^3.2.1",
     "rose": "*",
     "sinon": "^18.0.0",

--- a/addons/core/package.json
+++ b/addons/core/package.json
@@ -82,7 +82,7 @@
     "loader.js": "^4.7.0",
     "prettier": "^3.0.0",
     "qunit": "^2.19.4",
-    "qunit-dom": "^2.0.0",
+    "qunit-dom": "^3.2.1",
     "rose": "*",
     "sinon": "^18.0.0",
     "webpack": "^5.94.0"

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -88,7 +88,7 @@
     "loader.js": "^4.7.0",
     "postcss": "^8.4.31",
     "prettier": "^3.0.0",
-    "qunit": "^2.19.4",
+    "qunit": "^2.22.0",
     "qunit-dom": "^3.2.1",
     "react": "^16",
     "react-dom": "^16",

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -89,7 +89,7 @@
     "postcss": "^8.4.31",
     "prettier": "^3.0.0",
     "qunit": "^2.19.4",
-    "qunit-dom": "^2.0.0",
+    "qunit-dom": "^3.2.1",
     "react": "^16",
     "react-dom": "^16",
     "react-syntax-highlighter": "^15.6.1",

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -99,7 +99,7 @@
     "js-bexpr": "hashicorp/js-bexpr#9b4a4b54d85eba67fdfc0990133d1518d890b1e1",
     "loader.js": "^4.7.0",
     "prettier": "^3.0.0",
-    "qunit": "^2.19.4",
+    "qunit": "^2.22.0",
     "qunit-dom": "^3.2.1",
     "rose": "*",
     "sinon": "^18.0.0",

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -100,7 +100,7 @@
     "loader.js": "^4.7.0",
     "prettier": "^3.0.0",
     "qunit": "^2.19.4",
-    "qunit-dom": "^2.0.0",
+    "qunit-dom": "^3.2.1",
     "rose": "*",
     "sinon": "^18.0.0",
     "stylelint": "^15.10.1",

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -106,7 +106,7 @@
     "playwright": "^1.43.0",
     "prettier": "^3.0.0",
     "qunit": "^2.19.4",
-    "qunit-dom": "^2.0.0",
+    "qunit-dom": "^3.2.1",
     "rose": "*",
     "sass": "^1.69.5",
     "shx": "^0.3.4",

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -105,7 +105,7 @@
     "loader.js": "^4.7.0",
     "playwright": "^1.43.0",
     "prettier": "^3.0.0",
-    "qunit": "^2.19.4",
+    "qunit": "^2.22.0",
     "qunit-dom": "^3.2.1",
     "rose": "*",
     "sass": "^1.69.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15433,10 +15433,10 @@ qunit-theme-ember@^1.0.0:
   resolved "https://registry.yarnpkg.com/qunit-theme-ember/-/qunit-theme-ember-1.0.0.tgz#3b750b9e3ab2837cc3b31cc5b73a0b71b964b0db"
   integrity sha512-vdMVVo6ecdCkWttMTKeyq1ZTLGHcA6zdze2zhguNuc3ritlJMhOXY5RDseqazOwqZVfCg3rtlmL3fMUyIzUyFQ==
 
-qunit@^2.19.4:
-  version "2.19.4"
-  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.19.4.tgz#2d689bb1165edd4b812e3ed2ee06ff907e9f2ece"
-  integrity sha512-aqUzzUeCqlleWYKlpgfdHHw9C6KxkB9H3wNfiBg5yHqQMzy0xw/pbCRHYFkjl8MsP/t8qkTQE+JTYL71azgiew==
+qunit@^2.22.0:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.22.0.tgz#77c26ebfc337bbf82e0e69d4192f0e4454ef134d"
+  integrity sha512-wPYvAvpjTL3zlUeyCX75T8gfZfdVXZa8y1EVkGe/XZNORIsCH/WI2X8R2KlemT921X9EKSZUL6CLGSPC7Ks08g==
   dependencies:
     commander "7.2.0"
     node-watch "0.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8225,7 +8225,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-element-descriptors@^0.5.0:
+dom-element-descriptors@^0.5.0, dom-element-descriptors@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/dom-element-descriptors/-/dom-element-descriptors-0.5.1.tgz#3ebfcf64198f922dba928f84f7970bb571891317"
   integrity sha512-DLayMRQ+yJaziF4JJX1FMjwjdr7wdTr1y9XvZ+NfHELfOMcYDnCHneAYXAS4FT1gLILh4V0juMZohhH1N5FsoQ==
@@ -15421,15 +15421,12 @@ quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-qunit-dom@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/qunit-dom/-/qunit-dom-2.0.0.tgz#c4d7f7676dbb57f54151b72f8366d862134cd1c0"
-  integrity sha512-mElzLN99wYPOGekahqRA+mq7NcThXY9c+/tDkgJmT7W5LeZAFNyITr2rFKNnCbWLIhuLdFw88kCBMrJSfyBYpA==
+qunit-dom@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/qunit-dom/-/qunit-dom-3.2.1.tgz#650707b818d5a889ac1923a5cdbdc0d9daf4db7a"
+  integrity sha512-+qSm8zQ7hPA9NijmTDVsUFNGEFP/K+DTymjlsU01O3NhkGtb9rsZRztJXwaiAlmVSX4vSzjydPxpZCRhpWIq4A==
   dependencies:
-    broccoli-funnel "^3.0.3"
-    broccoli-merge-trees "^4.2.0"
-    ember-cli-babel "^7.23.0"
-    ember-cli-version-checker "^5.1.1"
+    dom-element-descriptors "^0.5.1"
 
 qunit-theme-ember@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# Description

- Upgrade qunit-dom from `2.0.0` to `3.2.1`.
- Upgrade quunit from `2.19.4` to `2.22.0`.

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-15660)
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-15661)

## Screenshots (if appropriate)

## How to Test
- Run test suite successfully, since `qunit-dom` is use in our tests.
