### PR TITLE
[ICU-15403] Trim whitespace on storage buckets and host sets json attrs serializers

### DIFF
--- a/addons/api/addon/generated/models/host-set.js
+++ b/addons/api/addon/generated/models/host-set.js
@@ -88,6 +88,7 @@ export default class GeneratedHostSetModel extends BaseModel {
       name: ['aws', 'azure', 'gcp'],
     },
     emptyArrayIfMissing: true,
+    trimWhitespace: true,
   })
   preferred_endpoints;
 

--- a/addons/api/addon/generated/models/storage-bucket.js
+++ b/addons/api/addon/generated/models/storage-bucket.js
@@ -70,6 +70,7 @@ export default class GeneratedStorageBucketModel extends BaseModel {
   @attr('string', {
     isNestedAttribute: true,
     description: 'The AWS region to use.',
+    trimWhitespace: true,
   })
   region;
 
@@ -109,6 +110,7 @@ export default class GeneratedStorageBucketModel extends BaseModel {
   @attr('string', {
     isNestedAttribute: true,
     description: 'The role ARN to use.',
+    trimWhitespace: true,
   })
   role_arn;
 

--- a/addons/api/addon/serializers/application.js
+++ b/addons/api/addon/serializers/application.js
@@ -109,18 +109,22 @@ export default class ApplicationSerializer extends RESTSerializer {
         deleteKey(json);
       }
     }
-    if (
-      options.trimWhitespace &&
-      json.attributes[attribute?.name] &&
-      options.isNestedAttribute &&
-      type === 'string'
-    ) {
-      console.log('str', json);
-      json.attributes[attribute.name] = json.attributes[attribute.name].trim();
-    } else if (options.trimWhitespace && type === 'array') {
-      console.log('arr', json);
-      // console.log(json.preferred_endpoints);
-      // json.preferred_endpoints = json.preferred_endpoints.map(str => str.trim());
+    if (options.trimWhitespace) {
+      if (
+        options.isNestedAttribute &&
+        json.attributes[attribute?.name] &&
+        type === 'string'
+      ) {
+        json.attributes[attribute.name] =
+          json.attributes[attribute.name].trim();
+      }
+      // Right now, we've only identified one string-array attribute that
+      // will err if not trimmed before sending to backend
+      // This fix may require a refactor in the future
+    } else if (type === 'string-array') {
+      json.preferred_endpoints = json.preferred_endpoints.map((str) =>
+        str.trim(),
+      );
     }
     return value;
   }

--- a/addons/api/addon/serializers/application.js
+++ b/addons/api/addon/serializers/application.js
@@ -60,7 +60,6 @@ export default class ApplicationSerializer extends RESTSerializer {
     // Do not serialize `disabled` fields.
     // TODO:  disabled is temporarily disabled
     if (key === 'disabled') delete json[key];
-    // Push nested attributes down into the attributes key
 
     // Before we transform our json
     // Let's trim the values in the json obj
@@ -73,6 +72,7 @@ export default class ApplicationSerializer extends RESTSerializer {
       }
     }
 
+    // Push nested attributes down into the attributes key
     if (options.isNestedAttribute && json[key] !== undefined) {
       if (!json.attributes) json.attributes = {};
       json.attributes[key] = json[key];

--- a/addons/api/addon/serializers/application.js
+++ b/addons/api/addon/serializers/application.js
@@ -112,9 +112,15 @@ export default class ApplicationSerializer extends RESTSerializer {
     if (
       options.trimWhitespace &&
       json.attributes[attribute?.name] &&
+      options.isNestedAttribute &&
       type === 'string'
     ) {
+      console.log('str', json);
       json.attributes[attribute.name] = json.attributes[attribute.name].trim();
+    } else if (options.trimWhitespace && type === 'array') {
+      console.log('arr', json);
+      // console.log(json.preferred_endpoints);
+      // json.preferred_endpoints = json.preferred_endpoints.map(str => str.trim());
     }
     return value;
   }

--- a/addons/api/addon/serializers/application.js
+++ b/addons/api/addon/serializers/application.js
@@ -109,6 +109,13 @@ export default class ApplicationSerializer extends RESTSerializer {
         deleteKey(json);
       }
     }
+    if (
+      options.trimWhitespace &&
+      json.attributes[attribute?.name] &&
+      type === 'string'
+    ) {
+      json.attributes[attribute.name] = json.attributes[attribute.name].trim();
+    }
     return value;
   }
 

