### PR TITLE
fix: 🐛 code block error in console when value is empty on save

### DIFF
--- a/ui/admin/app/components/form/storage-bucket/aws/index.hbs
+++ b/ui/admin/app/components/form/storage-bucket/aws/index.hbs
@@ -472,7 +472,7 @@
         </Hds::Link::Inline>
       </F.HelperText>
       <F.Control>
-        {{#if form.disabled}}
+        {{#if (and form.disabled (not @model.isSaving))}}
           <Hds::CodeBlock
             @language='bash'
             @value={{@model.worker_filter}}

--- a/ui/admin/app/components/form/storage-bucket/minio/index.hbs
+++ b/ui/admin/app/components/form/storage-bucket/minio/index.hbs
@@ -331,7 +331,7 @@
         </Hds::Link::Inline>
       </F.HelperText>
       <F.Control>
-        {{#if form.disabled}}
+        {{#if (and form.disabled (not @model.isSaving))}}
           <Hds::CodeBlock
             @maxHeight='300px'
             @language='bash'


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
Fix hds code block error manifesting itself when model is saving and code block is empty.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
Error msg:
![image](https://github.com/user-attachments/assets/14a48ffc-e310-4178-9e0b-63e82d8011b3)

After fix:

https://github.com/user-attachments/assets/00fc504d-228b-4a59-8ae3-4eb89daa74c1


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
1. Go to new storage bucket form
2. Try to save without a value in the code editor
3. Make sure no error is in the console.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [X] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
