### PR TITLE
[ICU-15647] Replace Rose::Dialog with Hds::Modal in admin ui only

### DIFF
--- a/addons/rose/app/styles/rose/components/_index.scss
+++ b/addons/rose/app/styles/rose/components/_index.scss
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+// This list is sorted in ascending order to improve readability
+
 @import 'button';
 @import 'card';
 @import 'cards';

--- a/addons/rose/app/styles/rose/components/_index.scss
+++ b/addons/rose/app/styles/rose/components/_index.scss
@@ -11,8 +11,8 @@
 @import 'dropdown';
 @import 'form';
 @import 'frame';
-@import 'icon';
 @import 'header';
+@import 'icon';
 @import 'layout';
 @import 'list';
 @import 'metadata-list';

--- a/addons/rose/app/styles/rose/components/_index.scss
+++ b/addons/rose/app/styles/rose/components/_index.scss
@@ -4,18 +4,18 @@
  */
 
 @import 'button';
+@import 'card';
+@import 'cards';
+@import 'code-editor';
 @import 'dialog';
 @import 'dropdown';
 @import 'form';
 @import 'frame';
+@import 'icon';
 @import 'header';
 @import 'layout';
-@import 'icon';
 @import 'list';
-@import 'card';
-@import 'cards';
-@import 'page-header';
-@import 'nav';
-@import 'toolbar';
-@import 'code-editor';
 @import 'metadata-list';
+@import 'nav';
+@import 'page-header';
+@import 'toolbar';

--- a/ui/admin/app/templates/application.hbs
+++ b/ui/admin/app/templates/application.hbs
@@ -137,7 +137,7 @@
       @dismissButtonText={{t 'actions.cancel'}}
       @modal={{true}}
       @dismiss={{deny}}
