### PR TITLE
test(e2e): Refactor imports for boundary cli helper methods

### DIFF
--- a/e2e-tests/admin/tests/alias-ent.spec.js
+++ b/e2e-tests/admin/tests/alias-ent.spec.js
@@ -77,13 +77,13 @@ test.describe('Aliases (Enterprise)', async () => {
       await page.getByRole('button', { name: 'Dismiss' }).click();
 
       // Connect to target using alias
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      await boundaryCli.authorizeSessionByAliasCli(alias);
+      await boundaryCli.authorizeSessionByAlias(alias);
 
       // Clear destination from alias
       await page.getByRole('link', { name: alias }).click();
@@ -101,20 +101,20 @@ test.describe('Aliases (Enterprise)', async () => {
       ).toBeVisible();
       await page.getByRole('button', { name: 'Dismiss' }).click();
     } finally {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
       if (orgName) {
-        const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+        const orgId = await boundaryCli.getOrgIdFromName(orgName);
         if (orgId) {
-          await boundaryCli.deleteScopeCli(orgId);
+          await boundaryCli.deleteScope(orgId);
         }
       }
       if (alias) {
-        await boundaryCli.deleteAliasCli(alias);
+        await boundaryCli.deleteAlias(alias);
       }
     }
   });
@@ -137,7 +137,7 @@ test.describe('Aliases (Enterprise)', async () => {
     try {
       const orgsPage = new OrgsPage(page);
       orgName = await orgsPage.createOrg();
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
@@ -165,9 +165,9 @@ test.describe('Aliases (Enterprise)', async () => {
       );
 
       // Connect to target using alias
-      await boundaryCli.authorizeSessionByAliasCli(alias);
+      await boundaryCli.authorizeSessionByAlias(alias);
     } finally {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
@@ -175,12 +175,12 @@ test.describe('Aliases (Enterprise)', async () => {
       );
 
       if (orgName) {
-        const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+        const orgId = await boundaryCli.getOrgIdFromName(orgName);
         if (orgId) {
-          await boundaryCli.deleteScopeCli(orgId);
+          await boundaryCli.deleteScope(orgId);
         }
         if (alias) {
-          await boundaryCli.deleteAliasCli(alias);
+          await boundaryCli.deleteAlias(alias);
         }
       }
     }
@@ -224,18 +224,18 @@ test.describe('Aliases (Enterprise)', async () => {
       );
 
       // Create new alias from scope page
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-      const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId = await boundaryCli.getOrgIdFromName(orgName);
+      const projectId = await boundaryCli.getProjectIdFromName(
         orgId,
         projectName,
       );
-      const targetId = await boundaryCli.getTargetIdFromNameCli(
+      const targetId = await boundaryCli.getTargetIdFromName(
         projectId,
         targetName,
       );
@@ -243,9 +243,9 @@ test.describe('Aliases (Enterprise)', async () => {
       alias = 'example.alias.' + nanoid();
       const aliasesPage = new AliasesPage(page);
       await aliasesPage.createAliasForTarget(alias, targetId);
-      await boundaryCli.authorizeSessionByAliasCli(alias);
+      await boundaryCli.authorizeSessionByAlias(alias);
     } finally {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
@@ -253,10 +253,10 @@ test.describe('Aliases (Enterprise)', async () => {
       );
 
       if (orgId) {
-        await boundaryCli.deleteScopeCli(orgId);
+        await boundaryCli.deleteScope(orgId);
       }
       if (alias) {
-        await boundaryCli.deleteAliasCli(alias);
+        await boundaryCli.deleteAlias(alias);
       }
     }
   });

--- a/e2e-tests/admin/tests/alias-ent.spec.js
+++ b/e2e-tests/admin/tests/alias-ent.spec.js
@@ -7,16 +7,7 @@ import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { customAlphabet } from 'nanoid';
 
-import {
-  authenticateBoundaryCli,
-  authorizeSessionByAliasCli,
-  checkBoundaryCli,
-  deleteAliasCli,
-  deleteScopeCli,
-  getOrgIdFromNameCli,
-  getProjectIdFromNameCli,
-  getTargetIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
 import { AliasesPage } from '../pages/aliases.js';
 import { CredentialStoresPage } from '../pages/credential-stores.js';
 import { OrgsPage } from '../pages/orgs.js';
@@ -26,7 +17,7 @@ import { TargetsPage } from '../pages/targets.js';
 test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
-  await checkBoundaryCli();
+  await boundaryCli.checkBoundaryCli();
 });
 
 test.describe('Aliases (Enterprise)', async () => {
@@ -86,13 +77,13 @@ test.describe('Aliases (Enterprise)', async () => {
       await page.getByRole('button', { name: 'Dismiss' }).click();
 
       // Connect to target using alias
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      await authorizeSessionByAliasCli(alias);
+      await boundaryCli.authorizeSessionByAliasCli(alias);
 
       // Clear destination from alias
       await page.getByRole('link', { name: alias }).click();
@@ -110,20 +101,20 @@ test.describe('Aliases (Enterprise)', async () => {
       ).toBeVisible();
       await page.getByRole('button', { name: 'Dismiss' }).click();
     } finally {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
       if (orgName) {
-        const orgId = await getOrgIdFromNameCli(orgName);
+        const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
         if (orgId) {
-          await deleteScopeCli(orgId);
+          await boundaryCli.deleteScopeCli(orgId);
         }
       }
       if (alias) {
-        await deleteAliasCli(alias);
+        await boundaryCli.deleteAliasCli(alias);
       }
     }
   });
@@ -146,7 +137,7 @@ test.describe('Aliases (Enterprise)', async () => {
     try {
       const orgsPage = new OrgsPage(page);
       orgName = await orgsPage.createOrg();
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
@@ -174,9 +165,9 @@ test.describe('Aliases (Enterprise)', async () => {
       );
 
       // Connect to target using alias
-      await authorizeSessionByAliasCli(alias);
+      await boundaryCli.authorizeSessionByAliasCli(alias);
     } finally {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
@@ -184,12 +175,12 @@ test.describe('Aliases (Enterprise)', async () => {
       );
 
       if (orgName) {
-        const orgId = await getOrgIdFromNameCli(orgName);
+        const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
         if (orgId) {
-          await deleteScopeCli(orgId);
+          await boundaryCli.deleteScopeCli(orgId);
         }
         if (alias) {
-          await deleteAliasCli(alias);
+          await boundaryCli.deleteAliasCli(alias);
         }
       }
     }
@@ -233,22 +224,28 @@ test.describe('Aliases (Enterprise)', async () => {
       );
 
       // Create new alias from scope page
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      orgId = await getOrgIdFromNameCli(orgName);
-      const projectId = await getProjectIdFromNameCli(orgId, projectName);
-      const targetId = await getTargetIdFromNameCli(projectId, targetName);
+      orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+      const projectId = await boundaryCli.getProjectIdFromNameCli(
+        orgId,
+        projectName,
+      );
+      const targetId = await boundaryCli.getTargetIdFromNameCli(
+        projectId,
+        targetName,
+      );
 
       alias = 'example.alias.' + nanoid();
       const aliasesPage = new AliasesPage(page);
       await aliasesPage.createAliasForTarget(alias, targetId);
-      await authorizeSessionByAliasCli(alias);
+      await boundaryCli.authorizeSessionByAliasCli(alias);
     } finally {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
@@ -256,10 +253,10 @@ test.describe('Aliases (Enterprise)', async () => {
       );
 
       if (orgId) {
-        await deleteScopeCli(orgId);
+        await boundaryCli.deleteScopeCli(orgId);
       }
       if (alias) {
-        await deleteAliasCli(alias);
+        await boundaryCli.deleteAliasCli(alias);
       }
     }
   });

--- a/e2e-tests/admin/tests/alias.spec.js
+++ b/e2e-tests/admin/tests/alias.spec.js
@@ -55,13 +55,13 @@ test.describe('Aliases', async () => {
       await page.getByRole('button', { name: 'Dismiss' }).click();
 
       // Connect to target using alias
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      await boundaryCli.authorizeSessionByAliasCli(alias);
+      await boundaryCli.authorizeSessionByAlias(alias);
 
       // Clear destination from alias
       await page.getByRole('link', { name: alias }).click();
@@ -79,20 +79,20 @@ test.describe('Aliases', async () => {
       ).toBeVisible();
       await page.getByRole('button', { name: 'Dismiss' }).click();
     } finally {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
       if (orgName) {
-        const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+        const orgId = await boundaryCli.getOrgIdFromName(orgName);
         if (orgId) {
-          await boundaryCli.deleteScopeCli(orgId);
+          await boundaryCli.deleteScope(orgId);
         }
       }
       if (alias) {
-        await boundaryCli.deleteAliasCli(alias);
+        await boundaryCli.deleteAlias(alias);
       }
     }
   });
@@ -113,7 +113,7 @@ test.describe('Aliases', async () => {
     try {
       const orgsPage = new OrgsPage(page);
       orgName = await orgsPage.createOrg();
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
@@ -130,21 +130,21 @@ test.describe('Aliases', async () => {
       );
 
       // Connect to target using alias
-      await boundaryCli.authorizeSessionByAliasCli(alias);
+      await boundaryCli.authorizeSessionByAlias(alias);
     } finally {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
       if (orgName) {
-        const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+        const orgId = await boundaryCli.getOrgIdFromName(orgName);
         if (orgId) {
-          await boundaryCli.deleteScopeCli(orgId);
+          await boundaryCli.deleteScope(orgId);
         }
         if (alias) {
-          await boundaryCli.deleteAliasCli(alias);
+          await boundaryCli.deleteAlias(alias);
         }
       }
     }
@@ -175,18 +175,18 @@ test.describe('Aliases', async () => {
       );
 
       // Create new alias from scope page
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-      const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId = await boundaryCli.getOrgIdFromName(orgName);
+      const projectId = await boundaryCli.getProjectIdFromName(
         orgId,
         projectName,
       );
-      const targetId = await boundaryCli.getTargetIdFromNameCli(
+      const targetId = await boundaryCli.getTargetIdFromName(
         projectId,
         targetName,
       );
@@ -194,19 +194,19 @@ test.describe('Aliases', async () => {
       alias = 'example.alias.' + nanoid();
       const aliasesPage = new AliasesPage(page);
       await aliasesPage.createAliasForTarget(alias, targetId);
-      await boundaryCli.authorizeSessionByAliasCli(alias);
+      await boundaryCli.authorizeSessionByAlias(alias);
     } finally {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
       if (orgId) {
-        await boundaryCli.deleteScopeCli(orgId);
+        await boundaryCli.deleteScope(orgId);
       }
       if (alias) {
-        await boundaryCli.deleteAliasCli(alias);
+        await boundaryCli.deleteAlias(alias);
       }
     }
   });

--- a/e2e-tests/admin/tests/alias.spec.js
+++ b/e2e-tests/admin/tests/alias.spec.js
@@ -7,16 +7,7 @@ import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { customAlphabet } from 'nanoid';
 
-import {
-  authenticateBoundaryCli,
-  authorizeSessionByAliasCli,
-  checkBoundaryCli,
-  deleteAliasCli,
-  deleteScopeCli,
-  getOrgIdFromNameCli,
-  getProjectIdFromNameCli,
-  getTargetIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
 import { AliasesPage } from '../pages/aliases.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
@@ -25,7 +16,7 @@ import { TargetsPage } from '../pages/targets.js';
 test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
-  await checkBoundaryCli();
+  await boundaryCli.checkBoundaryCli();
 });
 
 test.describe('Aliases', async () => {
@@ -64,13 +55,13 @@ test.describe('Aliases', async () => {
       await page.getByRole('button', { name: 'Dismiss' }).click();
 
       // Connect to target using alias
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      await authorizeSessionByAliasCli(alias);
+      await boundaryCli.authorizeSessionByAliasCli(alias);
 
       // Clear destination from alias
       await page.getByRole('link', { name: alias }).click();
@@ -88,20 +79,20 @@ test.describe('Aliases', async () => {
       ).toBeVisible();
       await page.getByRole('button', { name: 'Dismiss' }).click();
     } finally {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
       if (orgName) {
-        const orgId = await getOrgIdFromNameCli(orgName);
+        const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
         if (orgId) {
-          await deleteScopeCli(orgId);
+          await boundaryCli.deleteScopeCli(orgId);
         }
       }
       if (alias) {
-        await deleteAliasCli(alias);
+        await boundaryCli.deleteAliasCli(alias);
       }
     }
   });
@@ -122,7 +113,7 @@ test.describe('Aliases', async () => {
     try {
       const orgsPage = new OrgsPage(page);
       orgName = await orgsPage.createOrg();
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
@@ -139,21 +130,21 @@ test.describe('Aliases', async () => {
       );
 
       // Connect to target using alias
-      await authorizeSessionByAliasCli(alias);
+      await boundaryCli.authorizeSessionByAliasCli(alias);
     } finally {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
       if (orgName) {
-        const orgId = await getOrgIdFromNameCli(orgName);
+        const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
         if (orgId) {
-          await deleteScopeCli(orgId);
+          await boundaryCli.deleteScopeCli(orgId);
         }
         if (alias) {
-          await deleteAliasCli(alias);
+          await boundaryCli.deleteAliasCli(alias);
         }
       }
     }
@@ -184,32 +175,38 @@ test.describe('Aliases', async () => {
       );
 
       // Create new alias from scope page
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      orgId = await getOrgIdFromNameCli(orgName);
-      const projectId = await getProjectIdFromNameCli(orgId, projectName);
-      const targetId = await getTargetIdFromNameCli(projectId, targetName);
+      orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+      const projectId = await boundaryCli.getProjectIdFromNameCli(
+        orgId,
+        projectName,
+      );
+      const targetId = await boundaryCli.getTargetIdFromNameCli(
+        projectId,
+        targetName,
+      );
 
       alias = 'example.alias.' + nanoid();
       const aliasesPage = new AliasesPage(page);
       await aliasesPage.createAliasForTarget(alias, targetId);
-      await authorizeSessionByAliasCli(alias);
+      await boundaryCli.authorizeSessionByAliasCli(alias);
     } finally {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
       if (orgId) {
-        await deleteScopeCli(orgId);
+        await boundaryCli.deleteScopeCli(orgId);
       }
       if (alias) {
-        await deleteAliasCli(alias);
+        await boundaryCli.deleteAliasCli(alias);
       }
     }
   });

--- a/e2e-tests/admin/tests/auth-method-ldap.spec.js
+++ b/e2e-tests/admin/tests/auth-method-ldap.spec.js
@@ -7,12 +7,7 @@ import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { nanoid } from 'nanoid';
 
-import {
-  authenticateBoundaryCli,
-  checkBoundaryCli,
-  deleteScopeCli,
-  getOrgIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
 import { AuthMethodsPage } from '../pages/auth-methods.js';
 import { LoginPage } from '../pages/login.js';
 import { OrgsPage } from '../pages/orgs.js';
@@ -20,7 +15,7 @@ import { RolesPage } from '../pages/roles.js';
 import { UsersPage } from '../pages/users.js';
 
 test.beforeAll(async () => {
-  await checkBoundaryCli();
+  await boundaryCli.checkBoundaryCli();
 });
 
 test('Set up LDAP auth method @ce @ent @docker', async ({
@@ -250,15 +245,15 @@ test('Set up LDAP auth method @ce @ent @docker', async ({
     ).toContain(ldapUserName + '@mail.com');
   } finally {
     if (orgName) {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const orgId = await getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
       if (orgId) {
-        await deleteScopeCli(orgId);
+        await boundaryCli.deleteScopeCli(orgId);
       }
     }
   }

--- a/e2e-tests/admin/tests/auth-method-ldap.spec.js
+++ b/e2e-tests/admin/tests/auth-method-ldap.spec.js
@@ -245,15 +245,15 @@ test('Set up LDAP auth method @ce @ent @docker', async ({
     ).toContain(ldapUserName + '@mail.com');
   } finally {
     if (orgName) {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromName(orgName);
       if (orgId) {
-        await boundaryCli.deleteScopeCli(orgId);
+        await boundaryCli.deleteScope(orgId);
       }
     }
   }

--- a/e2e-tests/admin/tests/auth-method-password.spec.js
+++ b/e2e-tests/admin/tests/auth-method-password.spec.js
@@ -99,7 +99,7 @@ test('Verify new auth-method can be created and assigned to users @ce @ent @aws 
         .getByText('Projects'),
     ).toBeVisible();
   } finally {
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
@@ -125,9 +125,9 @@ test('Verify new auth-method can be created and assigned to users @ce @ent @aws 
     }
 
     if (orgName) {
-      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromName(orgName);
       if (orgId) {
-        await boundaryCli.deleteScopeCli(orgId);
+        await boundaryCli.deleteScope(orgId);
       }
     }
   }

--- a/e2e-tests/admin/tests/auth-method-password.spec.js
+++ b/e2e-tests/admin/tests/auth-method-password.spec.js
@@ -7,19 +7,14 @@ import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { execSync } from 'node:child_process';
 
-import {
-  authenticateBoundaryCli,
-  checkBoundaryCli,
-  deleteScopeCli,
-  getOrgIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
 import { AuthMethodsPage } from '../pages/auth-methods.js';
 import { LoginPage } from '../pages/login.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { UsersPage } from '../pages/users.js';
 
 test.beforeAll(async () => {
-  await checkBoundaryCli();
+  await boundaryCli.checkBoundaryCli();
 });
 
 test('Verify new auth-method can be created and assigned to users @ce @ent @aws @docker', async ({
@@ -104,7 +99,7 @@ test('Verify new auth-method can be created and assigned to users @ce @ent @aws 
         .getByText('Projects'),
     ).toBeVisible();
   } finally {
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
@@ -130,9 +125,9 @@ test('Verify new auth-method can be created and assigned to users @ce @ent @aws 
     }
 
     if (orgName) {
-      const orgId = await getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
       if (orgId) {
-        await deleteScopeCli(orgId);
+        await boundaryCli.deleteScopeCli(orgId);
       }
     }
   }

--- a/e2e-tests/admin/tests/credential-store-static-ent.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static-ent.spec.js
@@ -102,15 +102,15 @@ test('Multiple Credential Stores (ENT) @ent @aws @docker', async ({
     await page.getByRole('button', { name: 'Dismiss' }).click();
   } finally {
     if (orgName) {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromName(orgName);
       if (orgId) {
-        await boundaryCli.deleteScopeCli(orgId);
+        await boundaryCli.deleteScope(orgId);
       }
     }
   }

--- a/e2e-tests/admin/tests/credential-store-static-ent.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static-ent.spec.js
@@ -6,12 +6,7 @@
 import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
-import {
-  authenticateBoundaryCli,
-  checkBoundaryCli,
-  deleteScopeCli,
-  getOrgIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
 import { CredentialStoresPage } from '../pages/credential-stores.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
@@ -20,7 +15,7 @@ import { TargetsPage } from '../pages/targets.js';
 test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
-  await checkBoundaryCli();
+  await boundaryCli.checkBoundaryCli();
 });
 
 test('Multiple Credential Stores (ENT) @ent @aws @docker', async ({
@@ -107,15 +102,15 @@ test('Multiple Credential Stores (ENT) @ent @aws @docker', async ({
     await page.getByRole('button', { name: 'Dismiss' }).click();
   } finally {
     if (orgName) {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const orgId = await getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
       if (orgId) {
-        await deleteScopeCli(orgId);
+        await boundaryCli.deleteScopeCli(orgId);
       }
     }
   }

--- a/e2e-tests/admin/tests/credential-store-static.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static.spec.js
@@ -8,15 +8,7 @@ import { expect } from '@playwright/test';
 import { readFile } from 'fs/promises';
 import { nanoid } from 'nanoid';
 
-import {
-  authenticateBoundaryCli,
-  authorizeSessionByTargetIdCli,
-  checkBoundaryCli,
-  deleteScopeCli,
-  getOrgIdFromNameCli,
-  getProjectIdFromNameCli,
-  getTargetIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
 import { CredentialStoresPage } from '../pages/credential-stores.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
@@ -25,7 +17,7 @@ import { TargetsPage } from '../pages/targets.js';
 test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
-  await checkBoundaryCli();
+  await boundaryCli.checkBoundaryCli();
 });
 
 let orgName;
@@ -70,16 +62,22 @@ test('Static Credential Store (User & Key Pair) @ce @aws @docker', async ({
       credentialName,
     );
 
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    const orgId = await getOrgIdFromNameCli(orgName);
-    const projectId = await getProjectIdFromNameCli(orgId, projectName);
-    const targetId = await getTargetIdFromNameCli(projectId, targetName);
-    const session = await authorizeSessionByTargetIdCli(targetId);
+    const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId,
+      projectName,
+    );
+    const targetId = await boundaryCli.getTargetIdFromNameCli(
+      projectId,
+      targetName,
+    );
+    const session = await boundaryCli.authorizeSessionByTargetIdCli(targetId);
     const retrievedUser = session.item.credentials[0].credential.username;
     const retrievedKey = session.item.credentials[0].credential.private_key;
 
@@ -93,15 +91,15 @@ test('Static Credential Store (User & Key Pair) @ce @aws @docker', async ({
     }
   } finally {
     if (orgName) {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const orgId = await getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
       if (orgId) {
-        await deleteScopeCli(orgId);
+        await boundaryCli.deleteScopeCli(orgId);
       }
     }
   }
@@ -129,16 +127,22 @@ test('Static Credential Store (Username & Password) @ce @aws @docker', async ({
       credentialName,
     );
 
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    const orgId = await getOrgIdFromNameCli(orgName);
-    const projectId = await getProjectIdFromNameCli(orgId, projectName);
-    const targetId = await getTargetIdFromNameCli(projectId, targetName);
-    const session = await authorizeSessionByTargetIdCli(targetId);
+    const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId,
+      projectName,
+    );
+    const targetId = await boundaryCli.getTargetIdFromNameCli(
+      projectId,
+      targetName,
+    );
+    const session = await boundaryCli.authorizeSessionByTargetIdCli(targetId);
     const retrievedUser = session.item.credentials[0].credential.username;
     const retrievedPassword = session.item.credentials[0].credential.password;
 
@@ -146,15 +150,15 @@ test('Static Credential Store (Username & Password) @ce @aws @docker', async ({
     expect(retrievedPassword).toBe(testPassword);
   } finally {
     if (orgName) {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const orgId = await getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
       if (orgId) {
-        await deleteScopeCli(orgId);
+        await boundaryCli.deleteScopeCli(orgId);
       }
     }
   }
@@ -200,16 +204,22 @@ test('Static Credential Store (JSON) @ce @aws @docker', async ({
       credentialName,
     );
 
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    const orgId = await getOrgIdFromNameCli(orgName);
-    const projectId = await getProjectIdFromNameCli(orgId, projectName);
-    const targetId = await getTargetIdFromNameCli(projectId, targetName);
-    const session = await authorizeSessionByTargetIdCli(targetId);
+    const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId,
+      projectName,
+    );
+    const targetId = await boundaryCli.getTargetIdFromNameCli(
+      projectId,
+      targetName,
+    );
+    const session = await boundaryCli.authorizeSessionByTargetIdCli(targetId);
     const retrievedUser = session.item.credentials[0].credential.username;
     const retrievedPassword = session.item.credentials[0].credential.password;
     const retrievedId = session.item.credentials[0].credential.id;
@@ -219,15 +229,15 @@ test('Static Credential Store (JSON) @ce @aws @docker', async ({
     expect(retrievedId).toBe(testId);
   } finally {
     if (orgName) {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const orgId = await getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
       if (orgId) {
-        await deleteScopeCli(orgId);
+        await boundaryCli.deleteScopeCli(orgId);
       }
     }
   }
@@ -280,15 +290,15 @@ test('Multiple Credential Stores (CE) @ce @aws @docker', async ({
     await page.getByRole('button', { name: 'Dismiss' }).click();
   } finally {
     if (orgName) {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const orgId = await getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
       if (orgId) {
-        await deleteScopeCli(orgId);
+        await boundaryCli.deleteScopeCli(orgId);
       }
     }
   }

--- a/e2e-tests/admin/tests/credential-store-static.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static.spec.js
@@ -62,22 +62,22 @@ test('Static Credential Store (User & Key Pair) @ce @aws @docker', async ({
       credentialName,
     );
 
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    const orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
-    const session = await boundaryCli.authorizeSessionByTargetIdCli(targetId);
+    const session = await boundaryCli.authorizeSessionByTargetId(targetId);
     const retrievedUser = session.item.credentials[0].credential.username;
     const retrievedKey = session.item.credentials[0].credential.private_key;
 
@@ -91,15 +91,15 @@ test('Static Credential Store (User & Key Pair) @ce @aws @docker', async ({
     }
   } finally {
     if (orgName) {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromName(orgName);
       if (orgId) {
-        await boundaryCli.deleteScopeCli(orgId);
+        await boundaryCli.deleteScope(orgId);
       }
     }
   }
@@ -127,22 +127,22 @@ test('Static Credential Store (Username & Password) @ce @aws @docker', async ({
       credentialName,
     );
 
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    const orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
-    const session = await boundaryCli.authorizeSessionByTargetIdCli(targetId);
+    const session = await boundaryCli.authorizeSessionByTargetId(targetId);
     const retrievedUser = session.item.credentials[0].credential.username;
     const retrievedPassword = session.item.credentials[0].credential.password;
 
@@ -150,15 +150,15 @@ test('Static Credential Store (Username & Password) @ce @aws @docker', async ({
     expect(retrievedPassword).toBe(testPassword);
   } finally {
     if (orgName) {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromName(orgName);
       if (orgId) {
-        await boundaryCli.deleteScopeCli(orgId);
+        await boundaryCli.deleteScope(orgId);
       }
     }
   }
@@ -204,22 +204,22 @@ test('Static Credential Store (JSON) @ce @aws @docker', async ({
       credentialName,
     );
 
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    const orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
-    const session = await boundaryCli.authorizeSessionByTargetIdCli(targetId);
+    const session = await boundaryCli.authorizeSessionByTargetId(targetId);
     const retrievedUser = session.item.credentials[0].credential.username;
     const retrievedPassword = session.item.credentials[0].credential.password;
     const retrievedId = session.item.credentials[0].credential.id;
@@ -229,15 +229,15 @@ test('Static Credential Store (JSON) @ce @aws @docker', async ({
     expect(retrievedId).toBe(testId);
   } finally {
     if (orgName) {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromName(orgName);
       if (orgId) {
-        await boundaryCli.deleteScopeCli(orgId);
+        await boundaryCli.deleteScope(orgId);
       }
     }
   }
@@ -290,15 +290,15 @@ test('Multiple Credential Stores (CE) @ce @aws @docker', async ({
     await page.getByRole('button', { name: 'Dismiss' }).click();
   } finally {
     if (orgName) {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+      const orgId = await boundaryCli.getOrgIdFromName(orgName);
       if (orgId) {
-        await boundaryCli.deleteScopeCli(orgId);
+        await boundaryCli.deleteScope(orgId);
       }
     }
   }

--- a/e2e-tests/admin/tests/credential-store-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/credential-store-vault-ent.spec.js
@@ -97,25 +97,25 @@ test('Vault Credential Store (User & Key Pair) @ent @aws @docker', async ({
       credentialLibraryName,
     );
 
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
-    await boundaryCli.authorizeSessionByTargetIdCli(targetId);
+    await boundaryCli.authorizeSessionByTargetId(targetId);
   } finally {
     if (orgId) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
   }
 });

--- a/e2e-tests/admin/tests/credential-store-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/credential-store-vault-ent.spec.js
@@ -6,16 +6,8 @@
 import { test, authenticatedState } from '../../global-setup.js';
 import { execSync } from 'child_process';
 
-import {
-  authenticateBoundaryCli,
-  authorizeSessionByTargetIdCli,
-  checkBoundaryCli,
-  deleteScopeCli,
-  getOrgIdFromNameCli,
-  getProjectIdFromNameCli,
-  getTargetIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
-import { checkVaultCli } from '../../helpers/vault-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
+import * as vaultCli from '../../helpers/vault-cli';
 import { CredentialStoresPage } from '../pages/credential-stores.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
@@ -29,8 +21,8 @@ const boundaryPolicyName = 'boundary-controller';
 test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
-  await checkBoundaryCli();
-  await checkVaultCli();
+  await boundaryCli.checkBoundaryCli();
+  await vaultCli.checkVaultCli();
 });
 
 test.beforeEach(async ({ page }) => {
@@ -105,19 +97,25 @@ test('Vault Credential Store (User & Key Pair) @ent @aws @docker', async ({
       credentialLibraryName,
     );
 
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await getOrgIdFromNameCli(orgName);
-    const projectId = await getProjectIdFromNameCli(orgId, projectName);
-    const targetId = await getTargetIdFromNameCli(projectId, targetName);
-    await authorizeSessionByTargetIdCli(targetId);
+    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId,
+      projectName,
+    );
+    const targetId = await boundaryCli.getTargetIdFromNameCli(
+      projectId,
+      targetName,
+    );
+    await boundaryCli.authorizeSessionByTargetIdCli(targetId);
   } finally {
     if (orgId) {
-      await deleteScopeCli(orgId);
+      await boundaryCli.deleteScopeCli(orgId);
     }
   }
 });

--- a/e2e-tests/admin/tests/credential-store-vault.spec.js
+++ b/e2e-tests/admin/tests/credential-store-vault.spec.js
@@ -114,22 +114,22 @@ test('Vault Credential Store (User & Key Pair) @ce @aws @docker', async ({
       credentialLibraryName,
     );
 
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
-    const session = await boundaryCli.authorizeSessionByTargetIdCli(targetId);
+    const session = await boundaryCli.authorizeSessionByTargetId(targetId);
     const retrievedUser =
       session.item.credentials[0].secret.decoded.data.username;
     const retrievedKey =
@@ -145,7 +145,7 @@ test('Vault Credential Store (User & Key Pair) @ce @aws @docker', async ({
     }
   } finally {
     if (orgId) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
   }
 });

--- a/e2e-tests/admin/tests/delete-resources-ent.spec.js
+++ b/e2e-tests/admin/tests/delete-resources-ent.spec.js
@@ -31,7 +31,7 @@ test.beforeEach(
   async ({ baseURL, adminAuthMethodId, adminLoginName, adminPassword }) => {
     execSync(`vault policy delete ${secretPolicyName}`);
     execSync(`vault policy delete ${boundaryPolicyName}`);
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
@@ -48,48 +48,47 @@ test('Verify resources can be deleted (enterprise) @ent @aws', async ({
   let orgId;
   let orgDeleted = false;
   try {
-    orgId = await boundaryCli.createOrgCli();
-    let projectId = await boundaryCli.createProjectCli(orgId);
+    orgId = await boundaryCli.createOrg();
+    let projectId = await boundaryCli.createProject(orgId);
 
     // Create boundary resources using CLI
-    let workerId = await boundaryCli.createControllerLedWorkerCli();
-    let authMethodId = await boundaryCli.createPasswordAuthMethodCli(orgId);
-    await boundaryCli.makeAuthMethodPrimaryCli(orgId, authMethodId);
+    let workerId = await boundaryCli.createControllerLedWorker();
+    let authMethodId = await boundaryCli.createPasswordAuthMethod(orgId);
+    await boundaryCli.makeAuthMethodPrimary(orgId, authMethodId);
     let passwordAccountId =
-      await boundaryCli.reatePasswordAccountCli(authMethodId);
-    let projectScopeRoleId = await boundaryCli.createRoleCli(projectId);
-    let orgScopeRoleId = await boundaryCli.createRoleCli(orgId);
-    let globalScopeRoleId = await boundaryCli.createRoleCli('global');
-    let groupId = await boundaryCli.createGroupCli(orgId);
-    let userId = await boundaryCli.createUserCli(orgId);
+      await boundaryCli.createPasswordAccount(authMethodId);
+    let projectScopeRoleId = await boundaryCli.createRole(projectId);
+    let orgScopeRoleId = await boundaryCli.createRole(orgId);
+    let globalScopeRoleId = await boundaryCli.createRole('global');
+    let groupId = await boundaryCli.createGroup(orgId);
+    let userId = await boundaryCli.createUser(orgId);
     let staticHostCatalogId =
-      await boundaryCli.createStaticHostCatalogCli(projectId);
-    let dynamicAwsHostCatalogId =
-      await boundaryCli.createDynamicAwsHostCatalogCli(projectId, awsRegion);
-    let staticHostId =
-      await boundaryCli.createStaticHostCli(staticHostCatalogId);
-    let staticHostSetId =
-      await boundaryCli.createHostSetCli(staticHostCatalogId);
+      await boundaryCli.createStaticHostCatalog(projectId);
+    let dynamicAwsHostCatalogId = await boundaryCli.createDynamicAwsHostCatalog(
+      projectId,
+      awsRegion,
+    );
+    let staticHostId = await boundaryCli.createStaticHost(staticHostCatalogId);
+    let staticHostSetId = await boundaryCli.createHostSet(staticHostCatalogId);
     let staticCredentialStoreId =
-      await boundaryCli.createStaticCredentialStoreCli(projectId);
+      await boundaryCli.createStaticCredentialStore(projectId);
     const vaultToken = await vaultCli.getVaultToken(
       boundaryPolicyName,
       secretPolicyName,
     );
-    let vaultCredentialStoreId =
-      await boundaryCli.createVaultCredentialStoreCli(
-        projectId,
-        vaultAddr,
-        vaultToken,
-      );
+    let vaultCredentialStoreId = await boundaryCli.createVaultCredentialStore(
+      projectId,
+      vaultAddr,
+      vaultToken,
+    );
     let usernamePasswordCredentialId =
-      await boundaryCli.createUsernamePasswordCredentialCli(
+      await boundaryCli.createUsernamePasswordCredential(
         staticCredentialStoreId,
       );
     let tcpTargetId = await boundaryCli.createTcpTarget(projectId);
 
     // Create enterprise boundary resources using CLI
-    let sshTargetId = await boundaryCli.createSshTargetCli(projectId);
+    let sshTargetId = await boundaryCli.createSshTarget(projectId);
 
     // Delete resources
     const baseResourcePage = new BaseResourcePage(page);
@@ -158,7 +157,7 @@ test('Verify resources can be deleted (enterprise) @ent @aws', async ({
     orgDeleted = true;
   } finally {
     if (orgId && orgDeleted == false) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
   }
 });

--- a/e2e-tests/admin/tests/delete-resources.spec.js
+++ b/e2e-tests/admin/tests/delete-resources.spec.js
@@ -31,7 +31,7 @@ test.beforeEach(
   async ({ baseURL, adminAuthMethodId, adminLoginName, adminPassword }) => {
     execSync(`vault policy delete ${secretPolicyName}`);
     execSync(`vault policy delete ${boundaryPolicyName}`);
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
@@ -49,40 +49,39 @@ test('Verify resources can be deleted @ce @aws', async ({
   let orgDeleted = false;
   try {
     // Create boundary resources using CLI
-    orgId = await boundaryCli.createOrgCli();
-    let projectId = await boundaryCli.createProjectCli(orgId);
-    let workerId = await boundaryCli.createControllerLedWorkerCli();
-    let authMethodId = await boundaryCli.createPasswordAuthMethodCli(orgId);
-    await boundaryCli.makeAuthMethodPrimaryCli(orgId, authMethodId);
+    orgId = await boundaryCli.createOrg();
+    let projectId = await boundaryCli.createProject(orgId);
+    let workerId = await boundaryCli.createControllerLedWorker();
+    let authMethodId = await boundaryCli.createPasswordAuthMethod(orgId);
+    await boundaryCli.makeAuthMethodPrimary(orgId, authMethodId);
     let passwordAccountId =
-      await boundaryCli.createPasswordAccountCli(authMethodId);
-    let projectScopeRoleId = await boundaryCli.createRoleCli(projectId);
-    let orgScopeRoleId = await boundaryCli.createRoleCli(orgId);
-    let globalScopeRoleId = await boundaryCli.createRoleCli('global');
-    let groupId = await boundaryCli.createGroupCli(orgId);
-    let userId = await boundaryCli.createUserCli(orgId);
+      await boundaryCli.createPasswordAccount(authMethodId);
+    let projectScopeRoleId = await boundaryCli.createRole(projectId);
+    let orgScopeRoleId = await boundaryCli.createRole(orgId);
+    let globalScopeRoleId = await boundaryCli.createRole('global');
+    let groupId = await boundaryCli.createGroup(orgId);
+    let userId = await boundaryCli.createUser(orgId);
     let staticHostCatalogId =
-      await boundaryCli.createStaticHostCatalogCli(projectId);
-    let dynamicAwsHostCatalogId =
-      await boundaryCli.createDynamicAwsHostCatalogCli(projectId, awsRegion);
-    let staticHostId =
-      await boundaryCli.createStaticHostCli(staticHostCatalogId);
-    let staticHostSetId =
-      await boundaryCli.createHostSetCli(staticHostCatalogId);
+      await boundaryCli.createStaticHostCatalog(projectId);
+    let dynamicAwsHostCatalogId = await boundaryCli.createDynamicAwsHostCatalog(
+      projectId,
+      awsRegion,
+    );
+    let staticHostId = await boundaryCli.createStaticHost(staticHostCatalogId);
+    let staticHostSetId = await boundaryCli.createHostSet(staticHostCatalogId);
     let staticCredentialStoreId =
-      await boundaryCli.createStaticCredentialStoreCli(projectId);
+      await boundaryCli.createStaticCredentialStore(projectId);
     const vaultToken = await vaultCli.getVaultToken(
       boundaryPolicyName,
       secretPolicyName,
     );
-    let vaultCredentialStoreId =
-      await boundaryCli.createVaultCredentialStoreCli(
-        projectId,
-        vaultAddr,
-        vaultToken,
-      );
+    let vaultCredentialStoreId = await boundaryCli.createVaultCredentialStore(
+      projectId,
+      vaultAddr,
+      vaultToken,
+    );
     let usernamePasswordCredentialId =
-      await boundaryCli.createUsernamePasswordCredentialCli(
+      await boundaryCli.createUsernamePasswordCredential(
         staticCredentialStoreId,
       );
     let tcpTargetId = await boundaryCli.createTcpTarget(projectId);
@@ -183,7 +182,7 @@ test('Verify resources can be deleted @ce @aws', async ({
   } finally {
     // Delete org in case the test failed before deleting the org using UI
     if (orgId && orgDeleted === false) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
   }
 });

--- a/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
+++ b/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
@@ -7,11 +7,7 @@ import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { nanoid } from 'nanoid';
 
-import {
-  authenticateBoundaryCli,
-  deleteScopeCli,
-  getOrgIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
 import { HostCatalogsPage } from '../pages/host-catalogs.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
@@ -190,7 +186,7 @@ test.describe('AWS', async () => {
       // Add the host source back
       await targetsPage.addHostSourceToTarget(newHostSetName);
     } finally {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
@@ -198,9 +194,9 @@ test.describe('AWS', async () => {
       );
 
       if (orgName) {
-        const orgId = await getOrgIdFromNameCli(orgName);
+        const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
         if (orgId) {
-          await deleteScopeCli(orgId);
+          await boundaryCli.deleteScopeCli(orgId);
         }
       }
     }

--- a/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
+++ b/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
@@ -186,7 +186,7 @@ test.describe('AWS', async () => {
       // Add the host source back
       await targetsPage.addHostSourceToTarget(newHostSetName);
     } finally {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
@@ -194,9 +194,9 @@ test.describe('AWS', async () => {
       );
 
       if (orgName) {
-        const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+        const orgId = await boundaryCli.getOrgIdFromName(orgName);
         if (orgId) {
-          await boundaryCli.deleteScopeCli(orgId);
+          await boundaryCli.deleteScope(orgId);
         }
       }
     }

--- a/e2e-tests/admin/tests/global-settings.spec.js
+++ b/e2e-tests/admin/tests/global-settings.spec.js
@@ -6,11 +6,7 @@
 import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
-import {
-  authenticateBoundaryCli,
-  deletePolicyCli,
-  getPolicyIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
 import { OrgsPage } from '../pages/orgs.js';
 import { StoragePoliciesPage } from '../pages/storage-policies.js';
 
@@ -51,17 +47,17 @@ test('Global Settings @ent @aws @docker', async ({
     await expect(page.getByRole('heading', { name: 'Orgs' })).toBeVisible();
   } finally {
     if (policyName) {
-      await authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundaryCli(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const storagePolicyId = await getPolicyIdFromNameCli(
+      const storagePolicyId = await boundaryCli.getPolicyIdFromNameCli(
         'global',
         policyName,
       );
-      await deletePolicyCli(storagePolicyId);
+      await boundaryCli.deletePolicyCli(storagePolicyId);
     }
   }
 });

--- a/e2e-tests/admin/tests/global-settings.spec.js
+++ b/e2e-tests/admin/tests/global-settings.spec.js
@@ -47,17 +47,17 @@ test('Global Settings @ent @aws @docker', async ({
     await expect(page.getByRole('heading', { name: 'Orgs' })).toBeVisible();
   } finally {
     if (policyName) {
-      await boundaryCli.authenticateBoundaryCli(
+      await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
       );
-      const storagePolicyId = await boundaryCli.getPolicyIdFromNameCli(
+      const storagePolicyId = await boundaryCli.getPolicyIdFromName(
         'global',
         policyName,
       );
-      await boundaryCli.deletePolicyCli(storagePolicyId);
+      await boundaryCli.deletePolicy(storagePolicyId);
     }
   }
 });

--- a/e2e-tests/admin/tests/group-role.spec.js
+++ b/e2e-tests/admin/tests/group-role.spec.js
@@ -36,15 +36,15 @@ test('Verify a new role can be created and associated with a group @ce @ent @aws
     await rolesPage.addPrincipalToRole(groupName);
     await rolesPage.addGrantsToRole('ids=*;type=*;actions=read,list');
   } finally {
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const orgId = await boundaryCli.getOrgIdFromName(orgName);
     if (orgId) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
   }
 });

--- a/e2e-tests/admin/tests/group-role.spec.js
+++ b/e2e-tests/admin/tests/group-role.spec.js
@@ -5,12 +5,7 @@
 
 import { test, authenticatedState } from '../../global-setup.js';
 
-import {
-  authenticateBoundaryCli,
-  checkBoundaryCli,
-  deleteScopeCli,
-  getOrgIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
 import { GroupsPage } from '../pages/groups.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { RolesPage } from '../pages/roles.js';
@@ -18,7 +13,7 @@ import { RolesPage } from '../pages/roles.js';
 test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
-  await checkBoundaryCli();
+  await boundaryCli.checkBoundaryCli();
 });
 
 test('Verify a new role can be created and associated with a group @ce @ent @aws @docker', async ({
@@ -41,15 +36,15 @@ test('Verify a new role can be created and associated with a group @ce @ent @aws
     await rolesPage.addPrincipalToRole(groupName);
     await rolesPage.addGrantsToRole('ids=*;type=*;actions=read,list');
   } finally {
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    const orgId = await getOrgIdFromNameCli(orgName);
+    const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
     if (orgId) {
-      await deleteScopeCli(orgId);
+      await boundaryCli.deleteScopeCli(orgId);
     }
   }
 });

--- a/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
@@ -7,19 +7,7 @@ import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { execSync } from 'child_process';
 
-import {
-  authenticateBoundaryCli,
-  checkBoundaryCli,
-  connectSshToTarget,
-  deleteScopeCli,
-  waitForSessionRecordingCli,
-  deleteStorageBucketCli,
-  deletePolicyCli,
-  getOrgIdFromNameCli,
-  getPolicyIdFromNameCli,
-  getProjectIdFromNameCli,
-  getTargetIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
 import { CredentialStoresPage } from '../pages/credential-stores.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
@@ -32,7 +20,7 @@ import { TargetsPage } from '../pages/targets.js';
 test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
-  await checkBoundaryCli();
+  await boundaryCli.checkBoundaryCli();
 });
 
 test('Session Recording Test (AWS) @ent @aws', async ({
@@ -57,7 +45,7 @@ test('Session Recording Test (AWS) @ent @aws', async ({
   let storageBucket;
   let connect;
   try {
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
@@ -129,10 +117,16 @@ test('Session Recording Test (AWS) @ent @aws', async ({
     await orgsPage.attachStoragePolicy(policyName);
 
     // Establish connection to target and cancel it
-    orgId = await getOrgIdFromNameCli(orgName);
-    const projectId = await getProjectIdFromNameCli(orgId, projectName);
-    const targetId = await getTargetIdFromNameCli(projectId, targetName);
-    connect = await connectSshToTarget(targetId);
+    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId,
+      projectName,
+    );
+    const targetId = await boundaryCli.getTargetIdFromNameCli(
+      projectId,
+      targetName,
+    );
+    connect = await boundaryCli.connectSshToTarget(targetId);
     await page.getByRole('link', { name: 'Projects', exact: true }).click();
     await page.getByRole('link', { name: projectName }).click();
     const sessionsPage = new SessionsPage(page);
@@ -146,7 +140,7 @@ test('Session Recording Test (AWS) @ent @aws', async ({
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();
     await page.getByRole('button', { name: 'Dismiss', exact: true }).click();
-    await waitForSessionRecordingCli(storageBucket.id);
+    await boundaryCli.waitForSessionRecordingCli(storageBucket.id);
 
     // Play back session recording
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
@@ -234,14 +228,17 @@ test('Session Recording Test (AWS) @ent @aws', async ({
     await targetsPage.detachStorageBucket();
   } finally {
     if (policyName) {
-      const storagePolicyId = await getPolicyIdFromNameCli(orgId, policyName);
-      await deletePolicyCli(storagePolicyId);
+      const storagePolicyId = await boundaryCli.getPolicyIdFromNameCli(
+        orgId,
+        policyName,
+      );
+      await boundaryCli.deletePolicyCli(storagePolicyId);
     }
     if (storageBucket) {
-      await deleteStorageBucketCli(storageBucket.id);
+      await boundaryCli.deleteStorageBucketCli(storageBucket.id);
     }
     if (orgId) {
-      await deleteScopeCli(orgId);
+      await boundaryCli.deleteScopeCli(orgId);
     }
     // End `boundary connect` process
     if (connect) {

--- a/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
@@ -45,7 +45,7 @@ test('Session Recording Test (AWS) @ent @aws', async ({
   let storageBucket;
   let connect;
   try {
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
@@ -117,12 +117,12 @@ test('Session Recording Test (AWS) @ent @aws', async ({
     await orgsPage.attachStoragePolicy(policyName);
 
     // Establish connection to target and cancel it
-    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
@@ -140,7 +140,7 @@ test('Session Recording Test (AWS) @ent @aws', async ({
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();
     await page.getByRole('button', { name: 'Dismiss', exact: true }).click();
-    await boundaryCli.waitForSessionRecordingCli(storageBucket.id);
+    await boundaryCli.waitForSessionRecording(storageBucket.id);
 
     // Play back session recording
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
@@ -228,17 +228,17 @@ test('Session Recording Test (AWS) @ent @aws', async ({
     await targetsPage.detachStorageBucket();
   } finally {
     if (policyName) {
-      const storagePolicyId = await boundaryCli.getPolicyIdFromNameCli(
+      const storagePolicyId = await boundaryCli.getPolicyIdFromName(
         orgId,
         policyName,
       );
-      await boundaryCli.deletePolicyCli(storagePolicyId);
+      await boundaryCli.deletePolicy(storagePolicyId);
     }
     if (storageBucket) {
-      await boundaryCli.deleteStorageBucketCli(storageBucket.id);
+      await boundaryCli.deleteStorageBucket(storageBucket.id);
     }
     if (orgId) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
     // End `boundary connect` process
     if (connect) {

--- a/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
@@ -47,7 +47,7 @@ test('Session Recording Test (MinIO) @ent @docker', async ({
   let storageBucket;
   let connect;
   try {
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
@@ -124,12 +124,12 @@ test('Session Recording Test (MinIO) @ent @docker', async ({
     await orgsPage.attachStoragePolicy(policyName);
 
     // Establish connection to target and cancel it
-    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
@@ -147,7 +147,7 @@ test('Session Recording Test (MinIO) @ent @docker', async ({
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();
     await page.getByRole('button', { name: 'Dismiss', exact: true }).click();
-    await boundaryCli.waitForSessionRecordingCli(storageBucket.id);
+    await boundaryCli.waitForSessionRecording(storageBucket.id);
 
     // Play back session recording
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
@@ -235,17 +235,17 @@ test('Session Recording Test (MinIO) @ent @docker', async ({
     await targetsPage.detachStorageBucket();
   } finally {
     if (policyName) {
-      const storagePolicyId = await boundaryCli.getPolicyIdFromNameCli(
+      const storagePolicyId = await boundaryCli.getPolicyIdFromName(
         orgId,
         policyName,
       );
-      await boundaryCli.deletePolicyCli(storagePolicyId);
+      await boundaryCli.deletePolicy(storagePolicyId);
     }
     if (storageBucket) {
-      await boundaryCli.deleteStorageBucketCli(storageBucket.id);
+      await boundaryCli.deleteStorageBucket(storageBucket.id);
     }
     if (orgId) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
     // End `boundary connect` process
     if (connect) {

--- a/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
@@ -7,19 +7,7 @@ import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { execSync } from 'child_process';
 
-import {
-  authenticateBoundaryCli,
-  checkBoundaryCli,
-  connectSshToTarget,
-  deleteScopeCli,
-  waitForSessionRecordingCli,
-  deleteStorageBucketCli,
-  deletePolicyCli,
-  getOrgIdFromNameCli,
-  getPolicyIdFromNameCli,
-  getProjectIdFromNameCli,
-  getTargetIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
 import { CredentialStoresPage } from '../pages/credential-stores.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
@@ -32,7 +20,7 @@ import { TargetsPage } from '../pages/targets.js';
 test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
-  await checkBoundaryCli();
+  await boundaryCli.checkBoundaryCli();
 });
 
 test('Session Recording Test (MinIO) @ent @docker', async ({
@@ -59,7 +47,7 @@ test('Session Recording Test (MinIO) @ent @docker', async ({
   let storageBucket;
   let connect;
   try {
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
@@ -136,10 +124,16 @@ test('Session Recording Test (MinIO) @ent @docker', async ({
     await orgsPage.attachStoragePolicy(policyName);
 
     // Establish connection to target and cancel it
-    orgId = await getOrgIdFromNameCli(orgName);
-    const projectId = await getProjectIdFromNameCli(orgId, projectName);
-    const targetId = await getTargetIdFromNameCli(projectId, targetName);
-    connect = await connectSshToTarget(targetId);
+    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId,
+      projectName,
+    );
+    const targetId = await boundaryCli.getTargetIdFromNameCli(
+      projectId,
+      targetName,
+    );
+    connect = await boundaryCli.connectSshToTarget(targetId);
     await page.getByRole('link', { name: 'Projects', exact: true }).click();
     await page.getByRole('link', { name: projectName }).click();
     const sessionsPage = new SessionsPage(page);
@@ -153,7 +147,7 @@ test('Session Recording Test (MinIO) @ent @docker', async ({
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();
     await page.getByRole('button', { name: 'Dismiss', exact: true }).click();
-    await waitForSessionRecordingCli(storageBucket.id);
+    await boundaryCli.waitForSessionRecordingCli(storageBucket.id);
 
     // Play back session recording
     await page.getByRole('link', { name: 'Orgs', exact: true }).click();
@@ -241,14 +235,17 @@ test('Session Recording Test (MinIO) @ent @docker', async ({
     await targetsPage.detachStorageBucket();
   } finally {
     if (policyName) {
-      const storagePolicyId = await getPolicyIdFromNameCli(orgId, policyName);
-      await deletePolicyCli(storagePolicyId);
+      const storagePolicyId = await boundaryCli.getPolicyIdFromNameCli(
+        orgId,
+        policyName,
+      );
+      await boundaryCli.deletePolicyCli(storagePolicyId);
     }
     if (storageBucket) {
-      await deleteStorageBucketCli(storageBucket.id);
+      await boundaryCli.deleteStorageBucketCli(storageBucket.id);
     }
     if (orgId) {
-      await deleteScopeCli(orgId);
+      await boundaryCli.deleteScopeCli(orgId);
     }
     // End `boundary connect` process
     if (connect) {

--- a/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
@@ -6,16 +6,8 @@
 import { test, authenticatedState } from '../../global-setup.js';
 import { execSync } from 'child_process';
 
-import {
-  authenticateBoundaryCli,
-  checkBoundaryCli,
-  connectSshToTarget,
-  deleteScopeCli,
-  getOrgIdFromNameCli,
-  getProjectIdFromNameCli,
-  getTargetIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
-import { checkVaultCli } from '../../helpers/vault-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
+import * as vaultCli from '../../helpers/vault-cli';
 import { CredentialStoresPage } from '../pages/credential-stores.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
@@ -32,8 +24,8 @@ const secretName = 'boundary-client';
 test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
-  await checkBoundaryCli();
-  await checkVaultCli();
+  await boundaryCli.checkBoundaryCli();
+  await vaultCli.checkVaultCli();
 });
 
 test.beforeEach(async () => {
@@ -126,16 +118,22 @@ test('SSH Certificate Injection @ent @docker', async ({
     );
 
     // Connect to target
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await getOrgIdFromNameCli(orgName);
-    const projectId = await getProjectIdFromNameCli(orgId, projectName);
-    const targetId = await getTargetIdFromNameCli(projectId, targetName);
-    connect = await connectSshToTarget(targetId);
+    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId,
+      projectName,
+    );
+    const targetId = await boundaryCli.getTargetIdFromNameCli(
+      projectId,
+      targetName,
+    );
+    connect = await boundaryCli.connectSshToTarget(targetId);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page
@@ -145,7 +143,7 @@ test('SSH Certificate Injection @ent @docker', async ({
       .click();
   } finally {
     if (orgId) {
-      await deleteScopeCli(orgId);
+      await boundaryCli.deleteScopeCli(orgId);
     }
     // End `boundary connect` process
     if (connect) {

--- a/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
@@ -118,18 +118,18 @@ test('SSH Certificate Injection @ent @docker', async ({
     );
 
     // Connect to target
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
@@ -143,7 +143,7 @@ test('SSH Certificate Injection @ent @docker', async ({
       .click();
   } finally {
     if (orgId) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
     // End `boundary connect` process
     if (connect) {

--- a/e2e-tests/admin/tests/ssh-credential-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-credential-injection-vault-ent.spec.js
@@ -108,18 +108,18 @@ test('SSH Credential Injection (Vault User & Key Pair) @ent @docker', async ({
     );
 
     // Connect to target
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
@@ -133,7 +133,7 @@ test('SSH Credential Injection (Vault User & Key Pair) @ent @docker', async ({
       .click();
   } finally {
     if (orgId) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
     // End `boundary connect` process
     if (connect) {

--- a/e2e-tests/admin/tests/target-ent.spec.js
+++ b/e2e-tests/admin/tests/target-ent.spec.js
@@ -6,16 +6,7 @@
 import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
-import {
-  authenticateBoundaryCli,
-  checkBoundaryCli,
-  connectToTarget,
-  connectSshToTarget,
-  deleteScopeCli,
-  getOrgIdFromNameCli,
-  getProjectIdFromNameCli,
-  getTargetIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
 import { CredentialStoresPage } from '../pages/credential-stores.js';
 import { HostCatalogsPage } from '../pages/host-catalogs.js';
 import { OrgsPage } from '../pages/orgs.js';
@@ -26,7 +17,7 @@ import { TargetsPage } from '../pages/targets.js';
 test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
-  await checkBoundaryCli();
+  await boundaryCli.checkBoundaryCli();
 });
 
 test('Verify session created for TCP target @ent @aws @docker', async ({
@@ -54,16 +45,22 @@ test('Verify session created for TCP target @ent @aws @docker', async ({
       targetPort,
     );
 
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await getOrgIdFromNameCli(orgName);
-    const projectId = await getProjectIdFromNameCli(orgId, projectName);
-    const targetId = await getTargetIdFromNameCli(projectId, targetName);
-    connect = await connectToTarget(targetId, sshUser, sshKeyPath);
+    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId,
+      projectName,
+    );
+    const targetId = await boundaryCli.getTargetIdFromNameCli(
+      projectId,
+      targetName,
+    );
+    connect = await boundaryCli.connectToTarget(targetId, sshUser, sshKeyPath);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page
@@ -73,7 +70,7 @@ test('Verify session created for TCP target @ent @aws @docker', async ({
       .click();
   } finally {
     if (orgId) {
-      await deleteScopeCli(orgId);
+      await boundaryCli.deleteScopeCli(orgId);
     }
     // End `boundary connect` process
     if (connect) {
@@ -118,16 +115,22 @@ test('Verify session created for SSH target @ent @aws @docker', async ({
       credentialName,
     );
 
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await getOrgIdFromNameCli(orgName);
-    const projectId = await getProjectIdFromNameCli(orgId, projectName);
-    const targetId = await getTargetIdFromNameCli(projectId, targetName);
-    connect = await connectSshToTarget(targetId);
+    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId,
+      projectName,
+    );
+    const targetId = await boundaryCli.getTargetIdFromNameCli(
+      projectId,
+      targetName,
+    );
+    connect = await boundaryCli.connectSshToTarget(targetId);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page
@@ -137,7 +140,7 @@ test('Verify session created for SSH target @ent @aws @docker', async ({
       .click();
   } finally {
     if (orgId) {
-      await deleteScopeCli(orgId);
+      await boundaryCli.deleteScopeCli(orgId);
     }
     // End `boundary connect` process
     if (connect) {
@@ -214,16 +217,22 @@ test('SSH target with host sources @ent @aws @docker', async ({
     );
 
     // Connect to target
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await getOrgIdFromNameCli(orgName);
-    const projectId = await getProjectIdFromNameCli(orgId, projectName);
-    const targetId = await getTargetIdFromNameCli(projectId, targetName);
-    connect = await connectSshToTarget(targetId);
+    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId,
+      projectName,
+    );
+    const targetId = await boundaryCli.getTargetIdFromNameCli(
+      projectId,
+      targetName,
+    );
+    connect = await boundaryCli.connectSshToTarget(targetId);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page
@@ -233,7 +242,7 @@ test('SSH target with host sources @ent @aws @docker', async ({
       .click();
   } finally {
     if (orgId) {
-      await deleteScopeCli(orgId);
+      await boundaryCli.deleteScopeCli(orgId);
     }
     // End `boundary connect` process
     if (connect) {

--- a/e2e-tests/admin/tests/target-ent.spec.js
+++ b/e2e-tests/admin/tests/target-ent.spec.js
@@ -45,18 +45,18 @@ test('Verify session created for TCP target @ent @aws @docker', async ({
       targetPort,
     );
 
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
@@ -70,7 +70,7 @@ test('Verify session created for TCP target @ent @aws @docker', async ({
       .click();
   } finally {
     if (orgId) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
     // End `boundary connect` process
     if (connect) {
@@ -115,18 +115,18 @@ test('Verify session created for SSH target @ent @aws @docker', async ({
       credentialName,
     );
 
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
@@ -140,7 +140,7 @@ test('Verify session created for SSH target @ent @aws @docker', async ({
       .click();
   } finally {
     if (orgId) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
     // End `boundary connect` process
     if (connect) {
@@ -217,18 +217,18 @@ test('SSH target with host sources @ent @aws @docker', async ({
     );
 
     // Connect to target
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
@@ -242,7 +242,7 @@ test('SSH target with host sources @ent @aws @docker', async ({
       .click();
   } finally {
     if (orgId) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
     // End `boundary connect` process
     if (connect) {

--- a/e2e-tests/admin/tests/target.spec.js
+++ b/e2e-tests/admin/tests/target.spec.js
@@ -64,18 +64,18 @@ test('Verify session created to target with host, then cancel the session @ce @a
     await targetsPage.removeHostSourceFromTarget(hostSetName2);
 
     // Connect to target
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
@@ -89,7 +89,7 @@ test('Verify session created to target with host, then cancel the session @ce @a
       .click();
   } finally {
     if (orgId) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
     // End `boundary connect` process
     if (connect) {
@@ -123,18 +123,18 @@ test('Verify session created to target with address, then cancel the session @ce
       targetPort,
     );
 
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
-    const projectId = await boundaryCli.getProjectIdFromNameCli(
+    orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
       orgId,
       projectName,
     );
-    const targetId = await boundaryCli.getTargetIdFromNameCli(
+    const targetId = await boundaryCli.getTargetIdFromName(
       projectId,
       targetName,
     );
@@ -148,7 +148,7 @@ test('Verify session created to target with address, then cancel the session @ce
       .click();
   } finally {
     if (orgId) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
     // End `boundary connect` process
     if (connect) {
@@ -221,15 +221,15 @@ test('Verify TCP target is updated @ce @aws @docker', async ({
     const basePage = new BasePage(page);
     await basePage.dismissSuccessAlert();
   } finally {
-    await boundaryCli.authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const orgId = await boundaryCli.getOrgIdFromName(orgName);
     if (orgId) {
-      await boundaryCli.deleteScopeCli(orgId);
+      await boundaryCli.deleteScope(orgId);
     }
   }
 });

--- a/e2e-tests/admin/tests/target.spec.js
+++ b/e2e-tests/admin/tests/target.spec.js
@@ -6,15 +6,7 @@
 import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
-import {
-  authenticateBoundaryCli,
-  checkBoundaryCli,
-  connectToTarget,
-  deleteScopeCli,
-  getOrgIdFromNameCli,
-  getProjectIdFromNameCli,
-  getTargetIdFromNameCli,
-} from '../../helpers/boundary-cli.js';
+import * as boundaryCli from '../../helpers/boundary-cli';
 import { BasePage } from '../pages/base.js';
 import { HostCatalogsPage } from '../pages/host-catalogs.js';
 import { OrgsPage } from '../pages/orgs.js';
@@ -25,7 +17,7 @@ import { TargetsPage } from '../pages/targets.js';
 test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
-  await checkBoundaryCli();
+  await boundaryCli.checkBoundaryCli();
 });
 
 test('Verify session created to target with host, then cancel the session @ce @aws @docker', async ({
@@ -72,16 +64,22 @@ test('Verify session created to target with host, then cancel the session @ce @a
     await targetsPage.removeHostSourceFromTarget(hostSetName2);
 
     // Connect to target
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await getOrgIdFromNameCli(orgName);
-    const projectId = await getProjectIdFromNameCli(orgId, projectName);
-    const targetId = await getTargetIdFromNameCli(projectId, targetName);
-    connect = await connectToTarget(targetId, sshUser, sshKeyPath);
+    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId,
+      projectName,
+    );
+    const targetId = await boundaryCli.getTargetIdFromNameCli(
+      projectId,
+      targetName,
+    );
+    connect = await boundaryCli.connectToTarget(targetId, sshUser, sshKeyPath);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page
@@ -91,7 +89,7 @@ test('Verify session created to target with host, then cancel the session @ce @a
       .click();
   } finally {
     if (orgId) {
-      await deleteScopeCli(orgId);
+      await boundaryCli.deleteScopeCli(orgId);
     }
     // End `boundary connect` process
     if (connect) {
@@ -125,16 +123,22 @@ test('Verify session created to target with address, then cancel the session @ce
       targetPort,
     );
 
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    orgId = await getOrgIdFromNameCli(orgName);
-    const projectId = await getProjectIdFromNameCli(orgId, projectName);
-    const targetId = await getTargetIdFromNameCli(projectId, targetName);
-    connect = await connectToTarget(targetId, sshUser, sshKeyPath);
+    orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
+    const projectId = await boundaryCli.getProjectIdFromNameCli(
+      orgId,
+      projectName,
+    );
+    const targetId = await boundaryCli.getTargetIdFromNameCli(
+      projectId,
+      targetName,
+    );
+    connect = await boundaryCli.connectToTarget(targetId, sshUser, sshKeyPath);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page
@@ -144,7 +148,7 @@ test('Verify session created to target with address, then cancel the session @ce
       .click();
   } finally {
     if (orgId) {
-      await deleteScopeCli(orgId);
+      await boundaryCli.deleteScopeCli(orgId);
     }
     // End `boundary connect` process
     if (connect) {
@@ -217,15 +221,15 @@ test('Verify TCP target is updated @ce @aws @docker', async ({
     const basePage = new BasePage(page);
     await basePage.dismissSuccessAlert();
   } finally {
-    await authenticateBoundaryCli(
+    await boundaryCli.authenticateBoundaryCli(
       baseURL,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
     );
-    const orgId = await getOrgIdFromNameCli(orgName);
+    const orgId = await boundaryCli.getOrgIdFromNameCli(orgName);
     if (orgId) {
-      await deleteScopeCli(orgId);
+      await boundaryCli.deleteScopeCli(orgId);
     }
   }
 });

--- a/e2e-tests/helpers/boundary-cli/accounts.js
+++ b/e2e-tests/helpers/boundary-cli/accounts.js
@@ -10,7 +10,7 @@ import { execSync } from 'node:child_process';
  * @param {string} authMethodId ID of the auth-method that the new account will be created for.
  * @returns {Promise<string>} new account's ID
  */
-export async function createPasswordAccountCli(authMethodId) {
+export async function createPasswordAccount(authMethodId) {
   let passwordAccount;
   const login = 'test-login';
   try {

--- a/e2e-tests/helpers/boundary-cli/aliases.js
+++ b/e2e-tests/helpers/boundary-cli/aliases.js
@@ -9,7 +9,7 @@ import { execSync } from 'node:child_process';
  * Deletes the specified alias
  * @param {string} aliasValue Value of the alias to be deleted
  */
-export async function deleteAliasCli(aliasValue) {
+export async function deleteAlias(aliasValue) {
   try {
     const aliases = JSON.parse(execSync('boundary aliases list -format json'));
     const alias = aliases.items.filter((obj) => obj.value == aliasValue)[0];

--- a/e2e-tests/helpers/boundary-cli/auth-methods.js
+++ b/e2e-tests/helpers/boundary-cli/auth-methods.js
@@ -11,7 +11,7 @@ import { nanoid } from 'nanoid';
  * @param {string} scopeId ID of the scope under which the auth-method will be created.
  * @returns {Promise<string>} new auth-method's ID
  */
-export async function createPasswordAuthMethodCli(scopeId) {
+export async function createPasswordAuthMethod(scopeId) {
   const authMethodName = 'auth-method-' + nanoid();
   let newAuthMethod;
   try {

--- a/e2e-tests/helpers/boundary-cli/authenticate.js
+++ b/e2e-tests/helpers/boundary-cli/authenticate.js
@@ -12,7 +12,7 @@ import { execSync } from 'node:child_process';
  * @param {string} loginName Login name to be used for authentication
  * @param {string} password Password to be used for authentication
  */
-export async function authenticateBoundaryCli(
+export async function authenticateBoundary(
   addr,
   authMethodId,
   loginName,

--- a/e2e-tests/helpers/boundary-cli/credential-stores.js
+++ b/e2e-tests/helpers/boundary-cli/credential-stores.js
@@ -11,7 +11,7 @@ import { nanoid } from 'nanoid';
  * @param {string} projectId ID of the project under which the credential store will be created.
  * @returns {Promise<string>} new credential store's ID
  */
-export async function createStaticCredentialStoreCli(projectId) {
+export async function createStaticCredentialStore(projectId) {
   const credentialStoreName = 'static-credential-store-' + nanoid();
   let staticCredentialStore;
   try {
@@ -36,7 +36,7 @@ export async function createStaticCredentialStoreCli(projectId) {
  * @param {string} vaultToken Token for Boundary to authenticate with Vault
  * @returns {Promise<string>} new credential store's ID
  */
-export async function createVaultCredentialStoreCli(
+export async function createVaultCredentialStore(
   projectId,
   vaultAddr,
   vaultToken,

--- a/e2e-tests/helpers/boundary-cli/credentials.js
+++ b/e2e-tests/helpers/boundary-cli/credentials.js
@@ -10,7 +10,7 @@ import { execSync } from 'node:child_process';
  * @param {string} credentialStoreId ID of the credential store that the credential will be created for.
  * @returns {Promise<string>} new credential's ID
  */
-export async function createUsernamePasswordCredentialCli(credentialStoreId) {
+export async function createUsernamePasswordCredential(credentialStoreId) {
   let usernamePasswordCredential;
   const login = 'test-login';
   try {

--- a/e2e-tests/helpers/boundary-cli/groups.js
+++ b/e2e-tests/helpers/boundary-cli/groups.js
@@ -11,7 +11,7 @@ import { nanoid } from 'nanoid';
  * @param {string} scopeId ID of the scope under which the group will be created.
  * @returns {Promise<string>} new group's ID
  */
-export async function createGroupCli(scopeId) {
+export async function createGroup(scopeId) {
   const groupName = 'group-' + nanoid();
   let group;
   try {

--- a/e2e-tests/helpers/boundary-cli/host-catalogs.js
+++ b/e2e-tests/helpers/boundary-cli/host-catalogs.js
@@ -11,7 +11,7 @@ import { nanoid } from 'nanoid';
  * @param {string} projectId ID of the project under which the host catalog will be created.
  * @returns {Promise<string>} new host catalog's ID
  */
-export async function createStaticHostCatalogCli(projectId) {
+export async function createStaticHostCatalog(projectId) {
   const hostCatalogName = 'static-host-catalog-' + nanoid();
   let hostCatalog;
   try {
@@ -35,7 +35,7 @@ export async function createStaticHostCatalogCli(projectId) {
  * @param {string} region Name of the AWS region that the host catalog will be created for.
  * @returns {Promise<string>} new host catalog's ID
  */
-export async function createDynamicAwsHostCatalogCli(projectId, region) {
+export async function createDynamicAwsHostCatalog(projectId, region) {
   const hostCatalogName = 'dynamic-aws-host-catalog-' + nanoid();
   let hostCatalog;
   try {

--- a/e2e-tests/helpers/boundary-cli/host-sets.js
+++ b/e2e-tests/helpers/boundary-cli/host-sets.js
@@ -11,7 +11,7 @@ import { nanoid } from 'nanoid';
  * @param {string} hostCatalogId ID of the host catalog that the host set will be created for.
  * @returns {Promise<string>} new host set's ID
  */
-export async function createHostSetCli(hostCatalogId) {
+export async function createHostSet(hostCatalogId) {
   const hostSetName = 'static-host-' + nanoid();
   let hostSet;
   try {

--- a/e2e-tests/helpers/boundary-cli/hosts.js
+++ b/e2e-tests/helpers/boundary-cli/hosts.js
@@ -11,7 +11,7 @@ import { nanoid } from 'nanoid';
  * @param {string} hostCatalogId ID of the host catalog that the host will be created for.
  * @returns {Promise<string>} new host's ID
  */
-export async function createStaticHostCli(hostCatalogId) {
+export async function createStaticHost(hostCatalogId) {
   const hostName = 'static-host-' + nanoid();
   let host;
   try {

--- a/e2e-tests/helpers/boundary-cli/policies.js
+++ b/e2e-tests/helpers/boundary-cli/policies.js
@@ -9,7 +9,7 @@ import { execSync } from 'node:child_process';
  * Deletes the specified policy
  * @param {string} policyId ID of the policy to be deleted
  */
-export async function deletePolicyCli(policyId) {
+export async function deletePolicy(policyId) {
   try {
     execSync('boundary policies delete -id=' + policyId);
   } catch (e) {
@@ -23,7 +23,7 @@ export async function deletePolicyCli(policyId) {
  * @param {string} policyName Name of the policy
  * @returns {Promise<string>} ID of the policy
  */
-export async function getPolicyIdFromNameCli(scopeId, policyName) {
+export async function getPolicyIdFromName(scopeId, policyName) {
   const policies = JSON.parse(
     execSync(`boundary policies list -scope-id ${scopeId} -format json`),
   );

--- a/e2e-tests/helpers/boundary-cli/roles.js
+++ b/e2e-tests/helpers/boundary-cli/roles.js
@@ -11,7 +11,7 @@ import { nanoid } from 'nanoid';
  * @param {string} scopeId ID of the scope under which the role will be created.
  * @returns {Promise<string>} new role's ID
  */
-export async function createRoleCli(scopeId) {
+export async function createRole(scopeId) {
   const roleName = 'role-' + nanoid();
   let role;
   try {

--- a/e2e-tests/helpers/boundary-cli/scopes.js
+++ b/e2e-tests/helpers/boundary-cli/scopes.js
@@ -10,7 +10,7 @@ import { nanoid } from 'nanoid';
  * Creates an org
  * @returns {Promise<string>} new org's id
  */
-export async function createOrgCli() {
+export async function createOrg() {
   const orgName = 'Org ' + nanoid();
   let newOrg;
   try {
@@ -33,7 +33,7 @@ export async function createOrgCli() {
  * @param {string} orgId ID of the organization under which the project will be created.
  * @returns {Promise<string>} new project's ID
  */
-export async function createProjectCli(orgId) {
+export async function createProject(orgId) {
   const projectName = 'Project ' + nanoid();
   let newProject;
   try {
@@ -55,7 +55,7 @@ export async function createProjectCli(orgId) {
  * Deletes the specified scope
  * @param {string} scopeId ID of the scope to be deleted
  */
-export async function deleteScopeCli(scopeId) {
+export async function deleteScope(scopeId) {
   try {
     execSync('boundary scopes delete -id=' + scopeId);
   } catch (e) {
@@ -68,7 +68,7 @@ export async function deleteScopeCli(scopeId) {
  * @param {string} orgName Name of the org
  * @returns {Promise<string>} ID of the org
  */
-export async function getOrgIdFromNameCli(orgName) {
+export async function getOrgIdFromName(orgName) {
   const orgs = JSON.parse(execSync('boundary scopes list -format json'));
   const org = orgs.items.filter((obj) => obj.name == orgName)[0];
   if (org) {
@@ -83,7 +83,7 @@ export async function getOrgIdFromNameCli(orgName) {
  * @param {string} projectName Name of the project
  * @returns {Promise<string>} ID of the project
  */
-export async function getProjectIdFromNameCli(orgId, projectName) {
+export async function getProjectIdFromName(orgId, projectName) {
   const projects = JSON.parse(
     execSync(`boundary scopes list -scope-id ${orgId} -format json`),
   );
@@ -99,7 +99,7 @@ export async function getProjectIdFromNameCli(orgId, projectName) {
  * @param {string} scopeId ID of the scope that the auth-method belongs to
  * @param {string} authMethodId ID of the auth method that will be made primary
  */
-export async function makeAuthMethodPrimaryCli(scopeId, authMethodId) {
+export async function makeAuthMethodPrimary(scopeId, authMethodId) {
   try {
     execSync(
       `boundary scopes update \

--- a/e2e-tests/helpers/boundary-cli/session-recordings.js
+++ b/e2e-tests/helpers/boundary-cli/session-recordings.js
@@ -10,7 +10,7 @@ import { execSync } from 'node:child_process';
  * @param {string} storageBucketId ID of storage bucket that the session recording is associated with
  * @returns An object representing a session recording
  */
-export async function waitForSessionRecordingCli(storageBucketId) {
+export async function waitForSessionRecording(storageBucketId) {
   let i = 0;
   let filteredSessionRecording = [];
   do {

--- a/e2e-tests/helpers/boundary-cli/storage-buckets.js
+++ b/e2e-tests/helpers/boundary-cli/storage-buckets.js
@@ -9,7 +9,7 @@ import { execSync } from 'node:child_process';
  * Deletes the specified storage bucket
  * @param {string} storageBucketId ID of the storage bucket to be deleted
  */
-export async function deleteStorageBucketCli(storageBucketId) {
+export async function deleteStorageBucket(storageBucketId) {
   try {
     execSync('boundary storage-buckets delete -id=' + storageBucketId);
   } catch (e) {

--- a/e2e-tests/helpers/boundary-cli/targets.js
+++ b/e2e-tests/helpers/boundary-cli/targets.js
@@ -36,7 +36,7 @@ export async function createTcpTarget(projectId) {
  * @param {string} projectId ID of the project under which the target will be created.
  * @returns {Promise<string>} new target's ID
  */
-export async function createSshTargetCli(projectId) {
+export async function createSshTarget(projectId) {
   const targetName = 'target-' + nanoid();
   const defaultPort = 22;
   let target;
@@ -61,7 +61,7 @@ export async function createSshTargetCli(projectId) {
  * @param {string} alias alias of the target to be connected to
  * @returns Session information
  */
-export async function authorizeSessionByAliasCli(alias) {
+export async function authorizeSessionByAlias(alias) {
   let session;
   try {
     session = JSON.parse(
@@ -78,7 +78,7 @@ export async function authorizeSessionByAliasCli(alias) {
  * @param {string} targetId Id of the target to be connected to
  * @returns Session information
  */
-export async function authorizeSessionByTargetIdCli(targetId) {
+export async function authorizeSessionByTargetId(targetId) {
   let session;
   try {
     session = JSON.parse(
@@ -98,7 +98,7 @@ export async function authorizeSessionByTargetIdCli(targetId) {
  * @param {string} targetName Name of the target
  * @returns {Promise<string>} ID of the target
  */
-export async function getTargetIdFromNameCli(projectId, targetName) {
+export async function getTargetIdFromName(projectId, targetName) {
   const targets = JSON.parse(
     execSync(`boundary targets list -scope-id ${projectId} -format json`),
   );

--- a/e2e-tests/helpers/boundary-cli/users.js
+++ b/e2e-tests/helpers/boundary-cli/users.js
@@ -11,7 +11,7 @@ import { nanoid } from 'nanoid';
  * @param {string} scopeId ID of the scope under which the user will be created.
  * @returns {Promise<string>} new user's ID
  */
-export async function createUserCli(scopeId) {
+export async function createUser(scopeId) {
   const userName = 'user-' + nanoid();
   let user;
   try {

--- a/e2e-tests/helpers/boundary-cli/workers.js
+++ b/e2e-tests/helpers/boundary-cli/workers.js
@@ -10,7 +10,7 @@ import { nanoid } from 'nanoid';
  * Creates a new controller-led worker
  * @returns {Promise<string>} new worker's ID
  */
-export async function createControllerLedWorkerCli() {
+export async function createControllerLedWorker() {
   const workerName = 'worker-' + nanoid();
   let newWorker;
   try {


### PR DESCRIPTION
# Description
This PR does some refactoring of imports for boundary cli helper methods in Admin UI e2e tests
- Update import statements to use `import * as boundaryCli from '../../helpers/boundary-cli';` and method calls to `boundaryCli.<method_name>`
- Renamed boundaryCli methods to remove the `Cli` 

## How to Test
Run e2e tests

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

https://hashicorp.atlassian.net/browse/ICU-15848