### PR TITLE
fix: 🐛 Fix HDS deprecation message

### DIFF
--- a/ui/admin/app/components/credential-stores/credential-store/actions/index.hbs
+++ b/ui/admin/app/components/credential-stores/credential-store/actions/index.hbs
@@ -21,8 +21,9 @@
   {{#if (and (feature-flag 'vault-worker-filter') @model.isVault)}}
     <dd.Interactive
       @route='scopes.scope.credential-stores.credential-store.edit-worker-filter'
-      @text={{t 'actions.edit-worker-filter'}}
-    />
+    >
+      {{t 'actions.edit-worker-filter'}}
+    </dd.Interactive>
   {{/if}}
   {{#if (can 'delete model' @model)}}
     <dd.Separator />


### PR DESCRIPTION
# Description

Fix HDS deprecation message for HDS Dropdown interactive component using @text rather than yielding it.

## Screenshots:

Before:
<img width="1660" alt="Screenshot 2025-01-22 at 3 05 37 PM" src="https://github.com/user-attachments/assets/9313c353-1f2c-40c4-a73f-685a261eae6e" />

After:
<img width="1676" alt="Screenshot 2025-01-22 at 3 05 51 PM" src="https://github.com/user-attachments/assets/0eb339d4-f010-4a05-83f6-a962c4c76246" />


## How to Test
- Open the manage dropdown within a Credential store with the browser console open.
- Run admin ui tests successfully.