-      data-test-modal
+      dialog
     >
       {{if
         confirmation.options.title
@@ -151,7 +151,7 @@
       </Hds::Text::Body>
     </M.Body>
     <M.Footer>
-      <Hds::ButtonSet {{style width='15rem'}}>
+      <Hds::ButtonSet>
         <Hds::Button
           @text={{if
             confirmation.options.confirm
@@ -160,13 +160,11 @@
           }}
           @color='primary'
           {{on 'click' accept}}
-          data-test-modal-confirm-btn
         />
         <Hds::Button
           @text={{t 'actions.cancel'}}
           @color='secondary'
           {{on 'click' deny}}
-          data-test-modal-cancel-btn
         />
       </Hds::ButtonSet>
     </M.Footer>

--- a/ui/admin/app/templates/application.hbs
+++ b/ui/admin/app/templates/application.hbs
@@ -137,7 +137,6 @@
       @dismissButtonText={{t 'actions.cancel'}}
       @modal={{true}}
       @dismiss={{deny}}
-      dialog
     >
       {{if
         confirmation.options.title

--- a/ui/admin/app/templates/application.hbs
+++ b/ui/admin/app/templates/application.hbs
@@ -133,7 +133,7 @@
 
 <PendingConfirmations as |confirmation accept deny|>
   <Hds::Modal @color='warning' as |M|>
-    <M.Header @icon='alert-triangle'>
+    <M.Header @icon='alert-triangle' @onDismiss={{deny}}>
       {{if
         confirmation.options.title
         (t confirmation.options.title)

--- a/ui/admin/app/templates/application.hbs
+++ b/ui/admin/app/templates/application.hbs
@@ -137,6 +137,7 @@
       @dismissButtonText={{t 'actions.cancel'}}
       @modal={{true}}
       @dismiss={{deny}}
+      data-test-modal
     >
       {{if
         confirmation.options.title
@@ -159,11 +160,13 @@
           }}
           @color='primary'
           {{on 'click' accept}}
+          data-test-modal-confirm-btn
         />
         <Hds::Button
           @text={{t 'actions.cancel'}}
           @color='secondary'
           {{on 'click' deny}}
+          data-test-modal-cancel-btn
         />
       </Hds::ButtonSet>
     </M.Footer>

--- a/ui/admin/app/templates/application.hbs
+++ b/ui/admin/app/templates/application.hbs
@@ -132,33 +132,40 @@
 {{/if}}
 
 <PendingConfirmations as |confirmation accept deny|>
-  <Rose::Dialog
-    @heading={{if
-      confirmation.options.title
-      (t confirmation.options.title)
-      (t 'actions.confirm')
-    }}
-    @dismissButtonText={{t 'actions.cancel'}}
-    @icon='flight-icons/svg/alert-triangle-16'
-    @style='warning'
-    @modal={{true}}
-    @dismiss={{deny}}
-    as |dialog|
-  >
-    <dialog.body>
-      <p>{{confirmation.text}}</p>
-    </dialog.body>
-    <dialog.footer>
-      <Rose::Button @style='primary' {{on 'click' accept}}>
-        {{if
-          confirmation.options.confirm
-          (t confirmation.options.confirm)
-          (t 'actions.ok')
-        }}
-      </Rose::Button>
-      <Rose::Button @style='secondary' {{on 'click' deny}}>
-        {{t 'actions.cancel'}}
-      </Rose::Button>
-    </dialog.footer>
-  </Rose::Dialog>
+  <Hds::Modal @color='warning' as |M|>
+    <M.Header
+      @dismissButtonText={{t 'actions.cancel'}}
+      @modal={{true}}
+      @dismiss={{deny}}
+    >
+      {{if
+        confirmation.options.title
+        (t confirmation.options.title)
+        (t 'actions.confirm')
+      }}
+    </M.Header>
+    <M.Body>
+      <Hds::Text::Body @tag='p'>
+        {{confirmation.text}}
+      </Hds::Text::Body>
+    </M.Body>
+    <M.Footer>
+      <Hds::ButtonSet {{style width='15rem'}}>
+        <Hds::Button
+          @text={{if
+            confirmation.options.confirm
+            (t confirmation.options.confirm)
+            (t 'actions.ok')
+          }}
+          @color='primary'
+          {{on 'click' accept}}
+        />
+        <Hds::Button
+          @text={{t 'actions.cancel'}}
+          @color='secondary'
+          {{on 'click' deny}}
+        />
+      </Hds::ButtonSet>
+    </M.Footer>
+  </Hds::Modal>
 </PendingConfirmations>

--- a/ui/admin/app/templates/application.hbs
+++ b/ui/admin/app/templates/application.hbs
@@ -133,11 +133,7 @@
 
 <PendingConfirmations as |confirmation accept deny|>
   <Hds::Modal @color='warning' as |M|>
-    <M.Header
-      @dismissButtonText={{t 'actions.cancel'}}
-      @modal={{true}}
-      @dismiss={{deny}}
-    >
+    <M.Header @icon='alert-triangle'>
       {{if
         confirmation.options.title
         (t confirmation.options.title)

--- a/ui/admin/tests/acceptance/auth-methods/delete-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/delete-test.js
@@ -12,6 +12,7 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { TYPE_AUTH_METHOD_LDAP } from 'api/models/auth-method';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | auth-methods | delete', function (hooks) {
   setupApplicationTest(hooks);
@@ -21,8 +22,6 @@ module('Acceptance | auth-methods | delete', function (hooks) {
   let featuresService;
   let getAuthMethodCount;
 
-  const DIALOG_DELETE_BTN_SELECTOR = '.rose-dialog .rose-button-primary';
-  const DIALOG_CANCEL_BTN_SELECTOR = '.rose-dialog .rose-button-secondary';
   const ERROR_MSG_SELECTOR =
     '[data-test-toast-notification] .hds-alert__description';
 
@@ -176,7 +175,7 @@ module('Acceptance | auth-methods | delete', function (hooks) {
     await click(`[href="${urls.authMethod}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    await click(DIALOG_DELETE_BTN_SELECTOR);
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(currentURL(), urls.authMethods);
     assert.strictEqual(getAuthMethodCount(), authMethodCount - 1);
@@ -192,7 +191,7 @@ module('Acceptance | auth-methods | delete', function (hooks) {
     await click(`[href="${urls.ldapAuthMethod}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    await click(DIALOG_DELETE_BTN_SELECTOR);
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(currentURL(), urls.authMethods);
     assert.strictEqual(getAuthMethodCount(), authMethodCount - 1);
@@ -207,7 +206,7 @@ module('Acceptance | auth-methods | delete', function (hooks) {
     await click(`[href="${urls.authMethod}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    await click(DIALOG_CANCEL_BTN_SELECTOR);
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(currentURL(), urls.authMethod);
     assert.strictEqual(getAuthMethodCount(), authMethodCount);
@@ -223,7 +222,7 @@ module('Acceptance | auth-methods | delete', function (hooks) {
     await click(`[href="${urls.ldapAuthMethod}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    await click(DIALOG_CANCEL_BTN_SELECTOR);
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(currentURL(), urls.ldapAuthMethod);
     assert.strictEqual(getAuthMethodCount(), authMethodCount);

--- a/ui/admin/tests/acceptance/credential-library/update-test.js
+++ b/ui/admin/tests/acceptance/credential-library/update-test.js
@@ -184,9 +184,9 @@ module('Acceptance | credential-libraries | update', function (hooks) {
     try {
       await visit(urls.credentialLibraries);
     } catch (e) {
-      assert.dom(commonSelectors.DIALOG_UNSAVED_CHANGES).isVisible();
+      assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-      await click(commonSelectors.DIALOG_UNSAVED_CHANGES_DISCARD);
+      await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
       assert.strictEqual(currentURL(), urls.credentialLibraries);
       assert.notEqual(
@@ -215,9 +215,9 @@ module('Acceptance | credential-libraries | update', function (hooks) {
     try {
       await visit(urls.credentialLibraries);
     } catch {
-      assert.dom(commonSelectors.DIALOG_UNSAVED_CHANGES).isVisible();
+      assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-      await click(commonSelectors.DIALOG_UNSAVED_CHANGES_CANCEL);
+      await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
       assert.strictEqual(currentURL(), urls.credentialLibrary);
       assert.notEqual(

--- a/ui/admin/tests/acceptance/credential-store/credentials/delete-test.js
+++ b/ui/admin/tests/acceptance/credential-store/credentials/delete-test.js
@@ -9,6 +9,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { click, currentURL, visit } from '@ember/test-helpers';
 import { Response } from 'miragejs';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module(
   'Acceptance | credential-stores | credentials | delete',
@@ -182,7 +183,7 @@ module(
       await visit(urls.usernamePasswordCredential);
       await click(MANAGE_DROPDOWN_SELECTOR);
       await click(DELETE_ACTION_SELECTOR);
-      await click('.rose-dialog footer .rose-button-primary');
+      await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
       assert.strictEqual(currentURL(), urls.credentials);
       assert.strictEqual(
         getUsernamePasswordCredentialCount(),
@@ -198,7 +199,7 @@ module(
       await visit(urls.usernameKeyPairCredential);
       await click(MANAGE_DROPDOWN_SELECTOR);
       await click(DELETE_ACTION_SELECTOR);
-      await click('.rose-dialog footer .rose-button-primary');
+      await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
       assert.strictEqual(currentURL(), urls.credentials);
       assert.strictEqual(
         getUsernameKeyPairCredentialCount(),
@@ -213,7 +214,7 @@ module(
       await visit(urls.jsonCredential);
       await click(MANAGE_DROPDOWN_SELECTOR);
       await click(DELETE_ACTION_SELECTOR);
-      await click('.rose-dialog footer .rose-button-primary');
+      await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
       assert.strictEqual(currentURL(), urls.credentials);
       assert.strictEqual(getJSONCredentialCount(), jsonCredentialCount - 1);
     });
@@ -226,7 +227,7 @@ module(
       await visit(urls.usernamePasswordCredential);
       await click(MANAGE_DROPDOWN_SELECTOR);
       await click(DELETE_ACTION_SELECTOR);
-      await click('.rose-dialog footer .rose-button-secondary');
+      await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
       assert.strictEqual(currentURL(), urls.usernamePasswordCredential);
       assert.strictEqual(
         getUsernamePasswordCredentialCount(),
@@ -242,7 +243,7 @@ module(
       await visit(urls.usernameKeyPairCredential);
       await click(MANAGE_DROPDOWN_SELECTOR);
       await click(DELETE_ACTION_SELECTOR);
-      await click('.rose-dialog footer .rose-button-secondary');
+      await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
       assert.strictEqual(currentURL(), urls.usernameKeyPairCredential);
       assert.strictEqual(
         getUsernameKeyPairCredentialCount(),
@@ -257,7 +258,7 @@ module(
       await visit(urls.jsonCredential);
       await click(MANAGE_DROPDOWN_SELECTOR);
       await click(DELETE_ACTION_SELECTOR);
-      await click('.rose-dialog footer .rose-button-secondary');
+      await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
       assert.strictEqual(currentURL(), urls.jsonCredential);
       assert.strictEqual(getJSONCredentialCount(), jsonCredentialCount);
     });

--- a/ui/admin/tests/acceptance/credential-store/credentials/update-test.js
+++ b/ui/admin/tests/acceptance/credential-store/credentials/update-test.js
@@ -16,6 +16,7 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module(
   'Acceptance | credential-stores | credentials | update',
@@ -322,11 +323,8 @@ module(
       try {
         await visit(urls.credentials);
       } catch (e) {
-        assert.dom('.rose-dialog').isVisible();
-        await click(
-          '.rose-dialog-footer button:first-of-type',
-          'Click Discard',
-        );
+        assert.dom(commonSelectors.MODAL_WARNING).isVisible();
+        await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN, 'Click Discard');
         assert.strictEqual(currentURL(), urls.credentials);
         assert.notEqual(
           this.server.schema.credentials.where({ type: 'username_password' })
@@ -349,11 +347,8 @@ module(
       try {
         await visit(urls.credentials);
       } catch (e) {
-        assert.dom('.rose-dialog').isVisible();
-        await click(
-          '.rose-dialog-footer button:first-of-type',
-          'Click Discard',
-        );
+        assert.dom(commonSelectors.MODAL_WARNING).isVisible();
+        await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN, 'Click Discard');
         assert.strictEqual(currentURL(), urls.credentials);
         assert.notEqual(
           this.server.schema.credentials.where({ type: 'ssh_private_key' })
@@ -376,11 +371,8 @@ module(
       try {
         await visit(urls.credentials);
       } catch (e) {
-        assert.dom('.rose-dialog').isVisible();
-        await click(
-          '.rose-dialog-footer button:first-of-type',
-          'Click Discard',
-        );
+        assert.dom(commonSelectors.MODAL_WARNING).isVisible();
+        await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN, 'Click Discard');
         assert.strictEqual(currentURL(), urls.credentials);
         assert.notEqual(
           this.server.schema.credentials.where({ type: 'json' }).models[0].name,
@@ -403,8 +395,8 @@ module(
       try {
         await visit(urls.credentials);
       } catch (e) {
-        assert.dom('.rose-dialog').isVisible();
-        await click('.rose-dialog-footer button:last-child', 'Click Cancel');
+        assert.dom(commonSelectors.MODAL_WARNING).isVisible();
+        await click(commonSelectors.MODAL_WARNING_CANCEL_BTN, 'Click Cancel');
         assert.strictEqual(currentURL(), urls.usernamePasswordCredential);
         assert.strictEqual(find('[name="name"]').value, mockInput);
         assert.strictEqual(
@@ -429,8 +421,8 @@ module(
       try {
         await visit(urls.credentials);
       } catch (e) {
-        assert.dom('.rose-dialog').isVisible();
-        await click('.rose-dialog-footer button:last-child', 'Click Cancel');
+        assert.dom(commonSelectors.MODAL_WARNING).isVisible();
+        await click(commonSelectors.MODAL_WARNING_CANCEL_BTN, 'Click Cancel');
         assert.strictEqual(currentURL(), urls.usernameKeyPairCredential);
         assert.strictEqual(find('[name="name"]').value, mockInput);
         assert.strictEqual(
@@ -455,8 +447,8 @@ module(
       try {
         await visit(urls.credentials);
       } catch (e) {
-        assert.dom('.rose-dialog').isVisible();
-        await click('.rose-dialog-footer button:last-child', 'Click Cancel');
+        assert.dom(commonSelectors.MODAL_WARNING).isVisible();
+        await click(commonSelectors.MODAL_WARNING_CANCEL_BTN, 'Click Cancel');
         assert.strictEqual(currentURL(), urls.jsonCredential);
         assert.strictEqual(find('[name="name"]').value, mockInput);
         assert.strictEqual(

--- a/ui/admin/tests/acceptance/credential-store/update-test.js
+++ b/ui/admin/tests/acceptance/credential-store/update-test.js
@@ -220,8 +220,8 @@ module('Acceptance | credential-stores | update', function (hooks) {
     try {
       await visit(urls.credentialStores);
     } catch (e) {
-      assert.ok(find('.rose-dialog'));
-      await click('.rose-dialog-footer button:first-child', 'Click Discard');
+      assert.ok(find(commonSelectors.MODAL_WARNING));
+      await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN, 'Click Discard');
       assert.strictEqual(currentURL(), urls.credentialStores);
       assert.notEqual(
         this.server.schema.credentialStores.where({ type: 'static' }).models[0]
@@ -245,8 +245,8 @@ module('Acceptance | credential-stores | update', function (hooks) {
     try {
       await visit(urls.credentialStores);
     } catch (e) {
-      assert.ok(find('.rose-dialog'));
-      await click('.rose-dialog-footer button:first-child', 'Click Discard');
+      assert.ok(find(commonSelectors.MODAL_WARNING));
+      await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN, 'Click Discard');
       assert.strictEqual(currentURL(), urls.credentialStores);
       assert.notEqual(
         this.server.schema.credentialStores.where({ type: 'vault' }).models[0]
@@ -269,8 +269,8 @@ module('Acceptance | credential-stores | update', function (hooks) {
     try {
       await visit(urls.credentialStores);
     } catch (e) {
-      assert.ok(find('.rose-dialog'));
-      await click('.rose-dialog-footer button:last-child');
+      assert.ok(find(commonSelectors.MODAL_WARNING));
+      await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
       assert.strictEqual(currentURL(), urls.staticCredentialStore);
       assert.notEqual(
         this.server.schema.credentialStores.where({ type: 'static' }).models[0]
@@ -293,8 +293,8 @@ module('Acceptance | credential-stores | update', function (hooks) {
     try {
       await visit(urls.credentialStores);
     } catch (e) {
-      assert.ok(find('.rose-dialog'));
-      await click('.rose-dialog-footer button:last-child');
+      assert.ok(find(commonSelectors.MODAL_WARNING));
+      await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
       assert.strictEqual(currentURL(), urls.vaultCredentialStore);
       assert.notEqual(
         this.server.schema.credentialStores.where({ type: 'vault' }).models[0]

--- a/ui/admin/tests/acceptance/host-catalogs/delete-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/delete-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | host-catalogs | delete', function (hooks) {
   setupApplicationTest(hooks);
@@ -97,7 +98,7 @@ module('Acceptance | host-catalogs | delete', function (hooks) {
     await click(`[href="${urls.hostCatalog}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    await click('.rose-dialog .rose-button-primary');
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert
       .dom('[data-test-toast-notification] .hds-alert__description')
@@ -115,7 +116,7 @@ module('Acceptance | host-catalogs | delete', function (hooks) {
     await click(`[href="${urls.hostCatalog}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    await click('.rose-dialog .rose-button-secondary');
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(getHostCatalogCount(), hostCatalogCount);
     assert.strictEqual(currentURL(), urls.hostCatalog);

--- a/ui/admin/tests/acceptance/host-catalogs/host-sets/update-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/host-sets/update-test.js
@@ -16,6 +16,7 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | host-catalogs | host sets | update', function (hooks) {
   setupApplicationTest(hooks);
@@ -307,8 +308,8 @@ module('Acceptance | host-catalogs | host sets | update', function (hooks) {
     try {
       await visit(urls.hostSets);
     } catch (e) {
-      assert.ok(find('.rose-dialog'));
-      await click('.rose-dialog-footer button:first-child');
+      assert.ok(find(commonSelectors.MODAL_WARNING));
+      await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
       assert.strictEqual(currentURL(), urls.hostSets);
       assert.notEqual(
         this.server.schema.hostSets.first().name,

--- a/ui/admin/tests/acceptance/host-catalogs/hosts/update-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/hosts/update-test.js
@@ -166,8 +166,8 @@ module('Acceptance | host-catalogs | hosts | update', function (hooks) {
     try {
       await visit(urls.hosts);
     } catch (e) {
-      assert.dom(commonSelectors.DIALOG_UNSAVED_CHANGES).exists();
-      await click(commonSelectors.DIALOG_UNSAVED_CHANGES_DISCARD);
+      assert.dom(commonSelectors.MODAL_WARNING).exists();
+      await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
       assert.strictEqual(currentURL(), urls.hosts);
       assert.notEqual(name, commonSelectors.FIELD_NAME_VALUE);
       assert.notEqual(description, commonSelectors.FIELD_DESCRIPTION_VALUE);
@@ -195,8 +195,8 @@ module('Acceptance | host-catalogs | hosts | update', function (hooks) {
     try {
       await visit(urls.hosts);
     } catch (e) {
-      assert.dom(commonSelectors.DIALOG_UNSAVED_CHANGES).exists();
-      await click(commonSelectors.DIALOG_UNSAVED_CHANGES_CANCEL);
+      assert.dom(commonSelectors.MODAL_WARNING).exists();
+      await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
       assert.strictEqual(currentURL(), urls.host);
       assert.notEqual(name, commonSelectors.FIELD_NAME_VALUE);

--- a/ui/admin/tests/acceptance/host-catalogs/update-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/update-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 import {
   TYPE_HOST_CATALOG_DYNAMIC,
   TYPE_HOST_CATALOG_PLUGIN_AWS,
@@ -41,9 +42,6 @@ module('Acceptance | host-catalogs | update', function (hooks) {
   const EDIT_BUTTON_SELECTOR = 'form [type="button"]';
   const SAVE_BUTTON_SELECTOR = '.rose-form-actions [type="submit"]';
   const CANCEL_BUTTON_SELECTOR = '.rose-form-actions [type="button"]';
-  const MODAL_DISCARD_BUTTON_SELECTOR =
-    '.rose-dialog-footer button:first-child';
-  const MODAL_CANCEL_BUTTON_SELECTOR = '.rose-dialog-footer button:last-child';
   const CREDENTIAL_TYPE_SELECTOR =
     '.dynamic-credential-selection input:checked';
 
@@ -178,8 +176,8 @@ module('Acceptance | host-catalogs | update', function (hooks) {
     await fillIn(NAME_INPUT_SELECTOR, 'random string');
     assert.strictEqual(currentURL(), urls.hostCatalog);
     await click(`[href="${urls.hostCatalogs}"]`);
-    assert.dom('.rose-dialog').exists();
-    await click(MODAL_DISCARD_BUTTON_SELECTOR, 'Click Discard');
+    assert.dom(commonSelectors.MODAL_WARNING).exists();
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN, 'Click Discard');
 
     assert.strictEqual(currentURL(), urls.hostCatalogs);
     assert.notEqual(
@@ -198,8 +196,8 @@ module('Acceptance | host-catalogs | update', function (hooks) {
     await fillIn(NAME_INPUT_SELECTOR, 'random string');
     assert.strictEqual(currentURL(), urls.hostCatalog);
     await click(`[href="${urls.hostCatalogs}"]`);
-    assert.dom('.rose-dialog').exists();
-    await click(MODAL_CANCEL_BUTTON_SELECTOR, 'Click Cancel');
+    assert.dom(commonSelectors.MODAL_WARNING).exists();
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN, 'Click Cancel');
 
     assert.strictEqual(currentURL(), urls.hostCatalog);
     assert.notEqual(

--- a/ui/admin/tests/acceptance/roles/global-scope-test.js
+++ b/ui/admin/tests/acceptance/roles/global-scope-test.js
@@ -17,6 +17,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 import {
   GRANT_SCOPE_THIS,
   GRANT_SCOPE_CHILDREN,
@@ -58,11 +59,6 @@ module('Acceptance | roles | global-scope', function (hooks) {
   const BUTTON_ICON_SELECTOR =
     '.hds-button__icon [data-test-icon="check-circle"]';
   const PAGINATION_SELECTOR = '.hds-pagination';
-  const DISCARD_CHANGES_DIALOG = '.rose-dialog';
-  const DISCARD_CHANGES_DISCARD_BUTTON =
-    '.rose-dialog-footer .rose-button-primary';
-  const DISCARD_CHANGES_CANCEL_BUTTON =
-    '.rose-dialog-footer .rose-button-secondary';
   const REMOVE_ORG_MODAL = (name) =>
     `[data-test-manage-scopes-remove-${name}-modal]`;
   const REMOVE_ORG_PROJECTS_BUTTON = '.hds-modal .hds-button--color-primary';
@@ -376,9 +372,9 @@ module('Acceptance | roles | global-scope', function (hooks) {
     await click(SCOPE_TOGGLE_SELECTOR(GRANT_SCOPE_THIS));
     await click(`[href="${urls.roles}"]`);
 
-    assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(DISCARD_CHANGES_DISCARD_BUTTON);
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(currentURL(), urls.roles);
   });
@@ -393,9 +389,9 @@ module('Acceptance | roles | global-scope', function (hooks) {
     await click(SCOPE_TOGGLE_SELECTOR(GRANT_SCOPE_THIS));
     await click(`[href="${urls.roles}"]`);
 
-    assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(DISCARD_CHANGES_CANCEL_BUTTON);
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(currentURL(), urls.manageScopes);
   });
@@ -503,9 +499,9 @@ module('Acceptance | roles | global-scope', function (hooks) {
 
     await click(`[href="${urls.roles}"]`);
 
-    assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(DISCARD_CHANGES_DISCARD_BUTTON);
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(currentURL(), urls.roles);
   });
@@ -520,9 +516,9 @@ module('Acceptance | roles | global-scope', function (hooks) {
 
     await click(`[href="${urls.roles}"]`);
 
-    assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(DISCARD_CHANGES_CANCEL_BUTTON);
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(currentURL(), urls.manageCustomScopes);
   });
@@ -841,9 +837,9 @@ module('Acceptance | roles | global-scope', function (hooks) {
     );
     await click(`[href="${urls.roles}"]`);
 
-    assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(DISCARD_CHANGES_DISCARD_BUTTON);
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(currentURL(), urls.roles);
   });
@@ -862,9 +858,9 @@ module('Acceptance | roles | global-scope', function (hooks) {
     );
     await click(`[href="${urls.roles}"]`);
 
-    assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(DISCARD_CHANGES_CANCEL_BUTTON);
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(
       currentURL(),

--- a/ui/admin/tests/acceptance/roles/org-scope-test.js
+++ b/ui/admin/tests/acceptance/roles/org-scope-test.js
@@ -17,6 +17,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 import {
   GRANT_SCOPE_THIS,
   GRANT_SCOPE_CHILDREN,
@@ -55,12 +56,6 @@ module('Acceptance | roles | org-scope', function (hooks) {
   const BUTTON_ICON_SELECTOR =
     '.hds-button__icon [data-test-icon="check-circle"]';
   const PAGINATION_SELECTOR = '.hds-pagination';
-  const DISCARD_CHANGES_DIALOG = '.rose-dialog';
-  const DISCARD_CHANGES_DISCARD_BUTTON =
-    '.rose-dialog-footer .rose-button-primary';
-  const DISCARD_CHANGES_CANCEL_BUTTON =
-    '.rose-dialog-footer .rose-button-secondary';
-
   const instances = {
     scopes: {
       global: null,
@@ -327,9 +322,9 @@ module('Acceptance | roles | org-scope', function (hooks) {
     await click(SCOPE_TOGGLE_SELECTOR(GRANT_SCOPE_THIS));
     await click(`[href="${urls.roles}"]`);
 
-    assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(DISCARD_CHANGES_DISCARD_BUTTON);
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(currentURL(), urls.roles);
   });
@@ -344,9 +339,9 @@ module('Acceptance | roles | org-scope', function (hooks) {
     await click(SCOPE_TOGGLE_SELECTOR(GRANT_SCOPE_THIS));
     await click(`[href="${urls.roles}"]`);
 
-    assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(DISCARD_CHANGES_CANCEL_BUTTON);
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(currentURL(), urls.manageScopes);
   });
@@ -456,9 +451,9 @@ module('Acceptance | roles | org-scope', function (hooks) {
     );
     await click(`[href="${urls.roles}"]`);
 
-    assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(DISCARD_CHANGES_DISCARD_BUTTON);
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(currentURL(), urls.roles);
   });
@@ -474,9 +469,9 @@ module('Acceptance | roles | org-scope', function (hooks) {
     );
     await click(`[href="${urls.roles}"]`);
 
-    assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(DISCARD_CHANGES_CANCEL_BUTTON);
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(currentURL(), urls.manageOrgProjects);
   });

--- a/ui/admin/tests/acceptance/scopes/delete-test.js
+++ b/ui/admin/tests/acceptance/scopes/delete-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | scopes | delete', function (hooks) {
   setupApplicationTest(hooks);
@@ -92,7 +93,7 @@ module('Acceptance | scopes | delete', function (hooks) {
     await click(`[href="${urls.orgScopeEdit}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    await click('.rose-dialog .rose-button-primary');
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(getScopeCount('org'), orgScopeCount - 1);
     assert.strictEqual(currentURL(), urls.globalScope);
@@ -107,7 +108,7 @@ module('Acceptance | scopes | delete', function (hooks) {
     await click(`[href="${urls.orgScopeEdit}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    await click('.rose-dialog .rose-button-secondary');
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(getScopeCount('org'), orgScopeCount);
     assert.strictEqual(currentURL(), urls.orgScopeEdit);

--- a/ui/admin/tests/acceptance/scopes/update-test.js
+++ b/ui/admin/tests/acceptance/scopes/update-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | scopes | update', function (hooks) {
   setupApplicationTest(hooks);
@@ -139,8 +140,8 @@ module('Acceptance | scopes | update', function (hooks) {
     await fillIn('[name="name"]', 'random string');
     assert.strictEqual(currentURL(), urls.orgScopeEdit);
     await click(`[href="${urls.globalScope}"]`);
-    assert.dom('.rose-dialog').exists();
-    await click('.rose-dialog-footer button:first-child', 'Click Discard');
+    assert.dom(commonSelectors.MODAL_WARNING).exists();
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(currentURL(), urls.globalScope);
     assert.notEqual(
@@ -160,8 +161,8 @@ module('Acceptance | scopes | update', function (hooks) {
     await fillIn('[name="name"]', 'random string');
     assert.strictEqual(currentURL(), urls.orgScopeEdit);
     await click(`[href="${urls.globalScope}"]`);
-    assert.dom('.rose-dialog').exists();
-    await click('.rose-dialog-footer button:last-child', 'Click Cancel');
+    assert.dom(commonSelectors.MODAL_WARNING).exists();
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(currentURL(), urls.orgScopeEdit);
     assert.notEqual(

--- a/ui/admin/tests/acceptance/storage-buckets/delete-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/delete-test.js
@@ -103,14 +103,14 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
     await click(DELETE_DROPDOWN_SELECTOR);
 
     assert
-      .dom(commonSelectors.DIALOG_TITLE_SELECTOR)
+      .dom(commonSelectors.MODAL_WARNING_TITLE)
       .hasText(
         intl.t(
           'resources.storage-bucket.questions.delete-storage-bucket.title',
         ),
       );
     assert
-      .dom(commonSelectors.DIALOG_MESSAGE_SELECTOR)
+      .dom(commonSelectors.MODAL_WARNING_MESSAGE)
       .hasText(
         intl.t(
           'resources.storage-bucket.questions.delete-storage-bucket.message',

--- a/ui/admin/tests/acceptance/storage-buckets/delete-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/delete-test.js
@@ -9,6 +9,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | storage-buckets | delete', function (hooks) {
   setupApplicationTest(hooks);
@@ -21,10 +22,6 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
 
   const DROPDOWN_BUTTON_SELECTOR = '.hds-dropdown-toggle-icon';
   const DELETE_DROPDOWN_SELECTOR = '.hds-dropdown-list-item [type="button"]';
-  const DIALOG_DELETE_BTN_SELECTOR = '.rose-dialog .rose-button-primary';
-  const DIALOG_CANCEL_BTN_SELECTOR = '.rose-dialog .rose-button-secondary';
-  const DIALOG_MESSAGE_SELECTOR = '.rose-dialog-body';
-  const DIALOG_TITLE_SELECTOR = '.rose-dialog-header';
   const NOTIFICATION_MSG_SELECTOR =
     '[data-test-toast-notification] .hds-alert__description';
   const NOTIFICATION_MSG_TEXT = 'Deleted successfully.';
@@ -85,10 +82,10 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
     await click(DELETE_DROPDOWN_SELECTOR);
 
     assert
-      .dom(DIALOG_DELETE_BTN_SELECTOR)
+      .dom(commonSelectors.MODAL_WARNING_CONFIRM_BTN)
       .hasText(intl.t('resources.storage-bucket.actions.delete'));
 
-    await click(DIALOG_DELETE_BTN_SELECTOR);
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.dom(NOTIFICATION_MSG_SELECTOR).hasText(NOTIFICATION_MSG_TEXT);
     assert.strictEqual(currentURL(), urls.storageBuckets);
@@ -105,22 +102,24 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
     await click(DROPDOWN_BUTTON_SELECTOR);
     await click(DELETE_DROPDOWN_SELECTOR);
 
+    // await this.pauseTest();
+
     assert
-      .dom(DIALOG_TITLE_SELECTOR)
+      .dom(commonSelectors.DIALOG_TITLE_SELECTOR)
       .hasText(
         intl.t(
           'resources.storage-bucket.questions.delete-storage-bucket.title',
         ),
       );
     assert
-      .dom(DIALOG_MESSAGE_SELECTOR)
+      .dom(commonSelectors.DIALOG_MESSAGE_SELECTOR)
       .hasText(
         intl.t(
           'resources.storage-bucket.questions.delete-storage-bucket.message',
         ),
       );
 
-    await click(DIALOG_CANCEL_BTN_SELECTOR);
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(currentURL(), urls.storageBuckets);
     assert.strictEqual(getStorageBucketCount(), storageBucketCount);

--- a/ui/admin/tests/acceptance/storage-buckets/delete-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/delete-test.js
@@ -102,8 +102,6 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
     await click(DROPDOWN_BUTTON_SELECTOR);
     await click(DELETE_DROPDOWN_SELECTOR);
 
-    // await this.pauseTest();
-
     assert
       .dom(commonSelectors.DIALOG_TITLE_SELECTOR)
       .hasText(

--- a/ui/admin/tests/acceptance/targets/delete-test.js
+++ b/ui/admin/tests/acceptance/targets/delete-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | targets | delete', function (hooks) {
   setupApplicationTest(hooks);
@@ -82,7 +83,7 @@ module('Acceptance | targets | delete', function (hooks) {
     await click(`[href="${urls.target}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    await click('.rose-dialog .rose-button-primary');
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert
       .dom('[data-test-toast-notification] .hds-alert__description')
@@ -100,7 +101,7 @@ module('Acceptance | targets | delete', function (hooks) {
     await click(`[href="${urls.target}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    await click('.rose-dialog .rose-button-secondary');
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(getTargetCount(), targetCount);
     assert.strictEqual(currentURL(), urls.target);

--- a/ui/admin/tests/acceptance/targets/host-sources-test.js
+++ b/ui/admin/tests/acceptance/targets/host-sources-test.js
@@ -284,7 +284,7 @@ module('Acceptance | targets | host-sources', function (hooks) {
     await click('tbody label');
     await click('form [type="submit"]');
 
-    assert.dom(commonSelectors.MODAL_WARNING).exists;
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
     await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(
@@ -319,9 +319,8 @@ module('Acceptance | targets | host-sources', function (hooks) {
 
     await click('tbody label');
     await click('form [type="submit"]');
-    // await this.pauseTest();
 
-    assert.dom(commonSelectors.MODAL_WARNING).exists;
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
     await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(

--- a/ui/admin/tests/acceptance/targets/host-sources-test.js
+++ b/ui/admin/tests/acceptance/targets/host-sources-test.js
@@ -284,8 +284,8 @@ module('Acceptance | targets | host-sources', function (hooks) {
     await click('tbody label');
     await click('form [type="submit"]');
 
-    assert.dom('.rose-dialog').isVisible();
-    await click('.rose-dialog-footer .rose-button-primary', 'Remove resources');
+    assert.dom(commonSelectors.MODAL_WARNING).exists;
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(
       this.server.schema.targets.find(target.id).address,
@@ -319,12 +319,10 @@ module('Acceptance | targets | host-sources', function (hooks) {
 
     await click('tbody label');
     await click('form [type="submit"]');
+    // await this.pauseTest();
 
-    assert.dom('.rose-dialog').isVisible();
-    await click(
-      '.rose-dialog-footer .rose-button-secondary',
-      'Remove resources',
-    );
+    assert.dom(commonSelectors.MODAL_WARNING).exists;
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(
       this.server.schema.targets.find(target.id).address,

--- a/ui/admin/tests/acceptance/targets/update-test.js
+++ b/ui/admin/tests/acceptance/targets/update-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | targets | update', function (hooks) {
   setupApplicationTest(hooks);
@@ -135,9 +136,9 @@ module('Acceptance | targets | update', function (hooks) {
 
     await click(`[href="${urls.targets}"]`);
 
-    assert.dom('.rose-dialog').exists();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click('.rose-dialog-footer button:first-child', 'Click Discard');
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(currentURL(), urls.targets);
     assert.notEqual(this.server.schema.targets.first().name, 'random string');
@@ -155,8 +156,8 @@ module('Acceptance | targets | update', function (hooks) {
 
     assert.strictEqual(currentURL(), urls.target);
     await click(`[href="${urls.targets}"]`);
-    assert.dom('.rose-dialog').exists();
-    await click('.rose-dialog-footer button:last-child', 'Click Cancel');
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(currentURL(), urls.target);
     assert.notEqual(this.server.schema.targets.first().name, 'random string');
@@ -208,8 +209,8 @@ module('Acceptance | targets | update', function (hooks) {
     await fillIn('[name="address"]', '0.0.0.0');
     await click('[type="submit"]');
 
-    assert.dom('.rose-dialog').isVisible();
-    await click('.rose-dialog-footer .rose-button-primary', 'Remove resources');
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(
       this.server.schema.targets.find(target.id).address,
@@ -253,8 +254,8 @@ module('Acceptance | targets | update', function (hooks) {
     await fillIn('[name="address"]', '0.0.0.0');
     await click('[type="submit"]');
 
-    assert.dom('.rose-dialog').isVisible();
-    await click('.rose-dialog-footer .rose-button-secondary', 'Cancel');
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(
       this.server.schema.targets.find(target.id).address,

--- a/ui/admin/tests/acceptance/targets/workers-test.js
+++ b/ui/admin/tests/acceptance/targets/workers-test.js
@@ -9,6 +9,7 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | targets | workers', function (hooks) {
   setupApplicationTest(hooks);
@@ -28,10 +29,6 @@ module('Acceptance | targets | workers', function (hooks) {
     '[data-test-code-editor-field-editor] textarea';
   const SAVE_BUTTON_SELECTOR = '[type="submit"]';
   const CANCEL_BUTTON_SELECTOR = '.rose-form-actions [type="button"]';
-  const MODAL_DISCARD_BUTTON_SELECTOR =
-    '.rose-dialog-footer button:first-child';
-  const MODAL_CANCEL_BUTTON_SELECTOR = '.rose-dialog-footer button:last-child';
-  const CONFIRM_MODAL_SELECTOR = '.rose-dialog';
 
   const instances = {
     scopes: {
@@ -312,9 +309,9 @@ module('Acceptance | targets | workers', function (hooks) {
     await fillIn(CODE_EDITOR_CONTENT_SELECTOR, ingressWorkerFilter);
     await click(`[href="${urls.target}"]`);
 
-    assert.dom(CONFIRM_MODAL_SELECTOR).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(MODAL_DISCARD_BUTTON_SELECTOR, 'Click Discard');
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN, 'Click Discard');
 
     assert.strictEqual(currentURL(), urls.target);
     assert.notEqual(
@@ -337,9 +334,9 @@ module('Acceptance | targets | workers', function (hooks) {
     await fillIn(CODE_EDITOR_CONTENT_SELECTOR, ingressWorkerFilter);
     await click(`[href="${urls.target}"]`);
 
-    assert.dom(CONFIRM_MODAL_SELECTOR).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(MODAL_CANCEL_BUTTON_SELECTOR, 'Click Cancel');
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN, 'Click Cancel');
 
     assert.strictEqual(currentURL(), urls.targetEditIngressFilter);
     assert.notEqual(
@@ -361,9 +358,9 @@ module('Acceptance | targets | workers', function (hooks) {
     await fillIn(CODE_EDITOR_CONTENT_SELECTOR, egressWorkerFilter);
     await click(`[href="${urls.target}"]`);
 
-    assert.dom(CONFIRM_MODAL_SELECTOR).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(MODAL_DISCARD_BUTTON_SELECTOR, 'Click Discard');
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN, 'Click Discard');
 
     assert.strictEqual(currentURL(), urls.target);
     assert.notEqual(instances.target.egress_worker_filter, egressWorkerFilter);
@@ -382,9 +379,9 @@ module('Acceptance | targets | workers', function (hooks) {
     await fillIn(CODE_EDITOR_CONTENT_SELECTOR, egressWorkerFilter);
     await click(`[href="${urls.target}"]`);
 
-    assert.dom(CONFIRM_MODAL_SELECTOR).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(MODAL_CANCEL_BUTTON_SELECTOR, 'Click Cancel');
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN, 'Click Cancel');
 
     assert.strictEqual(currentURL(), urls.targetEditEgressFilter);
     assert.notEqual(instances.target.egress_worker_filter, egressWorkerFilter);

--- a/ui/admin/tests/acceptance/users/delete-test.js
+++ b/ui/admin/tests/acceptance/users/delete-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | users | delete', function (hooks) {
   setupApplicationTest(hooks);
@@ -81,7 +82,7 @@ module('Acceptance | users | delete', function (hooks) {
     await click(`[href="${urls.user}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    await click('.rose-dialog .rose-button-primary');
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert
       .dom('[data-test-toast-notification] .hds-alert__description')
@@ -99,7 +100,7 @@ module('Acceptance | users | delete', function (hooks) {
     await click(`[href="${urls.user}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    await click('.rose-dialog .rose-button-secondary');
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(this.server.db.users.length, usersCount);
     assert.strictEqual(currentURL(), urls.user);

--- a/ui/admin/tests/acceptance/users/update-test.js
+++ b/ui/admin/tests/acceptance/users/update-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | users | update', function (hooks) {
   setupApplicationTest(hooks);
@@ -127,8 +128,8 @@ module('Acceptance | users | update', function (hooks) {
     await fillIn('[name="name"]', 'Unsaved user name');
     assert.strictEqual(currentURL(), urls.user);
     await click(`[href="${urls.users}"]`);
-    assert.dom('.rose-dialog').exists();
-    await click('.rose-dialog-footer button:first-child', 'Click Discard');
+    assert.dom(commonSelectors.MODAL_WARNING).exists();
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN, 'Click Discard');
 
     assert.strictEqual(currentURL(), urls.users);
     assert.notEqual(this.server.schema.users.first().name, 'Unsaved user name');
@@ -144,8 +145,8 @@ module('Acceptance | users | update', function (hooks) {
     await fillIn('[name="name"]', 'Unsaved user name');
     assert.strictEqual(currentURL(), urls.user);
     await click(`[href="${urls.users}"]`);
-    assert.dom('.rose-dialog').exists();
-    await click('.rose-dialog-footer button:last-child', 'Click Cancel');
+    assert.dom(commonSelectors.MODAL_WARNING).exists();
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN, 'Click Cancel');
 
     assert.strictEqual(currentURL(), urls.user);
     assert.notEqual(this.server.schema.users.first().name, 'Unsaved user name');

--- a/ui/admin/tests/acceptance/workers/create-tags-test.js
+++ b/ui/admin/tests/acceptance/workers/create-tags-test.js
@@ -9,6 +9,7 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | workers | worker | create-tags', function (hooks) {
   setupApplicationTest(hooks);
@@ -23,11 +24,6 @@ module('Acceptance | workers | worker | create-tags', function (hooks) {
   const KEY_INPUT_SELECTOR = '[name="api_tags"] tr td:first-child input';
   const VALUE_INPUT_SELECTOR = '[name="api_tags"] tr td:nth-child(2) input';
   const ADD_INPUT_SELECTOR = '[name="api_tags"] tr td:last-child button';
-  const DISCARD_CHANGES_DIALOG = '.rose-dialog';
-  const DISCARD_CHANGES_DISCARD_BUTTON =
-    '.rose-dialog-footer .rose-button-primary';
-  const DISCARD_CHANGES_CANCEL_BUTTON =
-    '.rose-dialog-footer .rose-button-secondary';
 
   const instances = {
     scopes: {
@@ -116,9 +112,9 @@ module('Acceptance | workers | worker | create-tags', function (hooks) {
 
     await click(`[href="${urls.workers}"]`);
 
-    assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(DISCARD_CHANGES_DISCARD_BUTTON);
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert.strictEqual(currentURL(), urls.workers);
   });
@@ -133,9 +129,9 @@ module('Acceptance | workers | worker | create-tags', function (hooks) {
 
     await click(`[href="${urls.workers}"]`);
 
-    assert.dom(DISCARD_CHANGES_DIALOG).isVisible();
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
 
-    await click(DISCARD_CHANGES_CANCEL_BUTTON);
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
 
     assert.strictEqual(currentURL(), urls.createTags);
   });

--- a/ui/admin/tests/helpers/selectors.js
+++ b/ui/admin/tests/helpers/selectors.js
@@ -39,5 +39,5 @@ export const MODAL_WARNING_CONFIRM_BTN =
   'dialog .hds-modal__footer button:first-child';
 export const MODAL_WARNING_CANCEL_BTN =
   'dialog .hds-modal__footer button:last-child';
-export const DIALOG_TITLE_SELECTOR = '.hds-modal__header';
-export const DIALOG_MESSAGE_SELECTOR = '.hds-modal__body';
+export const MODAL_WARNING_TITLE = '.hds-modal__header';
+export const MODAL_WARNING_MESSAGE = '.hds-modal__body';

--- a/ui/admin/tests/helpers/selectors.js
+++ b/ui/admin/tests/helpers/selectors.js
@@ -39,3 +39,7 @@ export const DIALOG_UNSAVED_CHANGES_DISCARD =
   '.rose-dialog-footer button:first-child';
 export const DIALOG_UNSAVED_CHANGES_CANCEL =
   '.rose-dialog-footer button:last-child';
+
+export const MODAL_WARNING = '[data-test-modal]';
+export const MODAL_WARNING_CONFIRM_BTN = '[data-test-modal-confirm-btn]';
+export const MODAL_WARNING_CANCEL_BTN = '[data-test-modal-cancel-btn]';

--- a/ui/admin/tests/helpers/selectors.js
+++ b/ui/admin/tests/helpers/selectors.js
@@ -40,6 +40,8 @@ export const DIALOG_UNSAVED_CHANGES_DISCARD =
 export const DIALOG_UNSAVED_CHANGES_CANCEL =
   '.rose-dialog-footer button:last-child';
 
-export const MODAL_WARNING = '[data-test-modal]';
-export const MODAL_WARNING_CONFIRM_BTN = '[data-test-modal-confirm-btn]';
-export const MODAL_WARNING_CANCEL_BTN = '[data-test-modal-cancel-btn]';
+export const MODAL_WARNING = 'dialog';
+export const MODAL_WARNING_CONFIRM_BTN =
+  'dialog .hds-modal__footer button:first-child';
+export const MODAL_WARNING_CANCEL_BTN =
+  'dialog .hds-modal__footer button:last-child';

--- a/ui/admin/tests/helpers/selectors.js
+++ b/ui/admin/tests/helpers/selectors.js
@@ -45,3 +45,5 @@ export const MODAL_WARNING_CONFIRM_BTN =
   'dialog .hds-modal__footer button:first-child';
 export const MODAL_WARNING_CANCEL_BTN =
   'dialog .hds-modal__footer button:last-child';
+export const DIALOG_TITLE_SELECTOR = '.hds-modal__header';
+export const DIALOG_MESSAGE_SELECTOR = '.hds-modal__body';

--- a/ui/admin/tests/helpers/selectors.js
+++ b/ui/admin/tests/helpers/selectors.js
@@ -34,12 +34,6 @@ export const ALERT_TOAST_BODY =
 export const ALERT_TOAST_DISMISS =
   '[data-test-toast-notification] .hds-dismiss-button';
 
-export const DIALOG_UNSAVED_CHANGES = '.rose-dialog';
-export const DIALOG_UNSAVED_CHANGES_DISCARD =
-  '.rose-dialog-footer button:first-child';
-export const DIALOG_UNSAVED_CHANGES_CANCEL =
-  '.rose-dialog-footer button:last-child';
-
 export const MODAL_WARNING = 'dialog';
 export const MODAL_WARNING_CONFIRM_BTN =
   'dialog .hds-modal__footer button:first-child';


### PR DESCRIPTION
# Description
Replace `Rose::Dialog` component with `Hds::Modal` component in admin ui.

This change caused 63 tests to fail, which have also been fixed in this PR.

<!-- Uncomment line below to manually add link to JIRA ticket -->
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-15647)

## Screenshots 📸 
Before 👇 
<img width="1370" alt="Screenshot 2024-12-11 at 2 05 33 PM" src="https://github.com/user-attachments/assets/beba45c2-b675-4844-91ad-bc0420ea9832" />

After 👇 
<img width="1296" alt="Screenshot 2024-12-20 at 2 03 45 PM" src="https://github.com/user-attachments/assets/0a92c2dd-e7ef-4a4a-9067-008380c10b60" />


## Recording 📹

https://github.com/user-attachments/assets/e25f49ce-7820-4592-8014-c4af4734af65

## How to Test
1. Navigate to Targets
2. Enter any text in a required field
3. Navigate to another section in navbar to trigger modal

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