--- a/addons/api/addon/serializers/application.js
+++ b/addons/api/addon/serializers/application.js
@@ -61,6 +61,18 @@ export default class ApplicationSerializer extends RESTSerializer {
     // TODO:  disabled is temporarily disabled
     if (key === 'disabled') delete json[key];
     // Push nested attributes down into the attributes key
+
+    // Before we transform our json
+    // Let's trim the values in the json obj
+    // Currently, json values will only ever be a string or an array
+    if (options.trimWhitespace && json[key]) {
+      if (typeOf(json[key]) === 'array') {
+        json[key] = json[key].map((str) => str.trim());
+      } else if (typeOf(json[key] === 'string')) {
+        json[key] = json[key].trim();
+      }
+    }
+
     if (options.isNestedAttribute && json[key] !== undefined) {
       if (!json.attributes) json.attributes = {};
       json.attributes[key] = json[key];
@@ -108,23 +120,6 @@ export default class ApplicationSerializer extends RESTSerializer {
       ) {
         deleteKey(json);
       }
-    }
-    if (options.trimWhitespace) {
-      if (
-        options.isNestedAttribute &&
-        json.attributes[attribute?.name] &&
-        type === 'string'
-      ) {
-        json.attributes[attribute.name] =
-          json.attributes[attribute.name].trim();
-      }
-      // Right now, we've only identified one string-array attribute that
-      // will err if not trimmed before sending to backend
-      // This fix may require a refactor in the future
-    } else if (type === 'string-array' && json?.preferred_endpoints) {
-      json.preferred_endpoints = json.preferred_endpoints.map((str) =>
-        str.trim(),
-      );
     }
     return value;
   }

--- a/addons/api/addon/serializers/application.js
+++ b/addons/api/addon/serializers/application.js
@@ -121,7 +121,7 @@ export default class ApplicationSerializer extends RESTSerializer {
       // Right now, we've only identified one string-array attribute that
       // will err if not trimmed before sending to backend
       // This fix may require a refactor in the future
-    } else if (type === 'string-array') {
+    } else if (type === 'string-array' && json?.preferred_endpoints) {
       json.preferred_endpoints = json.preferred_endpoints.map((str) =>
         str.trim(),
       );

--- a/addons/api/addon/serializers/storage-bucket.js
+++ b/addons/api/addon/serializers/storage-bucket.js
@@ -75,14 +75,6 @@ export default class StorageBucketSerializer extends ApplicationSerializer {
 
     // This deletes any fields that don't belong to the record's credential type
     if (options.isNestedAttribute && json.attributes) {
-      if (json.attributes?.region) {
-        json.attributes.region = json.attributes.region.trim();
-      }
-
-      if (credentialType == 'dynamic' && json.attributes?.role_arn) {
-        json.attributes.role_arn = json.attributes.role_arn.trim();
-      }
-
       // The key must be included in the fieldsByType list above
       if (!fieldsByCredentialType[credentialType].includes(key))
         // API requires these fields to be null

--- a/addons/api/addon/serializers/storage-bucket.js
+++ b/addons/api/addon/serializers/storage-bucket.js
@@ -72,8 +72,17 @@ export default class StorageBucketSerializer extends ApplicationSerializer {
     const value = super.serializeAttribute(...arguments);
     const { credentialType } = snapshot.record;
     const { options } = attribute;
+
     // This deletes any fields that don't belong to the record's credential type
     if (options.isNestedAttribute && json.attributes) {
+      if (json.attributes?.region) {
+        json.attributes.region = json.attributes.region.trim();
+      }
+
+      if (credentialType == 'dynamic' && json.attributes?.role_arn) {
+        json.attributes.role_arn = json.attributes.role_arn.trim();
+      }
+
       // The key must be included in the fieldsByType list above
       if (!fieldsByCredentialType[credentialType].includes(key))
         // API requires these fields to be null

--- a/addons/api/tests/unit/serializers/application-test.js
+++ b/addons/api/tests/unit/serializers/application-test.js
@@ -381,4 +381,29 @@ module('Unit | Serializer | application', function (hooks) {
       },
     });
   });
+
+  // JSON values will only be trimmed if the model attr
+  // includes the trimWhitespace property set to true
+  // See preferred_endpoints attr on host-set model
+  test('it trims whitespace on json values', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const record = store.createRecord('host-set', {
+      name: 'Host Set 1',
+      compositeType: 'azure',
+      description: 'Description',
+      host_catalog_id: '123',
+      version: 1,
+      preferred_endpoints: [{ value: ' option 1' }, { value: 'option 2 ' }],
+      sync_interval_seconds: 1,
+    });
+    assert.deepEqual(record.serialize(), {
+      name: 'Host Set 1',
+      description: 'Description',
+      host_catalog_id: '123',
+      version: 1,
+      preferred_endpoints: ['option 1', 'option 2'],
+      sync_interval_seconds: 1,
+      attributes: {},
+    });
+  });
 });

