### PR TITLE
Refactor text input area readonly

### DIFF
--- a/ui/admin/app/components/form/account/ldap/index.hbs
+++ b/ui/admin/app/components/form/account/ldap/index.hbs
@@ -10,7 +10,7 @@
   @showEditToggle={{if @model.isNew false true}}
   as |form|
 >
-  <InfoField @value={{@model.type}} disabled={{form.disabled}} as |F|>
+  <InfoField @value={{@model.type}} as |F|>
     <F.Label>{{t 'form.type.label'}}</F.Label>
   </InfoField>
 
@@ -19,7 +19,7 @@
     name='name'
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -39,7 +39,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     name='description'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -58,7 +58,7 @@
       name='login_name'
       @value={{@model.login_name}}
       @isInvalid={{@model.errors.login_name}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'login_name')}}
       as |F|
     >
@@ -115,7 +115,7 @@
           {{#each @model.member_of_groups as |group|}}
             <Hds::Form::TextInput::Field
               @value={{group.value}}
-              disabled={{true}}
+              readonly={{true}}
             />
           {{/each}}
         {{/if}}

--- a/ui/admin/app/components/form/account/oidc/index.hbs
+++ b/ui/admin/app/components/form/account/oidc/index.hbs
@@ -10,25 +10,24 @@
   @showEditToggle={{if @model.isNew false true}}
   as |form|
 >
-  <InfoField @value={{@model.type}} readonly={{true}} as |F|>
+  <InfoField @value={{@model.type}} as |F|>
     <F.Label>{{t 'form.type.label'}}</F.Label>
   </InfoField>
 
   {{#unless @model.isNew}}
-
-    <InfoField @value={{@model.issuer}} readonly={{true}} as |F|>
+    <InfoField @value={{@model.issuer}} as |F|>
       <F.Label>{{t 'form.issuer.label'}}</F.Label>
     </InfoField>
 
-    <InfoField @value={{@model.subject}} readonly={{true}} as |F|>
+    <InfoField @value={{@model.subject}} as |F|>
       <F.Label>{{t 'form.subject.label'}}</F.Label>
     </InfoField>
 
-    <InfoField @value={{@model.email}} readonly={{true}} as |F|>
+    <InfoField @value={{@model.email}} as |F|>
       <F.Label>{{t 'form.email.label'}}</F.Label>
     </InfoField>
 
-    <InfoField @value={{@model.full_name}} readonly={{true}} as |F|>
+    <InfoField @value={{@model.full_name}} as |F|>
       <F.Label>{{t 'form.full_name.label'}}</F.Label>
     </InfoField>
   {{/unless}}
@@ -38,7 +37,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -58,7 +57,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     name='description'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -77,7 +76,7 @@
       name='issuer'
       @value={{@model.issuer}}
       @isInvalid={{@model.errors.issuer}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'issuer')}}
       as |F|
     >
@@ -95,7 +94,7 @@
       name='subject'
       @value={{@model.subject}}
       @isInvalid={{@model.errors.subject}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'subject')}}
       as |F|
     >

--- a/ui/admin/app/components/form/account/password/change-password/index.hbs
+++ b/ui/admin/app/components/form/account/password/change-password/index.hbs
@@ -17,7 +17,7 @@
     @type='password'
     name='currentPassword'
     autocomplete='current-password'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event this 'currentPassword')}}
     as |F|
   >
@@ -30,7 +30,7 @@
     @type='password'
     name='newPassword'
     autocomplete='new-password'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event this 'newPassword')}}
     as |F|
   >

--- a/ui/admin/app/components/form/account/password/index.hbs
+++ b/ui/admin/app/components/form/account/password/index.hbs
@@ -10,7 +10,7 @@
   @showEditToggle={{if @model.isNew false true}}
   as |form|
 >
-  <InfoField @value={{@model.type}} readonly={{true}} as |F|>
+  <InfoField @value={{@model.type}} as |F|>
     <F.Label>{{t 'form.type.label'}}</F.Label>
   </InfoField>
 
@@ -19,7 +19,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -39,7 +39,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -58,7 +58,7 @@
     @value={{@model.login_name}}
     @isInvalid={{@model.errors.login_name}}
     @isRequired={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'login_name')}}
     as |F|
   >
@@ -78,7 +78,7 @@
       @type='password'
       @value={{this.password}}
       @isInvalid={{@model.errors.password}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       autocomplete='new-password'
       {{on 'input' (set-from-event this 'password')}}
       as |F|

--- a/ui/admin/app/components/form/account/password/set-password/index.hbs
+++ b/ui/admin/app/components/form/account/password/set-password/index.hbs
@@ -11,7 +11,7 @@
     @type='password'
     name='password'
     autocomplete='new-password'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event this 'password')}}
     as |F|
   >

--- a/ui/admin/app/components/form/alias/index.hbs
+++ b/ui/admin/app/components/form/alias/index.hbs
@@ -15,7 +15,7 @@
     @isOptional={{true}}
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -29,12 +29,13 @@
       </F.Error>
     {{/if}}
   </Hds::Form::TextInput::Field>
+
   <Hds::Form::Textarea::Field
     name='description'
     @isOptional={{true}}
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -76,7 +77,7 @@
     @isRequired={{true}}
     @value={{@model.value}}
     @isInvalid={{@model.errors.value}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'value')}}
     as |F|
   >
@@ -96,8 +97,7 @@
     @isOptional={{true}}
     @value={{@model.destination_id}}
     @isInvalid={{@model.errors.destination_id}}
-    readonly={{@hideTargetId}}
-    disabled={{form.disabled}}
+    readonly={{(or form.disabled @hideTargetId)}}
     {{on 'input' (set-from-event @model 'destination_id')}}
     as |F|
   >
@@ -119,7 +119,7 @@
     @isOptional={{true}}
     @value={{@model.authorize_session_arguments.host_id}}
     @isInvalid={{@model.errors.authorize_session_arguments.host_id}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' this.handleHostIdChange}}
     as |F|
   >
@@ -138,12 +138,7 @@
     {{/if}}
   </Hds::Form::TextInput::Field>
 
-  <InfoField
-    @value={{@model.scopeModel.displayName}}
-    @icon='globe'
-    disabled={{form.disabled}}
-    as |F|
-  >
+  <InfoField @value={{@model.scopeModel.displayName}} @icon='globe' as |F|>
     <F.Label>{{t 'resources.scope.title'}}</F.Label>
   </InfoField>
 

--- a/ui/admin/app/components/form/auth-method/ldap/index.hbs
+++ b/ui/admin/app/components/form/auth-method/ldap/index.hbs
@@ -16,7 +16,7 @@
     @type='text'
     @value={{@model.type}}
     name='type'
-    disabled={{true}}
+    readonly={{true}}
     as |F|
   >
     <F.Label>{{t 'form.type.label'}}</F.Label>
@@ -27,7 +27,7 @@
     @value={{@model.name}}
     @type='text'
     name='name'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -39,7 +39,7 @@
     @isOptional={{true}}
     @value={{@model.description}}
     name='description'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -61,7 +61,7 @@
     @isInvalid={{@model.errors.urls}}
     @type='url'
     name='urls'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' this.setUrls}}
     as |F|
   >
@@ -115,7 +115,7 @@
       @isInvalid={{@model.errors.client_certificate}}
       @type='password'
       name='client_certificate'
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       @hasVisibilityToggle={{false}}
       {{on 'input' (set-from-event @model 'client_certificate')}}
       as |F|
@@ -141,7 +141,7 @@
       @isInvalid={{@model.errors.client_certificate_key}}
       @type='password'
       name='client_certificate_key'
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       @hasVisibilityToggle={{false}}
       {{on 'input' (set-from-event @model 'client_certificate_key')}}
       as |F|
@@ -228,7 +228,7 @@
     @value={{@model.bind_dn}}
     @type='text'
     name='bind_dn'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'bind_dn')}}
     as |F|
   >
