### PR TITLE
refactor: 💡 rename arialabel to aria-labelledby for key/value

### DIFF
--- a/ui/admin/app/components/form/field/list-wrapper/key-value/index.hbs
+++ b/ui/admin/app/components/form/field/list-wrapper/key-value/index.hbs
@@ -35,14 +35,14 @@
                   'form/field/list-wrapper/key-value/text'
                   disabled=@disabled
                   value=option.key
-                  aria-labelledby=keyHeaderID
+                  ariaLabelledBy=keyHeaderID
                   setContext=(set-from-event option 'key')
                 )
                 select=(component
                   'form/field/list-wrapper/key-value/select'
                   disabled=@disabled
                   value=option.key
-                  aria-labelledby=keyHeaderID
+                  ariaLabelledBy=keyHeaderID
                   setContext=(set-from-event option 'key')
                   width=@width
                 )
@@ -58,14 +58,14 @@
                   'form/field/list-wrapper/key-value/text'
                   disabled=@disabled
                   value=option.value
-                  aria-labelledby=valueHeaderID
+                  ariaLabelledBy=valueHeaderID
                   setContext=(set-from-event option 'value')
                 )
                 select=(component
                   'form/field/list-wrapper/key-value/select'
                   disabled=@disabled
                   value=option.value
-                  aria-labelledby=valueHeaderID
+                  ariaLabelledBy=valueHeaderID
                   width=@width
                   setContext=(set-from-event option 'value')
                 )
@@ -99,14 +99,14 @@
                     'form/field/list-wrapper/key-value/text'
                     disabled=@disabled
                     value=this.newOptionKey
-                    aria-labelledby=keyHeaderID
+                    ariaLabelledBy=keyHeaderID
                     setContext=(set-from-event this 'newOptionKey')
                   )
                   select=(component
                     'form/field/list-wrapper/key-value/select'
                     disabled=@disabled
                     value=this.newOptionKey
-                    aria-labelledby=keyHeaderID
+                    ariaLabelledBy=keyHeaderID
                     width=@width
                     setContext=(set-from-event this 'newOptionKey')
                   )
@@ -121,14 +121,14 @@
                     'form/field/list-wrapper/key-value/text'
                     disabled=@disabled
                     value=this.newOptionKey
-                    aria-labelledby=keyHeaderID
+                    ariaLabelledBy=keyHeaderID
                     setContext=(set-from-event this 'newOptionKey')
                   )
                   select=(component
                     'form/field/list-wrapper/key-value/select'
                     disabled=@disabled
                     value=this.newOptionKey
-                    aria-labelledby=keyHeaderID
+                    ariaLabelledBy=keyHeaderID
                     width=@width
                     setContext=(set-from-event this 'newOptionKey')
                   )
@@ -146,14 +146,14 @@
                     'form/field/list-wrapper/key-value/text'
                     disabled=@disabled
                     value=this.newOptionValue
-                    aria-labelledby=valueHeaderID
+                    ariaLabelledBy=valueHeaderID
                     setContext=(set-from-event this 'newOptionValue')
                   )
                   select=(component
                     'form/field/list-wrapper/key-value/select'
                     disabled=@disabled
                     value=this.newOptionValue
-                    aria-labelledby=valueHeaderID
+                    ariaLabelledBy=valueHeaderID
                     width=@width
                     setContext=(set-from-event this 'newOptionValue')
                   )
@@ -168,14 +168,14 @@
                     'form/field/list-wrapper/key-value/text'
                     disabled=@disabled
                     value=this.newOptionValue
-                    aria-labelledby=valueHeaderID
+                    ariaLabelledBy=valueHeaderID
                     setContext=(set-from-event this 'newOptionValue')
                   )
                   select=(component
                     'form/field/list-wrapper/key-value/select'
                     disabled=@disabled
                     value=this.newOptionValue
-                    aria-labelledby=valueHeaderID
+                    ariaLabelledBy=valueHeaderID
                     width=@width
                     setContext=(set-from-event this 'newOptionValue')
                   )

--- a/ui/admin/app/components/form/field/list-wrapper/key-value/index.hbs
+++ b/ui/admin/app/components/form/field/list-wrapper/key-value/index.hbs
@@ -35,14 +35,14 @@
                   'form/field/list-wrapper/key-value/text'
                   disabled=@disabled
                   value=option.key
-                  ariaLabel=keyHeaderID
+                  aria-labelledby=keyHeaderID
                   setContext=(set-from-event option 'key')
                 )
                 select=(component
                   'form/field/list-wrapper/key-value/select'
                   disabled=@disabled
                   value=option.key
-                  ariaLabel=keyHeaderID
+                  aria-labelledby=keyHeaderID
                   setContext=(set-from-event option 'key')
                   width=@width
                 )
@@ -58,14 +58,14 @@
                   'form/field/list-wrapper/key-value/text'
                   disabled=@disabled
                   value=option.value
