### PR TITLE
chore: fix eslint-related issues

### DIFF
--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -82,8 +82,8 @@
     "configPath": "tests/dummy/config"
   },
   "lint-staged": {
-    "*.js": "eslint --fix",
+    "*.js": ["eslint --fix", "prettier --write"],
     "*.hbs": "ember-template-lint --fix",
-    "*.{js,scss,yaml}": "prettier --write"
+    "*.{scss,yaml}": "prettier --write"
   }
 }

--- a/addons/auth/package.json
+++ b/addons/auth/package.json
@@ -77,8 +77,8 @@
     "configPath": "tests/dummy/config"
   },
   "lint-staged": {
-    "*.js": "eslint --fix",
+    "*.js": ["eslint --fix", "prettier --write"],
     "*.hbs": "ember-template-lint --fix",
-    "*.{js,scss,yaml}": "prettier --write"
+    "*.{scss,yaml}": "prettier --write"
   }
 }

--- a/addons/core/package.json
+++ b/addons/core/package.json
@@ -98,8 +98,8 @@
     "configPath": "tests/dummy/config"
   },
   "lint-staged": {
-    "*.js": "eslint --fix",
+    "*.js": ["eslint --fix", "prettier --write"],
     "*.hbs": "ember-template-lint --fix",
-    "*.{js,scss,yaml}": "prettier --write"
+    "*.{scss,yaml}": "prettier --write"
   }
 }

--- a/addons/rose/package.json
+++ b/addons/rose/package.json
@@ -107,9 +107,9 @@
     "configPath": "tests/dummy/config"
   },
   "lint-staged": {
-    "*.js": "eslint --fix",
+    "*.js": ["eslint --fix", "prettier --write"],
     "*.hbs": "ember-template-lint --fix",
-    "*.scss": "stylelint --fix",
-    "*.{js,scss,mdx,yaml}": "prettier --write"
+    "*.scss": ["stylelint --fix", "prettier --write"],
+    "*.{mdx,yaml}": "prettier --write"
   }
 }

--- a/e2e-tests/.eslintignore
+++ b/e2e-tests/.eslintignore
@@ -1,0 +1,1 @@
+playwright-report

--- a/e2e-tests/.eslintignore
+++ b/e2e-tests/.eslintignore
@@ -1,1 +1,4 @@
+# e2e test output
+admin/artifacts
+desktop/artifacts
 playwright-report

--- a/e2e-tests/desktop/tests/credentials.spec.js
+++ b/e2e-tests/desktop/tests/credentials.spec.js
@@ -303,11 +303,11 @@ test.describe('Credential Panel tests', () => {
     // Empty string and null should not be visible
     await expect(
       authedPage.getByRole('listitem').filter({ hasText: 'nested.key3' }),
-    ).not.toBeVisible();
+    ).toBeHidden();
 
     await expect(
       authedPage.getByRole('listitem').filter({ hasText: 'nested.key4' }),
-    ).not.toBeVisible();
+    ).toBeHidden();
 
     await authedPage
       .getByRole('listitem')

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -42,7 +42,7 @@
     "node": "20.* || 22.*"
   },
   "lint-staged": {
-    "*.js": "eslint --fix",
-    "*.{js,scss,yaml}": "prettier --write"
+    "*.js": ["eslint --fix", "prettier --write"],
+    "*.{scss,yaml}": "prettier --write"
   }
 }

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -107,8 +107,8 @@
     "edition": "octane"
   },
   "lint-staged": {
-    "*.js": "eslint --fix",
+    "*.js": ["eslint --fix", "prettier --write"],
     "*.hbs": "ember-template-lint --fix",
-    "*.{js,scss,yaml}": "prettier --write"
+    "*.{scss,yaml}": "prettier --write"
   }
 }

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -119,8 +119,8 @@
     "edition": "octane"
   },
   "lint-staged": {
-    "*.js": "eslint --fix",
+    "*.js": ["eslint --fix", "prettier --write"],
     "*.hbs": "ember-template-lint --fix",
-    "*.{js,scss,yaml}": "prettier --write"
+    "*.{scss,yaml}": "prettier --write"
   }
 }


### PR DESCRIPTION
# Description
This pull request fixes two eslint-related issues found from #2680, and one discovered follow up in investigating how an auto-fixable eslint change could have been missed by`lint-staged`.
1. An eslintignore is added to e2e to ignore the reports directory from playwright that may contain javascript (from @calcaide 's [comment](https://github.com/hashicorp/boundary-ui/pull/2680#issuecomment-2654318107))
2. An [auto-fixable changes](https://github.com/hashicorp/boundary-ui/compare/hashicc/e2e-tests-eslintignore?expand=1#diff-411688c020c9741d39b6c48029c502b7b4c831aa55f11a0f40dbfbe496bf7c77) that wasn't committed from [#2680](https://github.com/hashicorp/boundary-ui/pull/2680)
3. Avoid race conditions when `lint-staged` is running based on their [docs](https://github.com/lint-staged/lint-staged/blob/master/README.md?plain=1#L253-L281) by making writable tasks for a file type separate from other tasks

## How to Test
1. Run a playwright test and 
2. Run `yarn lint:js:fix` on this branch and there should be no files left to autofix
3. Make the following change:
```diff
diff --git a/e2e-tests/admin/tests/pagination.spec.js b/e2e-tests/admin/tests/pagination.spec.js
index ab4d4cdbb..aa6119faa 100644
--- a/e2e-tests/admin/tests/pagination.spec.js
+++ b/e2e-tests/admin/tests/pagination.spec.js
@@ -44,12 +44,14 @@ test(
       // Check pagination
       // The most recent target should be visible. The oldest target should not be
       // visible since there are 15 targets and the default page size is 10.
-      await expect(
+      await           expect(
         page.getByRole('link', { name: targets[targets.length - 1].name }),
       ).toBeVisible();
       await expect(
         page.getByRole('link', { name: targets[0].name }),
-      ).toBeHidden();
+      )
+      
+      .not.toBeVisible();
 
       // Navigate to the second page. The oldest target should now be visible.
       await page
```
This change represents a prettier fix and eslint auto-fix `.not.toBeVisible)` -> `.toBeHidden` will be autofixed as part of the eslint playwright plugin.

Git add this change, then run git commit, the `lint-staged` should run `prettier` and `eslint`
```
✔ Preparing lint-staged...
✔ Running tasks for staged files...
✖ Prevented an empty git commit!
✔ Reverting to original state because of errors...
✔ Cleaning up temporary files...

  ⚠ lint-staged prevented an empty git commit.
  Use the --allow-empty option to continue, or check your task configuration
```
Because the result of running `prettier` and `eslint --fix` ends up in the file looking the exact same as before the change and is now an empty commit.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

~~- [ ] I have added before and after screenshots for UI changes~~
~~- [ ] I have added JSON response output for API changes~~
~~- [ ] I have added steps to reproduce and test for bug fixes in the description~~
~~- [ ] I have commented on my code, particularly in hard-to-understand areas~~
~~- [ ] My changes generate no new warnings~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