@@ -242,7 +242,7 @@
       @value={{@model.bind_password}}
       @type='password'
       name='bind_password'
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       @hasVisibilityToggle={{false}}
       {{on 'input' (set-from-event @model 'bind_password')}}
       as |F|
@@ -283,7 +283,7 @@
     @value={{@model.upn_domain}}
     @type='text'
     name='upn_domain'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'upn_domain')}}
     as |F|
   >
@@ -344,7 +344,7 @@
     @value={{@model.user_dn}}
     @type='text'
     name='user_dn'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'user_dn')}}
     as |F|
   >
@@ -357,7 +357,7 @@
     @value={{@model.user_attr}}
     @type='text'
     name='user_attr'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'user_attr')}}
     as |F|
   >
@@ -372,7 +372,7 @@
     @value={{@model.user_filter}}
     @type='text'
     name='user_filter'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'user_filter')}}
     as |F|
   >
@@ -437,7 +437,7 @@
     @isInvalid={{@model.errors.group_dn}}
     @type='text'
     name='group_dn'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'group_dn')}}
     as |F|
   >
@@ -459,7 +459,7 @@
     @value={{@model.group_attr}}
     @type='text'
     name='group_attr'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'group_attr')}}
     as |F|
   >
@@ -474,7 +474,7 @@
     @value={{@model.group_filter}}
     @type='text'
     name='group_filter'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'group_filter')}}
     as |F|
   >
@@ -515,7 +515,7 @@
     @value={{@model.maximum_page_size}}
     @type='text'
     name='maximum_page_size'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'maximum_page_size')}}
     as |F|
   >

--- a/ui/admin/app/components/form/auth-method/oidc/index.hbs
+++ b/ui/admin/app/components/form/auth-method/oidc/index.hbs
@@ -12,7 +12,7 @@
   as |form|
 >
 
-  <InfoField @value={{@model.type}} disabled={{form.disabled}} as |F|>
+  <InfoField @value={{@model.type}} as |F|>
     <F.Label>{{t 'form.type.label'}}</F.Label>
   </InfoField>
 
@@ -21,7 +21,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -41,7 +41,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -59,7 +59,7 @@
     @value={{@model.issuer}}
     @isInvalid={{@model.errors.issuer}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     name='issuer'
     {{on 'input' (set-from-event @model 'issuer')}}
     as |F|
@@ -99,7 +99,7 @@
     @value={{@model.client_id}}
     @isRequired={{true}}
     @isInvalid={{@model.errors.client_id}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'client_id')}}
     as |F|
   >
@@ -119,7 +119,7 @@
     @value={{@model.client_secret}}
     @isRequired={{true}}
     @isInvalid={{@model.errors.client_secret}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     @hasVisibilityToggle={{false}}
     @type='password'
     {{on 'input' (set-from-event @model 'client_secret')}}
@@ -139,7 +139,7 @@
   {{#unless @model.isNew}}
     <Hds::Form::TextInput::Field
       @value={{@model.client_secret_hmac}}
-      disabled={{true}}
+      readonly={{true}}
       as |F|
     >
       <F.Label>{{t 'form.client_secret_hmac.label'}}</F.Label>
@@ -243,7 +243,6 @@
         @model={{@model}}
       />
     </:field>
-
   </Form::Field::ListWrapper>
 
   {{! Account Claim Maps }}
@@ -268,6 +267,7 @@
         </F.Error>
       {{/if}}
     </:fieldset>
+
     <:field as |F|>
       <F.KeyValue
         @name='account_claim_maps'
@@ -317,7 +317,6 @@
         @model={{@model}}
       />
     </:field>
-
   </Form::Field::ListWrapper>
 
   <Hds::Form::TextInput::Field
@@ -325,7 +324,7 @@
     @value={{@model.max_age}}
     @isOptional={{true}}
     @isInvalid={{@model.errors.max_age}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'max_age')}}
     as |F|
   >
@@ -345,7 +344,7 @@
     @value={{@model.api_url_prefix}}
     @isRequired={{true}}
     @isInvalid={{@model.errors.api_url_prefix}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'api_url_prefix')}}
     as |F|
   >
@@ -415,7 +414,7 @@
   {{#unless @model.isNew}}
     <Hds::Form::TextInput::Field
       @value={{@model.callback_url}}
-      disabled={{true}}
+      readonly={{true}}
       as |F|
     >
       <F.Label>{{t 'form.callback_url.label'}}</F.Label>

--- a/ui/admin/app/components/form/auth-method/password/index.hbs
+++ b/ui/admin/app/components/form/auth-method/password/index.hbs
@@ -19,7 +19,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -39,7 +39,7 @@
     @isOptional={{true}}
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>

--- a/ui/admin/app/components/form/auth-method/password/index.hbs
+++ b/ui/admin/app/components/form/auth-method/password/index.hbs
@@ -10,7 +10,7 @@
   @showEditToggle={{if @model.isNew false true}}
   as |form|
 >
-  <InfoField @value={{@model.type}} disabled={{form.disabled}} as |F|>
+  <InfoField @value={{@model.type}} as |F|>
     <F.Label>{{t 'form.type.label'}}</F.Label>
   </InfoField>
 

--- a/ui/admin/app/components/form/credential-library/vault-generic/index.hbs
+++ b/ui/admin/app/components/form/credential-library/vault-generic/index.hbs
@@ -15,7 +15,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -37,7 +37,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -94,7 +94,7 @@
     @isInvalid={{@model.errors.path}}
     @type='text'
     name='vault_path'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'path')}}
     as |F|
   >
@@ -228,7 +228,7 @@
       @value={{@model.http_request_body}}
       @isInvalid={{@model.errors.http_request_body}}
       name='http_request_body'
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       as |F|
     >
       <F.Label>{{t

--- a/ui/admin/app/components/form/credential-library/vault-ssh-certificate/index.hbs
+++ b/ui/admin/app/components/form/credential-library/vault-ssh-certificate/index.hbs
@@ -17,7 +17,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -39,7 +39,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -95,7 +95,7 @@
     @isInvalid={{@model.errors.path}}
     @type='text'
     name='vault_path'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'path')}}
     as |F|
   >
