### PR TITLE
test(e2e): add e2e test for scope chooser with filtered targets

### DIFF
--- a/e2e-tests/desktop/tests/scope.spec.js
+++ b/e2e-tests/desktop/tests/scope.spec.js
@@ -1,0 +1,85 @@
+import { expect, test } from '../fixtures/baseTest.js';
+import * as boundaryHttp from '../../helpers/boundary-http.js';
+
+test.describe('Scope tests', async () => {
+  let orgA;
+  let projectA;
+  let targetA;
+
+  let orgB;
+  let projectB;
+  let targetB;
+
+  test.beforeEach(async ({ request, targetAddress, targetPort }) => {
+    // Group A resources
+    orgA = await boundaryHttp.createOrg(request);
+    projectA = await boundaryHttp.createProject(request, orgA.id);
+    targetA = await boundaryHttp.createTarget(request, {
+      scopeId: projectA.id,
+      type: 'tcp',
+      port: targetPort,
+      address: targetAddress,
+    });
+
+    // Group B resources
+    orgB = await boundaryHttp.createOrg(request);
+    projectB = await boundaryHttp.createProject(request, orgB.id);
+    targetB = await boundaryHttp.createTarget(request, {
+      scopeId: projectB.id,
+      type: 'tcp',
+      port: targetPort,
+      address: targetAddress,
+    });
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (orgA) {
+      await boundaryHttp.deleteOrg(request, orgA.id);
+    }
+
+    if (orgB) {
+      await boundaryHttp.deleteOrg(request, orgB.id);
+    }
+  });
+
+  test('Shows the filtered targets based on selected scope', async ({ authedPage }) => {
+    const headerNav = await authedPage.getByLabel('header-nav');
+    await expect(headerNav).toBeVisible();
+    await expect(headerNav).toContainText('Global');
+
+    await expect(
+      authedPage.getByRole('link', { name: targetA.name }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole('link', { name: targetB.name }),
+    ).toBeVisible();
+
+    await headerNav.click();
+    const orgAHeaderNavLink = await authedPage.getByRole('link', {
+      name: orgA.name,
+    });
+    await orgAHeaderNavLink.click();
+
+    await expect(headerNav).toContainText(orgA.name);
+    await expect(
+      authedPage.getByRole('link', { name: targetA.name }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole('link', { name: targetB.name }),
+    ).not.toBeVisible();
+
+    await headerNav.click();
+    const orgBHeaderNavLink = await authedPage.getByRole('link', {
+      name: orgB.name,
+    });
+    await orgBHeaderNavLink.click();
+
+    await expect(headerNav).toContainText(orgB.name);
+    await expect(
+      authedPage.getByRole('link', { name: targetB.name }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole('link', { name: targetA.name }),
+    ).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes: https://hashicorp.atlassian.net/browse/ICU-16121

# Description
Adds an e2e test to ensure that the scope choose in the desktop app correctly filters the displayed targets.

<!-- Uncomment line below to manually add link to JIRA ticket -->
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-16121)

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
With enos and existing e2e setup working, run this command from the `e2e-tests` folder:
```
yarn playwright test --config desktop/playwright.config.js --ui
```

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

~~- [ ] I have added before and after screenshots for UI changes~~
~~- [ ] I have added JSON response output for API changes~~
~~- [ ] I have added steps to reproduce and test for bug fixes in the description~~
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
