### PR TITLE
feat: 🎸 add showFilterGenerator to WorkerFilterGenerator comp

### DIFF
--- a/ui/admin/app/components/form/worker-filter/index.hbs
+++ b/ui/admin/app/components/form/worker-filter/index.hbs
@@ -10,7 +10,11 @@
   @disabled={{@model.isSaving}}
   as |form|
 >
-  <WorkerFilterGenerator @model={{@model}} @name={{@name}} />
+  <WorkerFilterGenerator
+    @model={{@model}}
+    @name={{@name}}
+    @showFilterGenerator={{true}}
+  />
 
   {{#if (can 'save model' @model)}}
     <form.actions

--- a/ui/admin/app/components/worker-filter-generator/index.js
+++ b/ui/admin/app/components/worker-filter-generator/index.js
@@ -13,7 +13,7 @@ export default class WorkerFilterGeneratorIndexComponent extends Component {
   generatorTagType = 'tag';
   generatorNameType = 'name';
   operatorOptions = ['==', 'matches', 'contains'];
-  @tracked showFilterGenerator = true;
+  @tracked showFilterGenerator = this.args.showFilterGenerator;
   @tracked selectedGeneratorType = this.generatorTagType;
   @tracked key = '';
   @tracked value = '';

--- a/ui/admin/tests/integration/components/worker-filter-generator/index-test.js
+++ b/ui/admin/tests/integration/components/worker-filter-generator/index-test.js
@@ -53,15 +53,13 @@ module(
         hbs`<WorkerFilterGenerator @name='ingress_worker_filter' @model={{this.model}} />`,
       );
 
+      await click(SHOW_FILTER_GENERATOR);
+
       assert.dom(FILTER_GENERATOR).isVisible();
 
       await click(SHOW_FILTER_GENERATOR);
 
       assert.dom(FILTER_GENERATOR).isNotVisible();
-
-      await click(SHOW_FILTER_GENERATOR);
-
-      assert.dom(FILTER_GENERATOR).isVisible();
     });
 
     test('filter generator tag type shows key and value input boxes', async function (assert) {
@@ -70,7 +68,7 @@ module(
         hbs`<WorkerFilterGenerator @name='ingress_worker_filter' @model={{this.model}} />`,
       );
 
-      assert.dom(FILTER_GENERATOR).isVisible();
+      await click(SHOW_FILTER_GENERATOR);
 
       await click(TAG_TYPE_OPTION);
 
@@ -85,7 +83,7 @@ module(
         hbs`<WorkerFilterGenerator @name='ingress_worker_filter' @model={{this.model}} />`,
       );
 
-      assert.dom(FILTER_GENERATOR).isVisible();
+      await click(SHOW_FILTER_GENERATOR);
 
       await click(TAG_TYPE_OPTION);
       await fillIn(TAG_KEY, 'key1');
@@ -100,7 +98,7 @@ module(
         hbs`<WorkerFilterGenerator @name='ingress_worker_filter' @model={{this.model}} />`,
       );
 
-      assert.dom(FILTER_GENERATOR).isVisible();
+      await click(SHOW_FILTER_GENERATOR);
 
       await click(NAME_TYPE_OPTION);
 
@@ -115,7 +113,7 @@ module(
         hbs`<WorkerFilterGenerator @name='ingress_worker_filter' @model={{this.model}} />`,
       );
 
-      assert.dom(FILTER_GENERATOR).isVisible();
+      await click(SHOW_FILTER_GENERATOR);
 
       await click(NAME_TYPE_OPTION);
       await fillIn(TAG_VALUE, 'val1');
@@ -130,7 +128,7 @@ module(
         hbs`<WorkerFilterGenerator @name='ingress_worker_filter' @model={{this.model}} />`,
       );
 
-      assert.dom(FILTER_GENERATOR).isVisible();
+      await click(SHOW_FILTER_GENERATOR);
 
       await click(NAME_TYPE_OPTION);
       await fillIn(TAG_VALUE, 'val1');
@@ -141,6 +139,33 @@ module(
       await click(TAG_TYPE_OPTION);
 
       assert.dom(GENERATED_VALUE).hasNoValue();
+    });
+
+    test('filter generator is toggled on when showFilterGenerator is true and can be hidden', async function (assert) {
+      this.model = { ingress_worker_filter: 'ingress filter' };
+      this.showFilterGenerator = true;
+      await render(
+        hbs`<WorkerFilterGenerator @name='ingress_worker_filter' @model={{this.model}} @showFilterGenerator={{this.showFilterGenerator}} />`,
+      );
+
+      assert.dom(FILTER_GENERATOR).isVisible();
+
+      await click(SHOW_FILTER_GENERATOR);
+
+      assert.dom(FILTER_GENERATOR).isNotVisible();
+    });
+
+    test('filter generator is not toggled when showFilterGenerator is not provided and can be shown', async function (assert) {
+      this.model = { ingress_worker_filter: 'ingress filter' };
+      await render(
+        hbs`<WorkerFilterGenerator @name='ingress_worker_filter' @model={{this.model}} />`,
+      );
+
+      assert.dom(FILTER_GENERATOR).isNotVisible();
+
+      await click(SHOW_FILTER_GENERATOR);
+
+      assert.dom(FILTER_GENERATOR).isVisible();
     });
   },
 );


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-16282

# Description
<!-- Add a brief description of changes here -->
This change makes it so we can determine if the "Show filter generator" is toggled on by default or not. When the generator is used in a longer form like creating a Vault credential store or storage bucket, we want to hide the generator. This keeps the form from being overly long. In places like the Worker Filter tab for Target for Vault credential store, we have a route dedicated to updating the worker filter where showing the generator by default makes more sense.

New Storage Bucket:

https://github.com/user-attachments/assets/629e6f7a-c9a5-465e-bd20-902035b4c422

New Vault credential store:

https://github.com/user-attachments/assets/f99bfc22-db29-425f-b6b5-f4cf60b2a3b0

Editing Vault credential store worker filter:

https://github.com/user-attachments/assets/b779dadd-5fba-44ac-a143-3e7af0a97747

Editing Target worker filter:

https://github.com/user-attachments/assets/10089452-f9e7-4b23-94c8-39b3a635caa7



<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