@@ -122,7 +122,7 @@
     @isInvalid={{@model.errors.username}}
     @type='text'
     name='username'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'username')}}
     as |F|
   >
@@ -178,7 +178,7 @@
       @isInvalid={{@model.errors.key_bits}}
       @type='text'
       name='key_bits'
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'key_bits')}}
       as |F|
     >
@@ -204,7 +204,7 @@
     @isInvalid={{@model.errors.ttl}}
     @type='text'
     name='ttl'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'ttl')}}
     as |F|
   >
@@ -227,7 +227,7 @@
     @isInvalid={{@model.errors.key_id}}
     @type='text'
     name='key_id'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'key_id')}}
     as |F|
   >

--- a/ui/admin/app/components/form/credential-store/static/index.hbs
+++ b/ui/admin/app/components/form/credential-store/static/index.hbs
@@ -15,7 +15,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -37,7 +37,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -53,7 +53,6 @@
 
   {{#if (feature-flag 'static-credentials')}}
     {{#if @model.isNew}}
-
       <Hds::Form::RadioCard::Group
         @name={{t 'form.type.label'}}
         @alignment='center'

--- a/ui/admin/app/components/form/credential-store/vault/index.hbs
+++ b/ui/admin/app/components/form/credential-store/vault/index.hbs
@@ -16,7 +16,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -38,7 +38,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -82,7 +82,6 @@
       <InfoField
         @value={{t (concat 'resources.credential-store.types.' @model.type)}}
         @icon='vault'
-        readonly={{true}}
         as |F|
       >
         <F.Label>{{t 'form.type.label'}}</F.Label>
@@ -98,7 +97,7 @@
     @value={{@model.address}}
     @isInvalid={{@model.errors.address}}
     @isRequired={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'address')}}
     as |F|
   >
@@ -121,7 +120,7 @@
       @value={{@model.token}}
       @isInvalid={{@model.errors.token}}
       @isRequired={{true}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'token')}}
       as |F|
     >
@@ -142,7 +141,7 @@
   {{#unless @model.isNew}}
     <Hds::Form::TextInput::Field
       @value={{@model.token_hmac}}
-      disabled={{true}}
+      readonly={{true}}
       as |F|
     >
       <F.Label>
@@ -155,7 +154,7 @@
     @value={{@model.namespace}}
     @isOptional={{true}}
     @isInvalid={{@model.errors.namespace}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'namespace')}}
     as |F|
   >
@@ -177,7 +176,7 @@
     @value={{@model.tls_server_name}}
     @isOptional={{true}}
     @isInvalid={{@model.errors.tls_server_name}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'tls_server_name')}}
     as |F|
   >
@@ -226,7 +225,7 @@
     @value={{@model.client_certificate}}
     @isInvalid={{@model.errors.client_certificate}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t
@@ -249,7 +248,7 @@
     @value={{@model.client_certificate_key}}
     @isOptional={{true}}
     @isInvalid={{@model.errors.client_certificate_key}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t
@@ -270,7 +269,7 @@
   {{#unless @model.isNew}}
     <Hds::Form::TextInput::Field
       @value={{@model.client_certificate_key_hmac}}
-      disabled={{true}}
+      readonly={{true}}
       as |F|
     >
       <F.Label>
@@ -286,7 +285,7 @@
     @value={{@model.ca_cert}}
     @isOptional={{true}}
     @isInvalid={{@model.errors.ca_cert}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'resources.credential-store.form.ca_cert.label'}}</F.Label>

--- a/ui/admin/app/components/form/credential/json/index.hbs
+++ b/ui/admin/app/components/form/credential/json/index.hbs
@@ -16,7 +16,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -38,7 +38,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>

--- a/ui/admin/app/components/form/credential/ssh_private_key/index.hbs
+++ b/ui/admin/app/components/form/credential/ssh_private_key/index.hbs
@@ -16,7 +16,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -38,7 +38,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -51,6 +51,7 @@
       </F.Error>
     {{/if}}
   </Hds::Form::Textarea::Field>
+
   {{#if @model.isNew}}
     <Hds::Form::RadioCard::Group @name={{t 'form.type.label'}} as |G|>
       <G.Legend>{{t 'form.type.label'}}</G.Legend>
@@ -69,13 +70,11 @@
               (concat 'resources.credential.help.' credentialType)
             }}</R.Description>
         </G.RadioCard>
-
       {{/each}}
     </Hds::Form::RadioCard::Group>
   {{else}}
     <InfoField
       @value={{t (concat 'resources.credential.types.' @model.type)}}
-      readonly={{true}}
       as |F|
     >
       <F.Label>{{t 'form.type.label'}}</F.Label>
@@ -88,7 +87,7 @@
     name='username'
     @value={{@model.username}}
     @isInvalid={{@model.errors.username}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'username')}}
     as |F|
   >
@@ -111,7 +110,7 @@
       @value={{@model.private_key}}
       @isInvalid={{@model.errors.private_key}}
       @isRequired={{true}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       as |F|
     >
       <F.Label>{{t 'resources.credential.form.private_key.label'}}</F.Label>
@@ -135,7 +134,7 @@
       @value={{@model.private_key_passphrase}}
       @isInvalid={{@model.errors.private_key_passphrase}}
       @isOptional={{true}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       autocomplete='new-password'
       {{on 'input' (set-from-event @model 'private_key_passphrase')}}
       as |F|

--- a/ui/admin/app/components/form/credential/username_password/index.hbs
+++ b/ui/admin/app/components/form/credential/username_password/index.hbs
@@ -16,7 +16,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -38,7 +38,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -76,7 +76,6 @@
   {{else}}
     <InfoField
       @value={{t (concat 'resources.credential.types.' @model.type)}}
-      readonly={{true}}
       as |F|
     >
       <F.Label>{{t 'form.type.label'}}</F.Label>
@@ -89,7 +88,7 @@
     name='username'
     @value={{@model.username}}
     @isInvalid={{@model.errors.username}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'username')}}
     as |F|
   >
@@ -110,7 +109,7 @@
       @type='password'
       @value={{@model.password}}
       @isInvalid={{@model.errors.password}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       autocomplete='new-password'
       {{on 'input' (set-from-event @model 'password')}}
       as |F|

--- a/ui/admin/app/components/form/field/list-wrapper/key-value/text.hbs
+++ b/ui/admin/app/components/form/field/list-wrapper/key-value/text.hbs
@@ -5,7 +5,7 @@
 
 <Hds::Form::TextInput::Field
   @value={{@value}}
-  disabled={{@disabled}}
+  readonly={{@disabled}}
   aria-labelledby={{@ariaLabelledBy}}
   {{on 'input' @setContext}}
 />

--- a/ui/admin/app/components/form/field/list-wrapper/select-text/index.hbs
+++ b/ui/admin/app/components/form/field/list-wrapper/select-text/index.hbs
@@ -41,7 +41,7 @@
               @value={{val}}
               @type='text'
               @width={{@width}}
-              disabled={{@disabled}}
+              readonly={{@disabled}}
               aria-labelledby={{valueHeaderID}}
               {{on 'change' (fn this.updateInput select)}}
             />
@@ -93,7 +93,7 @@
               @value={{this.newOptionValue}}
               @type='text'
               @width={{@width}}
-              disabled={{@disabled}}
+              readonly={{@disabled}}
               aria-labelledby={{valueHeaderID}}
               {{on 'input' (set-from-event this 'newOptionValue')}}
             />

--- a/ui/admin/app/components/form/field/list-wrapper/text-input/index.hbs
+++ b/ui/admin/app/components/form/field/list-wrapper/text-input/index.hbs
@@ -13,7 +13,7 @@
           <Hds::Form::TextInput::Field
             @value={{option.value}}
             @type='text'
-            disabled={{@disabled}}
+            readonly={{@disabled}}
             aria-label={{t 'titles.value'}}
             {{on 'input' (set-from-event option 'value')}}
           />
@@ -41,7 +41,7 @@
         <Hds::Form::TextInput::Field
           @value={{this.newOptionValue}}
           @type='text'
-          disabled={{@disabled}}
+          readonly={{@disabled}}
           aria-label={{t 'titles.value'}}
           {{on 'input' (set-from-event this 'newOptionValue')}}
         />

--- a/ui/admin/app/components/form/field/list-wrapper/textarea/index.hbs
+++ b/ui/admin/app/components/form/field/list-wrapper/textarea/index.hbs
@@ -13,7 +13,7 @@
           <Hds::Form::Textarea::Field
             @value={{option.value}}
             @type='text'
-            disabled={{@disabled}}
+            readonly={{@disabled}}
             aria-label={{t 'titles.value'}}
           />
         </B.Td>
@@ -40,7 +40,7 @@
         <Hds::Form::Textarea::Field
           @value={{this.newOptionValue}}
           @type='text'
-          disabled={{@disabled}}
+          readonly={{@disabled}}
           aria-label={{t 'titles.value'}}
         />
       </B.Td>

--- a/ui/admin/app/components/form/field/secret-input/index.hbs
+++ b/ui/admin/app/components/form/field/secret-input/index.hbs
@@ -13,7 +13,7 @@
     @value={{@value}}
     @type={{(or @type 'password')}}
     name={{@name}}
-    disabled={{or @isDisabled (not this.isEditing)}}
+    readonly={{or @isDisabled (not this.isEditing)}}
     @hasVisibilityToggle={{false}}
     as |F|
   >

--- a/ui/admin/app/components/form/group/index.hbs
+++ b/ui/admin/app/components/form/group/index.hbs
@@ -16,7 +16,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -36,7 +36,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>

--- a/ui/admin/app/components/form/host-catalog/aws/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/aws/index.hbs
@@ -15,7 +15,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -41,7 +41,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>
@@ -117,7 +117,6 @@
     <InfoField
       @value={{t 'resources.host-catalog.types.aws'}}
       @icon='aws-color'
-      readonly={{true}}
       as |F|
     >
       <F.Label>
@@ -133,7 +132,7 @@
     name='region'
     @value={{@model.region}}
     @isRequired={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'region')}}
     as |F|
   >