--- a/addons/api/tests/unit/serializers/host-set-test.js
+++ b/addons/api/tests/unit/serializers/host-set-test.js
@@ -54,7 +54,7 @@ module('Unit | Serializer | host set', function (hooks) {
       description: 'Description',
       host_catalog_id: '123',
       version: 1,
-      preferred_endpoints: [{ value: 'option 1' }, { value: 'option 2' }],
+      preferred_endpoints: [{ value: ' option 1' }, { value: 'option 2 ' }],
       sync_interval_seconds: 1,
       filters: [{ value: 'filter 1' }, { value: 'filter 2' }],
     });
@@ -63,7 +63,7 @@ module('Unit | Serializer | host set', function (hooks) {
       description: 'Description',
       host_catalog_id: '123',
       version: 1,
-      preferred_endpoints: ['option 1 ', ' option 2'],
+      preferred_endpoints: ['option 1', 'option 2'],
       sync_interval_seconds: 1,
       attributes: {
         filters: ['filter 1', 'filter 2'],

--- a/addons/api/tests/unit/serializers/host-set-test.js
+++ b/addons/api/tests/unit/serializers/host-set-test.js
@@ -63,7 +63,7 @@ module('Unit | Serializer | host set', function (hooks) {
       description: 'Description',
       host_catalog_id: '123',
       version: 1,
-      preferred_endpoints: ['option 1', 'option 2'],
+      preferred_endpoints: ['option 1 ', ' option 2'],
       sync_interval_seconds: 1,
       attributes: {
         filters: ['filter 1', 'filter 2'],

--- a/addons/api/tests/unit/serializers/storage-bucket-test.js
+++ b/addons/api/tests/unit/serializers/storage-bucket-test.js
@@ -26,7 +26,7 @@ module('Unit | Serializer | storage bucket', function (hooks) {
       bucket_name: 'bucketname',
       bucket_prefix: 'bucketprefix',
       worker_filter: 'workerfilter',
-      region: 'eu-west-1',
+      region: 'eu-west-1 ',
       access_key_id: 'foobars',
       secret_access_key: 'testing',
       disable_credential_rotation: true,
@@ -117,7 +117,7 @@ module('Unit | Serializer | storage bucket', function (hooks) {
       access_key_id: '',
       secret_access_key: '',
       disable_credential_rotation: true,
-      role_arn: 'arn',
+      role_arn: 'arn ',
       role_external_id: 'Example987',
       role_session_name: 'my-session',
       role_tags: [
@@ -160,12 +160,12 @@ module('Unit | Serializer | storage bucket', function (hooks) {
           bucket_prefix: 'bucketprefix',
           worker_filter: 'workerfilter',
           plugin: { name: 'aws' },
-          region: 'eu-west-1',
+          region: ' eu-west-1 ',
           access_key_id: 'foobars',
           secret_access_key: 'testing',
           disable_credential_rotation: true,
           version: 1,
-          role_arn: 'role_arn_test',
+          role_arn: ' role_arn_test ',
           role_external_id: 'role_external_id_test',
           role_session_name: 'role_session_test',
           role_tags: [
@@ -358,47 +358,5 @@ module('Unit | Serializer | storage bucket', function (hooks) {
         relationships: {},
       },
     });
-  });
-
-  test('it trims whitespace on region and role_arn fields', async function (assert) {
-    const store = this.owner.lookup('service:store');
-    const record = store.createRecord('storage-bucket', {
-      compositeType: TYPE_STORAGE_BUCKET_PLUGIN_AWS_S3,
-      credentialType: TYPE_CREDENTIAL_DYNAMIC,
-      name: 'AWS',
-      description: 'this has an aws plugin',
-      bucket_name: 'bucketname',
-      bucket_prefix: 'bucketprefix',
-      worker_filter: 'workerfilter',
-      region: 'eu-west-1   ',
-      access_key_id: '',
-      secret_access_key: '',
-      disable_credential_rotation: true,
-      role_arn: ' arn  ',
-      role_external_id: 'Example987',
-      role_session_name: 'my-session',
-      role_tags: [
-        { key: 'Project', value: 'Automation' },
-        { key: 'foo', value: 'bar' },
-      ],
-    });
-    const expectedResult = {
-      name: 'AWS',
-      description: 'this has an aws plugin',
-      type: TYPE_STORAGE_BUCKET_PLUGIN,
-      bucket_name: 'bucketname',
-      bucket_prefix: 'bucketprefix',
-      worker_filter: 'workerfilter',
-      attributes: {
-        region: 'eu-west-1',
-        disable_credential_rotation: true,
-        role_arn: 'arn',
-        role_external_id: 'Example987',
-        role_session_name: 'my-session',
-        role_tags: { Project: 'Automation', foo: 'bar' },
-        secrets_hmac: null,
-      },
-    };
-    assert.deepEqual(record.serialize(), expectedResult);
   });
 });

--- a/addons/api/tests/unit/serializers/storage-bucket-test.js
+++ b/addons/api/tests/unit/serializers/storage-bucket-test.js
@@ -359,4 +359,46 @@ module('Unit | Serializer | storage bucket', function (hooks) {
       },
     });
   });
+
+  test('it trims whitespace on region and role_arn fields', async function (assert) {
+    const store = this.owner.lookup('service:store');
+    const record = store.createRecord('storage-bucket', {
+      compositeType: TYPE_STORAGE_BUCKET_PLUGIN_AWS_S3,
+      credentialType: TYPE_CREDENTIAL_DYNAMIC,
+      name: 'AWS',
+      description: 'this has an aws plugin',
+      bucket_name: 'bucketname',
+      bucket_prefix: 'bucketprefix',
+      worker_filter: 'workerfilter',
+      region: 'eu-west-1   ',
+      access_key_id: '',
+      secret_access_key: '',
+      disable_credential_rotation: true,
+      role_arn: ' arn  ',
+      role_external_id: 'Example987',
+      role_session_name: 'my-session',
+      role_tags: [
+        { key: 'Project', value: 'Automation' },
+        { key: 'foo', value: 'bar' },
+      ],
+    });
+    const expectedResult = {
+      name: 'AWS',
+      description: 'this has an aws plugin',
+      type: TYPE_STORAGE_BUCKET_PLUGIN,
+      bucket_name: 'bucketname',
+      bucket_prefix: 'bucketprefix',
+      worker_filter: 'workerfilter',
+      attributes: {
+        region: 'eu-west-1',
+        disable_credential_rotation: true,
+        role_arn: 'arn',
+        role_external_id: 'Example987',
+        role_session_name: 'my-session',
+        role_tags: { Project: 'Automation', foo: 'bar' },
+        secrets_hmac: null,
+      },
+    };
+    assert.deepEqual(record.serialize(), expectedResult);
+  });
 });


### PR DESCRIPTION
# Description
This PR  adds the `trimWhitespace` property to **storage bucket** and **host set** model attrs, and trims whitespace on serializer values before sending to the backend.

Context:
A bug was reported on the storage bucket and host set forms. The fields that will err if the values are not trimmed are: `role_arn`, `region`, and `preferred_endpoints`. We are handling this at the application level to account for the possibility that there may be other form fields that need to be trimmed in the future.

<!-- Uncomment line below to manually add link to JIRA ticket -->
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-15403)

## Screenshots 📸 
Before: 👇 
<img width="254" alt="Screenshot 2024-12-20 at 9 40 22 AM" src="https://github.com/user-attachments/assets/63e20874-749a-4a7b-ad7d-a9498f542fd7" />

After: 👇 
<img width="254" alt="Screenshot 2024-12-20 at 9 41 53 AM" src="https://github.com/user-attachments/assets/23920ab6-11a4-4a5a-9bf2-1685a1a3c473" />

## How to Test
### Storage Buckets
1. Spin up an env using: `ENABLE_MIRAGE=false API_HOST=http://localhost:9200 yarn start`
2. Navigate to Storage Bucket in left side navbar
3. Create a new storage bucket and make sure to fill either `region` or `role_arn` fields and leave whitespace
4. Submit the form
5. Use browser Network tab and view the response body from the POST request
6. Values should not have whitespace and UI should not throw an error

Steps to connect a storage bucket to AWS found [here](https://github.com/hashicorp/boundary-aws-demo-stack)

### Host Set
1. Spin up an env using: `ENABLE_MIRAGE=false API_HOST=http://localhost:9200 yarn start`
2. Navigate to Host Set in left side navbar
3. Create a host set within a host catalog (type: AWS, Azure, or GCP) and make sure to fill `preferred_endpoints` field and leave whitespace
4. Submit the form
5. Use browser Network tab and view the response body from the POST request
6. Values should not have whitespace and UI should not throw an error

Note: you need a valid worker filter to test these changes against prod, for example:
```
"dev" in "/tags/type"
```

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [x] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
