### PR TITLE
test(e2e): Add additional assertions to UI tests

### DIFF
--- a/e2e-tests/admin/pages/host-catalogs.js
+++ b/e2e-tests/admin/pages/host-catalogs.js
@@ -37,7 +37,7 @@ export class HostCatalogsPage extends BaseResourcePage {
     await this.page.getByLabel('Name').fill(hostCatalogName);
     await this.page.getByLabel('Description').fill('This is an automated test');
     await this.page
-      .getByRole('group', { name: 'Type' })
+      .getByRole('group', { name: 'Type', exact: 'true' })
       .getByLabel('Static')
       .click();
     await this.page.getByRole('button', { name: 'Save' }).click();

--- a/e2e-tests/admin/pages/sessions.js
+++ b/e2e-tests/admin/pages/sessions.js
@@ -17,15 +17,16 @@ export class SessionsPage extends BasePage {
       .getByRole('navigation', { name: 'Resources' })
       .getByRole('link', { name: 'Sessions' })
       .click();
-    await expect(
-      this.page
-        .getByRole('navigation', { name: 'breadcrumbs' })
-        .getByText('Sessions'),
-    ).toBeVisible();
     let i = 0;
     let sessionIsVisible = false;
     let sessionIsActive = false;
     do {
+      await expect(
+        this.page
+          .getByRole('navigation', { name: 'breadcrumbs' })
+          .getByText('Sessions'),
+      ).toBeVisible();
+
       i = i + 1;
       sessionIsVisible = await this.page
         .getByRole('cell', { name: targetName })

--- a/e2e-tests/admin/playwright.config.js
+++ b/e2e-tests/admin/playwright.config.js
@@ -4,6 +4,7 @@
  */
 
 import { defineConfig, devices } from '@playwright/test';
+import { authenticatedState } from '../global-setup';
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export default defineConfig({
@@ -13,12 +14,13 @@ export default defineConfig({
   workers: 1, // Tests need to be run in serial, otherwise there may be conflicts when using the CLI
   use: {
     baseURL: process.env.BOUNDARY_ADDR,
-    trace: 'retain-on-failure',
-    screenshot: 'only-on-failure',
     extraHTTPHeaders: {
       // This token is set in global-setup.js
       Authorization: `Bearer ${process.env.E2E_TOKEN}`,
     },
+    screenshot: 'only-on-failure',
+    storageState: authenticatedState,
+    trace: 'retain-on-failure',
   },
   projects: [
     {

--- a/e2e-tests/admin/tests/alias-ent.spec.js
+++ b/e2e-tests/admin/tests/alias-ent.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { customAlphabet } from 'nanoid';
 
@@ -14,8 +14,6 @@ import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
 import { SessionsPage } from '../pages/sessions.js';
 import { TargetsPage } from '../pages/targets.js';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();

--- a/e2e-tests/admin/tests/alias.spec.js
+++ b/e2e-tests/admin/tests/alias.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { customAlphabet } from 'nanoid';
 
@@ -13,8 +13,6 @@ import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
 import { SessionsPage } from '../pages/sessions.js';
 import { TargetsPage } from '../pages/targets.js';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();

--- a/e2e-tests/admin/tests/alias.spec.js
+++ b/e2e-tests/admin/tests/alias.spec.js
@@ -11,6 +11,7 @@ import * as boundaryCli from '../../helpers/boundary-cli';
 import { AliasesPage } from '../pages/aliases.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
+import { SessionsPage } from '../pages/sessions.js';
 import { TargetsPage } from '../pages/targets.js';
 
 test.use({ storageState: authenticatedState });
@@ -28,10 +29,13 @@ test.describe('Aliases', async () => {
     adminPassword,
     targetAddress,
     targetPort,
+    sshUser,
+    sshKeyPath,
   }) => {
     await page.goto('/');
     let orgName;
     let alias;
+    let connect;
     const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
     try {
       const orgsPage = new OrgsPage(page);
@@ -39,7 +43,10 @@ test.describe('Aliases', async () => {
       const projectsPage = new ProjectsPage(page);
       await projectsPage.createProject();
       const targetsPage = new TargetsPage(page);
-      await targetsPage.createTargetWithAddress(targetAddress, targetPort);
+      const targetName = await targetsPage.createTargetWithAddress(
+        targetAddress,
+        targetPort,
+      );
 
       // Create alias for target
       const aliasName = 'Alias ' + nanoid();
@@ -61,9 +68,16 @@ test.describe('Aliases', async () => {
         adminLoginName,
         adminPassword,
       );
-      await boundaryCli.authorizeSessionByAlias(alias);
+      connect = await boundaryCli.connectToAlias(alias, sshUser, sshKeyPath);
+      const sessionsPage = new SessionsPage(page);
+      await sessionsPage.waitForSessionToBeVisible(targetName);
 
       // Clear destination from alias
+      await page
+        .getByRole('navigation', { name: 'Resources' })
+        .getByRole('link', { name: 'Targets' })
+        .click();
+      await page.getByRole('link', { name: targetName }).click();
       await page.getByRole('link', { name: alias }).click();
       // Note: On the Target details page, there is a section with the header
       // "Aliases". The extra check here is to ensure that we are on the Alias
@@ -79,6 +93,9 @@ test.describe('Aliases', async () => {
       ).toBeVisible();
       await page.getByRole('button', { name: 'Dismiss' }).click();
     } finally {
+      if (connect) {
+        connect.kill('SIGTERM');
+      }
       await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
@@ -105,10 +122,13 @@ test.describe('Aliases', async () => {
     adminPassword,
     targetAddress,
     targetPort,
+    sshUser,
+    sshKeyPath,
   }) => {
     await page.goto('/');
     let orgName;
     let alias;
+    let connect;
     const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
     try {
       const orgsPage = new OrgsPage(page);
@@ -123,15 +143,20 @@ test.describe('Aliases', async () => {
       await projectsPage.createProject();
       alias = 'example.alias.' + nanoid();
       const targetsPage = new TargetsPage(page);
-      await targetsPage.createTargetWithAddressAndAlias(
+      const targetName = await targetsPage.createTargetWithAddressAndAlias(
         targetAddress,
         targetPort,
         alias,
       );
 
       // Connect to target using alias
-      await boundaryCli.authorizeSessionByAlias(alias);
+      connect = await boundaryCli.connectToAlias(alias, sshUser, sshKeyPath);
+      const sessionsPage = new SessionsPage(page);
+      await sessionsPage.waitForSessionToBeVisible(targetName);
     } finally {
+      if (connect) {
+        connect.kill('SIGTERM');
+      }
       await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,
@@ -158,11 +183,14 @@ test.describe('Aliases', async () => {
     adminPassword,
     targetAddress,
     targetPort,
+    sshUser,
+    sshKeyPath,
   }) => {
     await page.goto('/');
     const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
     let orgId;
     let alias;
+    let connect;
     try {
       const orgsPage = new OrgsPage(page);
       const orgName = await orgsPage.createOrg();
@@ -194,8 +222,18 @@ test.describe('Aliases', async () => {
       alias = 'example.alias.' + nanoid();
       const aliasesPage = new AliasesPage(page);
       await aliasesPage.createAliasForTarget(alias, targetId);
-      await boundaryCli.authorizeSessionByAlias(alias);
+      await page.getByRole('link', { name: 'Orgs', exact: true }).click();
+      await expect(page.getByRole('heading', { name: 'Orgs' })).toBeVisible();
+      await page.getByRole('link', { name: orgName }).click();
+      await page.getByRole('link', { name: projectName }).click();
+
+      connect = await boundaryCli.connectToAlias(alias, sshUser, sshKeyPath);
+      const sessionsPage = new SessionsPage(page);
+      await sessionsPage.waitForSessionToBeVisible(targetName);
     } finally {
+      if (connect) {
+        connect.kill('SIGTERM');
+      }
       await boundaryCli.authenticateBoundary(
         baseURL,
         adminAuthMethodId,

--- a/e2e-tests/admin/tests/auth-method-ldap.spec.js
+++ b/e2e-tests/admin/tests/auth-method-ldap.spec.js
@@ -14,6 +14,9 @@ import { OrgsPage } from '../pages/orgs.js';
 import { RolesPage } from '../pages/roles.js';
 import { UsersPage } from '../pages/users.js';
 
+// Reset storage state for this file to avoid being authenticated
+test.use({ storageState: { cookies: [], origins: [] } });
+
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();
 });

--- a/e2e-tests/admin/tests/auth-method-password.spec.js
+++ b/e2e-tests/admin/tests/auth-method-password.spec.js
@@ -13,6 +13,9 @@ import { LoginPage } from '../pages/login.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { UsersPage } from '../pages/users.js';
 
+// Reset storage state for this file to avoid being authenticated
+test.use({ storageState: { cookies: [], origins: [] } });
+
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();
 });

--- a/e2e-tests/admin/tests/credential-store-static-ent.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static-ent.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { readFile } from 'fs/promises';
 
@@ -13,8 +13,6 @@ import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
 import { SessionsPage } from '../pages/sessions.js';
 import { TargetsPage } from '../pages/targets.js';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();

--- a/e2e-tests/admin/tests/credential-store-static-ent.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static-ent.spec.js
@@ -5,11 +5,13 @@
 
 import { test, authenticatedState } from '../../global-setup.js';
 import { expect } from '@playwright/test';
+import { readFile } from 'fs/promises';
 
 import * as boundaryCli from '../../helpers/boundary-cli';
 import { CredentialStoresPage } from '../pages/credential-stores.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
+import { SessionsPage } from '../pages/sessions.js';
 import { TargetsPage } from '../pages/targets.js';
 
 test.use({ storageState: authenticatedState });
@@ -36,7 +38,7 @@ test('Multiple Credential Stores (ENT) @ent @aws @docker', async ({
     const orgsPage = new OrgsPage(page);
     orgName = await orgsPage.createOrg();
     const projectsPage = new ProjectsPage(page);
-    await projectsPage.createProject();
+    const projectName = await projectsPage.createProject();
     const targetsPage = new TargetsPage(page);
     const targetName = await targetsPage.createSshTargetWithAddressEnt(
       targetAddress,
@@ -100,6 +102,36 @@ test('Multiple Credential Stores (ENT) @ent @aws @docker', async ({
       page.getByRole('alert').getByText('Success', { exact: true }),
     ).toBeVisible();
     await page.getByRole('button', { name: 'Dismiss' }).click();
+
+    // Verify credentials
+    await boundaryCli.authenticateBoundary(
+      baseURL,
+      adminAuthMethodId,
+      adminLoginName,
+      adminPassword,
+    );
+    const orgId = await boundaryCli.getOrgIdFromName(orgName);
+    const projectId = await boundaryCli.getProjectIdFromName(
+      orgId,
+      projectName,
+    );
+    const targetId = await boundaryCli.getTargetIdFromName(
+      projectId,
+      targetName,
+    );
+    const session = await boundaryCli.authorizeSessionByTargetId(targetId);
+    const retrievedUser = session.item.credentials[0].credential.username;
+    const retrievedKey = session.item.credentials[0].credential.private_key;
+
+    expect(retrievedUser).toBe(sshUser);
+
+    const keyData = await readFile(sshKeyPath, {
+      encoding: 'utf-8',
+    });
+    expect(retrievedKey).toBe(keyData);
+
+    const sessionsPage = new SessionsPage(page);
+    await sessionsPage.waitForSessionToBeVisible(targetName);
   } finally {
     if (orgName) {
       await boundaryCli.authenticateBoundary(

--- a/e2e-tests/admin/tests/credential-store-static.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static.spec.js
@@ -12,6 +12,7 @@ import * as boundaryCli from '../../helpers/boundary-cli';
 import { CredentialStoresPage } from '../pages/credential-stores.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
+import { SessionsPage } from '../pages/sessions.js';
 import { TargetsPage } from '../pages/targets.js';
 
 test.use({ storageState: authenticatedState });
@@ -86,9 +87,10 @@ test('Static Credential Store (User & Key Pair) @ce @aws @docker', async ({
     const keyData = await readFile(sshKeyPath, {
       encoding: 'utf-8',
     });
-    if (keyData != retrievedKey) {
-      throw new Error('Stored Key does not match');
-    }
+    expect(retrievedKey).toBe(keyData);
+
+    const sessionsPage = new SessionsPage(page);
+    await sessionsPage.waitForSessionToBeVisible(targetName);
   } finally {
     if (orgName) {
       await boundaryCli.authenticateBoundary(
@@ -148,6 +150,9 @@ test('Static Credential Store (Username & Password) @ce @aws @docker', async ({
 
     expect(retrievedUser).toBe(sshUser);
     expect(retrievedPassword).toBe(testPassword);
+
+    const sessionsPage = new SessionsPage(page);
+    await sessionsPage.waitForSessionToBeVisible(targetName);
   } finally {
     if (orgName) {
       await boundaryCli.authenticateBoundary(
@@ -227,6 +232,9 @@ test('Static Credential Store (JSON) @ce @aws @docker', async ({
     expect(retrievedUser).toBe(testName);
     expect(retrievedPassword).toBe(testPassword);
     expect(retrievedId).toBe(testId);
+
+    const sessionsPage = new SessionsPage(page);
+    await sessionsPage.waitForSessionToBeVisible(targetName);
   } finally {
     if (orgName) {
       await boundaryCli.authenticateBoundary(

--- a/e2e-tests/admin/tests/credential-store-static.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { readFile } from 'fs/promises';
 import { nanoid } from 'nanoid';
@@ -14,8 +14,6 @@ import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
 import { SessionsPage } from '../pages/sessions.js';
 import { TargetsPage } from '../pages/targets.js';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();

--- a/e2e-tests/admin/tests/credential-store-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/credential-store-vault-ent.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { execSync } from 'child_process';
 
 import * as boundaryCli from '../../helpers/boundary-cli';
@@ -18,8 +18,6 @@ const secretsPath = 'e2e_secrets';
 const secretName = 'cred';
 const secretPolicyName = 'kv-policy';
 const boundaryPolicyName = 'boundary-controller';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();

--- a/e2e-tests/admin/tests/credential-store-vault.spec.js
+++ b/e2e-tests/admin/tests/credential-store-vault.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { execSync } from 'child_process';
 import { nanoid } from 'nanoid';
@@ -21,8 +21,6 @@ const secretsPath = 'e2e_secrets';
 const secretName = 'cred';
 const secretPolicyName = 'kv-policy';
 const boundaryPolicyName = 'boundary-controller';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();

--- a/e2e-tests/admin/tests/credential-store-vault.spec.js
+++ b/e2e-tests/admin/tests/credential-store-vault.spec.js
@@ -14,6 +14,7 @@ import * as vaultCli from '../../helpers/vault-cli';
 import { CredentialStoresPage } from '../pages/credential-stores.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
+import { SessionsPage } from '../pages/sessions.js';
 import { TargetsPage } from '../pages/targets.js';
 
 const secretsPath = 'e2e_secrets';
@@ -114,6 +115,7 @@ test('Vault Credential Store (User & Key Pair) @ce @aws @docker', async ({
       credentialLibraryName,
     );
 
+    // Verify correct credentials are returned after authorizing session
     await boundaryCli.authenticateBoundary(
       baseURL,
       adminAuthMethodId,
@@ -136,13 +138,13 @@ test('Vault Credential Store (User & Key Pair) @ce @aws @docker', async ({
       session.item.credentials[0].secret.decoded.data.private_key;
 
     expect(retrievedUser).toBe(sshUser);
-
     const keyData = await readFile(sshKeyPath, {
       encoding: 'utf-8',
     });
-    if (keyData !== retrievedKey) {
-      throw new Error('Stored Key does not match');
-    }
+    expect(retrievedKey).toBe(keyData);
+
+    const sessionsPage = new SessionsPage(page);
+    await sessionsPage.waitForSessionToBeVisible(targetName);
   } finally {
     if (orgId) {
       await boundaryCli.deleteScope(orgId);

--- a/e2e-tests/admin/tests/delete-resources-ent.spec.js
+++ b/e2e-tests/admin/tests/delete-resources-ent.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { execSync } from 'node:child_process';
 
 import * as boundaryCli from '../../helpers/boundary-cli';
@@ -14,8 +14,6 @@ import { WorkersPage } from '../pages/workers.js';
 
 const secretPolicyName = 'kv-policy';
 const boundaryPolicyName = 'boundary-controller';
-
-test.use({ storageState: authenticatedState });
 
 // Setting the test timeout to 120s
 // This test can often exceed the globally defined timeout due to the number of

--- a/e2e-tests/admin/tests/delete-resources.spec.js
+++ b/e2e-tests/admin/tests/delete-resources.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { execSync } from 'node:child_process';
 
 import * as boundaryCli from '../../helpers/boundary-cli';
@@ -14,8 +14,6 @@ import { WorkersPage } from '../pages/workers.js';
 
 const secretPolicyName = 'kv-policy';
 const boundaryPolicyName = 'boundary-controller';
-
-test.use({ storageState: authenticatedState });
 
 // Setting the test timeout to 180s
 // This test can often exceed the globally defined timeout due to the number of

--- a/e2e-tests/admin/tests/dynamic-host-catalog-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/dynamic-host-catalog-aws-ent.spec.js
@@ -110,26 +110,20 @@ test.describe('AWS', async () => {
       ).toBeVisible();
 
       // Check number of hosts in host set
-      let i = 0;
-      let rowCount = 0;
-      let expectedHosts = JSON.parse(awsHostSetIps);
-      do {
-        i = i + 1;
-        // Getting the number of rows in the second rowgroup (the first rowgroup is the header row)
-        rowCount = await page
+      const expectedHosts = JSON.parse(awsHostSetIps);
+      await expect(async () => {
+        const rowCount = await page
           .getByRole('table')
-          .getByRole('rowgroup')
-          .nth(1)
           .getByRole('row')
+          .filter({ hasNot: page.getByRole('columnheader') })
           .count();
         await page.reload();
         await page
           .getByRole('navigation', { name: 'breadcrumbs' })
           .getByText(hostSetName)
           .waitFor();
-      } while (i < 5);
-
-      expect(rowCount).toBe(expectedHosts.length);
+        expect(rowCount).toBe(expectedHosts.length);
+      }).toPass();
 
       // Navigate to each host in the host set
       for (let i = 0; i < expectedHosts.length; i++) {

--- a/e2e-tests/admin/tests/dynamic-host-catalog-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/dynamic-host-catalog-aws-ent.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { nanoid } from 'nanoid';
 
@@ -14,8 +14,6 @@ import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
 import { SessionsPage } from '../pages/sessions.js';
 import { TargetsPage } from '../pages/targets.js';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');

--- a/e2e-tests/admin/tests/dynamic-host-catalog-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/dynamic-host-catalog-aws-ent.spec.js
@@ -117,24 +117,25 @@ test.describe('AWS', async () => {
           .getByRole('row')
           .filter({ hasNot: page.getByRole('columnheader') })
           .count();
-        await page.reload();
-        await page
-          .getByRole('navigation', { name: 'breadcrumbs' })
-          .getByText(hostSetName)
-          .waitFor();
+
+        if (rowCount !== expectedHosts.length) {
+          await page.reload();
+          await page
+            .getByRole('navigation', { name: 'breadcrumbs' })
+            .getByText(hostSetName)
+            .waitFor();
+        }
         expect(rowCount).toBe(expectedHosts.length);
       }).toPass();
 
       // Navigate to each host in the host set
-      for (let i = 0; i < expectedHosts.length; i++) {
-        const host = page
-          .getByRole('table')
-          .getByRole('rowgroup')
-          .nth(1)
-          .getByRole('row')
-          .nth(i)
-          .getByRole('link');
-
+      for (const row of await page
+        .getByRole('table')
+        .getByRole('rowgroup')
+        .nth(1)
+        .getByRole('row')
+        .all()) {
+        const host = row.getByRole('link');
         let hostName = await host.innerText();
         await host.click();
         await expect(

--- a/e2e-tests/admin/tests/dynamic-host-catalog-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/dynamic-host-catalog-aws-ent.spec.js
@@ -22,7 +22,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe('AWS', async () => {
-  test('Create an AWS Dynamic Host Catalog and set up Host Sets @ce @aws', async ({
+  test('Create an AWS Dynamic Host Catalog and set up Host Sets @ent @aws', async ({
     page,
     baseURL,
     adminAuthMethodId,
@@ -160,7 +160,7 @@ test.describe('AWS', async () => {
 
       // Create a target and add DHC host set as a host source
       const targetsPage = new TargetsPage(page);
-      const targetName = await targetsPage.createTarget(targetPort);
+      const targetName = await targetsPage.createSshTargetEnt(targetPort);
       await targetsPage.addHostSourceToTarget(hostSetName);
 
       // Add another host source
@@ -196,7 +196,7 @@ test.describe('AWS', async () => {
           sshUser,
           sshKeyPath,
         );
-      await targetsPage.addBrokeredCredentialsToTarget(
+      await targetsPage.addInjectedCredentialsToTarget(
         targetName,
         credentialName,
       );

--- a/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
+++ b/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
@@ -110,26 +110,20 @@ test.describe('AWS', async () => {
       ).toBeVisible();
 
       // Check number of hosts in host set
-      let i = 0;
-      let rowCount = 0;
-      let expectedHosts = JSON.parse(awsHostSetIps);
-      do {
-        i = i + 1;
-        // Getting the number of rows in the second rowgroup (the first rowgroup is the header row)
-        rowCount = await page
+      const expectedHosts = JSON.parse(awsHostSetIps);
+      await expect(async () => {
+        const rowCount = await page
           .getByRole('table')
-          .getByRole('rowgroup')
-          .nth(1)
           .getByRole('row')
+          .filter({ hasNot: page.getByRole('columnheader') })
           .count();
         await page.reload();
         await page
           .getByRole('navigation', { name: 'breadcrumbs' })
           .getByText(hostSetName)
           .waitFor();
-      } while (i < 5);
-
-      expect(rowCount).toBe(expectedHosts.length);
+        expect(rowCount).toBe(expectedHosts.length);
+      }).toPass();
 
       // Navigate to each host in the host set
       for (let i = 0; i < expectedHosts.length; i++) {

--- a/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
+++ b/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { nanoid } from 'nanoid';
 
@@ -14,8 +14,6 @@ import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
 import { SessionsPage } from '../pages/sessions.js';
 import { TargetsPage } from '../pages/targets.js';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');

--- a/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
+++ b/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
@@ -117,24 +117,25 @@ test.describe('AWS', async () => {
           .getByRole('row')
           .filter({ hasNot: page.getByRole('columnheader') })
           .count();
-        await page.reload();
-        await page
-          .getByRole('navigation', { name: 'breadcrumbs' })
-          .getByText(hostSetName)
-          .waitFor();
+
+        if (rowCount !== expectedHosts.length) {
+          await page.reload();
+          await page
+            .getByRole('navigation', { name: 'breadcrumbs' })
+            .getByText(hostSetName)
+            .waitFor();
+        }
         expect(rowCount).toBe(expectedHosts.length);
       }).toPass();
 
       // Navigate to each host in the host set
-      for (let i = 0; i < expectedHosts.length; i++) {
-        const host = page
-          .getByRole('table')
-          .getByRole('rowgroup')
-          .nth(1)
-          .getByRole('row')
-          .nth(i)
-          .getByRole('link');
-
+      for (const row of await page
+        .getByRole('table')
+        .getByRole('rowgroup')
+        .nth(1)
+        .getByRole('row')
+        .all()) {
+        const host = row.getByRole('link');
         let hostName = await host.innerText();
         await host.click();
         await expect(

--- a/e2e-tests/admin/tests/global-settings.spec.js
+++ b/e2e-tests/admin/tests/global-settings.spec.js
@@ -3,14 +3,12 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
 import * as boundaryCli from '../../helpers/boundary-cli';
 import { OrgsPage } from '../pages/orgs.js';
 import { StoragePoliciesPage } from '../pages/storage-policies.js';
-
-test.use({ storageState: authenticatedState });
 
 test('Global Settings @ent @aws @docker', async ({
   page,

--- a/e2e-tests/admin/tests/group-role.spec.js
+++ b/e2e-tests/admin/tests/group-role.spec.js
@@ -3,14 +3,12 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 
 import * as boundaryCli from '../../helpers/boundary-cli';
 import { GroupsPage } from '../pages/groups.js';
 import { OrgsPage } from '../pages/orgs.js';
 import { RolesPage } from '../pages/roles.js';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();

--- a/e2e-tests/admin/tests/login.spec.js
+++ b/e2e-tests/admin/tests/login.spec.js
@@ -8,6 +8,9 @@ import { expect } from '@playwright/test';
 
 import { LoginPage } from '../pages/login.js';
 
+// Reset storage state for this file to avoid being authenticated
+test.use({ storageState: { cookies: [], origins: [] } });
+
 test('Log in, log out, and then log back in @ce @ent @aws @docker', async ({
   page,
   adminLoginName,

--- a/e2e-tests/admin/tests/pagination.spec.js
+++ b/e2e-tests/admin/tests/pagination.spec.js
@@ -3,12 +3,10 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
 import * as boundaryHttp from '../../helpers/boundary-http.js';
-
-test.use({ storageState: authenticatedState });
 
 test('Search and Pagination (Targets) @ce @ent @aws @docker', async ({
   page,

--- a/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
@@ -124,7 +124,7 @@ test('Session Recording Test (AWS) @ent @aws', async ({
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectSshToTarget(targetId, true);
+    connect = await boundaryCli.connectSshToTarget(targetId);
     await page.getByRole('link', { name: 'Projects', exact: true }).click();
     await page.getByRole('link', { name: projectName }).click();
     const sessionsPage = new SessionsPage(page);

--- a/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
@@ -126,7 +126,7 @@ test('Session Recording Test (AWS) @ent @aws', async ({
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectSshToTarget(targetId);
+    connect = await boundaryCli.connectSshToTarget(targetId, true);
     await page.getByRole('link', { name: 'Projects', exact: true }).click();
     await page.getByRole('link', { name: projectName }).click();
     const sessionsPage = new SessionsPage(page);
@@ -227,6 +227,11 @@ test('Session Recording Test (AWS) @ent @aws', async ({
     await page.getByRole('link', { name: targetName }).click();
     await targetsPage.detachStorageBucket();
   } finally {
+    // End `boundary connect` process
+    if (connect) {
+      connect.kill('SIGTERM');
+    }
+
     if (policyName) {
       const storagePolicyId = await boundaryCli.getPolicyIdFromName(
         orgId,
@@ -239,10 +244,6 @@ test('Session Recording Test (AWS) @ent @aws', async ({
     }
     if (orgId) {
       await boundaryCli.deleteScope(orgId);
-    }
-    // End `boundary connect` process
-    if (connect) {
-      connect.kill('SIGTERM');
     }
   }
 });

--- a/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { execSync } from 'child_process';
 
@@ -16,8 +16,6 @@ import { SessionsPage } from '../pages/sessions.js';
 import { StorageBucketsPage } from '../pages/storage-buckets.js';
 import { StoragePoliciesPage } from '../pages/storage-policies.js';
 import { TargetsPage } from '../pages/targets.js';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();

--- a/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
@@ -131,7 +131,7 @@ test('Session Recording Test (MinIO) @ent @docker', async ({
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectSshToTarget(targetId, true);
+    connect = await boundaryCli.connectSshToTarget(targetId);
     await page.getByRole('link', { name: 'Projects', exact: true }).click();
     await page.getByRole('link', { name: projectName }).click();
     const sessionsPage = new SessionsPage(page);

--- a/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
@@ -133,7 +133,7 @@ test('Session Recording Test (MinIO) @ent @docker', async ({
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectSshToTarget(targetId);
+    connect = await boundaryCli.connectSshToTarget(targetId, true);
     await page.getByRole('link', { name: 'Projects', exact: true }).click();
     await page.getByRole('link', { name: projectName }).click();
     const sessionsPage = new SessionsPage(page);
@@ -234,6 +234,11 @@ test('Session Recording Test (MinIO) @ent @docker', async ({
     await page.getByRole('link', { name: targetName }).click();
     await targetsPage.detachStorageBucket();
   } finally {
+    // End `boundary connect` process
+    if (connect) {
+      connect.kill('SIGTERM');
+    }
+
     if (policyName) {
       const storagePolicyId = await boundaryCli.getPolicyIdFromName(
         orgId,
@@ -246,10 +251,6 @@ test('Session Recording Test (MinIO) @ent @docker', async ({
     }
     if (orgId) {
       await boundaryCli.deleteScope(orgId);
-    }
-    // End `boundary connect` process
-    if (connect) {
-      connect.kill('SIGTERM');
     }
   }
 });

--- a/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { execSync } from 'child_process';
 
@@ -16,8 +16,6 @@ import { SessionsPage } from '../pages/sessions.js';
 import { StorageBucketsPage } from '../pages/storage-buckets.js';
 import { StoragePoliciesPage } from '../pages/storage-policies.js';
 import { TargetsPage } from '../pages/targets.js';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();

--- a/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { execSync } from 'child_process';
 
 import * as boundaryCli from '../../helpers/boundary-cli';
@@ -20,8 +20,6 @@ const boundaryPolicyName = 'boundary-controller';
 const secretsPath = 'e2e_secrets';
 // This must match the secret name in ssh-policy.hcl
 const secretName = 'boundary-client';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();

--- a/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
@@ -61,8 +61,8 @@ test('SSH Certificate Injection @ent @docker', async ({
       `vault write ${secretsPath}/roles/${secretName} @./admin/tests/fixtures/ssh-certificate-injection-role.json`,
     );
 
-    const private_key = atob(sshCaKey);
-    const public_key = atob(sshCaKeyPublic);
+    const private_key = Buffer.from(sshCaKey, 'base64');
+    const public_key = Buffer.from(sshCaKeyPublic, 'base64');
 
     execSync(
       `vault write ${secretsPath}/config/ca` +

--- a/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
@@ -136,18 +136,14 @@ test('SSH Certificate Injection @ent @docker', async ({
     connect = await boundaryCli.connectSshToTarget(targetId);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
-    await page
-      .getByRole('cell', { name: targetName })
-      .locator('..')
-      .getByRole('button', { name: 'Cancel' })
-      .click();
   } finally {
-    if (orgId) {
-      await boundaryCli.deleteScope(orgId);
-    }
     // End `boundary connect` process
     if (connect) {
       connect.kill('SIGTERM');
+    }
+
+    if (orgId) {
+      await boundaryCli.deleteScope(orgId);
     }
 
     execSync(`vault secrets disable ${secretsPath}`);

--- a/e2e-tests/admin/tests/ssh-credential-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-credential-injection-vault-ent.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { execSync } from 'child_process';
 
 import * as boundaryCli from '../../helpers/boundary-cli';
@@ -18,8 +18,6 @@ const secretsPath = 'e2e_secrets';
 const secretName = 'cred';
 const secretPolicyName = 'kv-policy';
 const boundaryPolicyName = 'boundary-controller';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();

--- a/e2e-tests/admin/tests/ssh-credential-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-credential-injection-vault-ent.spec.js
@@ -126,18 +126,14 @@ test('SSH Credential Injection (Vault User & Key Pair) @ent @docker', async ({
     connect = await boundaryCli.connectSshToTarget(targetId);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
-    await page
-      .getByRole('cell', { name: targetName })
-      .locator('..')
-      .getByRole('button', { name: 'Cancel' })
-      .click();
   } finally {
-    if (orgId) {
-      await boundaryCli.deleteScope(orgId);
-    }
     // End `boundary connect` process
     if (connect) {
       connect.kill('SIGTERM');
+    }
+
+    if (orgId) {
+      await boundaryCli.deleteScope(orgId);
     }
   }
 });

--- a/e2e-tests/admin/tests/target-ent.spec.js
+++ b/e2e-tests/admin/tests/target-ent.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
 import * as boundaryCli from '../../helpers/boundary-cli';
@@ -13,8 +13,6 @@ import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
 import { SessionsPage } from '../pages/sessions.js';
 import { TargetsPage } from '../pages/targets.js';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();

--- a/e2e-tests/admin/tests/target-ent.spec.js
+++ b/e2e-tests/admin/tests/target-ent.spec.js
@@ -58,12 +58,7 @@ test('Verify session created for TCP target @ent @aws @docker', async ({
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectToTarget(
-      targetId,
-      sshUser,
-      sshKeyPath,
-      true,
-    );
+    connect = await boundaryCli.connectToTarget(targetId, sshUser, sshKeyPath);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page
@@ -133,7 +128,7 @@ test('Verify session created for SSH target @ent @aws @docker', async ({
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectSshToTarget(targetId, true);
+    connect = await boundaryCli.connectSshToTarget(targetId);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page
@@ -235,7 +230,7 @@ test('SSH target with host sources @ent @aws @docker', async ({
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectSshToTarget(targetId, true);
+    connect = await boundaryCli.connectSshToTarget(targetId);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page

--- a/e2e-tests/admin/tests/target-ent.spec.js
+++ b/e2e-tests/admin/tests/target-ent.spec.js
@@ -60,7 +60,12 @@ test('Verify session created for TCP target @ent @aws @docker', async ({
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectToTarget(targetId, sshUser, sshKeyPath);
+    connect = await boundaryCli.connectToTarget(
+      targetId,
+      sshUser,
+      sshKeyPath,
+      true,
+    );
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page
@@ -130,7 +135,7 @@ test('Verify session created for SSH target @ent @aws @docker', async ({
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectSshToTarget(targetId);
+    connect = await boundaryCli.connectSshToTarget(targetId, true);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page
@@ -232,7 +237,7 @@ test('SSH target with host sources @ent @aws @docker', async ({
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectSshToTarget(targetId);
+    connect = await boundaryCli.connectSshToTarget(targetId, true);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page

--- a/e2e-tests/admin/tests/target.spec.js
+++ b/e2e-tests/admin/tests/target.spec.js
@@ -79,7 +79,12 @@ test('Verify session created to target with host, then cancel the session @ce @a
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectToTarget(targetId, sshUser, sshKeyPath);
+    connect = await boundaryCli.connectToTarget(
+      targetId,
+      sshUser,
+      sshKeyPath,
+      true,
+    );
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page
@@ -138,7 +143,12 @@ test('Verify session created to target with address, then cancel the session @ce
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectToTarget(targetId, sshUser, sshKeyPath);
+    connect = await boundaryCli.connectToTarget(
+      targetId,
+      sshUser,
+      sshKeyPath,
+      true,
+    );
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page

--- a/e2e-tests/admin/tests/target.spec.js
+++ b/e2e-tests/admin/tests/target.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 
 import * as boundaryCli from '../../helpers/boundary-cli';
@@ -13,8 +13,6 @@ import { OrgsPage } from '../pages/orgs.js';
 import { ProjectsPage } from '../pages/projects.js';
 import { SessionsPage } from '../pages/sessions.js';
 import { TargetsPage } from '../pages/targets.js';
-
-test.use({ storageState: authenticatedState });
 
 test.beforeAll(async () => {
   await boundaryCli.checkBoundaryCli();

--- a/e2e-tests/admin/tests/target.spec.js
+++ b/e2e-tests/admin/tests/target.spec.js
@@ -77,12 +77,7 @@ test('Verify session created to target with host, then cancel the session @ce @a
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectToTarget(
-      targetId,
-      sshUser,
-      sshKeyPath,
-      true,
-    );
+    connect = await boundaryCli.connectToTarget(targetId, sshUser, sshKeyPath);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page
@@ -141,12 +136,7 @@ test('Verify session created to target with address, then cancel the session @ce
       projectId,
       targetName,
     );
-    connect = await boundaryCli.connectToTarget(
-      targetId,
-      sshUser,
-      sshKeyPath,
-      true,
-    );
+    connect = await boundaryCli.connectToTarget(targetId, sshUser, sshKeyPath);
     const sessionsPage = new SessionsPage(page);
     await sessionsPage.waitForSessionToBeVisible(targetName);
     await page

--- a/e2e-tests/admin/tests/worker-ent.spec.js
+++ b/e2e-tests/admin/tests/worker-ent.spec.js
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
-
-test.use({ storageState: authenticatedState });
 
 test('Create a worker (enterprise) @ent @docker @aws', async ({
   page,

--- a/e2e-tests/admin/tests/worker-tags.spec.js
+++ b/e2e-tests/admin/tests/worker-tags.spec.js
@@ -3,13 +3,11 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
 import { customAlphabet } from 'nanoid';
 
 import { WorkersPage } from '../pages/workers.js';
-
-test.use({ storageState: authenticatedState });
 
 test('Worker Tags @ce @ent @aws @docker', async ({ page }) => {
   const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 10);

--- a/e2e-tests/admin/tests/worker.spec.js
+++ b/e2e-tests/admin/tests/worker.spec.js
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { test, authenticatedState } from '../../global-setup.js';
+import { test } from '../../global-setup.js';
 import { expect } from '@playwright/test';
-
-test.use({ storageState: authenticatedState });
 
 test('Create a worker @ce @docker @aws', async ({ page, browserName }) => {
   test.skip(browserName === 'webkit', 'Bug in worker form on Safari');

--- a/e2e-tests/helpers/boundary-cli/connect.js
+++ b/e2e-tests/helpers/boundary-cli/connect.js
@@ -17,7 +17,6 @@ const remoteCommand =
 async function spawnConnection(command, args) {
   return new Promise((resolve, reject) => {
     const childProcess = spawn(command, args, {
-      detached: true,
       shell: true,
     });
     childProcess.stdout.on('data', (data) => {
@@ -26,7 +25,7 @@ async function spawnConnection(command, args) {
       }
     });
     childProcess.stderr.on('data', (data) => {
-      if (!data.toString().includes('Warning')) {
+      if (!data.toString().includes('Warning: Permanently added')) {
         reject(data.toString());
       }
     });

--- a/e2e-tests/helpers/boundary-cli/connect.js
+++ b/e2e-tests/helpers/boundary-cli/connect.js
@@ -3,7 +3,51 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { exec } from 'node:child_process';
+import { spawn } from 'node:child_process';
+
+const remoteCommand =
+  'for i in {1..15}; do echo helloworld\\$i; sleep 1s; done';
+
+/**
+ * Spawns a child process for a Boundary connection and returns a promise.
+ * Resolves on any output from stdout or stderr.
+ * @param {string} command
+ * @param {Array<string>} args
+ */
+async function spawnConnection(command, args) {
+  return new Promise((resolve, reject) => {
+    const childProcess = spawn(command, args, {
+      detached: true,
+      shell: true,
+    });
+    childProcess.stdout.on('data', (data) => {
+      if (data.toString().includes('helloworld3')) {
+        resolve({ childProcess, stdout: data.toString() });
+      }
+    });
+    childProcess.stderr.on('data', (data) => {
+      if (!data.toString().includes('Warning')) {
+        reject(data.toString());
+      }
+    });
+    childProcess.on('error', (err) => {
+      reject(err);
+    });
+
+    // In case the process has no stdio and didn't error out, resolve a
+    // promise once the child process closes so we're not waiting forever.
+    // Windows doesn't seem to return any error nor any output from stderr when
+    // a timeout occurs so this guarantees we return a response to the caller.
+    // Otherwise this should not get hit as we should be returning a response
+    // from one of the handlers above.
+    childProcess.on('close', () => {
+      resolve({
+        childProcess,
+        stderr: JSON.stringify({ error: 'Process was closed.' }),
+      });
+    });
+  });
+}
 
 /**
  * Connects to the specified target
@@ -11,35 +55,31 @@ import { exec } from 'node:child_process';
  * @param {string} targetId ID of the target to be connected to
  * @param {string} sshUser User to be used for the ssh connection
  * @param {string} sshKeyPath Path to the ssh key to be used for the ssh connection
- * @param {boolean} ignoreErrors (Optional) boolean to ignore errors
  * @returns ChildProcess representing the result of the command execution
  */
-export async function connectToTarget(
-  targetId,
-  sshUser,
-  sshKeyPath,
-  ignoreErrors = false,
-) {
-  let connect = exec(
-    `boundary connect -target-id=${targetId}` +
-      ' -exec /usr/bin/ssh --' +
-      ' -T' + // forces tty allocation
-      ` -l ${sshUser}` +
-      ` -i ${sshKeyPath}` +
-      ' -o UserKnownHostsFile=/dev/null' +
-      ' -o StrictHostKeyChecking=no' +
-      ' -o IdentitiesOnly=yes' + // forces the use of the provided key
-      ' -p {{boundary.port}}' +
-      ' {{boundary.ip}}',
-    (error) => {
-      if (error.killed !== true && !ignoreErrors) {
-        throw new Error(`Failed to connect to the target: ${error}`);
-      }
-    },
-  );
-  // Wait for 2 seconds to allow for a connection to establish
-  await new Promise((resolve) => setTimeout(resolve, 2000));
-  return connect;
+export async function connectToTarget(targetId, sshUser, sshKeyPath) {
+  try {
+    const { childProcess } = await spawnConnection('boundary', [
+      'connect',
+      `-target-id=${targetId}`,
+      '-exec',
+      '/usr/bin/ssh',
+      '--',
+      '-T', // forces tty allocation
+      `-l ${sshUser}`,
+      `-i ${sshKeyPath}`,
+      '-o UserKnownHostsFile=/dev/null',
+      '-o StrictHostKeyChecking=no',
+      '-o IdentitiesOnly=yes', // forces the use of the provided key
+      '-p {{boundary.port}}',
+      '{{boundary.ip}}',
+      `"${remoteCommand}"`,
+    ]);
+
+    return childProcess;
+  } catch (e) {
+    throw new Error(`Failed to connect to the target: ${e}`);
+  }
 }
 
 /**
@@ -48,62 +88,57 @@ export async function connectToTarget(
  * @param {string} alias alias of the target to be connected to
  * @param {string} sshUser User to be used for the ssh connection
  * @param {string} sshKeyPath Path to the ssh key to be used for the ssh connection
- * @param {boolean} ignoreErrors (Optional) boolean to ignore errors
  * @returns ChildProcess representing the result of the command execution
  */
-export async function connectToAlias(
-  alias,
-  sshUser,
-  sshKeyPath,
-  ignoreErrors = false,
-) {
-  let connect = exec(
-    `boundary connect ${alias}` +
-      ' -exec /usr/bin/ssh --' +
-      ' -T' + // forces tty allocation
-      ` -l ${sshUser}` +
-      ` -i ${sshKeyPath}` +
-      ' -o UserKnownHostsFile=/dev/null' +
-      ' -o StrictHostKeyChecking=no' +
-      ' -o IdentitiesOnly=yes' + // forces the use of the provided key
-      ' -p {{boundary.port}}' +
-      ' {{boundary.ip}}',
-    (error) => {
-      if (error.killed !== true && !ignoreErrors) {
-        throw new Error(`Failed to connect to the target: ${error}`);
-      }
-    },
-  );
-  // Wait for 2 seconds to allow for a connection to establish
-  await new Promise((resolve) => setTimeout(resolve, 2000));
-  return connect;
+export async function connectToAlias(alias, sshUser, sshKeyPath) {
+  try {
+    const { childProcess } = await spawnConnection('boundary', [
+      'connect',
+      `${alias}`,
+      '-exec',
+      '/usr/bin/ssh',
+      '--',
+      '-T', // forces tty allocation
+      `-l ${sshUser}`,
+      `-i ${sshKeyPath}`,
+      '-o UserKnownHostsFile=/dev/null',
+      '-o StrictHostKeyChecking=no',
+      '-o IdentitiesOnly=yes', // forces the use of the provided key
+      '-p {{boundary.port}}',
+      '{{boundary.ip}}',
+      `"${remoteCommand}"`,
+    ]);
+
+    return childProcess;
+  } catch (e) {
+    throw new Error(`Failed to connect to the target: ${e}`);
+  }
 }
 
 /**
  * Connects via ssh to the specified target
  * exec is used here to keep the session open
  * @param {string} targetId ID of the target to be connected to
- * @param {boolean} ignoreErrors (Optional) boolean to ignore errors
  * @returns ChildProcess representing the result of the command execution
  */
-export async function connectSshToTarget(targetId, ignoreErrors = false) {
-  let connect = exec(
-    'boundary connect ssh' +
-      ` -target-id=${targetId}` +
-      ' --' +
-      ' -T' + // forces tty allocation
-      ' -o UserKnownHostsFile=/dev/null' +
-      ' -o StrictHostKeyChecking=no' +
-      ' -o IdentitiesOnly=yes', // forces the use of the provided key
-    (error) => {
-      if (error.killed !== true && !ignoreErrors) {
-        throw new Error(`Failed to connect to the target: ${error}`);
-      }
-    },
-  );
-  // Wait for 2 seconds to allow for a connection to establish
-  await new Promise((resolve) => setTimeout(resolve, 2000));
-  return connect;
+export async function connectSshToTarget(targetId) {
+  try {
+    const { childProcess } = await spawnConnection('boundary', [
+      'connect',
+      'ssh',
+      `-target-id=${targetId}`,
+      `-remote-command="${remoteCommand}"`,
+      '--',
+      '-T', // forces tty allocation
+      '-o UserKnownHostsFile=/dev/null',
+      '-o StrictHostKeyChecking=no',
+      '-o IdentitiesOnly=yes', // forces the use of the provided key
+    ]);
+
+    return childProcess;
+  } catch (e) {
+    throw new Error(`Failed to connect to the target: ${e}`);
+  }
 }
 
 /**
@@ -113,21 +148,21 @@ export async function connectSshToTarget(targetId, ignoreErrors = false) {
  * @returns ChildProcess representing the result of the command execution
  */
 export async function connectSshToAlias(alias) {
-  let connect = exec(
-    'boundary connect ssh' +
-      ` ${alias}` +
-      ' --' +
-      ' -T' + // forces tty allocation
-      ' -o UserKnownHostsFile=/dev/null' +
-      ' -o StrictHostKeyChecking=no' +
-      ' -o IdentitiesOnly=yes', // forces the use of the provided key
-    (error) => {
-      if (error.killed !== true) {
-        throw new Error(`Failed to connect to the target: ${error}`);
-      }
-    },
-  );
-  // Wait for 2 seconds to allow for a connection to establish
-  await new Promise((resolve) => setTimeout(resolve, 2000));
-  return connect;
+  try {
+    const { childProcess } = await spawnConnection('boundary', [
+      'connect',
+      `ssh`,
+      `${alias}`,
+      `-remote-command="${remoteCommand}"`,
+      '--',
+      '-T', // forces tty allocation
+      '-o UserKnownHostsFile=/dev/null',
+      '-o StrictHostKeyChecking=no',
+      '-o IdentitiesOnly=yes', // forces the use of the provided key
+    ]);
+
+    return childProcess;
+  } catch (e) {
+    throw new Error(`Failed to connect to the target: ${e}`);
+  }
 }

--- a/e2e-tests/helpers/boundary-cli/connect.js
+++ b/e2e-tests/helpers/boundary-cli/connect.js
@@ -37,6 +37,8 @@ export async function connectToTarget(
       }
     },
   );
+  // Wait for 2 seconds to allow for a connection to establish
+  await new Promise((resolve) => setTimeout(resolve, 2000));
   return connect;
 }
 
@@ -72,6 +74,8 @@ export async function connectToAlias(
       }
     },
   );
+  // Wait for 2 seconds to allow for a connection to establish
+  await new Promise((resolve) => setTimeout(resolve, 2000));
   return connect;
 }
 
@@ -97,6 +101,8 @@ export async function connectSshToTarget(targetId, ignoreErrors = false) {
       }
     },
   );
+  // Wait for 2 seconds to allow for a connection to establish
+  await new Promise((resolve) => setTimeout(resolve, 2000));
   return connect;
 }
 
@@ -121,5 +127,7 @@ export async function connectSshToAlias(alias) {
       }
     },
   );
+  // Wait for 2 seconds to allow for a connection to establish
+  await new Promise((resolve) => setTimeout(resolve, 2000));
   return connect;
 }

--- a/e2e-tests/helpers/boundary-cli/connect.js
+++ b/e2e-tests/helpers/boundary-cli/connect.js
@@ -11,25 +11,67 @@ import { exec } from 'node:child_process';
  * @param {string} targetId ID of the target to be connected to
  * @param {string} sshUser User to be used for the ssh connection
  * @param {string} sshKeyPath Path to the ssh key to be used for the ssh connection
+ * @param {boolean} ignoreErrors (Optional) boolean to ignore errors
  * @returns ChildProcess representing the result of the command execution
  */
-export async function connectToTarget(targetId, sshUser, sshKeyPath) {
-  let connect;
-  try {
-    connect = exec(
-      `boundary connect -target-id=${targetId}` +
-        ' -exec /usr/bin/ssh --' +
-        ` -l ${sshUser}` +
-        ` -i ${sshKeyPath}` +
-        ' -o UserKnownHostsFile=/dev/null' +
-        ' -o StrictHostKeyChecking=no' +
-        ' -o IdentitiesOnly=yes' + // forces the use of the provided key
-        ' -p {{boundary.port}}' +
-        ' {{boundary.ip}}',
-    );
-  } catch (e) {
-    console.log(`${e.stderr}`);
-  }
+export async function connectToTarget(
+  targetId,
+  sshUser,
+  sshKeyPath,
+  ignoreErrors = false,
+) {
+  let connect = exec(
+    `boundary connect -target-id=${targetId}` +
+      ' -exec /usr/bin/ssh --' +
+      ' -T' + // forces tty allocation
+      ` -l ${sshUser}` +
+      ` -i ${sshKeyPath}` +
+      ' -o UserKnownHostsFile=/dev/null' +
+      ' -o StrictHostKeyChecking=no' +
+      ' -o IdentitiesOnly=yes' + // forces the use of the provided key
+      ' -p {{boundary.port}}' +
+      ' {{boundary.ip}}',
+    (error) => {
+      if (error.killed !== true && !ignoreErrors) {
+        throw new Error(`Failed to connect to the target: ${error}`);
+      }
+    },
+  );
+  return connect;
+}
+
+/**
+ * Connects to the specified alias
+ * exec is used here to keep the session open
+ * @param {string} alias alias of the target to be connected to
+ * @param {string} sshUser User to be used for the ssh connection
+ * @param {string} sshKeyPath Path to the ssh key to be used for the ssh connection
+ * @param {boolean} ignoreErrors (Optional) boolean to ignore errors
+ * @returns ChildProcess representing the result of the command execution
+ */
+export async function connectToAlias(
+  alias,
+  sshUser,
+  sshKeyPath,
+  ignoreErrors = false,
+) {
+  let connect = exec(
+    `boundary connect ${alias}` +
+      ' -exec /usr/bin/ssh --' +
+      ' -T' + // forces tty allocation
+      ` -l ${sshUser}` +
+      ` -i ${sshKeyPath}` +
+      ' -o UserKnownHostsFile=/dev/null' +
+      ' -o StrictHostKeyChecking=no' +
+      ' -o IdentitiesOnly=yes' + // forces the use of the provided key
+      ' -p {{boundary.port}}' +
+      ' {{boundary.ip}}',
+    (error) => {
+      if (error.killed !== true && !ignoreErrors) {
+        throw new Error(`Failed to connect to the target: ${error}`);
+      }
+    },
+  );
   return connect;
 }
 
@@ -37,21 +79,47 @@ export async function connectToTarget(targetId, sshUser, sshKeyPath) {
  * Connects via ssh to the specified target
  * exec is used here to keep the session open
  * @param {string} targetId ID of the target to be connected to
+ * @param {boolean} ignoreErrors (Optional) boolean to ignore errors
  * @returns ChildProcess representing the result of the command execution
  */
-export async function connectSshToTarget(targetId) {
-  let connect;
-  try {
-    connect = exec(
-      'boundary connect ssh' +
-        ` -target-id=${targetId}` +
-        ' --' +
-        ' -o UserKnownHostsFile=/dev/null' +
-        ' -o StrictHostKeyChecking=no' +
-        ' -o IdentitiesOnly=yes', // forces the use of the provided key
-    );
-  } catch (e) {
-    console.log(`${e.stderr}`);
-  }
+export async function connectSshToTarget(targetId, ignoreErrors = false) {
+  let connect = exec(
+    'boundary connect ssh' +
+      ` -target-id=${targetId}` +
+      ' --' +
+      ' -T' + // forces tty allocation
+      ' -o UserKnownHostsFile=/dev/null' +
+      ' -o StrictHostKeyChecking=no' +
+      ' -o IdentitiesOnly=yes', // forces the use of the provided key
+    (error) => {
+      if (error.killed !== true && !ignoreErrors) {
+        throw new Error(`Failed to connect to the target: ${error}`);
+      }
+    },
+  );
+  return connect;
+}
+
+/**
+ * Connects via ssh to the specified alias
+ * exec is used here to keep the session open
+ * @param {string} alias alias of the target to be connected to
+ * @returns ChildProcess representing the result of the command execution
+ */
+export async function connectSshToAlias(alias) {
+  let connect = exec(
+    'boundary connect ssh' +
+      ` ${alias}` +
+      ' --' +
+      ' -T' + // forces tty allocation
+      ' -o UserKnownHostsFile=/dev/null' +
+      ' -o StrictHostKeyChecking=no' +
+      ' -o IdentitiesOnly=yes', // forces the use of the provided key
+    (error) => {
+      if (error.killed !== true) {
+        throw new Error(`Failed to connect to the target: ${error}`);
+      }
+    },
+  );
   return connect;
 }


### PR DESCRIPTION
# Description
This PR is a follow-up to this comment: https://github.com/hashicorp/boundary-ui/pull/2563#discussion_r1842641348

This PR adds additional assertions to UI tests, specifically, ensuring that a session is successfully created after setting up resources via the Admin UI. 

## How to Test
Run e2e tests

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

https://hashicorp.atlassian.net/browse/ICU-15765