### PR TITLE
Icu 14777 add more target tests

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,10 +1,7 @@
-
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-# Admin UI e2e tests
 
-- [Admin UI e2e tests](#admin-ui-e2e-tests)
-- [Admin UI e2e tests](#admin-ui-e2e-tests-1)
+- [Boundary UI E2E tests](#boundary-ui-e2e-tests)
   - [Prerequisites:](#prerequisites)
     - [Accesses](#accesses)
     - [Software](#software)
@@ -12,18 +9,19 @@
     - [Set up Boundary CLI](#set-up-boundary-cli)
     - [Setup Boundary UI](#setup-boundary-ui)
     - [Setup AWS:](#setup-aws)
-    - [Setup HCP Terraform (Terraform cloud):](#setup-hcp-terraform-terraform-cloud)
     - [Setup Enos:](#setup-enos)
   - [Run tests:](#run-tests)
     - [Launch Enos Scenario](#launch-enos-scenario)
-    - [Run tests](#run-tests-1)
+    - [Admin](#admin)
+    - [Desktop](#desktop)
     - [Destroy Enos Scenario](#destroy-enos-scenario)
   - [Developing Tests](#developing-tests)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-# Admin UI e2e tests
 
-This test suite tests the Boundary Admin UI in an end-to-end setting. It was designed to be run in a
+# Boundary UI E2E tests
+
+This test suite tests the Boundary admin UI and desktop client in an end-to-end setting. It was designed to be run in a
 variety of environments as long as the appropriate environment variables are set. You can choose to
 spin up your own infrastructure or use [Enos](https://github.com/hashicorp/boundary/tree/main/enos)
 to generate it for you. More information about [Enos available here.](https://github.com/hashicorp/Enos-Docs)
@@ -32,15 +30,12 @@ The test suite uses the [Playwright](https://playwright.dev/) framework.
 
 ## Prerequisites:
 
-You will need [Homebrew](https://brew.sh/) install. For secure persisting your SSH keys and tokens we recommend using 1Password.
+You will need [Homebrew](https://brew.sh/) installed. To securely store your SSH keys and tokens we recommend using 1Password.
 
 ### Accesses
 
 - Doormat account: `boundary_team_acctest_dev`.
   - Request access through Doormat.
-- HCP account: you will need to use Terraform cloud to spin up enos.
-- app.terraform.io org: `hashicorp-qti`.
-  - Request access in `#proj-boundary-qe` slack channel.
 
 ### Software
 
@@ -59,21 +54,23 @@ We will cover everything you need to set up before being able to run Enos + the 
 
 Ensure the `boundary` CLI is available on the path. You can validate this by making sure this
 command returns something.
+
 ```bash
 which boundary
 ```
 
-Otherwise, follow instructions to [install Boundary](https://developer.hashicorp.com/boundary/downloads?product_intent=boundary) or install it locally running `$ make install` within [Boundary repository](https://github.com/hashicorp/boundary/tree/main).
+Otherwise, follow instructions to [install Boundary](https://developer.hashicorp.com/boundary/downloads?product_intent=boundary) or install it locally running `make install` within [Boundary repository](https://github.com/hashicorp/boundary/tree/main).
 
 ### Setup Boundary UI
 
 Ensure you install project dependencies and playwright needs.
 
 ```bash
-cd boundary-ui/ui/admin
+cd boundary-ui/e2e-tests/admin
 yarn install
 npx playwright install # this installs the browsers used by Playwright
 ```
+
 ### Setup AWS:
 
 **Region awareness:** take note of the AWS region you are setting up because we will need it later to configure enos. [More information about AWS regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html).
@@ -84,61 +81,66 @@ You need to provide an SSH Key pair for the EC2 instance. We recommend creating 
 
 [How to create EC2 SSH key pair](https://docs.aws.amazon.com/ground-station/latest/ug/create-ec2-ssh-key-pair.html).
 
-### Setup HCP Terraform (Terraform cloud):
-
-Log in to [HCP Production env](https://portal.cloud.hashicorp.com/). Through HCP Terraform, open Terraform cloud, or [access here](https://app.terraform.io/). Then create an API token [following this documentation](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/users#tokens). Make sure you are added to the `hashicorp-qti` org in order for the created token to be valid.
-
-**Token awareness:** Copy your token from the box and save it in a secure location. Terraform Cloud only displays the token once, right after you create it. And we will need the token later for enos configuration.
-
 ### Setup Enos:
+
+Make sure you're in the correct boundary repository for the version of Boundary you plan on using.
+The enos scenarios for CE need to be run in `boundary` and the enos scenarios for enterprise need to be run in `boundary-enterprise`.
 
 Enos needs some configuration variables to run the scenario successfully. [See the configuration file](https://github.com/hashicorp/boundary/blob/main/enos/enos.vars.hcl). The file has comments per each variable, but some awareness:
 
+- `boundary_edition`: The edition of Boundary you are using. Options are `oss` or `enterprise`.
 - `aws_region`: The AWS region you are using. Very important as mentioned within the EC2 Setup.
 - `aws_ssh_keypair_name`: The name of the AWS keypair.
 - `aws_ssh_private_key_path`: The path to the private key associated with your keypair.
-- `enos_user`: The user name to use for Boundary.
-- `tfc_api_token`: you need to provide the previously created token in Terraform cloud, there is no shared token within Boundary team.
-- `local_boundary_dir`: The directory that contains Boundary binary.
-- `local_boundary_ui_src_dir`: The directory that contains the copy of boundary-ui you want to use for UI tests.
-- `e2e_debug_no_run`: make sure this is set to true.
+- `enos_user`: The user name to use for tagged resources in AWS.
+- `e2e_debug_no_run`: Make sure this is set to true.
 
 More documentation about [scenario variables](https://github.com/hashicorp/boundary/tree/main/enos#scenarios-variables).
 
 ## Run tests:
 
-Before running the e2e test locally, we need to launch Enos Scenario, make sure you followed all the steps within the [Getting started section](#getting-started).
+Before running the e2e test locally, we need to launch an Enos Scenario. Make sure you followed all the steps within the [Getting started section](#getting-started).
 
-It is not necessary, but from this point we recommend having 2 terminals open. 
+It is not necessary, but from this point we recommend having 2 terminals open.
+
 - Terminal 1: Will be use to run enos (Boundary).
 - Terminal 2: Will be use to run e2e UI tests (Boundary UI).
 
 ### Launch Enos Scenario
 
 Using Terminal 1:
-- `$ cd boundary/enos`.
-- `$ doormat login`. Login with Doormat.
-- `$ eval "$(doormat aws export --account boundary_team_acctest_dev)"`. Exporting AWS env variables from doormat to your terminal.
-- `$ enos scenario launch e2e_ui_aws builder:local`. Launch enos scenario, this will take from 5 to 10 minutes. When its done, you will see a Enos Operations finished! within your terminal. Check out more scenarios [here](https://github.com/hashicorp/boundary/tree/main/enos).
-- `$ bash scripts/test_e2e_env.sh`. Prints all the env variables within Enos scenario. Copy the output and paste it within your Terminal 2 (Boundary UI). These env variables are need within Boundary UI to run the test against the enos scenario.
 
-*Be aware once the scenario is launch you will create and run resources within AWS, once you are done using the scenario, [you should destroy it](#destroy-enos-scenario).*
+- `cd boundary/enos` or `cd boundary_enterprise/enos`.
+- `doormat login`. Login with Doormat.
+- `eval "$(doormat aws export --account boundary_team_acctest_dev)"`. Exporting AWS env variables from doormat to your terminal.
+- `enos scenario launch e2e_ui_aws builder:local` or `enos scenario launch e2e_ui_aws_ent builder:local` if in enterprise.
+  - Launches enos scenario, this will take from 5 to 10 minutes. When its done, you will see a Enos Operations finished! within your terminal. Check out more scenarios [here](https://github.com/hashicorp/boundary/tree/main/enos).
+- `bash scripts/test_e2e_env.sh`. Prints all the env variables within Enos scenario. Copy the output and paste it within your Terminal 2 (Boundary UI). These env variables are need within Boundary UI to run the test against the enos scenario.
 
-### Run tests
+> [!IMPORTANT]
+> Be aware that once the scenario is launched you will create and run resources within AWS. After you are done using the scenario, [you should destroy it](#destroy-enos-scenario).
+
+### Admin
 
 Using Terminal 2:
-- Set the env varibales `test_e2e_env.sh` script output within this terminal.
-- `$ cd boundary-ui/ui/admin`.
-- `$ yarn run e2e`.
+
+Set the env variables `test_e2e_env.sh` script output in this terminal.
+
+```bash
+cd boundary-ui/e2e-tests
+yarn run admin
+```
 
 Here are some additional commands to assist with debugging.
+
 ```bash
-PWDEBUG=console yarn playwright test --headed --config ./tests/e2e/playwright.config.js login.spec.js
-PWDEBUG=console yarn playwright test --headed --config ./tests/e2e/playwright.config.js login.spec.js:13 --debug
-PWDEBUG=console yarn playwright test --headed --config ./tests/e2e/playwright.config.js login.spec.js --debug
+PWDEBUG=console yarn playwright test --headed --config admin/playwright.config.js login.spec.js
+PWDEBUG=console yarn playwright test --headed --config admin/playwright.config.js login.spec.js:13 --debug
+PWDEBUG=console yarn playwright test --headed --config admin/playwright.config.js login.spec.js --debug
 ```
 
 To run all tests for a certain configuration, you can use the following shortcuts
+
 ```bash
 # Runs all tests pertaining to the Community Edition
 yarn run e2e:ce:aws
@@ -149,15 +151,35 @@ yarn run e2e:ent:aws
 yarn run e2e:ent:docker
 ```
 
+### Desktop
+
+> [!NOTE]
+> Currently the desktop client e2e tests assumes that the Boundary server is an enterprise edition.
+
+Using Terminal 2:
+
+Set the env variables `test_e2e_env.sh` script output in this terminal.
+
+```bash
+cd boundary-ui/e2e-tests
+yarn run desktop
+```
+
 [Playwright documentation about running tests](https://playwright.dev/docs/running-tests).
 
 ### Destroy Enos Scenario
 
 Using Terminal 1:
-- `$ enos scenario destroy e2e_ui_aws builder:local`
-- After all the steps pass, you should see a `Enos operations finished!`.
 
+```bash
+# Community Edition
+enos scenario destroy e2e_ui_aws builder:local
 
+# Enterprise Edition
+enos scenario destroy e2e_ui_aws_ent builder:local
+```
+
+After all the steps pass, you should see a `Enos operations finished!`.
 
 ## Developing Tests
 

--- a/e2e-tests/admin/playwright.config.js
+++ b/e2e-tests/admin/playwright.config.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { defineConfig, devices, test as baseTest } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export default defineConfig({
-  globalSetup: './global-setup',
+  globalSetup: '../global-setup',
   outputDir: './artifacts/test-failures',
   timeout: 90000, // Each test is given 90s to complete
   workers: 1, // Tests need to be run in serial, otherwise there may be conflicts when using the CLI
@@ -34,36 +34,4 @@ export default defineConfig({
       use: { ...devices['Desktop Safari'] },
     },
   ],
-});
-
-export const test = baseTest.extend({
-  adminAuthMethodId: process.env.E2E_PASSWORD_AUTH_METHOD_ID,
-  adminLoginName: process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
-  adminPassword: process.env.E2E_PASSWORD_ADMIN_PASSWORD,
-  awsAccessKeyId: process.env.E2E_AWS_ACCESS_KEY_ID,
-  awsBucketName: process.env.E2E_AWS_BUCKET_NAME,
-  awsHostSetFilter: process.env.E2E_AWS_HOST_SET_FILTER,
-  awsHostSetIps: process.env.E2E_AWS_HOST_SET_IPS,
-  awsRegion: process.env.E2E_AWS_REGION,
-  awsSecretAccessKey: process.env.E2E_AWS_SECRET_ACCESS_KEY,
-  bucketAccessKeyId: process.env.E2E_BUCKET_ACCESS_KEY_ID,
-  bucketEndpointUrl: process.env.E2E_BUCKET_ENDPOINT_URL,
-  bucketName: process.env.E2E_BUCKET_NAME,
-  bucketSecretAccessKey: process.env.E2E_BUCKET_SECRET_ACCESS_KEY,
-  ldapAddr: process.env.E2E_LDAP_ADDR,
-  ldapAdminDn: process.env.E2E_LDAP_ADMIN_DN,
-  ldapAdminPassword: process.env.E2E_LDAP_ADMIN_PASSWORD,
-  ldapDomainDn: process.env.E2E_LDAP_DOMAIN_DN,
-  ldapGroupName: process.env.E2E_LDAP_GROUP_NAME,
-  ldapUserName: process.env.E2E_LDAP_USER_NAME,
-  ldapUserPassword: process.env.E2E_LDAP_USER_PASSWORD,
-  region: process.env.E2E_REGION,
-  sshCaKey: process.env.E2E_SSH_CA_KEY,
-  sshCaKeyPublic: process.env.E2E_SSH_CA_KEY_PUBLIC,
-  sshKeyPath: process.env.E2E_SSH_KEY_PATH,
-  sshUser: process.env.E2E_SSH_USER,
-  targetAddress: process.env.E2E_TARGET_ADDRESS,
-  targetPort: process.env.E2E_TARGET_PORT,
-  vaultAddr: process.env.E2E_VAULT_ADDR,
-  workerTagEgress: process.env.E2E_WORKER_TAG_EGRESS,
 });

--- a/e2e-tests/admin/tests/alias-ent.spec.js
+++ b/e2e-tests/admin/tests/alias-ent.spec.js
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { customAlphabet } from 'nanoid';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   authorizeSessionByAliasCli,

--- a/e2e-tests/admin/tests/alias-ent.spec.js
+++ b/e2e-tests/admin/tests/alias-ent.spec.js
@@ -7,7 +7,7 @@ import { test } from '../playwright.config.js';
 import { expect } from '@playwright/test';
 import { customAlphabet } from 'nanoid';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   authorizeSessionByAliasCli,

--- a/e2e-tests/admin/tests/alias.spec.js
+++ b/e2e-tests/admin/tests/alias.spec.js
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { customAlphabet } from 'nanoid';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   authorizeSessionByAliasCli,

--- a/e2e-tests/admin/tests/alias.spec.js
+++ b/e2e-tests/admin/tests/alias.spec.js
@@ -7,7 +7,7 @@ import { test } from '../playwright.config.js';
 import { expect } from '@playwright/test';
 import { customAlphabet } from 'nanoid';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   authorizeSessionByAliasCli,

--- a/e2e-tests/admin/tests/auth-method-ldap.spec.js
+++ b/e2e-tests/admin/tests/auth-method-ldap.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { nanoid } from 'nanoid';
 

--- a/e2e-tests/admin/tests/auth-method-password.spec.js
+++ b/e2e-tests/admin/tests/auth-method-password.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { execSync } from 'node:child_process';
 

--- a/e2e-tests/admin/tests/credential-store-static-ent.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static-ent.spec.js
@@ -6,7 +6,7 @@
 import { test } from '../playwright.config.js';
 import { expect } from '@playwright/test';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/credential-store-static-ent.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static-ent.spec.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/credential-store-static.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static.spec.js
@@ -8,7 +8,7 @@ import { expect } from '@playwright/test';
 import { readFile } from 'fs/promises';
 import { nanoid } from 'nanoid';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   authorizeSessionByTargetIdCli,

--- a/e2e-tests/admin/tests/credential-store-static.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static.spec.js
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { readFile } from 'fs/promises';
 import { nanoid } from 'nanoid';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   authorizeSessionByTargetIdCli,

--- a/e2e-tests/admin/tests/credential-store-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/credential-store-vault-ent.spec.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { execSync } from 'child_process';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   authorizeSessionByTargetIdCli,

--- a/e2e-tests/admin/tests/credential-store-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/credential-store-vault-ent.spec.js
@@ -6,7 +6,7 @@
 import { test } from '../playwright.config.js';
 import { execSync } from 'child_process';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   authorizeSessionByTargetIdCli,

--- a/e2e-tests/admin/tests/credential-store-vault.spec.js
+++ b/e2e-tests/admin/tests/credential-store-vault.spec.js
@@ -3,13 +3,12 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { execSync } from 'child_process';
 import { nanoid } from 'nanoid';
 import { readFile } from 'fs/promises';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   authorizeSessionByTargetIdCli,

--- a/e2e-tests/admin/tests/credential-store-vault.spec.js
+++ b/e2e-tests/admin/tests/credential-store-vault.spec.js
@@ -9,7 +9,7 @@ import { execSync } from 'child_process';
 import { nanoid } from 'nanoid';
 import { readFile } from 'fs/promises';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   authorizeSessionByTargetIdCli,

--- a/e2e-tests/admin/tests/delete-resources-ent.spec.js
+++ b/e2e-tests/admin/tests/delete-resources-ent.spec.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { execSync } from 'node:child_process';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/delete-resources-ent.spec.js
+++ b/e2e-tests/admin/tests/delete-resources-ent.spec.js
@@ -6,7 +6,7 @@
 import { test } from '../playwright.config.js';
 import { execSync } from 'node:child_process';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/delete-resources.spec.js
+++ b/e2e-tests/admin/tests/delete-resources.spec.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { execSync } from 'node:child_process';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/delete-resources.spec.js
+++ b/e2e-tests/admin/tests/delete-resources.spec.js
@@ -6,7 +6,7 @@
 import { test } from '../playwright.config.js';
 import { execSync } from 'node:child_process';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
+++ b/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { nanoid } from 'nanoid';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   deleteScopeCli,

--- a/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
+++ b/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
@@ -7,7 +7,7 @@ import { test } from '../playwright.config.js';
 import { expect } from '@playwright/test';
 import { nanoid } from 'nanoid';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   deleteScopeCli,

--- a/e2e-tests/admin/tests/global-settings.spec.js
+++ b/e2e-tests/admin/tests/global-settings.spec.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   deletePolicyCli,

--- a/e2e-tests/admin/tests/global-settings.spec.js
+++ b/e2e-tests/admin/tests/global-settings.spec.js
@@ -6,7 +6,7 @@
 import { test } from '../playwright.config.js';
 import { expect } from '@playwright/test';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   deletePolicyCli,

--- a/e2e-tests/admin/tests/group-role.spec.js
+++ b/e2e-tests/admin/tests/group-role.spec.js
@@ -5,7 +5,7 @@
 
 import { test } from '../playwright.config.js';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/group-role.spec.js
+++ b/e2e-tests/admin/tests/group-role.spec.js
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/login.spec.js
+++ b/e2e-tests/admin/tests/login.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
 import { LoginPage } from '../pages/login.js';

--- a/e2e-tests/admin/tests/pagination.spec.js
+++ b/e2e-tests/admin/tests/pagination.spec.js
@@ -6,7 +6,7 @@
 import { test } from '../playwright.config.js';
 import { expect } from '@playwright/test';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   createOrgHttp,
   createProjectHttp,

--- a/e2e-tests/admin/tests/pagination.spec.js
+++ b/e2e-tests/admin/tests/pagination.spec.js
@@ -6,11 +6,7 @@
 import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
-import {
-  createOrgHttp,
-  createProjectHttp,
-  createTargetHttp,
-} from '../../helpers/boundary-http.js';
+import * as boundaryHttp from '../../helpers/boundary-http.js';
 
 test.use({ storageState: authenticatedState });
 
@@ -20,14 +16,18 @@ test('Search and Pagination (Targets) @ce @ent @aws @docker', async ({
 }) => {
   let org;
   try {
-    org = await createOrgHttp(request);
-    const project = await createProjectHttp(request, org.id);
+    org = await boundaryHttp.createOrg(request);
+    const project = await boundaryHttp.createProject(request, org.id);
 
     // Create targets
     let targets = [];
     const targetCount = 15;
     for (let i = 0; i < targetCount; i++) {
-      const target = await createTargetHttp(request, project.id, 'tcp', 22);
+      const target = await boundaryHttp.createTarget(request, {
+        scopeId: project.id,
+        type: 'tcp',
+        port: 22,
+      });
       targets.push(target);
     }
 

--- a/e2e-tests/admin/tests/pagination.spec.js
+++ b/e2e-tests/admin/tests/pagination.spec.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   createOrgHttp,
   createProjectHttp,

--- a/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
@@ -7,7 +7,7 @@ import { test } from '../playwright.config.js';
 import { expect } from '@playwright/test';
 import { execSync } from 'child_process';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { execSync } from 'child_process';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
@@ -7,7 +7,7 @@ import { test } from '../playwright.config.js';
 import { expect } from '@playwright/test';
 import { execSync } from 'child_process';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { execSync } from 'child_process';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
@@ -6,7 +6,7 @@
 import { test } from '../playwright.config.js';
 import { execSync } from 'child_process';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { execSync } from 'child_process';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/ssh-credential-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-credential-injection-vault-ent.spec.js
@@ -6,7 +6,7 @@
 import { test } from '../playwright.config.js';
 import { execSync } from 'child_process';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/ssh-credential-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-credential-injection-vault-ent.spec.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { execSync } from 'child_process';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/target-ent.spec.js
+++ b/e2e-tests/admin/tests/target-ent.spec.js
@@ -6,7 +6,7 @@
 import { test } from '../playwright.config.js';
 import { expect } from '@playwright/test';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/target-ent.spec.js
+++ b/e2e-tests/admin/tests/target-ent.spec.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/target.spec.js
+++ b/e2e-tests/admin/tests/target.spec.js
@@ -6,7 +6,7 @@
 import { test } from '../playwright.config.js';
 import { expect } from '@playwright/test';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/target.spec.js
+++ b/e2e-tests/admin/tests/target.spec.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
-import { authenticatedState } from '../../global-setup.js';
 import {
   authenticateBoundaryCli,
   checkBoundaryCli,

--- a/e2e-tests/admin/tests/worker-ent.spec.js
+++ b/e2e-tests/admin/tests/worker-ent.spec.js
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
-
-import { authenticatedState } from '../../global-setup.js';
 
 test.use({ storageState: authenticatedState });
 

--- a/e2e-tests/admin/tests/worker-ent.spec.js
+++ b/e2e-tests/admin/tests/worker-ent.spec.js
@@ -6,7 +6,7 @@
 import { test } from '../playwright.config.js';
 import { expect } from '@playwright/test';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 
 test.use({ storageState: authenticatedState });
 

--- a/e2e-tests/admin/tests/worker-tags.spec.js
+++ b/e2e-tests/admin/tests/worker-tags.spec.js
@@ -7,7 +7,7 @@ import { test } from '../playwright.config.js';
 import { expect } from '@playwright/test';
 import { customAlphabet } from 'nanoid';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 import { WorkersPage } from '../pages/workers.js';
 
 test.use({ storageState: authenticatedState });

--- a/e2e-tests/admin/tests/worker-tags.spec.js
+++ b/e2e-tests/admin/tests/worker-tags.spec.js
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { customAlphabet } from 'nanoid';
 
-import { authenticatedState } from '../../global-setup.js';
 import { WorkersPage } from '../pages/workers.js';
 
 test.use({ storageState: authenticatedState });

--- a/e2e-tests/admin/tests/worker.spec.js
+++ b/e2e-tests/admin/tests/worker.spec.js
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test } from '../playwright.config.js';
+import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
-
-import { authenticatedState } from '../../global-setup.js';
 
 test.use({ storageState: authenticatedState });
 

--- a/e2e-tests/admin/tests/worker.spec.js
+++ b/e2e-tests/admin/tests/worker.spec.js
@@ -6,7 +6,7 @@
 import { test } from '../playwright.config.js';
 import { expect } from '@playwright/test';
 
-import { authenticatedState } from '../global-setup.js';
+import { authenticatedState } from '../../global-setup.js';
 
 test.use({ storageState: authenticatedState });
 

--- a/e2e-tests/desktop/fixtures/baseTest.js
+++ b/e2e-tests/desktop/fixtures/baseTest.js
@@ -6,8 +6,8 @@
 import { mergeTests } from '@playwright/test';
 import { electronTest } from './electronTest.js';
 import { authenticateTest } from './authenticateTest.js';
+import { test as envTest } from '../../global-setup.js';
 
-// Redundant since authenticateTest already extends electronTest but this is for demonstration purposes
 // The last item in the list will override any previous ones in a fixture name collision
-export const test = mergeTests(authenticateTest, electronTest);
+export const test = mergeTests(envTest, authenticateTest, electronTest);
 export { expect } from '@playwright/test';

--- a/e2e-tests/desktop/playwright.config.js
+++ b/e2e-tests/desktop/playwright.config.js
@@ -6,6 +6,18 @@ import { defineConfig } from '@playwright/test';
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export default defineConfig({
+  globalSetup: '../global-setup',
   outputDir: './artifacts',
   workers: 1, // Tests need to be run in serial, otherwise there may be conflicts when using the CLI
+  use: {
+    baseURL: process.env.BOUNDARY_ADDR,
+    storageState: './admin/artifacts/authenticated-state.json',
+    extraHTTPHeaders: {
+      // This token is set in global-setup.js
+      Authorization: `Bearer ${process.env.E2E_TOKEN}`,
+    },
+  },
+  expect: {
+    timeout: 10000,
+  },
 });

--- a/e2e-tests/desktop/tests/authentication.spec.js
+++ b/e2e-tests/desktop/tests/authentication.spec.js
@@ -44,7 +44,8 @@ test.describe('user/password authentication tests', async () => {
   });
 });
 
-test.describe('LDAP authentication tests', async () => {
+// Setup an LDAP server for these tests
+test.fixme('LDAP authentication tests', async () => {
   test('Authenticates and signs out', async ({
     electronPage,
     clusterUrl,

--- a/e2e-tests/desktop/tests/targets.spec.js
+++ b/e2e-tests/desktop/tests/targets.spec.js
@@ -149,7 +149,7 @@ test.describe('Targets test', async () => {
         .getByRole('listitem')
         .filter({ hasText: 'private_key' })
         .locator('pre'),
-    ).toContainText('BEGIN OPENSSH PRIVATE KEY');
+    ).toContainText(/BEGIN (OPENSSH|RSA) PRIVATE KEY/);
 
     await authedPage.getByRole('button', { name: 'End Session' }).click();
     await expect(authedPage.getByText('Canceled successfully.')).toBeVisible();
@@ -202,7 +202,7 @@ test.describe('Targets test', async () => {
           .getByRole('listitem')
           .filter({ hasText: 'private_key' })
           .locator('pre'),
-      ).toContainText('BEGIN OPENSSH PRIVATE KEY');
+      ).toContainText(/BEGIN (OPENSSH|RSA) PRIVATE KEY/);
 
       await authedPage.getByRole('button', { name: 'End Session' }).click();
       await expect(

--- a/e2e-tests/desktop/tests/targets.spec.js
+++ b/e2e-tests/desktop/tests/targets.spec.js
@@ -4,18 +4,227 @@
  */
 
 import { expect, test } from '../fixtures/baseTest.js';
+import * as boundaryHttp from '../../helpers/boundary-http';
+
+const hostName = 'Host name for test';
+let org;
+let targetWithHost;
+let targetWithTwoHosts;
+let sshTarget;
+let credential;
+
+test.beforeAll(
+  async ({ request, targetAddress, targetPort, sshUser, sshKeyPath }) => {
+    org = await boundaryHttp.createOrg(request);
+    const project = await boundaryHttp.createProject(request, org.id);
+
+    // Create host set
+    const hostCatalog = await boundaryHttp.createStaticHostCatalog(
+      request,
+      project.id,
+    );
+    const host = await boundaryHttp.createHost(request, {
+      hostCatalogId: hostCatalog.id,
+      address: targetAddress,
+    });
+    const host2 = await boundaryHttp.createHost(request, {
+      hostCatalogId: hostCatalog.id,
+      address: targetAddress,
+      name: hostName,
+    });
+
+    const hostSet = await boundaryHttp.createHostSet(request, hostCatalog.id);
+    await boundaryHttp.addHostToHostSet(request, {
+      hostSet,
+      hostIds: [host.id],
+    });
+
+    // Create a host set with 2 hosts
+    let hostSetWithTwoHosts = await boundaryHttp.createHostSet(
+      request,
+      hostCatalog.id,
+    );
+    hostSetWithTwoHosts = await boundaryHttp.addHostToHostSet(request, {
+      hostSet: hostSetWithTwoHosts,
+      hostIds: [host.id],
+    });
+    hostSetWithTwoHosts = await boundaryHttp.addHostToHostSet(request, {
+      hostSet: hostSetWithTwoHosts,
+      hostIds: [host2.id],
+    });
+
+    // Create a static credential store and key pair credential
+    const credentialStore = await boundaryHttp.createStaticCredentialStore(
+      request,
+      project.id,
+    );
+    credential = await boundaryHttp.createStaticCredentialKeyPair(request, {
+      credentialStoreId: credentialStore.id,
+      username: sshUser,
+      sshKeyPath,
+    });
+
+    // Create tcp target with host set and 1 host
+    targetWithHost = await boundaryHttp.createTarget(request, {
+      scopeId: project.id,
+      type: 'tcp',
+      port: targetPort,
+    });
+    targetWithHost = await boundaryHttp.addHostSource(request, {
+      target: targetWithHost,
+      hostSourceIds: [hostSet.id],
+    });
+    targetWithHost = await boundaryHttp.addBrokeredCredentials(request, {
+      target: targetWithHost,
+      credentialIds: [credential.id],
+    });
+
+    // Create tcp target with host set and 2 hosts
+    targetWithTwoHosts = await boundaryHttp.createTarget(request, {
+      scopeId: project.id,
+      type: 'tcp',
+      port: targetPort,
+    });
+    targetWithTwoHosts = await boundaryHttp.addHostSource(request, {
+      target: targetWithTwoHosts,
+      hostSourceIds: [hostSetWithTwoHosts.id],
+    });
+    targetWithTwoHosts = await boundaryHttp.addBrokeredCredentials(request, {
+      target: targetWithTwoHosts,
+      credentialIds: [credential.id],
+    });
+
+    // Create an SSH target with address
+    sshTarget = await boundaryHttp.createTarget(request, {
+      scopeId: project.id,
+      type: 'ssh',
+      port: targetPort,
+      address: targetAddress,
+    });
+    sshTarget = await boundaryHttp.addInjectedCredentials(request, {
+      target: sshTarget,
+      credentialIds: [credential.id],
+    });
+  },
+);
+
+test.afterAll(async ({ request }) => {
+  if (org) {
+    await boundaryHttp.deleteOrg(request, org.id);
+  }
+});
 
 test.describe('Targets test', async () => {
-  test('Connects to a target and ends session', async ({ authedPage }) => {
-    await authedPage
-      .getByRole('link', { name: 'Generated target with a direct address' })
-      .click();
-
+  test('Connects to a tcp target with one host', async ({ authedPage }) => {
+    await authedPage.getByRole('link', { name: targetWithHost.name }).click();
     await authedPage.getByRole('button', { name: 'Connect' }).click();
 
     await expect(authedPage).toHaveURL(
       /.*\/scopes\/global\/projects\/sessions/,
     );
+
+    await expect(authedPage.getByText(credential.name)).toBeVisible();
+    await expect(authedPage.getByText('username')).toBeVisible();
+    await expect(authedPage.getByText('private_key')).toBeVisible();
+
+    await authedPage
+      .getByRole('listitem')
+      .filter({ hasText: 'username' })
+      .getByLabel('Toggle secret visibility')
+      .click();
+    await expect(
+      authedPage
+        .getByRole('listitem')
+        .filter({ hasText: 'username' })
+        .locator('pre'),
+    ).toHaveText(credential.attributes.username);
+
+    await authedPage
+      .getByRole('listitem')
+      .filter({ hasText: 'private_key' })
+      .getByLabel('Toggle secret visibility')
+      .click();
+    await expect(
+      authedPage
+        .getByRole('listitem')
+        .filter({ hasText: 'private_key' })
+        .locator('pre'),
+    ).toContainText('BEGIN OPENSSH PRIVATE KEY');
+
+    await authedPage.getByRole('button', { name: 'End Session' }).click();
+    await expect(authedPage.getByText('Canceled successfully.')).toBeVisible();
+    await expect(authedPage).toHaveURL(
+      /.*\/scopes\/global\/projects\/targets$/,
+    );
+  });
+
+  [{ host: 'Quick Connect' }, { host: hostName }].forEach(({ host }) => {
+    test(`Connects to a tcp target with two hosts using ${host}`, async ({
+      authedPage,
+    }) => {
+      await authedPage
+        .getByRole('link', { name: targetWithTwoHosts.name })
+        .click();
+      await authedPage.getByRole('button', { name: 'Connect' }).click();
+
+      await expect(authedPage).toHaveURL(
+        /.*\/scopes\/global\/projects\/targets/,
+      );
+      await authedPage.getByRole('button', { name: host }).click();
+
+      await expect(authedPage).toHaveURL(
+        /.*\/scopes\/global\/projects\/sessions/,
+      );
+
+      await expect(authedPage.getByText(credential.name)).toBeVisible();
+      await expect(authedPage.getByText('username')).toBeVisible();
+      await expect(authedPage.getByText('private_key')).toBeVisible();
+
+      await authedPage
+        .getByRole('listitem')
+        .filter({ hasText: 'username' })
+        .getByLabel('Toggle secret visibility')
+        .click();
+      await expect(
+        authedPage
+          .getByRole('listitem')
+          .filter({ hasText: 'username' })
+          .locator('pre'),
+      ).toHaveText(credential.attributes.username);
+
+      await authedPage
+        .getByRole('listitem')
+        .filter({ hasText: 'private_key' })
+        .getByLabel('Toggle secret visibility')
+        .click();
+      await expect(
+        authedPage
+          .getByRole('listitem')
+          .filter({ hasText: 'private_key' })
+          .locator('pre'),
+      ).toContainText('BEGIN OPENSSH PRIVATE KEY');
+
+      await authedPage.getByRole('button', { name: 'End Session' }).click();
+      await expect(
+        authedPage.getByText('Canceled successfully.'),
+      ).toBeVisible();
+      await expect(authedPage).toHaveURL(
+        /.*\/scopes\/global\/projects\/targets$/,
+      );
+    });
+  });
+
+  test('Connects to an SSH target', async ({ authedPage }) => {
+    await authedPage.getByRole('link', { name: sshTarget.name }).click();
+    await authedPage.getByRole('button', { name: 'Connect' }).click();
+
+    await expect(authedPage).toHaveURL(
+      /.*\/scopes\/global\/projects\/sessions/,
+    );
+
+    await authedPage.getByRole('tab', { name: 'Shell' }).click();
+    // TODO: Research a better way to test canvas elements for the shell,
+    //  would it be too brittle to assert a snapshot of an expected image?
 
     await authedPage.getByRole('button', { name: 'End Session' }).click();
     await expect(authedPage.getByText('Canceled successfully.')).toBeVisible();
@@ -25,12 +234,12 @@ test.describe('Targets test', async () => {
   });
 
   test('Searches targets correctly', async ({ authedPage }) => {
-    await authedPage.getByLabel('Search').fill('hashicorp');
+    await authedPage.getByLabel('Search').fill(targetWithHost.name);
 
     // One row is the header
     await expect(authedPage.getByRole('row')).toHaveCount(2);
     await expect(
-      authedPage.getByRole('link', { name: 'www.hashicorp.com' }),
+      authedPage.getByRole('link', { name: targetWithHost.name }),
     ).toBeVisible();
   });
 });

--- a/e2e-tests/global-setup.js
+++ b/e2e-tests/global-setup.js
@@ -4,9 +4,9 @@
  */
 
 import { chromium } from '@playwright/test';
-import { checkEnv } from '../helpers/general.js';
+import { checkEnv } from './helpers/general.js';
 
-import { LoginPage } from './pages/login.js';
+import { LoginPage } from './admin/pages/login.js';
 
 async function globalSetup() {
   await checkEnv([

--- a/e2e-tests/global-setup.js
+++ b/e2e-tests/global-setup.js
@@ -7,6 +7,7 @@ import { chromium } from '@playwright/test';
 import { checkEnv } from './helpers/general.js';
 
 import { LoginPage } from './admin/pages/login.js';
+import { test as baseTest } from 'playwright/types/test';
 
 async function globalSetup() {
   await checkEnv([
@@ -41,3 +42,35 @@ async function globalSetup() {
 export default globalSetup;
 
 export const authenticatedState = './admin/artifacts/authenticated-state.json';
+
+export const test = baseTest.extend({
+  adminAuthMethodId: process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+  adminLoginName: process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+  adminPassword: process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+  awsAccessKeyId: process.env.E2E_AWS_ACCESS_KEY_ID,
+  awsBucketName: process.env.E2E_AWS_BUCKET_NAME,
+  awsHostSetFilter: process.env.E2E_AWS_HOST_SET_FILTER,
+  awsHostSetIps: process.env.E2E_AWS_HOST_SET_IPS,
+  awsRegion: process.env.E2E_AWS_REGION,
+  awsSecretAccessKey: process.env.E2E_AWS_SECRET_ACCESS_KEY,
+  bucketAccessKeyId: process.env.E2E_BUCKET_ACCESS_KEY_ID,
+  bucketEndpointUrl: process.env.E2E_BUCKET_ENDPOINT_URL,
+  bucketName: process.env.E2E_BUCKET_NAME,
+  bucketSecretAccessKey: process.env.E2E_BUCKET_SECRET_ACCESS_KEY,
+  ldapAddr: process.env.E2E_LDAP_ADDR,
+  ldapAdminDn: process.env.E2E_LDAP_ADMIN_DN,
+  ldapAdminPassword: process.env.E2E_LDAP_ADMIN_PASSWORD,
+  ldapDomainDn: process.env.E2E_LDAP_DOMAIN_DN,
+  ldapGroupName: process.env.E2E_LDAP_GROUP_NAME,
+  ldapUserName: process.env.E2E_LDAP_USER_NAME,
+  ldapUserPassword: process.env.E2E_LDAP_USER_PASSWORD,
+  region: process.env.E2E_REGION,
+  sshCaKey: process.env.E2E_SSH_CA_KEY,
+  sshCaKeyPublic: process.env.E2E_SSH_CA_KEY_PUBLIC,
+  sshKeyPath: process.env.E2E_SSH_KEY_PATH,
+  sshUser: process.env.E2E_SSH_USER,
+  targetAddress: process.env.E2E_TARGET_ADDRESS,
+  targetPort: process.env.E2E_TARGET_PORT,
+  vaultAddr: process.env.E2E_VAULT_ADDR,
+  workerTagEgress: process.env.E2E_WORKER_TAG_EGRESS,
+});

--- a/e2e-tests/global-setup.js
+++ b/e2e-tests/global-setup.js
@@ -5,7 +5,6 @@
 
 import { chromium, test as baseTest } from '@playwright/test';
 import { checkEnv } from './helpers/general.js';
-
 import { LoginPage } from './admin/pages/login.js';
 
 async function globalSetup() {
@@ -15,7 +14,10 @@ async function globalSetup() {
     'E2E_PASSWORD_ADMIN_PASSWORD',
     'E2E_PASSWORD_AUTH_METHOD_ID',
   ]);
+  await authenticateToBoundary();
+}
 
+const authenticateToBoundary = async () => {
   // Log in and save the authenticated state to reuse in tests
   const browser = await chromium.launch();
   const page = await browser.newPage();
@@ -36,12 +38,13 @@ async function globalSetup() {
   process.env.E2E_TOKEN = state.authenticated.token;
 
   await browser.close();
-}
+};
 
 export default globalSetup;
 
 export const authenticatedState = './admin/artifacts/authenticated-state.json';
 
+// Centralized location for environment variables used in tests
 export const test = baseTest.extend({
   adminAuthMethodId: process.env.E2E_PASSWORD_AUTH_METHOD_ID,
   adminLoginName: process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,

--- a/e2e-tests/global-setup.js
+++ b/e2e-tests/global-setup.js
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { chromium } from '@playwright/test';
+import { chromium, test as baseTest } from '@playwright/test';
 import { checkEnv } from './helpers/general.js';
 
 import { LoginPage } from './admin/pages/login.js';
-import { test as baseTest } from 'playwright/types/test';
 
 async function globalSetup() {
   await checkEnv([

--- a/e2e-tests/helpers/boundary-http.js
+++ b/e2e-tests/helpers/boundary-http.js
@@ -5,3 +5,8 @@
 
 export * from './boundary-http/scopes.js';
 export * from './boundary-http/targets.js';
+export * from './boundary-http/host-catalogs.js';
+export * from './boundary-http/host-sets.js';
+export * from './boundary-http/hosts.js';
+export * from './boundary-http/credential-stores.js';
+export * from './boundary-http/credentials.js';

--- a/e2e-tests/helpers/boundary-http/credential-stores.js
+++ b/e2e-tests/helpers/boundary-http/credential-stores.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { nanoid } from 'nanoid';
+import { checkResponse } from './responseHelper.js';
+
+/**
+ * Creates a new static credential store
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} projectId ID of the project where the credential store will be created
+ * @returns {Promise<Serializable>}
+ */
+export async function createStaticCredentialStore(request, projectId) {
+  const response = await request.post(`/v1/credential-stores`, {
+    data: {
+      name: `static-credential-store-${nanoid()}`,
+      scope_id: projectId,
+      type: 'static',
+    },
+  });
+
+  return checkResponse(response);
+}

--- a/e2e-tests/helpers/boundary-http/credentials.js
+++ b/e2e-tests/helpers/boundary-http/credentials.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { nanoid } from 'nanoid';
+import { checkResponse } from './responseHelper.js';
+import { readFile } from 'fs/promises';
+
+/**
+ * Creates a new ssh keypair credential
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} credentialStoreId ID of the credential store where the credential will be created
+ * @param {string} username Username of the user credential
+ * @param {string} sshKeyPath Path to private key of the user credential
+ * @returns {Promise<Serializable>}
+ */
+export async function createStaticCredentialKeyPair(
+  request,
+  { credentialStoreId, username, sshKeyPath },
+) {
+  const privateKey = await readFile(sshKeyPath, {
+    encoding: 'utf-8',
+  });
+
+  const response = await request.post(`/v1/credentials`, {
+    data: {
+      name: `static-credential-store-${nanoid()}`,
+      credential_store_id: credentialStoreId,
+      type: 'ssh_private_key',
+      attributes: {
+        username,
+        private_key: privateKey,
+      },
+    },
+  });
+
+  return checkResponse(response);
+}

--- a/e2e-tests/helpers/boundary-http/host-catalogs.js
+++ b/e2e-tests/helpers/boundary-http/host-catalogs.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { nanoid } from 'nanoid';
+import { checkResponse } from './responseHelper.js';
+
+/**
+ * Creates a new static host catalog
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} projectId ID of the project where the catalog will be created
+ * @returns {Promise<Serializable>}
+ */
+export async function createStaticHostCatalog(request, projectId) {
+  const response = await request.post(`/v1/host-catalogs`, {
+    data: {
+      name: `static-host-catalog-${nanoid()}`,
+      scope_id: projectId,
+      type: 'static',
+    },
+  });
+
+  return checkResponse(response);
+}

--- a/e2e-tests/helpers/boundary-http/host-sets.js
+++ b/e2e-tests/helpers/boundary-http/host-sets.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { nanoid } from 'nanoid';
+import { checkResponse } from './responseHelper.js';
+
+/**
+ * Creates a host set
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} hostCatalogId ID of the host catalog
+ * @returns {Promise<Serializable>}
+ */
+export async function createHostSet(request, hostCatalogId) {
+  const response = await request.post(`/v1/host-sets`, {
+    data: {
+      name: `static-host-sets-${nanoid()}`,
+      host_catalog_id: hostCatalogId,
+    },
+  });
+
+  return checkResponse(response);
+}
+
+/**
+ * Adds a host
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {Object} hostSet The host set object
+ * @param {string} hostIds ID of the host to add
+ * @returns {Promise<Serializable>}
+ */
+export async function addHostToHostSet(request, { hostSet, hostIds }) {
+  const response = await request.post(`/v1/host-sets/${hostSet.id}:add-hosts`, {
+    data: {
+      host_ids: hostIds,
+      version: hostSet.version,
+    },
+  });
+
+  return checkResponse(response);
+}

--- a/e2e-tests/helpers/boundary-http/hosts.js
+++ b/e2e-tests/helpers/boundary-http/hosts.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { nanoid } from 'nanoid';
+import { checkResponse } from './responseHelper.js';
+
+/**
+ * Creates a host
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} hostCatalogId ID of the host catalog
+ * @param {string} name Optional name of the host
+ * @param {string} address Address of the host
+ * @returns {Promise<Serializable>}
+ */
+export async function createHost(request, { hostCatalogId, name, address }) {
+  const response = await request.post(`/v1/hosts`, {
+    data: {
+      name: name ?? `static-host-${nanoid()}`,
+      host_catalog_id: hostCatalogId,
+      type: 'static',
+      attributes: {
+        address: address,
+      },
+    },
+  });
+
+  return checkResponse(response);
+}

--- a/e2e-tests/helpers/boundary-http/responseHelper.js
+++ b/e2e-tests/helpers/boundary-http/responseHelper.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+/**
+ * Check if the response is OK
+ * @param {import('@playwright/test').APIResponse} response
+ * @param {boolean=} isResponseEmpty
+ * @return {Promise<Serializable>|void}
+ */
+export async function checkResponse(response, isResponseEmpty) {
+  if (!response.ok()) {
+    throw new Error(
+      `Request failed with ${response.status()}: ${await response.text()}`,
+    );
+  }
+
+  if (isResponseEmpty) {
+    return;
+  }
+  return await response.json();
+}

--- a/e2e-tests/helpers/boundary-http/scopes.js
+++ b/e2e-tests/helpers/boundary-http/scopes.js
@@ -4,20 +4,33 @@
  */
 
 import { nanoid } from 'nanoid';
+import { checkResponse } from './responseHelper.js';
 
 /**
  * Creates a new org
  * @param {import('@playwright/test').APIRequestContext} request
  * @returns {Promise<Serializable>}
  */
-export async function createOrgHttp(request) {
-  const org = await request.post(`/v1/scopes`, {
+export async function createOrg(request) {
+  const response = await request.post(`/v1/scopes`, {
     data: {
-      name: 'Org ' + nanoid(),
+      name: `Org-${nanoid()}`,
       scope_id: 'global',
     },
   });
-  return await org.json();
+  return checkResponse(response);
+}
+
+/**
+ *
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} orgId
+ * @returns {Promise<Serializable>}
+ */
+export async function deleteOrg(request, orgId) {
+  const response = await request.delete(`/v1/scopes/${orgId}`);
+
+  return checkResponse(response, true);
 }
 
 /**
@@ -26,12 +39,12 @@ export async function createOrgHttp(request) {
  * @param {string} scopeId ID of the scope where target will be created
  * @returns {Promise<Serializable>}
  */
-export async function createProjectHttp(request, scopeId) {
-  const project = await request.post(`/v1/scopes`, {
+export async function createProject(request, scopeId) {
+  const response = await request.post(`/v1/scopes`, {
     data: {
-      name: 'Project ' + nanoid(),
+      name: `Project-${nanoid()}`,
       scope_id: scopeId,
     },
   });
-  return await project.json();
+  return checkResponse(response);
 }

--- a/e2e-tests/helpers/boundary-http/targets.js
+++ b/e2e-tests/helpers/boundary-http/targets.js
@@ -4,6 +4,7 @@
  */
 
 import { nanoid } from 'nanoid';
+import { checkResponse } from './responseHelper.js';
 
 /**
  * Creates a new target
@@ -11,19 +12,90 @@ import { nanoid } from 'nanoid';
  * @param {string} scopeId ID of the scope where target will be created
  * @param {string} type type of the target: 'tcp, 'ssh'
  * @param {number} port default port of the target
+ * @param {string} address Optional target address
  * @returns {Promise<Serializable>}
  */
-export async function createTargetHttp(request, scopeId, type, port) {
-  const target = await request.post(`/v1/targets`, {
+export async function createTarget(request, { scopeId, type, port, address }) {
+  const response = await request.post(`/v1/targets`, {
     data: {
-      name: 'Target ' + nanoid(),
+      name: `Target-${nanoid()}`,
       scope_id: scopeId,
       type: type,
       attributes: {
         default_port: port,
       },
+      address,
     },
   });
 
-  return await target.json();
+  return checkResponse(response);
+}
+
+/**
+ * Adds a brokered credential to a target
+ * @param request
+ * @param {Object} target The target to attach the credential to
+ * @param {string[]} credentialIds The credential IDs to attach to the target
+ * @return {Promise<Serializable>}
+ */
+export async function addBrokeredCredentials(
+  request,
+  { target, credentialIds },
+) {
+  const response = await request.post(
+    `/v1/targets/${target.id}:add-credential-sources`,
+    {
+      data: {
+        brokered_credential_source_ids: credentialIds,
+        version: target.version,
+      },
+    },
+  );
+
+  return checkResponse(response);
+}
+
+/**
+ * Adds an injected credential to a target
+ * @param request
+ * @param {Object} target The target to attach the credential to
+ * @param {string[]} credentialIds The credential IDs to attach to the target
+ * @return {Promise<Serializable>}
+ */
+export async function addInjectedCredentials(
+  request,
+  { target, credentialIds },
+) {
+  const response = await request.post(
+    `/v1/targets/${target.id}:add-credential-sources`,
+    {
+      data: {
+        injected_application_credential_source_ids: credentialIds,
+        version: target.version,
+      },
+    },
+  );
+
+  return checkResponse(response);
+}
+
+/**
+ * Adds a host source to a target
+ * @param request
+ * @param {Object} target The target to attach the host source to
+ * @param {string[]} hostSourceIds The host source IDs to attach to the target
+ * @return {Promise<Serializable>}
+ */
+export async function addHostSource(request, { target, hostSourceIds }) {
+  const response = await request.post(
+    `/v1/targets/${target.id}:add-host-sources`,
+    {
+      data: {
+        host_source_ids: hostSourceIds,
+        version: target.version,
+      },
+    },
+  );
+
+  return checkResponse(response);
 }

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -33,6 +33,7 @@
     "eslint": "^8.54.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-n": "^16.3.1",
+    "nanoid": "^5.0.8",
     "prettier": "^3.0.0"
   },
   "engines": {

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,6 +7,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "doc:toc": "doctoc README.md",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint .",

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -10,7 +10,7 @@
     "test": "tests"
   },
   "scripts": {
-    "doc:toc": "doctoc README.md tests/e2e/README.md",
+    "doc:toc": "doctoc README.md",
     "build:development": "ember build",
     "build": "ember build --environment=production",
     "build:oss": "EDITION=oss ember build --environment=production",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14092,6 +14092,11 @@ nanoid@^3.3.6:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
+nanoid@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.8.tgz#7610003f6b3b761b5c244bb342c112c5312512bf"
+  integrity sha512-TcJPw+9RV9dibz1hHUzlLVy8N4X9TnwirAjrU08Juo6BNKggzVfP2ZJ/3ZUSq15Xl5i85i+Z89XBO90pB2PghQ==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"


### PR DESCRIPTION
# Description
Added some more target tests that utilize enos for e2e. I decided to setup much of the boundary bits needed for testing using HTTP requests. Open to discussion about this.

There's realistically 3 ways to interact with boundary for a lot of our test setups:
1. Using the boundary CLI.
2. Make HTTP requests to the boundary controller
3. Use admin UI

I tried the boundary CLI first but I didn't see much of a benefit using it over HTTP besides @moduli having already built out most of the commands. It also introduces more overhead having to spin up shells to execute the commands.

I tried using admin UI to setup tests which also has the huge benefit of having @moduli already built most of what we need and it worked well except for a few quirks:
1. I had to reach in the admin side of e2e tests to access the pages which I wasn't a fan of, it didn't feel quite right to pull those out to the root either.
2. Some of the pages did make a few assumptions of how they were used so I had to modify them which also requires me to verify the admin UI tests weren't affected. I'm not a fan of having these pages now affecting both sets of tests.
3. The biggest con is it's _slow_ and using an actual browser to set things up takes forever.

I decided mainly to keep things separate between admin and desktop as well as to keep test setups much faster and to just build out the boundary HTTP client requests. It setups up quite fast and and is still straight forward to interact with.

I also updated the README into a shared one at the root.
 
## How to Test
Run through the admin README to setup enos using enterprise boundary. At the e2e root folder, run `yarn desktop`.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- ~[ ] My changes generate no new warnings~
- [x] I have added tests that prove my fix is effective or that my feature works
