### PR TITLE
fix: 🐛 oidc retry not working for secure links in desktop ui

### DIFF
--- a/ui/admin/app/controllers/scopes/scope/authenticate/method/oidc.js
+++ b/ui/admin/app/controllers/scopes/scope/authenticate/method/oidc.js
@@ -3,21 +3,35 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import Controller from '@ember/controller';
+import Controller, { inject as controller } from '@ember/controller';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class ScopesScopeAuthenticateMethodOidcController extends Controller {
+  @controller('scopes/scope/authenticate/method/index') authenticateMethod;
+
   // =services
 
   @service session;
 
-  // =attributes
+  // =actions
 
   /**
-   * Authentication URL for the pending OIDC flow, if any.
-   * @type {?string}
+   * Retry by starting a new OIDC authentication flow.
+   * @param {object} e
    */
-  get authURL() {
-    return this.session.data.pending.oidc.attributes.auth_url;
+  @action
+  async retryAuthentication(e) {
+    // TODO: These event handlers can be removed when rose dialog gets
+    // refactored to use hds.
+    e.preventDefault();
+    e.stopPropagation();
+
+    const scope = this.authMethod.scope;
+    const authenticatorName = `authenticator:${this.authMethod.type}`;
+    await this.authenticateMethod.startOIDCAuthentication(authenticatorName, {
+      scope,
+      authMethod: this.authMethod,
+    });
   }
 }

--- a/ui/admin/app/controllers/scopes/scope/authenticate/method/oidc.js
+++ b/ui/admin/app/controllers/scopes/scope/authenticate/method/oidc.js
@@ -22,10 +22,9 @@ export default class ScopesScopeAuthenticateMethodOidcController extends Control
    */
   @action
   async retryAuthentication(e) {
-    // TODO: These event handlers can be removed when rose dialog gets
+    // TODO: This event handler can be removed when rose dialog gets
     // refactored to use hds.
     e.preventDefault();
-    e.stopPropagation();
 
     const scope = this.authMethod.scope;
     const authenticatorName = `authenticator:${this.authMethod.type}`;

--- a/ui/admin/app/routes/scopes/scope/authenticate/method/oidc.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate/method/oidc.js
@@ -33,6 +33,16 @@ export default class ScopesScopeAuthenticateMethodOidcRoute extends Route {
     return oidc.attemptFetchToken({ scope, authMethod });
   }
 
+  /**
+   * Adds the auth-method to the controller context.
+   * @param {Controller} controller
+   */
+  setupController(controller) {
+    super.setupController(...arguments);
+    const authMethod = this.modelFor('scopes.scope.authenticate.method');
+    controller.authMethod = authMethod;
+  }
+
   @runEvery(POLL_TIMEOUT_SECONDS * 1000)
   poller() {
     this.refresh();

--- a/ui/admin/app/templates/scopes/scope/authenticate/method/oidc.hbs
+++ b/ui/admin/app/templates/scopes/scope/authenticate/method/oidc.hbs
@@ -12,7 +12,7 @@
     <p>{{t 'resources.auth-method.messages.pending.description'}}</p>
     <p>
       {{t 'resources.auth-method.questions.no-see-window'}}
-      <a href={{this.authURL}} target='_blank' rel='noreferrer noopener'>
+      <a href='#' role='button' {{on 'click' this.retryAuthentication}}>
         {{t 'actions.retry'}}
       </a>
     </p>

--- a/ui/admin/app/templates/scopes/scope/authenticate/method/oidc.hbs
+++ b/ui/admin/app/templates/scopes/scope/authenticate/method/oidc.hbs
@@ -12,7 +12,7 @@
     <p>{{t 'resources.auth-method.messages.pending.description'}}</p>
     <p>
       {{t 'resources.auth-method.questions.no-see-window'}}
-      <a href='#' role='button' {{on 'click' this.retryAuthentication}}>
+      <a href='#' {{on 'click' this.retryAuthentication}}>
         {{t 'actions.retry'}}
       </a>
     </p>

--- a/ui/desktop/app/controllers/scopes/scope/authenticate/method/oidc.js
+++ b/ui/desktop/app/controllers/scopes/scope/authenticate/method/oidc.js
@@ -22,10 +22,9 @@ export default class ScopesScopeAuthenticateMethodOidcController extends Control
    */
   @action
   async retryAuthentication(e) {
-    // TODO: These event handlers can be removed when rose dialog gets
+    // TODO: This event handler can be removed when rose dialog gets
     // refactored to use hds.
     e.preventDefault();
-    e.stopPropagation();
 
     const scope = this.authMethod.scope;
     const authenticatorName = `authenticator:${this.authMethod.type}`;

--- a/ui/desktop/app/controllers/scopes/scope/authenticate/method/oidc.js
+++ b/ui/desktop/app/controllers/scopes/scope/authenticate/method/oidc.js
@@ -3,21 +3,35 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import Controller from '@ember/controller';
+import Controller, { inject as controller } from '@ember/controller';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class ScopesScopeAuthenticateMethodOidcController extends Controller {
+  @controller('scopes/scope/authenticate/method/index') authenticateMethod;
+
   // =services
 
   @service session;
 
-  // =attributes
+  // =actions
 
   /**
-   * Authentication URL for the pending OIDC flow, if any.
-   * @type {?string}
+   * Retry by starting a new OIDC authentication flow.
+   * @param {object} e
    */
-  get authURL() {
-    return this.session.data.pending.oidc.attributes.auth_url;
+  @action
+  async retryAuthentication(e) {
+    // TODO: These event handlers can be removed when rose dialog gets
+    // refactored to use hds.
+    e.preventDefault();
+    e.stopPropagation();
+
+    const scope = this.authMethod.scope;
+    const authenticatorName = `authenticator:${this.authMethod.type}`;
+    await this.authenticateMethod.startOIDCAuthentication(authenticatorName, {
+      scope,
+      authMethod: this.authMethod,
+    });
   }
 }

--- a/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
@@ -31,6 +31,16 @@ export default class ScopesScopeAuthenticateMethodOidcRoute extends Route {
     return oidc.attemptFetchToken({ scope, authMethod });
   }
 
+  /**
+   * Adds the auth-method to the controller context.
+   * @param {Controller} controller
+   */
+  setupController(controller) {
+    super.setupController(...arguments);
+    const authMethod = this.modelFor('scopes.scope.authenticate.method');
+    controller.authMethod = authMethod;
+  }
+
   @runEvery(POLL_TIMEOUT_SECONDS * 1000)
   poller() {
     this.refresh();

--- a/ui/desktop/app/templates/scopes/scope/authenticate/method/oidc.hbs
+++ b/ui/desktop/app/templates/scopes/scope/authenticate/method/oidc.hbs
@@ -11,7 +11,7 @@
     <p>{{t 'resources.auth-method.messages.pending.description'}}</p>
     <p>
       {{t 'resources.auth-method.questions.no-see-window'}}
-      <a href={{this.authURL}} target='_blank' rel='noreferrer noopener'>
+      <a href='#' role='button' {{on 'click' this.retryAuthentication}}>
         {{t 'actions.retry'}}
       </a>
     </p>

--- a/ui/desktop/app/templates/scopes/scope/authenticate/method/oidc.hbs
+++ b/ui/desktop/app/templates/scopes/scope/authenticate/method/oidc.hbs
@@ -11,7 +11,7 @@
     <p>{{t 'resources.auth-method.messages.pending.description'}}</p>
     <p>
       {{t 'resources.auth-method.questions.no-see-window'}}
-      <a href='#' role='button' {{on 'click' this.retryAuthentication}}>
+      <a href='#' {{on 'click' this.retryAuthentication}}>
         {{t 'actions.retry'}}
       </a>
     </p>

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -156,16 +156,10 @@ const createWindow = (partition, closeWindowCB) => {
   });
 
   // Opens external links in the host default browser.
-  // We allow developer.hashicorp.com domain to open on external window
-  // and releases.hashicorp.com domain to download the desktop app or
-  // link to the release page for the desktop app.
+  // We allow secure links and localhost to open an external window.
   browserWindow.webContents.setWindowOpenHandler(({ url }) => {
-    if (
-      isLocalhost(url) ||
-      url.startsWith('https://developer.hashicorp.com/') ||
-      url.startsWith('https://releases.hashicorp.com/boundary-desktop/') ||
-      url.startsWith('https://support.hashicorp.com/hc/en-us')
-    ) {
+    const isSecure = url.startsWith('https://');
+    if (isSecure || isLocalhost(url)) {
       shell.openExternal(url);
     }
 

--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -156,10 +156,16 @@ const createWindow = (partition, closeWindowCB) => {
   });
 
   // Opens external links in the host default browser.
-  // We allow secure links and localhost to open an external window.
+  // We allow developer.hashicorp.com domain to open on external window
+  // and releases.hashicorp.com domain to download the desktop app or
+  // link to the release page for the desktop app.
   browserWindow.webContents.setWindowOpenHandler(({ url }) => {
-    const isSecure = url.startsWith('https://');
-    if (isSecure || isLocalhost(url)) {
+    if (
+      isLocalhost(url) ||
+      url.startsWith('https://developer.hashicorp.com/') ||
+      url.startsWith('https://releases.hashicorp.com/boundary-desktop/') ||
+      url.startsWith('https://support.hashicorp.com/hc/en-us')
+    ) {
       shell.openExternal(url);
     }
 


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
Looks like I missed a case when fixing the retry bug.
So the retry link was only working when using localhost env and this needs to be tested with secure oidc auth.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)


https://github.com/user-attachments/assets/b58786a9-eeda-4916-b1ca-0b5fc9cab3d4



## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
1. Use hcpb cluster w/ oidc auth method configured
2. Click sign in
3. Authentication Pending should appear.
4. Clicking "Retry" link should open new window.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [X] I have added steps to reproduce and test for bug fixes in the description
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