@@ -195,7 +194,7 @@
       @isOptional={{true}}
       @value={{@model.role_arn}}
       @isInvalid={{@model.errors.role_arn}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'role_arn')}}
       as |F|
     >
@@ -222,7 +221,7 @@
       @isOptional={{true}}
       @value={{@model.role_external_id}}
       @isInvalid={{@model.errors.role_external_id}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'role_external_id')}}
       as |F|
     >
@@ -249,7 +248,7 @@
       @isOptional={{true}}
       @value={{@model.role_session_name}}
       @isInvalid={{@model.errors.role_session_name}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'role_session_name')}}
       as |F|
     >
@@ -315,7 +314,7 @@
       name='access_key_id'
       @value={{@model.access_key_id}}
       @isOptional={{true}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'access_key_id')}}
       as |F|
     >
@@ -334,7 +333,7 @@
       name='secret_access_key'
       @value={{@model.secret_access_key}}
       @isOptional={{true}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'secret_access_key')}}
       as |F|
     >
@@ -357,7 +356,7 @@
       @value={{@model.worker_filter}}
       @isOptional={{true}}
       @isInvalid={{@model.errors.worker_filter}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       as |F|
     >
       <F.Label>{{t 'form.worker_filter.label'}}</F.Label>

--- a/ui/admin/app/components/form/host-catalog/azure/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/azure/index.hbs
@@ -15,7 +15,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -35,7 +35,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -69,6 +69,7 @@
         </G.RadioCard>
       {{/each}}
     </Hds::Form::RadioCard::Group>
+
     <Hds::Form::RadioCard::Group
       @name={{t 'form.plugin_type.label'}}
       @alignment='center'
@@ -99,7 +100,6 @@
     <InfoField
       @value={{t 'resources.host-catalog.types.azure'}}
       @icon='azure-color'
-      readonly={{true}}
       as |F|
     >
       <F.Label>{{t 'titles.provider'}}</F.Label>
@@ -112,7 +112,7 @@
     name='tenant_id'
     @value={{@model.tenant_id}}
     @isRequired={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'tenant_id')}}
     as |F|
   >
@@ -129,7 +129,7 @@
     name='subscription_id'
     @value={{@model.subscription_id}}
     @isRequired={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'subscription_id')}}
     as |F|
   >
@@ -146,7 +146,7 @@
     name='client_id'
     @value={{@model.client_id}}
     @isRequired={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'client_id')}}
     as |F|
   >
@@ -163,7 +163,7 @@
     name='secret_value'
     @value={{@model.secret_value}}
     @isRequired={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'secret_value')}}
     as |F|
   >

