### PR TITLE
fix: 🐛 hds modal text wrong color when system mode is dark

### DIFF
--- a/addons/rose/app/styles/rose/variables/color/_css.scss
+++ b/addons/rose/app/styles/rose/variables/color/_css.scss
@@ -76,6 +76,8 @@
   --ui-gray-starker-3: #{color(ui-gray, 800)};
   --ui-gray-starker-4: #{color(ui-gray, 900)};
   --ui-header-subtler: #{color(ui-cool-gray, 700)};
+
+  color-scheme: light;
 }
 
 // Dark Mode


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
Looks like the dark mode css property was not being overridden causing the text in the hds dialog box to be the wrong color when system color mode was set to dark but admin ui was set to light mode.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

After:

https://github.com/user-attachments/assets/66db146f-6f49-4e5b-aec2-0de2f9b04af5

Before:

https://github.com/user-attachments/assets/ec98e1d9-6e84-470f-974a-a2eb8ea8c128



## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
1. Turn on "Dark mode" in system.
2. Have light mode enabled in admin ui
3. Go to a resource form
4. Click "Edit Form"
5. Make a trivial change
6. Navigate away from form to trigger "Discard unsaved changes?" modal
7. Validate Modal text appears as it should.
8. Repeat steps with different color setting combinations.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
