### PR TITLE
fix: 🐛 update @name attribute for RadioCard Groups

### DIFF
--- a/addons/core/translations/form/en-us.yaml
+++ b/addons/core/translations/form/en-us.yaml
@@ -18,6 +18,8 @@ description:
 type:
   label: Type
   help: The type of the resource, to help differentiate schemas
+plugin_type:
+  label: plugin_type
 login_name:
   label: Login Name
   help: The account login name

--- a/ui/admin/app/components/form/alias/index.hbs
+++ b/ui/admin/app/components/form/alias/index.hbs
@@ -56,7 +56,11 @@
       {{t 'resources.alias.description'}}
     </F.HelperText>
     <F.Control>
-      <Hds::Form::RadioCard::Group @name='type' @alignment='center' as |G|>
+      <Hds::Form::RadioCard::Group
+        @name={{t 'form.type.label'}}
+        @alignment='center'
+        as |G|
+      >
         <G.Legend>{{t 'resources.target.form.type.label'}}</G.Legend>
         <G.RadioCard @maxWidth='15rem' @checked='true' @disabled='true' as |R|>
           <R.Label>{{t 'resources.alias.form.type.label'}}</R.Label>

--- a/ui/admin/app/components/form/credential-library/vault-generic/index.hbs
+++ b/ui/admin/app/components/form/credential-library/vault-generic/index.hbs
@@ -52,7 +52,11 @@
   </Hds::Form::Textarea::Field>
 
   {{#if (and @model.isNew (feature-flag 'ssh-target'))}}
-    <Hds::Form::RadioCard::Group @name='type' @alignment='center' as |G|>
+    <Hds::Form::RadioCard::Group
+      @name={{t 'form.type.label'}}
+      @alignment='center'
+      as |G|
+    >
       <G.Legend>{{t 'form.type.label'}}</G.Legend>
       {{#each this.types as |type|}}
         <G.RadioCard

--- a/ui/admin/app/components/form/credential-library/vault-ssh-certificate/index.hbs
+++ b/ui/admin/app/components/form/credential-library/vault-ssh-certificate/index.hbs
@@ -54,7 +54,11 @@
   </Hds::Form::Textarea::Field>
 
   {{#if @model.isNew}}
-    <Hds::Form::RadioCard::Group @name='type' @alignment='center' as |G|>
+    <Hds::Form::RadioCard::Group
+      @name={{t 'form.type.label'}}
+      @alignment='center'
+      as |G|
+    >
       <G.Legend>{{t 'form.type.label'}}</G.Legend>
       {{#each this.types as |type|}}
         <G.RadioCard

--- a/ui/admin/app/components/form/credential-store/static/index.hbs
+++ b/ui/admin/app/components/form/credential-store/static/index.hbs
@@ -54,11 +54,14 @@
   {{#if (feature-flag 'static-credentials')}}
     {{#if @model.isNew}}
 
-      <Hds::Form::RadioCard::Group @alignment='center' as |G|>
+      <Hds::Form::RadioCard::Group
+        @name={{t 'form.type.label'}}
+        @alignment='center'
+        as |G|
+      >
         <G.Legend>{{t 'form.type.label'}}</G.Legend>
         {{#each-in this.mapResourceTypeWithIcon as |credentialStoreType icon|}}
           <G.RadioCard
-            @name={{credentialStoreType}}
             @value={{credentialStoreType}}
             @checked={{eq credentialStoreType @model.type}}
             @maxWidth='20rem'

--- a/ui/admin/app/components/form/credential-store/vault/index.hbs
+++ b/ui/admin/app/components/form/credential-store/vault/index.hbs
@@ -54,11 +54,14 @@
 
   {{#if (feature-flag 'static-credentials')}}
     {{#if @model.isNew}}
-      <Hds::Form::RadioCard::Group @alignment='center' as |G|>
+      <Hds::Form::RadioCard::Group
+        @name={{t 'form.type.label'}}
+        @alignment='center'
+        as |G|
+      >
         <G.Legend>{{t 'form.type.label'}}</G.Legend>
         {{#each-in this.mapResourceTypeWithIcon as |credentialStoreType icon|}}
           <G.RadioCard
-            @name={{credentialStoreType}}
             @value={{credentialStoreType}}
             @checked={{eq credentialStoreType @model.type}}
             @maxWidth='20rem'

--- a/ui/admin/app/components/form/credential/json/index.hbs
+++ b/ui/admin/app/components/form/credential/json/index.hbs
@@ -53,11 +53,10 @@
   </Hds::Form::Textarea::Field>
 
   {{#if @model.isNew}}
-    <Hds::Form::RadioCard::Group as |G|>
+    <Hds::Form::RadioCard::Group @name={{t 'form.type.label'}} as |G|>
       <G.Legend>{{t 'form.type.label'}}</G.Legend>
       {{#each @types as |credentialType|}}
         <G.RadioCard
-          @name={{credentialType}}
           @value={{credentialType}}
           @checked={{eq credentialType @model.type}}
           @maxWidth='20rem'

--- a/ui/admin/app/components/form/credential/ssh_private_key/index.hbs
+++ b/ui/admin/app/components/form/credential/ssh_private_key/index.hbs
@@ -52,11 +52,10 @@
     {{/if}}
   </Hds::Form::Textarea::Field>
   {{#if @model.isNew}}
-    <Hds::Form::RadioCard::Group @name='type' as |G|>
+    <Hds::Form::RadioCard::Group @name={{t 'form.type.label'}} as |G|>
       <G.Legend>{{t 'form.type.label'}}</G.Legend>
       {{#each @types as |credentialType|}}
         <G.RadioCard
-          @name={{credentialType}}
           @value={{credentialType}}
           @maxWidth='20rem'
           @checked={{eq credentialType @model.type}}

--- a/ui/admin/app/components/form/credential/username_password/index.hbs
+++ b/ui/admin/app/components/form/credential/username_password/index.hbs
@@ -53,11 +53,10 @@
   </Hds::Form::Textarea::Field>
 
   {{#if @model.isNew}}
-    <Hds::Form::RadioCard::Group @name='type' as |G|>
+    <Hds::Form::RadioCard::Group @name={{t 'form.type.label'}} as |G|>
       <G.Legend>{{t 'form.type.label'}}</G.Legend>
       {{#each @types as |credentialType|}}
         <G.RadioCard
-          @name={{credentialType}}
           @value={{credentialType}}
           @maxWidth='20rem'
           @checked={{eq credentialType @model.type}}

--- a/ui/admin/app/components/form/host-catalog/aws/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/aws/index.hbs
@@ -62,7 +62,7 @@
   </Hds::Form::Textarea::Field>
 
   {{#if @model.isNew}}
-    <Hds::Form::RadioCard::Group @name='type' as |G|>
+    <Hds::Form::RadioCard::Group @name={{t 'form.type.label'}} as |G|>
       <G.Legend>
         {{t 'form.type.label'}}
       </G.Legend>
@@ -83,7 +83,11 @@
         </G.RadioCard>
       {{/each}}
     </Hds::Form::RadioCard::Group>
-    <Hds::Form::RadioCard::Group @name='plugin_type' @alignment='center' as |G|>
+    <Hds::Form::RadioCard::Group
+      @name={{t 'form.plugin_type.label'}}
+      @alignment='center'
+      as |G|
+    >
       <G.Legend>
         {{t 'titles.provider'}}
       </G.Legend>

--- a/ui/admin/app/components/form/host-catalog/azure/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/azure/index.hbs
@@ -50,7 +50,7 @@
   </Hds::Form::Textarea::Field>
 
   {{#if @model.isNew}}
-    <Hds::Form::RadioCard::Group @name='type' as |G|>
+    <Hds::Form::RadioCard::Group @name={{t 'form.type.label'}} as |G|>
       <G.Legend>{{t 'form.type.label'}}</G.Legend>
       {{#each this.hostCatalogTypes as |hostCatalogType|}}
         <G.RadioCard
@@ -69,7 +69,11 @@
         </G.RadioCard>
       {{/each}}
     </Hds::Form::RadioCard::Group>
-    <Hds::Form::RadioCard::Group @name='plugin_type' @alignment='center' as |G|>
+    <Hds::Form::RadioCard::Group
+      @name={{t 'form.plugin_type.label'}}
+      @alignment='center'
+      as |G|
+    >
       <G.Legend>{{t 'titles.provider'}}</G.Legend>
       <G.Legend>{{t 'titles.choose-a-provider'}}</G.Legend>
       <G.HelperText>{{concat

--- a/ui/admin/app/components/form/host-catalog/static/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/static/index.hbs
@@ -51,7 +51,7 @@
 
   {{#if @model.isNew}}
 
-    <Hds::Form::RadioCard::Group @name='type' as |G|>
+    <Hds::Form::RadioCard::Group @name={{t 'form.type.label'}} as |G|>
       <G.Legend>{{t 'form.type.label'}}</G.Legend>
       {{#each this.hostCatalogTypes as |hostCatalogType|}}
         <G.RadioCard

--- a/ui/admin/app/components/form/storage-bucket/aws/index.hbs
+++ b/ui/admin/app/components/form/storage-bucket/aws/index.hbs
@@ -115,7 +115,11 @@
   {{/if}}
 
   {{! Provider / plugin.name }}
-  <Hds::Form::RadioCard::Group @name='plugin_type' @alignment='center' as |G|>
+  <Hds::Form::RadioCard::Group
+    @name={{t 'form.plugin_type.label'}}
+    @alignment='center'
+    as |G|
+  >
     <G.Legend>{{t 'titles.provider'}}</G.Legend>
     <G.HelperText>{{t 'descriptions.choose-a-provider'}}</G.HelperText>
 
@@ -212,11 +216,10 @@
   </Hds::Form::TextInput::Field>
 
   {{! credential_type }}
-  <Hds::Form::RadioCard::Group name='credential_type' as |G|>
+  <Hds::Form::RadioCard::Group @name={{t 'form.type.label'}} as |G|>
     <G.Legend>{{t 'resources.storage-bucket.types.credential'}}</G.Legend>
     {{#each this.credentials as |credentialType|}}
       <G.RadioCard
-        @name={{credentialType}}
         @value={{credentialType}}
         @checked={{eq credentialType this.selectedCredentialType}}
         @disabled={{form.disabled}}

--- a/ui/admin/app/components/form/storage-bucket/minio/index.hbs
+++ b/ui/admin/app/components/form/storage-bucket/minio/index.hbs
@@ -115,7 +115,11 @@
   {{/if}}
 
   {{! Provider / plugin.name }}
-  <Hds::Form::RadioCard::Group @name='plugin_type' @alignment='center' as |G|>
+  <Hds::Form::RadioCard::Group
+    @name={{t 'form.plugin_type.label'}}
+    @alignment='center'
+    as |G|
+  >
     <G.Legend>{{t 'titles.provider'}}</G.Legend>
     <G.HelperText>{{t 'descriptions.choose-a-provider'}}</G.HelperText>
 

--- a/ui/admin/app/components/form/target/details/index.hbs
+++ b/ui/admin/app/components/form/target/details/index.hbs
@@ -53,7 +53,11 @@
   </Hds::Form::Textarea::Field>
 
   {{#if (and @model.isNew (feature-flag 'ssh-target'))}}
-    <Hds::Form::RadioCard::Group @name='type' @alignment='center' as |G|>
+    <Hds::Form::RadioCard::Group
+      @name={{t 'form.type.label'}}
+      @alignment='center'
+      as |G|
+    >
       <G.Legend>{{t 'resources.target.form.type.label'}}</G.Legend>
       <G.HelperText>{{t 'resources.target.form.type.help'}}</G.HelperText>
       {{#each this.typeMetas as |type|}}

--- a/ui/admin/tests/acceptance/host-catalogs/create-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/create-test.js
@@ -21,7 +21,7 @@ module('Acceptance | host-catalogs | create', function (hooks) {
 
   const NAME_INPUT_SELECTOR = '[name="name"]';
   const DESCRIPTION_INPUT_SELECTOR = '[name="description"]';
-  const TYPE_INPUT_SELECTOR = '[name="type"]';
+  const TYPE_INPUT_SELECTOR = '[name="Type"]';
   const SAVE_BUTTON_SELECTOR = '[type="submit"]';
   const CANCEL_BUTTON_SELECTOR = '.rose-form-actions [type="button"]';
   const ALERT_TEXT_SELECTOR =

--- a/ui/admin/tests/acceptance/storage-buckets/create-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/create-test.js
@@ -148,9 +148,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
     await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
 
     // There are 2 credential types
-    assert
-      .dom(`${selectors.GROUP_CREDENTIAL_TYPE} .hds-form-radio-card`)
-      .exists({ count: 2 });
+    assert.dom(selectors.GROUP_CREDENTIAL_TYPE).exists({ count: 2 });
 
     await click(selectors.FIELD_DYNAMIC_CREDENTIAL);
     await fillIn(selectors.FIELD_ROLE_ARN, selectors.FIELD_ROLE_ARN_VALUE);
@@ -172,9 +170,7 @@ module('Acceptance | storage-buckets | create', function (hooks) {
 
     await click(`[href="${urls.newStorageBucket}"]`);
     await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
-    assert
-      .dom(`${selectors.GROUP_CREDENTIAL_TYPE} .hds-form-radio-card`)
-      .exists({ count: 2 });
+    assert.dom(selectors.GROUP_CREDENTIAL_TYPE).exists({ count: 2 });
 
     await click(selectors.FIELD_STATIC_CREDENTIAL);
     await fillIn(selectors.FIELD_ACCESS_KEY, selectors.FIELD_ACCESS_KEY_VALUE);

--- a/ui/admin/tests/acceptance/storage-buckets/selectors.js
+++ b/ui/admin/tests/acceptance/storage-buckets/selectors.js
@@ -14,7 +14,7 @@ export const FIELD_BUCKET_NAME_VALUE = 'Test Bucket name';
 export const FIELD_BUCKET_NAME_ERROR = '[data-test-bucket-name-error]';
 export const FIELD_BUCKET_PREFIX = '[name=bucket_prefix]';
 export const FIELD_REGION = '[name=region]';
-export const GROUP_CREDENTIAL_TYPE = '[name=credential_type]';
+export const GROUP_CREDENTIAL_TYPE = '[name=Type]';
 export const FIELD_STATIC_CREDENTIAL = '[value=static]';
 export const FIELD_DYNAMIC_CREDENTIAL = '[value=dynamic]';
 export const FIELD_ROLE_ARN = '[name=role_arn]';

--- a/ui/admin/tests/acceptance/targets/create-test.js
+++ b/ui/admin/tests/acceptance/targets/create-test.js
@@ -85,7 +85,7 @@ module('Acceptance | targets | create', function (hooks) {
   test('defaults to type `ssh` when no query param provided', async function (assert) {
     featuresService.enable('ssh-target');
     await visit(urls.newTarget);
-    assert.strictEqual(find('[name="type"]:checked').value, TYPE_TARGET_SSH);
+    assert.strictEqual(find('[name="Type"]:checked').value, TYPE_TARGET_SSH);
   });
 
   test('can create a type `ssh` target', async function (assert) {


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-15676

# Description
<!-- Add a brief description of changes here -->
This fixes an a11y audit issue where the `name` attribute for our radio card groups did not match. In a few places, the name matched the value but the name should be the same for all radio options.
I opted to simply use `Type` as the name value in most cases, except `plugin_type` which I created a new translation entry for. If we feel we need to be more specific for each resource type I can make that refactor.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
Before:
<img width="589" alt="Screenshot 2024-12-06 at 4 10 22 PM" src="https://github.com/user-attachments/assets/c11d686e-0984-40f6-83f5-f4b8270b7c73">
After:
<img width="589" alt="Screenshot 2024-12-06 at 4 09 29 PM" src="https://github.com/user-attachments/assets/089a38b9-94b6-4e81-b28e-d20893ef5686">



## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
To test you can use the vercel build and create a new credential store. When you inspect the input for the Radio Cards the `name` attribute should be the same for both now.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
