### PR TITLE
test(e2e): Remove attempt to delete session recording due to UI change

### DIFF
--- a/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
@@ -163,24 +163,6 @@ test(
       await page.locator('div.session-recording-player').hover();
       await page.locator('.ap-playback-button').click();
 
-      // Try to delete session recording: expect failure
-      await page.getByRole('link', { name: 'Orgs', exact: true }).click();
-      await page
-        .getByRole('navigation', { name: 'General' })
-        .getByRole('link', { name: 'Session Recordings', exact: true })
-        .click();
-      await page
-        .getByRole('row', { name: targetName })
-        .getByRole('link', { name: 'View' })
-        .click();
-      await page.getByText('Manage').click();
-      await page.getByRole('button', { name: 'Delete recording' }).click();
-      await page.getByRole('button', { name: 'OK', exact: true }).click();
-      await expect(
-        page.getByRole('alert').getByText('Error', { exact: true }),
-      ).toBeVisible();
-      await page.getByRole('button', { name: 'Dismiss' }).click();
-
       // Edit storage policy: do not protect from deletion
       await page.getByRole('link', { name: 'Orgs', exact: true }).click();
       await expect(page.getByRole('heading', { name: 'Orgs' })).toBeVisible();
@@ -206,11 +188,6 @@ test(
         page.getByRole('alert').getByText('Success', { exact: true }),
       ).toBeVisible();
       await page.getByRole('button', { name: 'Dismiss' }).click();
-
-      // BUG? After the error trying to delete the session recording, subsequent
-      // actions result in an error. Reloading the page fixes the issue. This is a
-      // temporary workaround.
-      await page.reload();
 
       // Re-apply storage policy to the session recording and delete
       await page.getByRole('link', { name: 'Orgs', exact: true }).click();

--- a/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
@@ -171,24 +171,6 @@ test(
       await page.locator('div.session-recording-player').hover();
       await page.locator('.ap-playback-button').click();
 
-      // Try to delete session recording: expect failure
-      await page.getByRole('link', { name: 'Orgs', exact: true }).click();
-      await page
-        .getByRole('navigation', { name: 'General' })
-        .getByRole('link', { name: 'Session Recordings', exact: true })
-        .click();
-      await page
-        .getByRole('row', { name: targetName })
-        .getByRole('link', { name: 'View' })
-        .click();
-      await page.getByText('Manage').click();
-      await page.getByRole('button', { name: 'Delete recording' }).click();
-      await page.getByRole('button', { name: 'OK', exact: true }).click();
-      await expect(
-        page.getByRole('alert').getByText('Error', { exact: true }),
-      ).toBeVisible();
-      await page.getByRole('button', { name: 'Dismiss' }).click();
-
       // Edit storage policy: do not protect from deletion
       await page.getByRole('link', { name: 'Orgs', exact: true }).click();
       await expect(page.getByRole('heading', { name: 'Orgs' })).toBeVisible();
@@ -214,11 +196,6 @@ test(
         page.getByRole('alert').getByText('Success', { exact: true }),
       ).toBeVisible();
       await page.getByRole('button', { name: 'Dismiss' }).click();
-
-      // BUG? After the error trying to delete the session recording, subsequent
-      // actions result in an error. Reloading the page fixes the issue. This is a
-      // temporary workaround.
-      await page.reload();
 
       // Re-apply storage policy to the session recording and delete
       await page.getByRole('link', { name: 'Orgs', exact: true }).click();


### PR DESCRIPTION
# Description
In the Admin UI test suite, the session recording tests would attempt to delete a session recording when the policy did not allow it and expect an error. However, it seems there was a [recent UI change](https://github.com/hashicorp/boundary-ui/pull/2674) that removed that ability altogether (the delete option isn't shown), so this PR removes this check.

![test-failed-1](https://github.com/user-attachments/assets/0585c21d-f4bf-4324-9397-2dff1bc40f17)

https://hashicorp.atlassian.net/browse/ICU-16377

## How to Test
```
❯ yarn admin:ent:docker --project=chromium tests/session-recording-minio-ent.spec.js        
yarn run v1.22.22
$ yarn run admin --grep "(?=.*@ent)(?=.*@docker)" --project=chromium tests/session-recording-minio-ent.spec.js
$ yarn playwright test --config admin/playwright.config.js --grep '(?=.*@ent)(?=.*@docker)' --project=chromium tests/session-recording-minio-ent.spec.js
$ /Users/mycow/Developer/boundary-ui/node_modules/.bin/playwright test --config admin/playwright.config.js --grep '(?=.*@ent)(?=.*@docker)' --project=chromium tests/session-recording-minio-ent.spec.js

Running 1 test using 1 worker

  ✓  1 [chromium] › tests/session-recording-minio-ent.spec.js:24:1 › Session Recording Test (MinIO) @ent @docker (35.7s)

  Slow test file: [chromium] › tests/session-recording-minio-ent.spec.js (35.7s)
  Consider splitting slow test files to speed up parallel execution
  1 passed (37.9s)
✨  Done in 39.20s.
```

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
