### PR TITLE
chore: 🤖 Upgrade and Migrate husky from v8 to v9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 yarn compliance:licenses
 npx lint-staged

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 COMMIT_MSG_FILE=$1
 COMMIT_SOURCE=$2
 SHA1=$3

--- a/package.json
+++ b/package.json
@@ -39,13 +39,13 @@
     "test:ui-desktop": "yarn --cwd ui/desktop test",
     "compliance:licenses": "license-checker --onlyAllow 'Apache*;Apache License, Version 2.0;Apache-2.0;Apache 2.0;Artistic-2.0;BSD;BSD-3-Clause;CC-BY-3.0;CC-BY-4.0;CC0-1.0;ISC;MIT;MPL-2.0;BUSL-1.1;Public Domain;Python-2.0;Unicode-TOU;Unlicense;WTFPL' --excludePackages 'boundary-ui;admin@0.0.0;desktop@0.0.0;e2e-tests@0.0.0;cycle@1.0.3;cldr-core@43.1.0;make-plural@7.2.0;@hashicorp/ember-asciinema-player@0.0.0;path-scurry@1.10.1'",
     "doc:toc": "doctoc README.md",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "devDependencies": {
     "cz-conventional-changelog": "^3.3.0",
     "doctoc": "^2.2.0",
     "git-cz": "^4.9.0",
-    "husky": "^8.0.0",
+    "husky": "^9.1.6",
     "license-checker": "^25.0.1",
     "lint-staged": "^13.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11726,10 +11726,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^8.0.0:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
-  integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==
+husky@^9.1.6:
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.6.tgz#e23aa996b6203ab33534bdc82306b0cf2cb07d6c"
+  integrity sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==
 
 i18n@^0.15.1:
   version "0.15.1"


### PR DESCRIPTION
# Description
Upgrade and migrate Husky from `v8` to `v9.1.6`

Followed the [migration guide](https://github.com/typicode/husky/releases/tag/v9.0.1).

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-15773)

## How to Test
- Run any task that requires Husky, a `commit` for example.
