### PR TITLE
refactor: 💡 Add await to invalidSession within desktop

### DIFF
--- a/ui/desktop/tests/acceptance/application-test.js
+++ b/ui/desktop/tests/acceptance/application-test.js
@@ -24,8 +24,8 @@ module('Acceptance | index', function (hooks) {
     clusterUrl: null,
   };
 
-  hooks.beforeEach(function () {
-    invalidateSession();
+  hooks.beforeEach(async function () {
+    await invalidateSession();
 
     urls.clusterUrl = '/cluster-url';
 

--- a/ui/desktop/tests/acceptance/authentication-test.js
+++ b/ui/desktop/tests/acceptance/authentication-test.js
@@ -64,12 +64,12 @@ module('Acceptance | authentication', function (hooks) {
     clusterUrl.rendererClusterUrl = windowOrigin;
   };
 
-  hooks.beforeEach(function () {
+  hooks.beforeEach(async function () {
     instances.user = this.server.create('user', {
       scope: instances.scopes.global,
     });
 
-    invalidateSession();
+    await invalidateSession();
 
     // create scopes
     instances.scopes.global = this.server.create('scope', { id: 'global' });

--- a/ui/desktop/tests/acceptance/cluster-url-test.js
+++ b/ui/desktop/tests/acceptance/cluster-url-test.js
@@ -63,8 +63,8 @@ module('Acceptance | clusterUrl', function (hooks) {
     mockIPC = test.owner.lookup('service:browser/window').mockIPC;
   };
 
-  hooks.beforeEach(function () {
-    invalidateSession();
+  hooks.beforeEach(async function () {
+    await invalidateSession();
 
     // create scopes
     instances.scopes.global = this.server.create('scope', { id: 'global' });

--- a/ui/desktop/tests/acceptance/projects-test.js
+++ b/ui/desktop/tests/acceptance/projects-test.js
@@ -102,7 +102,7 @@ module('Acceptance | projects', function (hooks) {
   });
 
   test('visiting index while unauthenticated redirects to global authenticate method', async function (assert) {
-    invalidateSession();
+    await invalidateSession();
     assert.expect(2);
     await visit(urls.projects);
     await a11yAudit();

--- a/ui/desktop/tests/acceptance/projects/sessions/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/index-test.js
@@ -163,7 +163,7 @@ module('Acceptance | projects | sessions | index', function (hooks) {
   });
 
   test('visiting index while unauthenticated redirects to global authenticate method', async function (assert) {
-    invalidateSession();
+    await invalidateSession();
     this.stubCacheDaemonSearch();
 
     await visit(urls.sessions);

--- a/ui/desktop/tests/acceptance/projects/targets/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/index-test.js
@@ -165,7 +165,7 @@ module('Acceptance | projects | targets | index', function (hooks) {
   });
 
   test('visiting index while unauthenticated redirects to global authenticate method', async function (assert) {
-    invalidateSession();
+    await invalidateSession();
     this.stubCacheDaemonSearch();
     await visit(urls.targets);
     await a11yAudit();

--- a/ui/desktop/tests/acceptance/scopes-test.js
+++ b/ui/desktop/tests/acceptance/scopes-test.js
@@ -239,7 +239,7 @@ module('Acceptance | scopes', function (hooks) {
   });
 
   test('visiting index while unauthenticated redirects to global authenticate method', async function (assert) {
-    invalidateSession();
+    await invalidateSession();
     assert.expect(2);
     this.stubCacheDaemonSearch();
 
@@ -363,7 +363,7 @@ module('Acceptance | scopes', function (hooks) {
   });
 
   test('pagination is not supported - navigate to cluster url page', async function (assert) {
-    invalidateSession();
+    await invalidateSession();
     this.stubCacheDaemonSearch();
     this.ipcStub.withArgs('checkOS').returns({
       isWindows: true,


### PR DESCRIPTION
# Description

Add await to `invalidSession` from `ember-simple-auth` within `ui/desktop`.

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-15875)

## How to Test
- Run desktop tests successfully
