### PR TITLE
fix: 🐛 reapply storage policy errors out after a failed delete

### DIFF
--- a/addons/api/addon/adapters/application.js
+++ b/addons/api/addon/adapters/application.js
@@ -163,7 +163,7 @@ export default class ApplicationAdapter extends RESTAdapter.extend(
   }
 
   /**
-   * Overrides default ajax method by rewritting PUT requests as PATCH.
+   * Overrides default ajax method by rewriting PUT requests as PATCH.
    * PATCH is the request method used by our API for updates.
    *
    * @override

--- a/addons/api/addon/mixins/adapter-build-url.js
+++ b/addons/api/addon/mixins/adapter-build-url.js
@@ -6,7 +6,7 @@
 import Mixin from '@ember/object/mixin';
 
 /**
- * Overrides URL-building methods in an adpater for greater flexibility.
+ * Overrides URL-building methods in an adapter for greater flexibility.
  * Specifically enhances calls to `urlPrefix` with `modelName`, `id`, and
  * `snapshot`, which aren't normally passed.  And adds support for a
  * `urlSuffix` method, the return value of which is appended to the end of
@@ -22,7 +22,7 @@ export default Mixin.create({
 
   /**
    * This override behaves identically to the default method by default.
-   * It exists only to document the additional paramters to the method.
+   * It exists only to document the additional parameters to the method.
    * @override
    * @param {string} path
    * @param {string} parentURL

--- a/addons/api/addon/models/session-recording.js
+++ b/addons/api/addon/models/session-recording.js
@@ -71,7 +71,7 @@ export default class SessionRecordingModel extends GeneratedSessionRecordingMode
   }
 
   /**
-   * Reapply policy dates via the `reapply-staorage-policy` method.
+   * Reapply policy dates via the `reapply-storage-policy` method.
    * @param {object} options
    * @param {object} options.adapterOptions
    * @return {Promise}

--- a/addons/api/addon/models/session-recording.js
+++ b/addons/api/addon/models/session-recording.js
@@ -71,6 +71,14 @@ export default class SessionRecordingModel extends GeneratedSessionRecordingMode
   }
 
   /**
+   * Returns true if retention of session-recording is forever.
+   * @type {boolean}
+   */
+  get retainForever() {
+    return this.retain_until?.toISOString() === '9999-12-31T23:23:23.999Z';
+  }
+
+  /**
    * Reapply policy dates via the `reapply-storage-policy` method.
    * @param {object} options
    * @param {object} options.adapterOptions

--- a/ui/admin/app/abilities/session-recording.js
+++ b/ui/admin/app/abilities/session-recording.js
@@ -32,10 +32,12 @@ export default class OverrideSessionRecordingAbility extends SessionRecordingAbi
 
   /**
    * This override ensures that session recordings may be deleted only if the
-   * session-recording feature flag is enabled.
+   * session-recording feature flag is enabled and policy allows deletion.
    */
   get canDelete() {
-    return this.features.isEnabled('ssh-session-recording')
+    const retainForever =
+      this.model.retain_until?.toISOString() === '9999-12-31T23:23:23.999Z';
+    return this.features.isEnabled('ssh-session-recording') && !retainForever
       ? super.canDelete
       : false;
   }

--- a/ui/admin/app/abilities/session-recording.js
+++ b/ui/admin/app/abilities/session-recording.js
@@ -35,9 +35,8 @@ export default class OverrideSessionRecordingAbility extends SessionRecordingAbi
    * session-recording feature flag is enabled and policy allows deletion.
    */
   get canDelete() {
-    const retainForever =
-      this.model.retain_until?.toISOString() === '9999-12-31T23:23:23.999Z';
-    return this.features.isEnabled('ssh-session-recording') && !retainForever
+    return this.features.isEnabled('ssh-session-recording') &&
+      !this.model.retainForever
       ? super.canDelete
       : false;
   }

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index.js
@@ -78,8 +78,13 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
   @notifyError(({ message }) => message, { catch: true })
   @notifySuccess('notifications.delete-success')
   async delete(sessionRecording) {
-    await sessionRecording.destroyRecord();
-    this.router.replaceWith('scopes.scope.session-recordings');
-    this.router.refresh();
+    try {
+      await sessionRecording.destroyRecord();
+      this.router.replaceWith('scopes.scope.session-recordings');
+      await this.router.refresh('scopes.scope.session-recordings');
+    } catch (e) {
+      sessionRecording.rollbackAttributes();
+      throw new Error(e);
+    }
   }
 }

--- a/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
@@ -260,12 +260,7 @@
                       @model.sessionRecording.retain_until
                     }}
                   >
-                    {{#if
-                      (eq
-                        (format-date-iso @model.sessionRecording.retain_until)
-                        '9999-12-31T23:23:23.999Z'
-                      )
-                    }}
+                    {{#if @model.sessionRecording.retainForever}}
                       {{t 'resources.policy.titles.forever'}}
                     {{else}}
                       {{format-date-iso @model.sessionRecording.retain_until}}


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
When a delete fails on a session-recording, the `isDeleted` attribute is set to `true` but `isDestroyed` is set to `false` so when we try to use `this.save` on model it sends another `DELETE` request instead of a `POST` request for the `reapply-storage-policy` method. Solution was to `rollbackAttributes` after a failed `DELETE`.

Additionally, hide delete button when storage policy is retain "forever" on a session recording.


<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
BEFORE:


https://github.com/user-attachments/assets/5d841191-f87e-4690-8914-211765132526



AFTER:


https://github.com/user-attachments/assets/0fbd3f9b-b003-49e1-9b24-9c9d6ba1ef7f

hide delete button when retain policy is "Forever"


Uploading Screen Recording 2025-02-04 at 1.23.35 PM.mov…


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
