### PR TITLE
Vault cred store filter create

### DIFF
--- a/ui/admin/app/components/form/credential-store/vault/index.hbs
+++ b/ui/admin/app/components/form/credential-store/vault/index.hbs
@@ -117,6 +117,33 @@
     {{/if}}
   </Hds::Form::TextInput::Field>
 
+  {{! worker_filter }}
+  {{#if (and (feature-flag 'vault-worker-filter') @model.isNew)}}
+    {{#let (unique-id) (unique-id) as |labelId helpId|}}
+      <Hds::Form::Fieldset
+        aria-labelledby={{labelId}}
+        aria-describedby={{helpId}}
+        class='worker-filter-generator-form-layout'
+        as |F|
+      >
+        <F.Legend id={{labelId}}>{{t 'form.worker_filter.label'}}</F.Legend>
+        <F.HelperText id={{helpId}}>
+          {{t 'resources.credential-store.form.worker_filter.help'}}
+          <Hds::Link::Inline @href={{doc-url 'worker-filters'}}>
+            {{t 'actions.learn-more'}}
+          </Hds::Link::Inline>
+        </F.HelperText>
+        <F.Control>
+          <WorkerFilterGenerator
+            @model={{@model}}
+            @name='worker_filter'
+            @hideToolbar={{true}}
+          />
+        </F.Control>
+      </Hds::Form::Fieldset>
+    {{/let}}
+  {{/if}}
+
   {{#if (or @model.isNew form.isEditable)}}
     <Hds::Form::TextInput::Field
       name='token'

--- a/ui/admin/app/components/form/credential-store/vault/index.hbs
+++ b/ui/admin/app/components/form/credential-store/vault/index.hbs
@@ -121,6 +121,7 @@
   {{#if (and (feature-flag 'vault-worker-filter') @model.isNew)}}
     {{#let (unique-id) (unique-id) as |labelId helpId|}}
       <Hds::Form::Fieldset
+        @isOptional={{true}}
         aria-labelledby={{labelId}}
         aria-describedby={{helpId}}
         class='worker-filter-generator-form-layout'

--- a/ui/admin/app/components/form/credential-store/vault/index.hbs
+++ b/ui/admin/app/components/form/credential-store/vault/index.hbs
@@ -128,7 +128,7 @@
       >
         <F.Legend id={{labelId}}>{{t 'form.worker_filter.label'}}</F.Legend>
         <F.HelperText id={{helpId}}>
-          {{t 'resources.credential-store.form.worker_filter.help'}}
+          {{t 'resources.credential-store.worker-filter.description'}}
           <Hds::Link::Inline @href={{doc-url 'worker-filters'}}>
             {{t 'actions.learn-more'}}
           </Hds::Link::Inline>

--- a/ui/admin/app/components/form/storage-bucket/aws/index.hbs
+++ b/ui/admin/app/components/form/storage-bucket/aws/index.hbs
@@ -460,7 +460,7 @@
     <Hds::Form::Fieldset
       aria-labelledby={{labelId}}
       aria-describedby={{helpId}}
-      class='storage-bucket-worker-filter'
+      class='worker-filter-generator-form-layout'
       @isRequired={{true}}
       as |F|
     >

--- a/ui/admin/app/components/form/storage-bucket/minio/index.hbs
+++ b/ui/admin/app/components/form/storage-bucket/minio/index.hbs
@@ -319,7 +319,7 @@
     <Hds::Form::Fieldset
       aria-labelledby={{labelId}}
       aria-describedby={{helpId}}
-      class='storage-bucket-worker-filter'
+      class='worker-filter-generator-form-layout'
       @isRequired={{true}}
       as |F|
     >

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -1077,8 +1077,8 @@
   align-items: flex-start;
 }
 
-// storage buckets
-.storage-bucket-worker-filter {
+// worker filter generator layout in form
+.worker-filter-generator-form-layout {
   .hds-form-field--layout-flag {
     margin-bottom: 0;
   }

--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/worker-filter.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/worker-filter.hbs
@@ -36,6 +36,7 @@
         @language='bash'
         @value={{@model.worker_filter}}
         @hasCopyButton={{true}}
+        @isOptional={{true}}
         as |CB|
       >
         <CB.Title>{{t 'form.worker_filter.label'}}</CB.Title>

--- a/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/worker-filter.hbs
+++ b/ui/admin/app/templates/scopes/scope/credential-stores/credential-store/worker-filter.hbs
@@ -36,7 +36,6 @@
         @language='bash'
         @value={{@model.worker_filter}}
         @hasCopyButton={{true}}
-        @isOptional={{true}}
         as |CB|
       >
         <CB.Title>{{t 'form.worker_filter.label'}}</CB.Title>

--- a/ui/admin/tests/acceptance/credential-store/create-test.js
+++ b/ui/admin/tests/acceptance/credential-store/create-test.js
@@ -89,6 +89,24 @@ module('Acceptance | credential-stores | create', function (hooks) {
     assert.strictEqual(getVaultCredentialStoresCount(), count + 1);
   });
 
+  test('Users can create a new credential store of type vault with a worker filter', async function (assert) {
+    featuresService.enable('static-credentials');
+    featuresService.enable('vault-worker-filter');
+    const count = getVaultCredentialStoresCount();
+    await visit(urls.newCredentialStore);
+
+    await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
+    await click(selectors.TYPE_VAULT);
+    await fillIn(
+      selectors.CODE_EDITOR_BODY,
+      selectors.EDITOR_WORKER_FILTER_VALUE,
+    );
+    await click(commonSelectors.SAVE_BTN);
+
+    assert.dom(selectors.CODE_BLOCK_BODY).doesNotExist();
+    assert.strictEqual(getVaultCredentialStoresCount(), count + 1);
+  });
+
   test('Users can cancel create new credential stores', async function (assert) {
     const count = getCredentialStoresCount();
     await visit(urls.newCredentialStore);

--- a/ui/admin/tests/acceptance/credential-store/selectors.js
+++ b/ui/admin/tests/acceptance/credential-store/selectors.js
@@ -11,6 +11,7 @@ export const EDIT_ACTION =
 
 export const CODE_EDITOR_BODY = '[data-test-code-editor-field-editor] textarea';
 export const CODE_BLOCK_BODY = '.hds-code-block__code';
+export const EDITOR_WORKER_FILTER_VALUE = '"dev" in "/tags/env"';
 
 export const TYPE_VAULT = '[value="vault"]';
 


### PR DESCRIPTION
# Description
This PR adds the worker filter generator to the form when creating a new vault credential store.

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-16281)

## Screenshots (if appropriate)
Before 👇 
<img width="1510" alt="Screenshot 2025-01-28 at 4 42 33 PM" src="https://github.com/user-attachments/assets/1e6c47c0-f634-4b46-a769-5803ee6b9b8a" />

After 👇 
<img width="1510" alt="Screenshot 2025-01-28 at 4 37 08 PM" src="https://github.com/user-attachments/assets/2276583c-0257-4ef2-8a55-e90a5c42f4df" />


## How to Test
1. Create a new vault credential store
2. Confirm that the worker filter generator exists on the form upon creation
3. Save the form
4. Confirm that the worker filter generator is no longer visible on the form after creation
5. Confirm that you are able to edit the worker filter via the `Worker Filter` tab

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
