### PR TITLE
refactor: 💡 update icon logic for egress worker filter

### DIFF
--- a/ui/admin/app/templates/scopes/scope/targets/target/workers.hbs
+++ b/ui/admin/app/templates/scopes/scope/targets/target/workers.hbs
@@ -105,7 +105,7 @@
                 'resources.target.workers.accordion-label.egress-workers'
               }}</span>
             <Hds::Link::Standalone
-              @icon='edit'
+              @icon={{if @model.egress_worker_filter 'edit' 'plus-circle'}}
               @text={{t
                 (if
                   @model.egress_worker_filter


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
The icon in the accordion for Target egress worker filter was only showing the `edit` icon. Update adds logic to dynamically change the icon depending if the egress worker filter has been set or not.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
Before:
<img width="1112" alt="Screenshot 2024-12-05 at 12 41 41 PM" src="https://github.com/user-attachments/assets/365fdb21-9cb4-4802-8b22-973643f5ad95">

After:
<img width="1112" alt="Screenshot 2024-12-05 at 12 53 56 PM" src="https://github.com/user-attachments/assets/0651e893-14ed-447c-b31e-6eaf8a69844d">
<img width="1112" alt="Screenshot 2024-12-05 at 12 54 23 PM" src="https://github.com/user-attachments/assets/182bd593-f02d-4daa-8e20-47ee75223ed2">


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