--- a/ui/admin/app/components/form/host-catalog/static/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/static/index.hbs
@@ -15,7 +15,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -35,7 +35,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -50,7 +50,6 @@
   </Hds::Form::Textarea::Field>
 
   {{#if @model.isNew}}
-
     <Hds::Form::RadioCard::Group @name={{t 'form.type.label'}} as |G|>
       <G.Legend>{{t 'form.type.label'}}</G.Legend>
       {{#each this.hostCatalogTypes as |hostCatalogType|}}

--- a/ui/admin/app/components/form/host-set/aws/index.hbs
+++ b/ui/admin/app/components/form/host-set/aws/index.hbs
@@ -17,7 +17,7 @@
     @value={{@model.name}}
     @isOptional={{true}}
     @isInvalid={{@model.errors.name}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -37,7 +37,7 @@
     @value={{@model.description}}
     @isOptional={{true}}
     @isInvalid={{@model.errors.description}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -51,16 +51,11 @@
     {{/if}}
   </Hds::Form::Textarea::Field>
 
-  <InfoField @value={{@model.type}} disabled={{form.disabled}} as |F|>
+  <InfoField @value={{@model.type}} as |F|>
     <F.Label>{{t 'form.type.label'}}</F.Label>
   </InfoField>
 
-  <InfoField
-    @value={{t 'descriptions.provider'}}
-    @icon='aws-color'
-    disabled={{form.disabled}}
-    as |F|
-  >
+  <InfoField @value={{t 'descriptions.provider'}} @icon='aws-color' as |F|>
     <F.Label>{{t 'titles.provider'}}</F.Label>
     <F.HelperText>
       {{t 'resources.host-catalog.types.aws'}}
@@ -132,7 +127,7 @@
     @value={{@model.sync_interval_seconds}}
     @isInvalid={{@model.errors.sync_interval_seconds}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'sync_interval_seconds')}}
     as |F|
   >

--- a/ui/admin/app/components/form/host-set/azure/index.hbs
+++ b/ui/admin/app/components/form/host-set/azure/index.hbs
@@ -17,7 +17,7 @@
     @value={{@model.name}}
     @isOptional={{true}}
     @isInvalid={{@model.errors.name}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -37,7 +37,7 @@
     @isOptional={{true}}
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -51,16 +51,11 @@
     {{/if}}
   </Hds::Form::Textarea::Field>
 
-  <InfoField @value={{@model.type}} readonly={{true}} as |F|>
+  <InfoField @value={{@model.type}} as |F|>
     <F.Label>{{t 'form.type.label'}}</F.Label>
   </InfoField>
 
-  <InfoField
-    @value={{t 'descriptions.provider'}}
-    @icon='azure-color'
-    readonly={{true}}
-    as |F|
-  >
+  <InfoField @value={{t 'descriptions.provider'}} @icon='azure-color' as |F|>
     <F.Label>{{t 'titles.provider'}}</F.Label>
     <F.HelperText>
       {{t 'resources.host-catalog.types.azure'}}
@@ -103,7 +98,7 @@
     @value={{@model.filter_string}}
     @isOptional={{true}}
     @isInvalid={{@model.errors.filter_string}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'resources.host-set.form.filter.label'}}</F.Label>
@@ -124,7 +119,7 @@
     @value={{@model.sync_interval_seconds}}
     @isInvalid={{@model.errors.sync_interval_seconds}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'sync_interval_seconds')}}
     as |F|
   >

--- a/ui/admin/app/components/form/host-set/static/index.hbs
+++ b/ui/admin/app/components/form/host-set/static/index.hbs
@@ -16,7 +16,7 @@
     @value={{@model.name}}
     @isOptional={{true}}
     @isInvalid={{@model.errors.name}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -36,7 +36,7 @@
     @value={{@model.description}}
     @isOptional={{true}}
     @isInvalid={{@model.errors.description}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>

--- a/ui/admin/app/components/form/host/aws/index.hbs
+++ b/ui/admin/app/components/form/host/aws/index.hbs
@@ -14,7 +14,7 @@
   <Hds::Form::TextInput::Field
     @value={{@model.type}}
     name='type'
-    disabled={{true}}
+    readonly={{true}}
     as |F|
   >
     <F.Label>{{t 'form.type.label'}}</F.Label>
@@ -25,7 +25,7 @@
       @value={{@model.external_name}}
       @isInvalid={{@model.errors.external_name}}
       name='external_name'
-      disabled={{true}}
+      readonly={{true}}
       as |F|
     >
       <F.Label>{{t 'form.external_name.label'}}</F.Label>
@@ -44,7 +44,7 @@
     @value={{@model.external_id}}
     @isInvalid={{@model.errors.external_id}}
     name='external_id'
-    disabled={{true}}
+    readonly={{true}}
     as |F|
   >
     <F.Label>{{t 'form.external_id.label'}}</F.Label>
@@ -62,7 +62,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     name='description'
-    disabled={{true}}
+    readonly={{true}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -76,12 +76,7 @@
     {{/if}}
   </Hds::Form::Textarea::Field>
 
-  <InfoField
-    @value={{t 'descriptions.provider'}}
-    @icon='aws-color'
-    disabled={{form.disabled}}
-    as |F|
-  >
+  <InfoField @value={{t 'descriptions.provider'}} @icon='aws-color' as |F|>
     <F.Label>{{t 'titles.provider'}}</F.Label>
     <F.HelperText>
       {{t 'resources.host-catalog.types.aws'}}
@@ -95,7 +90,7 @@
       <F.Control>
         <Hds::Form::TextInput::Base
           @value={{ip_address}}
-          disabled={{true}}
+          readonly={{true}}
           @width='unset'
         />
       </F.Control>
@@ -109,7 +104,7 @@
       <F.Control>
         <Hds::Form::TextInput::Base
           @value={{dns_name}}
-          disabled={{true}}
+          readonly={{true}}
           @width='unset'
         />
       </F.Control>

--- a/ui/admin/app/components/form/host/azure/index.hbs
+++ b/ui/admin/app/components/form/host/azure/index.hbs
@@ -14,7 +14,7 @@
   <Hds::Form::TextInput::Field
     @value={{@model.type}}
     name='type'
-    disabled={{true}}
+    readonly={{true}}
     as |F|
   >
     <F.Label>{{t 'form.type.label'}}</F.Label>
@@ -25,7 +25,7 @@
       @value={{@model.external_name}}
       @isInvalid={{@model.errors.external_name}}
       name='external_name'
-      disabled={{true}}
+      readonly={{true}}
       as |F|
     >
       <F.Label>{{t 'form.external_name.label'}}</F.Label>
@@ -44,7 +44,7 @@
     @value={{@model.external_id}}
     @isInvalid={{@model.errors.external_id}}
     name='external_id'
-    disabled={{true}}
+    readonly={{true}}
     as |F|
   >
     <F.Label>{{t 'form.external_id.label'}}</F.Label>
@@ -62,7 +62,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     name='description'
-    disabled={{true}}
+    readonly={{true}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -76,12 +76,7 @@
     {{/if}}
   </Hds::Form::Textarea::Field>
 
-  <InfoField
-    @value={{t 'descriptions.provider'}}
-    @icon='azure-color'
-    disabled={{form.disabled}}
-    as |F|
-  >
+  <InfoField @value={{t 'descriptions.provider'}} @icon='azure-color' as |F|>
     <F.Label>{{t 'titles.provider'}}</F.Label>
     <F.HelperText>
       {{t 'resources.host-catalog.types.azure'}}
@@ -95,7 +90,7 @@
       <F.Control>
         <Hds::Form::TextInput::Base
           @value={{ip_address}}
-          disabled={{true}}
+          readonly={{true}}
           @width='unset'
         />
       </F.Control>

--- a/ui/admin/app/components/form/host/static/index.hbs
+++ b/ui/admin/app/components/form/host/static/index.hbs
@@ -11,7 +11,7 @@
   as |form|
 >
 
-  <Hds::Form::TextInput::Field @value={{@model.type}} disabled={{true}} as |F|>
+  <Hds::Form::TextInput::Field @value={{@model.type}} readonly={{true}} as |F|>
     <F.Label>{{t 'form.type.label'}}</F.Label>
   </Hds::Form::TextInput::Field>
 
@@ -20,7 +20,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -40,7 +40,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -59,7 +59,7 @@
     @value={{@model.address}}
     @isInvalid={{@model.errors.address}}
     @isRequired={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'address')}}
     as |F|
   >

--- a/ui/admin/app/components/form/managed-group/ldap/index.hbs
+++ b/ui/admin/app/components/form/managed-group/ldap/index.hbs
@@ -11,7 +11,7 @@
   @showEditToggle={{if @model.isNew false true}}
   as |form|
 >
-  <InfoField @value={{@model.type}} disabled={{form.disabled}} as |F|>
+  <InfoField @value={{@model.type}} as |F|>
     <F.Label>{{t 'form.type.label'}}</F.Label>
   </InfoField>
 
@@ -20,7 +20,7 @@
     name='name'
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -40,7 +40,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     name='description'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -74,7 +74,7 @@
                 <B.Td>
                   <Hds::Form::TextInput::Field
                     @value={{group.value}}
-                    disabled={{form.disabled}}
+                    readonly={{form.disabled}}
                     aria-labelledby={{valueHeaderID}}
                     {{on 'input' (set-from-event group 'value')}}
                   />
@@ -96,7 +96,7 @@
                 <Hds::Form::TextInput::Field
                   @value={{this.newGroup}}
                   @type='text'
-                  disabled={{form.disabled}}
+                  readonly={{form.disabled}}
                   aria-labelledby={{valueHeaderID}}
                   {{on 'input' (set-from-event this 'newGroup')}}
                 />

--- a/ui/admin/app/components/form/managed-group/oidc/index.hbs
+++ b/ui/admin/app/components/form/managed-group/oidc/index.hbs
@@ -10,7 +10,7 @@
   @showEditToggle={{if @model.isNew false true}}
   as |form|
 >
-  <InfoField @value={{@model.type}} readonly={{true}} as |F|>
+  <InfoField @value={{@model.type}} as |F|>
     <F.Label>{{t 'form.type.label'}}</F.Label>
   </InfoField>
 
@@ -19,7 +19,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -39,7 +39,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     name='description'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -58,7 +58,7 @@
     @value={{@model.filter_string}}
     @isInvalid={{@model.errors.filter_string}}
     @isRequired={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'filter_string')}}
     as |F|
   >

--- a/ui/admin/app/components/form/policy/index.hbs
+++ b/ui/admin/app/components/form/policy/index.hbs
@@ -54,7 +54,7 @@
     @name='retention_policy'
     @disabled={{form.disabled}}
     @model={{@model}}
-    @options={{this.listRententionOptions}}
+    @options={{this.listRetentionOptions}}
     @customInputName='retain_for'
     @inputValue={{@model.retain_for.days}}
     @selectedOption={{this.selectRetentionPolicyType}}

--- a/ui/admin/app/components/form/policy/index.hbs
+++ b/ui/admin/app/components/form/policy/index.hbs
@@ -16,7 +16,7 @@
     @isInvalid={{@model.errors.name}}
     @type='text'
     name='name'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -30,12 +30,13 @@
       </F.Error>
     {{/if}}
   </Hds::Form::TextInput::Field>
+
   <Hds::Form::Textarea::Field
     @isOptional={{true}}
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     name='description'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>

--- a/ui/admin/app/components/form/policy/index.js
+++ b/ui/admin/app/components/form/policy/index.js
@@ -24,7 +24,7 @@ export default class FormPolicyComponent extends Component {
    * Returns retention policy options list
    * @type {array}
    */
-  get listRententionOptions() {
+  get listRetentionOptions() {
     return RETENTION_POLICY;
   }
 

--- a/ui/admin/app/components/form/policy/policy-selection/index.hbs
+++ b/ui/admin/app/components/form/policy/policy-selection/index.hbs
@@ -57,7 +57,7 @@
         <S.TextInput
           name={{@customInputName}}
           @value={{@inputValue}}
-          disabled={{@disabled}}
+          readonly={{@disabled}}
           aria-label={{t 'resources.policy.title'}}
           data-input={{@customInputName}}
           {{on 'input' this.handleInputChange}}

--- a/ui/admin/app/components/form/scope/index.hbs
+++ b/ui/admin/app/components/form/scope/index.hbs
@@ -17,7 +17,7 @@
     @isInvalid={{@model.errors.name}}
     @type='text'
     name='name'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -37,7 +37,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     name='description'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>

--- a/ui/admin/app/components/form/storage-bucket/aws/index.hbs
+++ b/ui/admin/app/components/form/storage-bucket/aws/index.hbs
@@ -17,7 +17,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @type='text'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -38,7 +38,7 @@
     @isOptional={{true}}
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -100,7 +100,6 @@
     <InfoField
       @value={{@model.scopeModel.displayName}}
       @icon={{if @model.scopeModel.isGlobal 'globe' 'org'}}
-      disabled={{form.disabled}}
       as |F|
     >
       <F.Label>{{t 'resources.storage-bucket.form.scope.label'}}</F.Label>
@@ -149,8 +148,7 @@
     @isRequired={{true}}
     @value={{@model.bucket_name}}
     @isInvalid={{@model.errors.bucket_name}}
-    disabled={{form.disabled}}
-    readOnly={{not @model.isNew}}
+    readOnly={{(or form.disabled (not @model.isNew))}}
     {{on 'input' (set-from-event @model 'bucket_name')}}
     as |F|
   >
@@ -173,8 +171,7 @@
     @isOptional={{true}}
     @value={{@model.bucket_prefix}}
     @isInvalid={{@model.errors.bucket_prefix}}
-    disabled={{form.disabled}}
-    readOnly={{not @model.isNew}}
+    readOnly={{(or form.disabled (not @model.isNew))}}
     {{on 'input' (set-from-event @model 'bucket_prefix')}}
     as |F|
   >
@@ -197,8 +194,7 @@
     @isRequired={{true}}
     @value={{@model.region}}
     @isInvalid={{@model.errors.region}}
-    disabled={{form.disabled}}
-    readOnly={{not @model.isNew}}
+    readOnly={{(or form.disabled (not @model.isNew))}}
     {{on 'input' (set-from-event @model 'region')}}
     as |F|
   >
@@ -275,7 +271,7 @@
         @isRequired={{true}}
         @value={{@model.secret_access_key}}
         @isInvalid={{@model.errors.secrets}}
-        disabled={{form.disabled}}
+        readonly={{form.disabled}}
         @hasVisibilityToggle={{false}}
         {{on 'input' (set-from-event @model 'secret_access_key')}}
         as |F|
@@ -349,7 +345,7 @@
       @isRequired={{true}}
       @value={{@model.role_arn}}
       @isInvalid={{@model.errors.role_arn}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'role_arn')}}
       as |F|
     >
@@ -372,7 +368,7 @@
       @isOptional={{true}}
       @value={{@model.role_external_id}}
       @isInvalid={{@model.errors.role_external_id}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'role_external_id')}}
       as |F|
     >