-                  ariaLabel=valueHeaderID
+                  aria-labelledby=valueHeaderID
                   setContext=(set-from-event option 'value')
                 )
                 select=(component
                   'form/field/list-wrapper/key-value/select'
                   disabled=@disabled
                   value=option.value
-                  ariaLabel=valueHeaderID
+                  aria-labelledby=valueHeaderID
                   width=@width
                   setContext=(set-from-event option 'value')
                 )
@@ -99,14 +99,14 @@
                     'form/field/list-wrapper/key-value/text'
                     disabled=@disabled
                     value=this.newOptionKey
-                    ariaLabel=keyHeaderID
+                    aria-labelledby=keyHeaderID
                     setContext=(set-from-event this 'newOptionKey')
                   )
                   select=(component
                     'form/field/list-wrapper/key-value/select'
                     disabled=@disabled
                     value=this.newOptionKey
-                    ariaLabel=keyHeaderID
+                    aria-labelledby=keyHeaderID
                     width=@width
                     setContext=(set-from-event this 'newOptionKey')
                   )
@@ -121,14 +121,14 @@
                     'form/field/list-wrapper/key-value/text'
                     disabled=@disabled
                     value=this.newOptionKey
-                    ariaLabel=keyHeaderID
+                    aria-labelledby=keyHeaderID
                     setContext=(set-from-event this 'newOptionKey')
                   )
                   select=(component
                     'form/field/list-wrapper/key-value/select'
                     disabled=@disabled
                     value=this.newOptionKey
-                    ariaLabel=keyHeaderID
+                    aria-labelledby=keyHeaderID
                     width=@width
                     setContext=(set-from-event this 'newOptionKey')
                   )
@@ -146,14 +146,14 @@
                     'form/field/list-wrapper/key-value/text'
                     disabled=@disabled
                     value=this.newOptionValue
-                    ariaLabel=valueHeaderID
+                    aria-labelledby=valueHeaderID
                     setContext=(set-from-event this 'newOptionValue')
                   )
                   select=(component
                     'form/field/list-wrapper/key-value/select'
                     disabled=@disabled
                     value=this.newOptionValue
-                    ariaLabel=valueHeaderID
+                    aria-labelledby=valueHeaderID
                     width=@width
                     setContext=(set-from-event this 'newOptionValue')
                   )
@@ -168,14 +168,14 @@
                     'form/field/list-wrapper/key-value/text'
                     disabled=@disabled
                     value=this.newOptionValue
-                    ariaLabel=valueHeaderID
+                    aria-labelledby=valueHeaderID
                     setContext=(set-from-event this 'newOptionValue')
                   )
                   select=(component
                     'form/field/list-wrapper/key-value/select'
                     disabled=@disabled
                     value=this.newOptionValue
-                    ariaLabel=valueHeaderID
+                    aria-labelledby=valueHeaderID
                     width=@width
                     setContext=(set-from-event this 'newOptionValue')
                   )

--- a/ui/admin/app/components/form/field/list-wrapper/key-value/select.hbs
+++ b/ui/admin/app/components/form/field/list-wrapper/key-value/select.hbs
@@ -7,7 +7,7 @@
   @value={{@value}}
   @width={{@width}}
   disabled={{@disabled}}
-  aria-labelledby={{@ariaLabel}}
+  aria-labelledby={{@aria-labelledby}}
   {{on 'change' @setContext}}
   as |F|
 >

--- a/ui/admin/app/components/form/field/list-wrapper/key-value/select.hbs
+++ b/ui/admin/app/components/form/field/list-wrapper/key-value/select.hbs
@@ -7,7 +7,7 @@
   @value={{@value}}
   @width={{@width}}
   disabled={{@disabled}}
-  aria-labelledby={{@aria-labelledby}}
+  aria-labelledby={{@ariaLabelledBy}}
   {{on 'change' @setContext}}
   as |F|
 >

--- a/ui/admin/app/components/form/field/list-wrapper/key-value/text.hbs
+++ b/ui/admin/app/components/form/field/list-wrapper/key-value/text.hbs
@@ -6,6 +6,6 @@
 <Hds::Form::TextInput::Field
   @value={{@value}}
   disabled={{@disabled}}
-  aria-labelledby={{@aria-labelledby}}
+  aria-labelledby={{@ariaLabelledBy}}
   {{on 'input' @setContext}}
 />

--- a/ui/admin/app/components/form/field/list-wrapper/key-value/text.hbs
+++ b/ui/admin/app/components/form/field/list-wrapper/key-value/text.hbs
@@ -6,6 +6,6 @@
 <Hds::Form::TextInput::Field
   @value={{@value}}
   disabled={{@disabled}}
-  aria-labelledby={{@ariaLabel}}
+  aria-labelledby={{@aria-labelledby}}
   {{on 'input' @setContext}}
 />


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-15701

# Description
<!-- Add a brief description of changes here -->
I noticed this slight naming issue while investigating one of our a11y audit issues. The main issue of no `aria-label` has already been taking care of but the naming of the attributes was a little off. I updated it to say `aria-labelledby` to reduce confusion on what is actually be used when rendering new inputs for the key/value component.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
