### PR TITLE
Migrate embe-autofocus-modifier to HTML autofocus standard

### DIFF
--- a/ui/desktop/app/templates/cluster-url.hbs
+++ b/ui/desktop/app/templates/cluster-url.hbs
@@ -15,10 +15,12 @@
       @disabled={{(is-loading)}}
       as |form|
     >
+
+      {{! template-lint-disable no-autofocus-attribute  }}
       <Hds::Form::TextInput::Field
         name='host'
         @value={{this.clusterUrl}}
-        {{autofocus}}
+        autofocus
         {{on 'input' (set-from-event this 'clusterUrl')}}
         as |F|
       >

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -69,7 +69,6 @@
     "doctoc": "^2.2.0",
     "ember-a11y-testing": "^7.0.0",
     "ember-auto-import": "^2.8.1",
-    "ember-autofocus-modifier": "^4.0.1",
     "ember-cli": "^5.12.0",
     "ember-cli-app-version": "^6.0.0",
     "ember-cli-babel": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8315,14 +8315,6 @@ ember-auto-import@2.8.1, ember-auto-import@^2.2.3, ember-auto-import@^2.2.4, emb
     typescript-memoize "^1.0.0-alpha.3"
     walk-sync "^3.0.0"
 
-ember-autofocus-modifier@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/ember-autofocus-modifier/-/ember-autofocus-modifier-4.0.1.tgz#3ebfed826b2544831fd1e4b77540142cd4d3ac2b"
-  integrity sha512-WhRXG3JvrwNW7O/CFgduJ9V7zqD2QI2K89BYLD8Ai18D3nLJfKDdAkizYb+noIfHone6ttZ/PxNmW8+KdfapNg==
-  dependencies:
-    ember-cli-babel "^7.26.6"
-    ember-modifier "^3.2.7"
-
 ember-browser-services@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ember-browser-services/-/ember-browser-services-4.0.3.tgz#c32b4127c2868a5668c4bfe8d8413885a613ec8c"


### PR DESCRIPTION
# Description
Migrate embe-autofocus-modifier to HTML autofocus standard. [More info within the Jira ticket](https://hashicorp.atlassian.net/browse/ICU-15798)

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-15798)

## Screenshots:

Before:
<img width="1273" alt="Screenshot 2024-11-20 at 2 14 34 PM" src="https://github.com/user-attachments/assets/0572d708-355d-40df-92bd-59443242f032">

After:
<img width="1275" alt="Screenshot 2024-11-20 at 2 30 56 PM" src="https://github.com/user-attachments/assets/0d5ff46f-b1e9-4c92-8d20-dff20e7e5935">


## How to Test
- Run the desktop client, navigate to the change cluster page and make sure at loading, it autofocus the cluster url input.