@@ -397,7 +393,7 @@
       @isOptional={{true}}
       @value={{@model.role_session_name}}
       @isInvalid={{@model.errors.role_session_name}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'role_session_name')}}
       as |F|
     >

--- a/ui/admin/app/components/form/storage-bucket/minio/index.hbs
+++ b/ui/admin/app/components/form/storage-bucket/minio/index.hbs
@@ -17,7 +17,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @type='text'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -38,7 +38,7 @@
     @isOptional={{true}}
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -100,7 +100,6 @@
     <InfoField
       @value={{@model.scopeModel.displayName}}
       @icon={{if @model.scopeModel.isGlobal 'globe' 'org'}}
-      disabled={{form.disabled}}
       as |F|
     >
       <F.Label>{{t 'resources.storage-bucket.form.scope.label'}}</F.Label>
@@ -149,8 +148,7 @@
     @isRequired={{true}}
     @value={{@model.endpoint_url}}
     @isInvalid={{@model.errors.endpoint_url}}
-    disabled={{form.disabled}}
-    readOnly={{not @model.isNew}}
+    readOnly={{(or form.disabled (not @model.isNew))}}
     {{on 'input' (set-from-event @model 'endpoint_url')}}
     as |F|
   >
@@ -173,8 +171,7 @@
     @isRequired={{true}}
     @value={{@model.bucket_name}}
     @isInvalid={{@model.errors.bucket_name}}
