### PR TITLE
chore: add more test cases to credential display e2e test

### DIFF
--- a/e2e-tests/desktop/tests/credentials.spec.js
+++ b/e2e-tests/desktop/tests/credentials.spec.js
@@ -300,6 +300,48 @@ test.describe('Credential Panel tests', async () => {
         .filter({ hasText: 'nested.key2' })
         .locator('pre'),
     ).toHaveText(String.raw`val\tue2`);
+    // empty string and null should not be visible
+    expect(
+      authedPage.getByRole('listitem').filter({ hasText: 'nested.key3' }),
+    ).not.toBeVisible();
+
+    expect(
+      authedPage.getByRole('listitem').filter({ hasText: 'nested.key4' }),
+    ).not.toBeVisible();
+
+    await authedPage
+      .getByRole('listitem')
+      .filter({ hasText: 'nested.key5' })
+      .getByLabel('Toggle secret visibility')
+      .click();
+    await expect(
+      authedPage
+        .getByRole('listitem')
+        .filter({ hasText: 'nested.key5' })
+        .locator('pre'),
+    ).toHaveText('0');
+    await authedPage
+      .getByRole('listitem')
+      .filter({ hasText: 'nested.key6' })
+      .getByLabel('Toggle secret visibility')
+      .click();
+    await expect(
+      authedPage
+        .getByRole('listitem')
+        .filter({ hasText: 'nested.key6' })
+        .locator('pre'),
+    ).toHaveText('false');
+    await authedPage
+      .getByRole('listitem')
+      .filter({ hasText: 'nested.key7' })
+      .getByLabel('Toggle secret visibility')
+      .click();
+    await expect(
+      authedPage
+        .getByRole('listitem')
+        .filter({ hasText: 'nested.key7' })
+        .locator('pre'),
+    ).toHaveText('true');
 
     // SSH private key credential
     await expect(

--- a/e2e-tests/desktop/tests/credentials.spec.js
+++ b/e2e-tests/desktop/tests/credentials.spec.js
@@ -89,6 +89,11 @@ test.beforeEach(
         nested: {
           key1: String.raw`val\bue1`,
           key2: String.raw`val\tue2`,
+          key3: '',
+          key4: null,
+          key5: 0,
+          key6: false,
+          key7: true,
         },
       },
     });
@@ -111,6 +116,8 @@ test.beforeEach(
         secretsPath,
         secretName,
         `password=${String.raw`pass\word`}`,
+        'private_key=0',
+        'username=false',
       ],
       {
         encoding: 'utf-8',
@@ -224,6 +231,28 @@ test.describe('Credential Panel tests', async () => {
         .filter({ hasText: 'password' })
         .locator('pre'),
     ).toHaveText(String.raw`pass\word`);
+    await authedPage
+      .getByRole('listitem')
+      .filter({ hasText: 'private_key' })
+      .getByLabel('Toggle secret visibility')
+      .click();
+    await expect(
+      authedPage
+        .getByRole('listitem')
+        .filter({ hasText: 'private_key' })
+        .locator('pre'),
+    ).toHaveText('0');
+    await authedPage
+      .getByRole('listitem')
+      .filter({ hasText: 'username' })
+      .getByLabel('Toggle secret visibility')
+      .click();
+    await expect(
+      authedPage
+        .getByRole('listitem')
+        .filter({ hasText: 'username' })
+        .locator('pre'),
+    ).toHaveText('false');
 
     // End session as active sessions will show a popup when trying to close the DC
     await authedPage.getByRole('button', { name: 'End Session' }).click();

--- a/e2e-tests/desktop/tests/credentials.spec.js
+++ b/e2e-tests/desktop/tests/credentials.spec.js
@@ -300,12 +300,12 @@ test.describe('Credential Panel tests', async () => {
         .filter({ hasText: 'nested.key2' })
         .locator('pre'),
     ).toHaveText(String.raw`val\tue2`);
-    // empty string and null should not be visible
-    expect(
+    // Empty string and null should not be visible
+    await expect(
       authedPage.getByRole('listitem').filter({ hasText: 'nested.key3' }),
     ).not.toBeVisible();
 
-    expect(
+    await expect(
       authedPage.getByRole('listitem').filter({ hasText: 'nested.key4' }),
     ).not.toBeVisible();
 


### PR DESCRIPTION
# Description
This pr adds more test cases to e2e credentials display test 

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
 - Follow the e2e readme to use enos and then cd into e2e-tests and run `yarn run desktop` 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