-    disabled={{form.disabled}}
-    readOnly={{not @model.isNew}}
+    readOnly={{(or form.disabled (not @model.isNew))}}
     {{on 'input' (set-from-event @model 'bucket_name')}}
     as |F|
   >
@@ -197,8 +194,7 @@
     @isOptional={{true}}
     @value={{@model.region}}
     @isInvalid={{@model.errors.region}}
-    disabled={{form.disabled}}
-    readOnly={{not @model.isNew}}
+    readOnly={{(or form.disabled (not @model.isNew))}}
     {{on 'input' (set-from-event @model 'region')}}
     as |F|
   >
@@ -250,7 +246,7 @@
       @isRequired={{true}}
       @value={{@model.secret_access_key}}
       @isInvalid={{@model.errors.secrets}}
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       @hasVisibilityToggle={{false}}
       {{on 'input' (set-from-event @model 'secret_access_key')}}
       as |F|

--- a/ui/admin/app/components/form/target/details/index.hbs
+++ b/ui/admin/app/components/form/target/details/index.hbs
@@ -18,7 +18,7 @@
     @isInvalid={{@model.errors.name}}
     @type='text'
     name='name'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -38,7 +38,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     name='description'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -96,7 +96,7 @@
       @isInvalid={{@model.errors.address}}
       @type='text'
       name='address'
-      disabled={{form.disabled}}
+      readonly={{form.disabled}}
       {{on 'input' (set-from-event @model 'address')}}
       as |F|
     >
@@ -121,7 +121,7 @@
     @isInvalid={{@model.errors.default_port}}
     @type='text'
     name='default_port'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     placeholder={{@defaultPort}}
     {{on 'input' (set-from-event @model 'default_port')}}
     as |F|
@@ -145,7 +145,7 @@
     @isInvalid={{@model.errors.default_client_port}}
     @type='text'
     name='default_client_port'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'default_client_port')}}
     as |F|
   >
@@ -168,7 +168,7 @@
     @isInvalid={{@model.errors.session_max_seconds}}
     @type='text'
     name='session_max_seconds'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'session_max_seconds')}}
     as |F|
   >
@@ -189,7 +189,7 @@
     @isInvalid={{@model.errors.session_connection_limit}}
     @type='text'
     name='session_connection_limit'
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'session_connection_limit')}}
     as |F|
   >

--- a/ui/admin/app/components/form/user/index.hbs
+++ b/ui/admin/app/components/form/user/index.hbs
@@ -16,7 +16,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -36,7 +36,7 @@
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>

--- a/ui/admin/app/components/form/worker/create-worker-led/index.hbs
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.hbs
@@ -209,7 +209,7 @@
         @value={{this.generatedWorkerAuthToken}}
         @isRequired={{true}}
         @isInvalid={{@model.errors.worker_generated_auth_token}}
-        disabled={{form.disabled}}
+        readonly={{form.disabled}}
         {{on 'input' (set-from-event this 'generatedWorkerAuthToken')}}
         as |F|
       >

--- a/ui/admin/app/components/form/worker/index.hbs
+++ b/ui/admin/app/components/form/worker/index.hbs
@@ -16,7 +16,7 @@
     @value={{@model.name}}
     @isInvalid={{@model.errors.name}}
     @isOptional={{true}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     {{on 'input' (set-from-event @model 'name')}}
     as |F|
   >
@@ -36,7 +36,7 @@
     @isOptional={{true}}
     @value={{@model.description}}
     @isInvalid={{@model.errors.description}}
-    disabled={{form.disabled}}
+    readonly={{form.disabled}}
     as |F|
   >
     <F.Label>{{t 'form.description.label'}}</F.Label>
@@ -50,7 +50,7 @@
     {{/if}}
   </Hds::Form::Textarea::Field>
 
-  <InfoField @value={{@model.address}} disabled={{form.disabled}} as |F|>
+  <InfoField @value={{@model.address}} as |F|>
     <F.Label>{{t 'form.address.label'}}</F.Label>
     <F.HelperText>{{t 'form.worker_address.help'}}</F.HelperText>
   </InfoField>
@@ -65,7 +65,6 @@
         @model.last_status_time
         (concat relativeDate ', ' customFormat)
       }}
-      readonly={{true}}
       as |F|
     >
       <F.Label>{{t 'form.worker_last_seen.label'}}</F.Label>
@@ -74,7 +73,7 @@
 
   {{/let}}
 
-  <InfoField @value={{@model.release_version}} readonly={{true}} as |F|>
+  <InfoField @value={{@model.release_version}} as |F|>
     <F.Label>{{t 'form.worker_release_version.label'}}</F.Label>
     <F.HelperText>{{t 'form.worker_release_version.help'}}</F.HelperText>
   </InfoField>

--- a/ui/admin/tests/acceptance/storage-buckets/update-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/update-test.js
@@ -187,16 +187,16 @@ module('Acceptance | storage-buckets | update', function (hooks) {
 
     await click(commonSelectors.HREF(urls.storageBucket));
 
-    assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readOnly');
-    assert.dom(selectors.FIELD_BUCKET_PREFIX).hasAttribute('readOnly');
+    assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readonly');
+    assert.dom(selectors.FIELD_BUCKET_PREFIX).hasAttribute('readonly');
 
     await click(commonSelectors.EDIT_BTN, 'Click edit mode');
 
     assert.dom(selectors.FIELD_SCOPE).doesNotExist();
     assert.dom(selectors.FIELD_PLUGIN_TYPE).isDisabled();
-    assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readOnly');
-    assert.dom(selectors.FIELD_BUCKET_PREFIX).hasAttribute('readOnly');
-    assert.dom(selectors.FIELD_REGION).hasAttribute('readOnly');
+    assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readonly');
+    assert.dom(selectors.FIELD_BUCKET_PREFIX).hasAttribute('readonly');
+    assert.dom(selectors.FIELD_REGION).hasAttribute('readonly');
     assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readonly');
     assert.dom(selectors.FIELD_BUCKET_PREFIX).hasAttribute('readonly');
     assert.dom(selectors.FIELD_REGION).hasAttribute('readonly');
@@ -207,15 +207,15 @@ module('Acceptance | storage-buckets | update', function (hooks) {
 
     await click(commonSelectors.HREF(urls.storageBucketMinio));
 
-    assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readOnly');
+    assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readonly');
 
     await click(commonSelectors.EDIT_BTN, 'Click edit mode');
 
     assert.dom(selectors.FIELD_SCOPE).doesNotExist();
     assert.dom(selectors.FIELD_PLUGIN_TYPE).isDisabled();
     assert.dom(selectors.FIELD_ENDPOINT_URL).hasAttribute('readonly');
-    assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readOnly');
-    assert.dom(selectors.FIELD_REGION).hasAttribute('readOnly');
+    assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readonly');
+    assert.dom(selectors.FIELD_REGION).hasAttribute('readonly');
   });
 
   test('user sees an editable code editor while updating and readonly code block before/after', async function (assert) {

--- a/ui/admin/tests/acceptance/storage-buckets/update-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/update-test.js
@@ -187,8 +187,8 @@ module('Acceptance | storage-buckets | update', function (hooks) {
 
     await click(commonSelectors.HREF(urls.storageBucket));
 
-    assert.dom(selectors.FIELD_BUCKET_NAME).isDisabled();
-    assert.dom(selectors.FIELD_BUCKET_PREFIX).isDisabled();
+    assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readOnly');
+    assert.dom(selectors.FIELD_BUCKET_PREFIX).hasAttribute('readOnly');
 
     await click(commonSelectors.EDIT_BTN, 'Click edit mode');
 
@@ -197,9 +197,9 @@ module('Acceptance | storage-buckets | update', function (hooks) {
     assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readOnly');
     assert.dom(selectors.FIELD_BUCKET_PREFIX).hasAttribute('readOnly');
     assert.dom(selectors.FIELD_REGION).hasAttribute('readOnly');
-    assert.dom(selectors.FIELD_BUCKET_NAME).isNotDisabled();
-    assert.dom(selectors.FIELD_BUCKET_PREFIX).isNotDisabled();
-    assert.dom(selectors.FIELD_REGION).isNotDisabled();
+    assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readonly');
+    assert.dom(selectors.FIELD_BUCKET_PREFIX).hasAttribute('readonly');
+    assert.dom(selectors.FIELD_REGION).hasAttribute('readonly');
   });
 
   test('user cannot edit scope, provider, endpoint_url, bucket name or region fields in a MinIO storage bucket', async function (assert) {
@@ -207,13 +207,13 @@ module('Acceptance | storage-buckets | update', function (hooks) {
 
     await click(commonSelectors.HREF(urls.storageBucketMinio));
 
-    assert.dom(selectors.FIELD_BUCKET_NAME).isDisabled();
+    assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readOnly');
 
     await click(commonSelectors.EDIT_BTN, 'Click edit mode');
 
     assert.dom(selectors.FIELD_SCOPE).doesNotExist();
     assert.dom(selectors.FIELD_PLUGIN_TYPE).isDisabled();
-    assert.dom(selectors.FIELD_ENDPOINT_URL).isNotDisabled();
+    assert.dom(selectors.FIELD_ENDPOINT_URL).hasAttribute('readonly');
     assert.dom(selectors.FIELD_BUCKET_NAME).hasAttribute('readOnly');
     assert.dom(selectors.FIELD_REGION).hasAttribute('readOnly');
   });

--- a/ui/admin/tests/acceptance/targets/create-alias-test.js
+++ b/ui/admin/tests/acceptance/targets/create-alias-test.js
@@ -146,7 +146,7 @@ module('Acceptance | targets | create-alias', function (hooks) {
 
     await fillIn(NAME_FIELD_SELECTOR, NAME_FIELD_TEXT);
     await fillIn(ALIAS_FIELD_SELECTOR, ALIAS_VALUE_TEXT);
-    assert.dom(DEST_FIELD_SELECTOR).hasAttribute('readOnly');
+    assert.dom(DEST_FIELD_SELECTOR).hasAttribute('readonly');
     await click(SAVE_BTN_SELECTOR);
     const alias = this.server.schema.aliases.findBy({
       name: NAME_FIELD_TEXT,

--- a/ui/admin/tests/acceptance/targets/manage-alias-test.js
+++ b/ui/admin/tests/acceptance/targets/manage-alias-test.js
@@ -139,7 +139,7 @@ module('Acceptance | targets | manage-alias', function (hooks) {
 
     await click(ITEM_SELECTOR);
 
-    assert.dom(DEST_FIELD_SELECTOR).hasAttribute('readOnly');
+    assert.dom(DEST_FIELD_SELECTOR).hasAttribute('readonly');
 
     assert.strictEqual(currentURL(), urls.tcpAlias);
     await click(DROPDOWN_ACTION);

--- a/ui/admin/tests/acceptance/targets/manage-alias-test.js
+++ b/ui/admin/tests/acceptance/targets/manage-alias-test.js
@@ -128,7 +128,7 @@ module('Acceptance | targets | manage-alias', function (hooks) {
     assert.dom(LINK_TO_NEW_ALIAS).exists;
   });
 
-  test('clicking on `delete alias` from the dropdown should remove the destination ID and alias should disapper from the target sidebar and deleted from aliases list', async function (assert) {
+  test('clicking on `delete alias` from the dropdown should remove the destination ID and alias should disappear from the target sidebar and deleted from aliases list', async function (assert) {
     const aliasCount = getAliasCount();
     aliasResourceOne.update({
       destination_id: instances.tcpTarget.id,
@@ -139,7 +139,7 @@ module('Acceptance | targets | manage-alias', function (hooks) {
 
     await click(ITEM_SELECTOR);
 
-    assert.dom(DEST_FIELD_SELECTOR).doesNotHaveAttribute('readOnly');
+    assert.dom(DEST_FIELD_SELECTOR).hasAttribute('readOnly');
 
     assert.strictEqual(currentURL(), urls.tcpAlias);
     await click(DROPDOWN_ACTION);


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
This PR only address the change to `readonly` for text inputs and text areas. These changes will be merged into an LLB so all changes can be merged to main together.

Reason for this change:
After an a11y audit, we noticed that when viewing or reading a resource's information, a screen reader was not able to view the information because the elements all had the `disabled` attribute. By switching to `readonly` a screen reader will now properly view the information and make it navigable for users.

<!-- Uncomment line below to manually add link to JIRA ticket -->
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-15667)

## Screenshots (if appropriate)
Visually there is not much difference. The only real difference here is the new readonly fields are a little darker than before.
Before:
<img width="890" alt="Screenshot 2024-12-09 at 3 42 00 PM" src="https://github.com/user-attachments/assets/99faa410-dffe-421b-ae00-bc7dd52232d7" />
After:
<img width="890" alt="Screenshot 2024-12-09 at 3 42 28 PM" src="https://github.com/user-attachments/assets/d7f6c3a1-642d-46ec-b4f2-a3c37016d3c0" />


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
