### PR TITLE
refactor: 💅 Use common selector ALERT_TOAST_BODY across test suite

### DIFF
--- a/ui/admin/tests/acceptance/aliases/create-test.js
+++ b/ui/admin/tests/acceptance/aliases/create-test.js
@@ -11,6 +11,7 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | aliases | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -25,9 +26,6 @@ module('Acceptance | aliases | create', function (hooks) {
   const NAME_FIELD_SELECTOR = '[name="name"]';
   const DESTINATION_ID_SELECTOR = '[name="destination_id"]';
   const HOST_ID_SELECTOR = '[name="authorize_session_arguments"]';
-
-  const ALERT_TEXT_SELECTOR =
-    '[data-test-toast-notification] .hds-alert__description';
   const FIELD_ERROR_TEXT_SELECTOR = '.hds-form-error__message';
   const NAME_FIELD_TEXT = 'random string';
 
@@ -118,7 +116,9 @@ module('Acceptance | aliases | create', function (hooks) {
     await click(SAVE_BTN_SELECTOR);
     await a11yAudit();
 
-    assert.dom(ALERT_TEXT_SELECTOR).hasText('The request was invalid.');
+    assert
+      .dom(commonSelectors.ALERT_TOAST_BODY)
+      .hasText('The request was invalid.');
     assert.dom(FIELD_ERROR_TEXT_SELECTOR).hasText('Name is required.');
   });
 

--- a/ui/admin/tests/acceptance/auth-methods/oidc-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/oidc-test.js
@@ -72,7 +72,7 @@ module('Acceptance | auth-methods | oidc', function (hooks) {
     await visit(urls.authMethod);
     await click(CHANGE_STATE_SELECTOR);
     await click(`${CHANGE_STATE_INPUT_SELECTOR} input[value="${updateValue}"]`);
-    const authMethod = this.server.db.authMethods.findBy({
+    const authMethod = this.server.schema.authMethods.findBy({
       id: instances.authMethod.id,
     });
 
@@ -84,7 +84,7 @@ module('Acceptance | auth-methods | oidc', function (hooks) {
     await visit(urls.authMethod);
     await click(CHANGE_STATE_SELECTOR);
     await click(`${CHANGE_STATE_INPUT_SELECTOR} input[value="${updateValue}"]`);
-    const authMethod = this.server.db.authMethods.findBy({
+    const authMethod = this.server.schema.authMethods.findBy({
       id: instances.authMethod.id,
     });
     assert.strictEqual(
@@ -100,7 +100,7 @@ module('Acceptance | auth-methods | oidc', function (hooks) {
     await visit(urls.authMethod);
     await click(CHANGE_STATE_SELECTOR);
     await click(`${CHANGE_STATE_INPUT_SELECTOR} input[value="${updateValue}"]`);
-    const authMethod = this.server.db.authMethods.findBy({
+    const authMethod = this.server.schema.authMethods.findBy({
       id: instances.authMethod.id,
     });
 

--- a/ui/admin/tests/acceptance/auth-methods/oidc-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/oidc-test.js
@@ -10,8 +10,8 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 //import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-
 import { TYPE_AUTH_METHOD_OIDC } from 'api/models/auth-method';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 const CHANGE_STATE_SELECTOR = '[data-test-change-state] button:first-child';
 const CHANGE_STATE_INPUT_CHECKED = '[data-test-change-state] input:checked';
@@ -72,7 +72,7 @@ module('Acceptance | auth-methods | oidc', function (hooks) {
     await visit(urls.authMethod);
     await click(CHANGE_STATE_SELECTOR);
     await click(`${CHANGE_STATE_INPUT_SELECTOR} input[value="${updateValue}"]`);
-    const authMethod = this.server.schema.authMethods.findBy({
+    const authMethod = this.server.db.authMethods.findBy({
       id: instances.authMethod.id,
     });
 
@@ -84,7 +84,7 @@ module('Acceptance | auth-methods | oidc', function (hooks) {
     await visit(urls.authMethod);
     await click(CHANGE_STATE_SELECTOR);
     await click(`${CHANGE_STATE_INPUT_SELECTOR} input[value="${updateValue}"]`);
-    const authMethod = this.server.schema.authMethods.findBy({
+    const authMethod = this.server.db.authMethods.findBy({
       id: instances.authMethod.id,
     });
     assert.strictEqual(
@@ -100,7 +100,7 @@ module('Acceptance | auth-methods | oidc', function (hooks) {
     await visit(urls.authMethod);
     await click(CHANGE_STATE_SELECTOR);
     await click(`${CHANGE_STATE_INPUT_SELECTOR} input[value="${updateValue}"]`);
-    const authMethod = this.server.schema.authMethods.findBy({
+    const authMethod = this.server.db.authMethods.findBy({
       id: instances.authMethod.id,
     });
 
@@ -139,8 +139,6 @@ module('Acceptance | auth-methods | oidc', function (hooks) {
       authMethod.attributes.state,
       'Auth method state is not be updated.',
     );
-    assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
-      .hasText('Sorry!');
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Sorry!');
   });
 });

--- a/ui/admin/tests/acceptance/credential-store/credentials/create-test.js
+++ b/ui/admin/tests/acceptance/credential-store/credentials/create-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { Response } from 'miragejs';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module(
   'Acceptance | credential-stores | credentials | create',
@@ -234,7 +235,7 @@ module(
       await click('[type="submit"]');
 
       assert
-        .dom('[data-test-toast-notification] .hds-alert__description')
+        .dom(commonSelectors.ALERT_TOAST_BODY)
         .hasText('Error in provided request.');
       assert
         .dom('[data-test-error-message-password]')
@@ -269,7 +270,7 @@ module(
       await click('[type="submit"]');
 
       assert
-        .dom('[data-test-toast-notification] .hds-alert__description')
+        .dom(commonSelectors.ALERT_TOAST_BODY)
         .hasText('Error in provided request.');
       assert
         .dom('[data-test-error-message-private-key]')
@@ -304,7 +305,7 @@ module(
       await click('[type="submit"]');
 
       assert
-        .dom('[data-test-toast-notification] .hds-alert__description')
+        .dom(commonSelectors.ALERT_TOAST_BODY)
         .hasText('Error in provided request.');
     });
 

--- a/ui/admin/tests/acceptance/credential-store/credentials/delete-test.js
+++ b/ui/admin/tests/acceptance/credential-store/credentials/delete-test.js
@@ -278,9 +278,7 @@ module(
       await visit(urls.usernamePasswordCredential);
       await click(MANAGE_DROPDOWN_SELECTOR);
       await click(DELETE_ACTION_SELECTOR);
-      assert
-        .dom('[data-test-toast-notification] .hds-alert__description')
-        .hasText('Oops.');
+      assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
     });
 
     test('deleting a username & key pair credential which errors displays error message', async function (assert) {
@@ -298,9 +296,7 @@ module(
       await visit(urls.usernameKeyPairCredential);
       await click(MANAGE_DROPDOWN_SELECTOR);
       await click(DELETE_ACTION_SELECTOR);
-      assert
-        .dom('[data-test-toast-notification] .hds-alert__description')
-        .hasText('Oops.');
+      assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
     });
 
     test('deleting a JSON credential which errors displays error message', async function (assert) {
@@ -318,9 +314,7 @@ module(
       await visit(urls.jsonCredential);
       await click(MANAGE_DROPDOWN_SELECTOR);
       await click(DELETE_ACTION_SELECTOR);
-      assert
-        .dom('[data-test-toast-notification] .hds-alert__description')
-        .hasText('Oops.');
+      assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
     });
   },
 );

--- a/ui/admin/tests/acceptance/credential-store/credentials/update-test.js
+++ b/ui/admin/tests/acceptance/credential-store/credentials/update-test.js
@@ -234,7 +234,7 @@ module(
       await fillIn('[name="name"]', mockInput);
       await click('[type="submit"]');
       assert
-        .dom('[data-test-toast-notification] .hds-alert__description')
+        .dom(commonSelectors.ALERT_TOAST_BODY)
         .hasText('Error in provided request.');
       assert.ok(
         find('[data-test-error-message-name]').textContent.trim(),
@@ -268,7 +268,7 @@ module(
       await fillIn('[name="name"]', mockInput);
       await click('[type="submit"]');
       assert
-        .dom('[data-test-toast-notification] .hds-alert__description')
+        .dom(commonSelectors.ALERT_TOAST_BODY)
         .hasText('Error in provided request.');
       assert.ok(
         find('[data-test-error-message-name]').textContent.trim(),
@@ -302,7 +302,7 @@ module(
       await fillIn('[name="name"]', mockInput);
       await click('[type="submit"]');
       assert
-        .dom('[data-test-toast-notification] .hds-alert__description')
+        .dom(commonSelectors.ALERT_TOAST_BODY)
         .hasText('Error in provided request.');
       assert.ok(
         find('[data-test-error-message-name]').textContent.trim(),

--- a/ui/admin/tests/acceptance/groups/delete-test.js
+++ b/ui/admin/tests/acceptance/groups/delete-test.js
@@ -9,6 +9,7 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | groups | delete', function (hooks) {
   setupApplicationTest(hooks);
@@ -80,8 +81,6 @@ module('Acceptance | groups | delete', function (hooks) {
     await visit(urls.group);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
-      .hasText('Oops.');
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
   });
 });

--- a/ui/admin/tests/acceptance/groups/members-test.js
+++ b/ui/admin/tests/acceptance/groups/members-test.js
@@ -11,6 +11,7 @@ import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | groups | members', function (hooks) {
   setupApplicationTest(hooks);
@@ -100,7 +101,7 @@ module('Acceptance | groups | members', function (hooks) {
     await click('.hds-dropdown-toggle-icon');
     await click('tbody tr .hds-dropdown-list-item button');
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
   });
 
@@ -174,7 +175,7 @@ module('Acceptance | groups | members', function (hooks) {
     await click('tbody label');
     await click('form [type="submit"]');
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
   });
 });

--- a/ui/admin/tests/acceptance/groups/update-test.js
+++ b/ui/admin/tests/acceptance/groups/update-test.js
@@ -9,6 +9,7 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | groups | update', function (hooks) {
   setupApplicationTest(hooks);
@@ -92,7 +93,7 @@ module('Acceptance | groups | update', function (hooks) {
     await fillIn('[name="name"]', 'random string');
     await click('[type="submit"]');
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.strictEqual(
       find('[data-test-error-message-name]').textContent.trim(),

--- a/ui/admin/tests/acceptance/host-catalogs/create-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/create-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | host-catalogs | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -24,8 +25,6 @@ module('Acceptance | host-catalogs | create', function (hooks) {
   const TYPE_INPUT_SELECTOR = '[name="Type"]';
   const SAVE_BUTTON_SELECTOR = '[type="submit"]';
   const CANCEL_BUTTON_SELECTOR = '.rose-form-actions [type="button"]';
-  const ALERT_TEXT_SELECTOR =
-    '[data-test-toast-notification] .hds-alert__description';
   const WORKER_FILTER_INPUT_SELECTOR = '[name=worker_filter]';
 
   const instances = {
@@ -215,7 +214,9 @@ module('Acceptance | host-catalogs | create', function (hooks) {
     });
     await visit(urls.newStaticHostCatalog);
     await click(SAVE_BUTTON_SELECTOR);
-    assert.dom(ALERT_TEXT_SELECTOR).includesText('The request was invalid.');
+    assert
+      .dom(commonSelectors.ALERT_TOAST_BODY)
+      .includesText('The request was invalid.');
     assert.dom('[data-test-error-message-name]').hasText('Name is required.');
   });
 

--- a/ui/admin/tests/acceptance/host-catalogs/delete-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/delete-test.js
@@ -127,7 +127,7 @@ module('Acceptance | host-catalogs | delete', function (hooks) {
     await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('Deleted successfully.');
     assert.strictEqual(getHostCatalogCount(), hostCatalogCount - 1);
     assert.strictEqual(currentURL(), urls.hostCatalogs);
@@ -166,8 +166,6 @@ module('Acceptance | host-catalogs | delete', function (hooks) {
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
 
-    assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
-      .hasText('Oops.');
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
   });
 });

--- a/ui/admin/tests/acceptance/host-catalogs/host-sets/create-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/host-sets/create-test.js
@@ -9,6 +9,7 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | host-catalogs | host sets | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -235,7 +236,7 @@ module('Acceptance | host-catalogs | host sets | create', function (hooks) {
     await visit(urls.newHostSet);
     await click(SUBMIT_BTN_SELECTOR);
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.ok(
       find('[data-test-error-message-name]').textContent.trim(),

--- a/ui/admin/tests/acceptance/host-catalogs/host-sets/delete-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/host-sets/delete-test.js
@@ -11,6 +11,7 @@ import { Response } from 'miragejs';
 import { resolve, reject } from 'rsvp';
 import sinon from 'sinon';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | host-catalogs | host sets | delete', function (hooks) {
   setupApplicationTest(hooks);
@@ -133,8 +134,6 @@ module('Acceptance | host-catalogs | host sets | delete', function (hooks) {
     await visit(urls.hostSet);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
-      .hasText('Oops.');
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
   });
 });

--- a/ui/admin/tests/acceptance/host-catalogs/host-sets/hosts-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/host-sets/hosts-test.js
@@ -17,6 +17,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
   setupApplicationTest(hooks);
@@ -132,7 +133,7 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
     await click('[data-test-host-set-hosts-dropdown-toggle]');
     await click('[data-test-host-set-hosts-dropdown-remove-host]');
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
   });
 
@@ -207,7 +208,7 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
     await click('tbody .hds-table__tr .hds-form-label');
     await click('form [type="submit"]');
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
   });
 
@@ -255,7 +256,7 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
     await fillIn('[name="name"]', 'New Host');
     await click('form [type="submit"]');
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
   });
 
@@ -277,7 +278,7 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
     await fillIn('[name="name"]', 'New Host');
     await click('form [type="submit"]');
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
   });
 

--- a/ui/admin/tests/acceptance/host-catalogs/host-sets/update-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/host-sets/update-test.js
@@ -146,7 +146,7 @@ module('Acceptance | host-catalogs | host sets | update', function (hooks) {
     await visit(urls.newHostSet);
     await click(SUBMIT_BTN_SELECTOR);
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.ok(
       find('[data-test-error-message-name]').textContent.trim(),
@@ -334,7 +334,7 @@ module('Acceptance | host-catalogs | host sets | update', function (hooks) {
     await fillIn('[name="name"]', 'random string');
     await click(SUBMIT_BTN_SELECTOR);
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.ok(
       find('[data-test-error-message-name]').textContent.trim(),

--- a/ui/admin/tests/acceptance/host-catalogs/update-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/update-test.js
@@ -185,7 +185,7 @@ module('Acceptance | host-catalogs | update', function (hooks) {
     await click('[type="submit"]');
 
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.dom('[data-test-error-message-name]').hasText('Name is required.');
   });

--- a/ui/admin/tests/acceptance/managed-groups/create-test.js
+++ b/ui/admin/tests/acceptance/managed-groups/create-test.js
@@ -15,6 +15,7 @@ import {
   TYPE_AUTH_METHOD_OIDC,
   TYPE_AUTH_METHOD_LDAP,
 } from 'api/models/auth-method';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | managed-groups | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -28,8 +29,6 @@ module('Acceptance | managed-groups | create', function (hooks) {
   const CANCEL_BTN_SELECTOR = '.rose-form-actions [type="button"]';
   const NAME_INPUT_SELECTOR = '[name="name"]';
   const DESC_INPUT_SELECTOR = '[name="description"]';
-  const ERROR_MSG_SELECTOR =
-    '[data-test-toast-notification] .hds-alert__description';
   const FIELD_ERROR_TEXT_SELECTOR = '.hds-form-error__message';
   const MANAGE_DROPDOWN_SELECTOR =
     '[data-test-manage-auth-method] button:first-child';
@@ -210,7 +209,9 @@ module('Acceptance | managed-groups | create', function (hooks) {
     await click(SAVE_BTN_SELECTOR);
     await a11yAudit();
 
-    assert.dom(ERROR_MSG_SELECTOR).hasText('The request was invalid.');
+    assert
+      .dom(commonSelectors.ALERT_TOAST_BODY)
+      .hasText('The request was invalid.');
     assert.dom('[data-test-error-message-name]').hasText('Name is required.');
   });
 
@@ -242,7 +243,9 @@ module('Acceptance | managed-groups | create', function (hooks) {
     await click(SAVE_BTN_SELECTOR);
     await a11yAudit();
 
-    assert.dom(ERROR_MSG_SELECTOR).hasText('The request was invalid.');
+    assert
+      .dom(commonSelectors.ALERT_TOAST_BODY)
+      .hasText('The request was invalid.');
     assert.dom(FIELD_ERROR_TEXT_SELECTOR).hasText('Name is required.');
   });
 

--- a/ui/admin/tests/acceptance/managed-groups/delete-test.js
+++ b/ui/admin/tests/acceptance/managed-groups/delete-test.js
@@ -14,6 +14,7 @@ import {
   TYPE_AUTH_METHOD_OIDC,
   TYPE_AUTH_METHOD_LDAP,
 } from 'api/models/auth-method';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | managed-groups | delete', function (hooks) {
   setupApplicationTest(hooks);
@@ -25,8 +26,6 @@ module('Acceptance | managed-groups | delete', function (hooks) {
     '[data-test-managed-group-dropdown] button:first-child';
   const DELETE_ACTION_SELECTOR =
     '[data-test-managed-group-dropdown] ul li button';
-  const ERROR_MSG_SELECTOR =
-    '[data-test-toast-notification] .hds-alert__description';
 
   const instances = {
     scopes: {
@@ -154,7 +153,7 @@ module('Acceptance | managed-groups | delete', function (hooks) {
     await click(DELETE_ACTION_SELECTOR);
     await a11yAudit();
 
-    assert.dom(ERROR_MSG_SELECTOR).hasText('Oops.');
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
     assert.strictEqual(currentURL(), urls.managedGroup);
   });
 
@@ -177,7 +176,7 @@ module('Acceptance | managed-groups | delete', function (hooks) {
     await click(DELETE_ACTION_SELECTOR);
     await a11yAudit();
 
-    assert.dom(ERROR_MSG_SELECTOR).hasText('Oops.');
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
     assert.strictEqual(currentURL(), urls.ldapManagedGroup);
   });
 });

--- a/ui/admin/tests/acceptance/policy/create-test.js
+++ b/ui/admin/tests/acceptance/policy/create-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | policies | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -22,8 +23,6 @@ module('Acceptance | policies | create', function (hooks) {
   const CANCEL_BTN_SELECTOR = '.rose-form-actions [type="button"]';
   const NAME_FIELD_SELECTOR = '[name="name"]';
   const RETAIN_FOR_TEXT_INPUT = '[data-input="retain_for"]';
-  const ALERT_TEXT_SELECTOR =
-    '[data-test-toast-notification] .hds-alert__description';
   const FIELD_ERROR_TEXT_SELECTOR = '.hds-form-error__message';
   const NAME_FIELD_TEXT = 'random string';
   const DELETE_AFTER_TEXT_INPUT = '[data-input="delete_after"]';
@@ -167,7 +166,9 @@ module('Acceptance | policies | create', function (hooks) {
     await click(SAVE_BTN_SELECTOR);
     await a11yAudit();
 
-    assert.dom(ALERT_TEXT_SELECTOR).hasText('The request was invalid.');
+    assert
+      .dom(commonSelectors.ALERT_TOAST_BODY)
+      .hasText('The request was invalid.');
     assert.dom(FIELD_ERROR_TEXT_SELECTOR).hasText('Name is required.');
   });
 

--- a/ui/admin/tests/acceptance/roles/create-test.js
+++ b/ui/admin/tests/acceptance/roles/create-test.js
@@ -11,6 +11,7 @@ import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | roles | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -93,12 +94,12 @@ module('Acceptance | roles | create', function (hooks) {
   });
 
   test('can cancel new role creation', async function (assert) {
-    const rolesCount = this.server.db.roles.length;
+    const rolesCount = this.server.schema.roles.length;
     await visit(urls.newRole);
     await fillIn('[name="name"]', 'role name');
     await click('.rose-form-actions [type="button"]');
     assert.strictEqual(currentURL(), urls.roles);
-    assert.strictEqual(this.server.db.roles.length, rolesCount);
+    assert.strictEqual(this.server.schema.roles.length, rolesCount);
   });
 
   test('saving a new role with invalid fields displays error messages', async function (assert) {
@@ -126,7 +127,7 @@ module('Acceptance | roles | create', function (hooks) {
     await click('form [type="submit"]');
     await a11yAudit();
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.ok(find('.hds-form-error__message'));
   });

--- a/ui/admin/tests/acceptance/roles/create-test.js
+++ b/ui/admin/tests/acceptance/roles/create-test.js
@@ -94,12 +94,12 @@ module('Acceptance | roles | create', function (hooks) {
   });
 
   test('can cancel new role creation', async function (assert) {
-    const rolesCount = this.server.schema.roles.length;
+    const rolesCount = this.server.db.roles.length;
     await visit(urls.newRole);
     await fillIn('[name="name"]', 'role name');
     await click('.rose-form-actions [type="button"]');
     assert.strictEqual(currentURL(), urls.roles);
-    assert.strictEqual(this.server.schema.roles.length, rolesCount);
+    assert.strictEqual(this.server.db.roles.length, rolesCount);
   });
 
   test('saving a new role with invalid fields displays error messages', async function (assert) {

--- a/ui/admin/tests/acceptance/roles/delete-test.js
+++ b/ui/admin/tests/acceptance/roles/delete-test.js
@@ -9,6 +9,7 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | roles | delete', function (hooks) {
   setupApplicationTest(hooks);
@@ -91,8 +92,6 @@ module('Acceptance | roles | delete', function (hooks) {
     await visit(urls.role);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_DROPDOWN_SELECTOR);
-    assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
-      .hasText('Oops.');
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
   });
 });

--- a/ui/admin/tests/acceptance/roles/global-scope-test.js
+++ b/ui/admin/tests/acceptance/roles/global-scope-test.js
@@ -49,8 +49,6 @@ module('Acceptance | roles | global-scope', function (hooks) {
   const CANCEL_BTN_SELECTOR = '.rose-form-actions [type="button"]';
   const MANAGE_DROPDOWN_SELECTOR = '.hds-dropdown-toggle-button';
   const MANAGE_SCOPES_SELECTOR = '[data-test-manage-dropdown-scopes]';
-  const TOAST_SELECTOR =
-    '[data-test-toast-notification] .hds-alert__description';
   const SEARCH_INPUT_SELECTOR = '.search-filtering [type="search"]';
   const NO_RESULTS_MSG_SELECTOR = '[data-test-no-grant-scope-results]';
   const NO_SCOPES_MSG_SELECTOR = '.role-grant-scopes div';
@@ -359,7 +357,7 @@ module('Acceptance | roles | global-scope', function (hooks) {
     await click(SCOPE_TOGGLE_SELECTOR(GRANT_SCOPE_THIS));
     await click(SAVE_BTN_SELECTOR);
 
-    assert.dom(TOAST_SELECTOR).isVisible();
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).isVisible();
   });
 
   test('user is prompted to confirm exit when there are unsaved changes on manage scopes page', async function (assert) {
@@ -486,7 +484,7 @@ module('Acceptance | roles | global-scope', function (hooks) {
     await click(SCOPE_CHECKBOX_SELECTOR('org', instances.scopes.org.id));
     await click(SAVE_BTN_SELECTOR);
 
-    assert.dom(TOAST_SELECTOR).isVisible();
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).isVisible();
   });
 
   test('user is prompted to confirm exit when there are unsaved changes on manage custom scopes page', async function (assert) {
@@ -820,7 +818,7 @@ module('Acceptance | roles | global-scope', function (hooks) {
     );
     await click(SAVE_BTN_SELECTOR);
 
-    assert.dom(TOAST_SELECTOR).isVisible();
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).isVisible();
   });
 
   test('user is prompted to confirm exit when there are unsaved changes on manage org projects page', async function (assert) {

--- a/ui/admin/tests/acceptance/roles/grants-test.js
+++ b/ui/admin/tests/acceptance/roles/grants-test.js
@@ -17,6 +17,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | roles | grants', function (hooks) {
   setupApplicationTest(hooks);
@@ -135,7 +136,7 @@ module('Acceptance | roles | grants', function (hooks) {
     await fillIn(`${grantsForm} [name="grant"]`, 'ids=123,action=delete');
     await click('.rose-form-actions [type="submit"]:not(:disabled)');
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
   });
 
@@ -189,7 +190,7 @@ module('Acceptance | roles | grants', function (hooks) {
     await fillIn(`${newGrantForm} [name="grant"]`, 'ids=123,action=delete');
     await click(`${newGrantForm} [type="submit"]:not(:disabled)`);
     await click('.rose-form-actions [type="submit"]:not(:disabled)');
-    assert.ok(find('[data-test-toast-notification] .hds-alert__description'));
+    assert.ok(find(commonSelectors.ALERT_TOAST_BODY));
   });
 
   test('delete a grant', async function (assert) {
@@ -232,6 +233,6 @@ module('Acceptance | roles | grants', function (hooks) {
     );
     await click(`${grantsForm} button:not([type="submit"])`);
     await click('.rose-form-actions [type="submit"]:not(:disabled)');
-    assert.ok(find('[data-test-toast-notification] .hds-alert__description'));
+    assert.ok(find(commonSelectors.ALERT_TOAST_BODY));
   });
 });

--- a/ui/admin/tests/acceptance/roles/org-scope-test.js
+++ b/ui/admin/tests/acceptance/roles/org-scope-test.js
@@ -46,8 +46,6 @@ module('Acceptance | roles | org-scope', function (hooks) {
   const CANCEL_BTN_SELECTOR = '.rose-form-actions [type="button"]';
   const MANAGE_DROPDOWN_SELECTOR = '.hds-dropdown-toggle-button';
   const MANAGE_SCOPES_SELECTOR = '[data-test-manage-dropdown-scopes]';
-  const TOAST_SELECTOR =
-    '[data-test-toast-notification] .hds-alert__description';
   const SEARCH_INPUT_SELECTOR = '.search-filtering [type="search"]';
   const NO_RESULTS_MSG_SELECTOR = '[data-test-no-grant-scope-results]';
   const NO_SCOPES_MSG_SELECTOR = '.role-grant-scopes div';
@@ -309,7 +307,7 @@ module('Acceptance | roles | org-scope', function (hooks) {
     await click(SCOPE_TOGGLE_SELECTOR(GRANT_SCOPE_THIS));
     await click(SAVE_BTN_SELECTOR);
 
-    assert.dom(TOAST_SELECTOR).isVisible();
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).isVisible();
   });
 
   test('user is prompted to confirm exit when there are unsaved changes on manage scopes page', async function (assert) {
@@ -437,7 +435,7 @@ module('Acceptance | roles | org-scope', function (hooks) {
     );
     await click(SAVE_BTN_SELECTOR);
 
-    assert.dom(TOAST_SELECTOR).isVisible();
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).isVisible();
   });
 
   test('user is prompted to confirm exit when there are unsaved changes on manage org projects page', async function (assert) {

--- a/ui/admin/tests/acceptance/roles/principals-test.js
+++ b/ui/admin/tests/acceptance/roles/principals-test.js
@@ -11,6 +11,7 @@ import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | roles | principals', function (hooks) {
   setupApplicationTest(hooks);
@@ -101,7 +102,7 @@ module('Acceptance | roles | principals', function (hooks) {
     await click('.hds-dropdown-toggle-icon');
     await click('tbody tr .hds-dropdown-list-item button');
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
   });
 
@@ -163,6 +164,6 @@ module('Acceptance | roles | principals', function (hooks) {
     await visit(urls.addPrincipals);
     await click('tbody label');
     await click('form [type="submit"]');
-    assert.ok(find('[data-test-toast-notification] .hds-alert__description'));
+    assert.ok(find(commonSelectors.ALERT_TOAST_BODY));
   });
 });

--- a/ui/admin/tests/acceptance/roles/update-test.js
+++ b/ui/admin/tests/acceptance/roles/update-test.js
@@ -9,6 +9,7 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | roles | update', function (hooks) {
   setupApplicationTest(hooks);
@@ -104,7 +105,7 @@ module('Acceptance | roles | update', function (hooks) {
     await fillIn('[name="name"]', 'random string');
     await click('[type="submit"]');
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.strictEqual(
       find('.hds-form-error__message').textContent.trim(),

--- a/ui/admin/tests/acceptance/scopes-test.js
+++ b/ui/admin/tests/acceptance/scopes-test.js
@@ -11,6 +11,7 @@ import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | scopes', function (hooks) {
   setupApplicationTest(hooks);
@@ -213,7 +214,7 @@ module('Acceptance | scopes', function (hooks) {
     await click(SAVE_BUTTON_SELECTOR);
 
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.dom('.hds-form-error__message').hasText('Name is required.');
   });

--- a/ui/admin/tests/acceptance/scopes/delete-test.js
+++ b/ui/admin/tests/acceptance/scopes/delete-test.js
@@ -132,8 +132,6 @@ module('Acceptance | scopes | delete', function (hooks) {
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
 
-    assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
-      .hasText('Oops.');
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
   });
 });

--- a/ui/admin/tests/acceptance/scopes/update-test.js
+++ b/ui/admin/tests/acceptance/scopes/update-test.js
@@ -124,7 +124,7 @@ module('Acceptance | scopes | update', function (hooks) {
     await click('[type="submit"]');
 
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.dom('.hds-form-error__message').hasText('Name is required.');
   });

--- a/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { Response } from 'miragejs';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module(
   'Acceptance | session-recordings | session-recording | channels-by-connection | channel',
@@ -23,8 +24,6 @@ module(
 
     const DELETE_DROPDOWN_SELECTOR = '[data-test-manage-dropdown-delete]';
     const DROPDOWN_SELECTOR = '[data-test-manage-dropdown]';
-    const ERROR_MSG_SELECTOR =
-      '[data-test-toast-notification] .hds-alert__description';
 
     // Instances
     const instances = {
@@ -142,7 +141,9 @@ module(
       // if there was an error player will not render
       assert.dom('.session-recording-player').doesNotExist();
       assert.dom('.hds-application-state__title').hasText('Playback error');
-      assert.dom(ERROR_MSG_SELECTOR).includesText('rpc error: code = Unknown');
+      assert
+        .dom(commonSelectors.ALERT_TOAST_BODY)
+        .includesText('rpc error: code = Unknown');
     });
 
     test('user can navigate back to session recording screen', async function (assert) {
@@ -182,7 +183,9 @@ module(
       await visit(incorrectUrl);
 
       assert.strictEqual(currentURL(), urls.sessionRecordings);
-      assert.dom(ERROR_MSG_SELECTOR).hasText('Resource not found');
+      assert
+        .dom(commonSelectors.ALERT_TOAST_BODY)
+        .hasText('Resource not found');
     });
 
     test('user cannot view manage dropdown without proper authorization', async function (assert) {

--- a/ui/admin/tests/acceptance/storage-buckets/delete-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/delete-test.js
@@ -22,8 +22,6 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
 
   const DROPDOWN_BUTTON_SELECTOR = '.hds-dropdown-toggle-icon';
   const DELETE_DROPDOWN_SELECTOR = '.hds-dropdown-list-item [type="button"]';
-  const NOTIFICATION_MSG_SELECTOR =
-    '[data-test-toast-notification] .hds-alert__description';
   const NOTIFICATION_MSG_TEXT = 'Deleted successfully.';
 
   const instances = {
@@ -87,7 +85,7 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
 
     await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
-    assert.dom(NOTIFICATION_MSG_SELECTOR).hasText(NOTIFICATION_MSG_TEXT);
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText(NOTIFICATION_MSG_TEXT);
     assert.strictEqual(currentURL(), urls.storageBuckets);
     assert.strictEqual(getStorageBucketCount(), storageBucketCount - 1);
   });
@@ -154,6 +152,6 @@ module('Acceptance | storage-buckets | delete', function (hooks) {
     await click(DROPDOWN_BUTTON_SELECTOR);
     await click(DELETE_DROPDOWN_SELECTOR);
 
-    assert.dom(NOTIFICATION_MSG_SELECTOR).hasText('Oops.');
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
   });
 });

--- a/ui/admin/tests/acceptance/targets/brokered-credential-sources-test.js
+++ b/ui/admin/tests/acceptance/targets/brokered-credential-sources-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | targets | brokered credential sources', function (hooks) {
   setupApplicationTest(hooks);
@@ -297,9 +298,7 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
     await click('tbody tr:last-child label');
     await click('tbody tr:first-child label');
     await click('form [type="submit"]');
-    assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
-      .isVisible();
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).isVisible();
   });
 
   test('can remove a vault type credential library', async function (assert) {
@@ -368,9 +367,7 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
     assert.strictEqual(findAll('tbody tr').length, count);
     await click('.hds-dropdown-toggle-icon');
     await click('tbody tr .hds-dropdown-list-item button');
-    assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
-      .isVisible();
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).isVisible();
   });
 
   test('removing a target credential which errors displays error messages', async function (assert) {
@@ -394,8 +391,6 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
     assert.strictEqual(findAll('tbody tr').length, count);
     await click('.hds-dropdown-toggle-icon');
     await click('tbody tr .hds-dropdown-list-item button');
-    assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
-      .isVisible();
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).isVisible();
   });
 });

--- a/ui/admin/tests/acceptance/targets/create-alias-test.js
+++ b/ui/admin/tests/acceptance/targets/create-alias-test.js
@@ -11,6 +11,7 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 import { TYPE_TARGET_TCP, TYPE_TARGET_SSH } from 'api/models/target';
 
@@ -27,8 +28,6 @@ module('Acceptance | targets | create-alias', function (hooks) {
   const NAME_FIELD_SELECTOR = '[name="name"]';
   const ALIAS_FIELD_SELECTOR = '[name="value"]';
   const DEST_FIELD_SELECTOR = '[name="destination_id"]';
-  const ALERT_TEXT_SELECTOR =
-    '[data-test-toast-notification] .hds-alert__description';
   const FIELD_ERROR_TEXT_SELECTOR = '.hds-form-error__message';
   const NAME_FIELD_TEXT = 'random string';
   const ALIAS_VALUE_TEXT = 'www.target1.com';
@@ -199,7 +198,9 @@ module('Acceptance | targets | create-alias', function (hooks) {
     await click(SAVE_BTN_SELECTOR);
     await a11yAudit();
 
-    assert.dom(ALERT_TEXT_SELECTOR).hasText('The request was invalid.');
+    assert
+      .dom(commonSelectors.ALERT_TOAST_BODY)
+      .hasText('The request was invalid.');
     assert.dom(FIELD_ERROR_TEXT_SELECTOR).hasText('Name is required.');
   });
 });

--- a/ui/admin/tests/acceptance/targets/create-test.js
+++ b/ui/admin/tests/acceptance/targets/create-test.js
@@ -18,6 +18,7 @@ import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { TYPE_TARGET_TCP, TYPE_TARGET_SSH } from 'api/models/target';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | targets | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -277,7 +278,7 @@ module('Acceptance | targets | create', function (hooks) {
     await click(SAVE_BTN_SELECTOR);
 
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.dom('.hds-form-error__message').hasText('Name is required.');
   });
@@ -306,7 +307,7 @@ module('Acceptance | targets | create', function (hooks) {
     await click(SAVE_BTN_SELECTOR);
 
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.dom('.hds-form-error__message').hasText('Name is required.');
   });

--- a/ui/admin/tests/acceptance/targets/delete-test.js
+++ b/ui/admin/tests/acceptance/targets/delete-test.js
@@ -86,7 +86,7 @@ module('Acceptance | targets | delete', function (hooks) {
     await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('Deleted successfully.');
     assert.strictEqual(getTargetCount(), targetCount - 1);
     assert.strictEqual(currentURL(), urls.targets);
@@ -137,8 +137,6 @@ module('Acceptance | targets | delete', function (hooks) {
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
 
-    assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
-      .hasText('Oops.');
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
   });
 });

--- a/ui/admin/tests/acceptance/targets/enable-session-recording/create-storage-bucket-test.js
+++ b/ui/admin/tests/acceptance/targets/enable-session-recording/create-storage-bucket-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { TYPE_TARGET_SSH } from 'api/models/target';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module(
   'Acceptance | targets | enable session recording | create storage bucket',
@@ -23,8 +24,6 @@ module(
     const SAVE_BTN_SELECTOR = '[type="submit"]';
     const CANCEL_BTN_SELECTOR = '.rose-form-actions [type="button"]';
     const NAME_FIELD_SELECTOR = '[name="name"]';
-    const ALERT_TEXT_SELECTOR =
-      '[data-test-toast-notification] .hds-alert__description';
     const FIELD_ERROR_TEXT_SELECTOR = '.hds-form-error__message';
     const NAME_FIELD_TEXT = 'random string';
     const BUCKET_NAME_FIELD_SELECTOR = '[name="bucket_name"]';
@@ -165,7 +164,9 @@ module(
       await fillIn(EDITOR_WORKER_FILTER, EDITOR_WORKER_FILTER_VALUE);
       await click(SAVE_BTN_SELECTOR);
 
-      assert.dom(ALERT_TEXT_SELECTOR).hasText('The request was invalid.');
+      assert
+        .dom(commonSelectors.ALERT_TOAST_BODY)
+        .hasText('The request was invalid.');
       assert.dom(FIELD_ERROR_TEXT_SELECTOR).hasText('Name is required.');
     });
   },

--- a/ui/admin/tests/acceptance/targets/host-sources-test.js
+++ b/ui/admin/tests/acceptance/targets/host-sources-test.js
@@ -171,7 +171,7 @@ module('Acceptance | targets | host-sources', function (hooks) {
 
     assert.dom('tbody tr').exists({ count: targetHostSetCount });
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
   });
 
@@ -257,7 +257,7 @@ module('Acceptance | targets | host-sources', function (hooks) {
     assert.strictEqual(currentURL(), urls.targetAddHostSources);
     assert.strictEqual(getTargetHostSetCount(), targetHostSetCount);
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
   });
 

--- a/ui/admin/tests/acceptance/targets/injected-application-credential-sources-test.js
+++ b/ui/admin/tests/acceptance/targets/injected-application-credential-sources-test.js
@@ -11,6 +11,7 @@ import { Response } from 'miragejs';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { TYPE_TARGET_SSH } from 'api/models/target';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module(
   'Acceptance | targets | injected application credential sources',
@@ -318,9 +319,7 @@ module(
       await click('tbody tr:last-child label');
       await click('tbody tr:first-child label');
       await click('form [type="submit"]');
-      assert
-        .dom('[data-test-toast-notification] .hds-alert__description')
-        .isVisible();
+      assert.dom(commonSelectors.ALERT_TOAST_BODY).isVisible();
     });
 
     test('can remove a vault type credential library', async function (assert) {
@@ -393,9 +392,7 @@ module(
       assert.strictEqual(findAll('tbody tr').length, count);
       await click('.hds-dropdown-toggle-icon');
       await click('tbody tr .hds-dropdown-list-item button');
-      assert
-        .dom('[data-test-toast-notification] .hds-alert__description')
-        .isVisible();
+      assert.dom(commonSelectors.ALERT_TOAST_BODY).isVisible();
     });
 
     test('removing a target credential which errors displays error messages', async function (assert) {
@@ -421,9 +418,7 @@ module(
       assert.strictEqual(findAll('tbody tr').length, count);
       await click('.hds-dropdown-toggle-icon');
       await click('tbody tr .hds-dropdown-list-item button');
-      assert
-        .dom('[data-test-toast-notification] .hds-alert__description')
-        .isVisible();
+      assert.dom(commonSelectors.ALERT_TOAST_BODY).isVisible();
     });
   },
 );

--- a/ui/admin/tests/acceptance/targets/update-test.js
+++ b/ui/admin/tests/acceptance/targets/update-test.js
@@ -117,7 +117,7 @@ module('Acceptance | targets | update', function (hooks) {
     await click('[type="submit"]');
 
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.dom('.hds-form-error__message').hasText('Name is required.');
   });

--- a/ui/admin/tests/acceptance/users/accounts-test.js
+++ b/ui/admin/tests/acceptance/users/accounts-test.js
@@ -11,6 +11,7 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { TYPE_AUTH_METHOD_LDAP } from 'api/models/auth-method';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | users | accounts', function (hooks) {
   setupApplicationTest(hooks);
@@ -24,8 +25,6 @@ module('Acceptance | users | accounts', function (hooks) {
     '[data-test-manage-user-dropdown] ul li:first-child a';
   const MANAGE_DROPDOWN_SELECTOR =
     '[data-test-manage-user-dropdown] button:first-child';
-  const ERROR_MSG_SELECTOR =
-    '[data-test-toast-notification] .hds-alert__description';
   const TABLE_ROWS_SELECTOR = 'tbody tr';
   const CHECKBOX_SELECTOR = 'tbody label';
   const SUBMIT_BTN_SELECTOR = 'form [type="submit"]';
@@ -162,7 +161,7 @@ module('Acceptance | users | accounts', function (hooks) {
     assert.dom(TABLE_ROWS_SELECTOR).exists({ count: accountsCount });
     await click(ACCOUNTS_ACTION_SELECTOR);
     await click(REMOVE_ACTION_SELECTOR);
-    assert.dom(ERROR_MSG_SELECTOR).isVisible();
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).isVisible();
   });
 
   test('visiting account add accounts', async function (assert) {
@@ -296,6 +295,6 @@ module('Acceptance | users | accounts', function (hooks) {
     await visit(urls.addAccounts);
     await click(CHECKBOX_SELECTOR);
     await click(SUBMIT_BTN_SELECTOR);
-    assert.dom(ERROR_MSG_SELECTOR).isVisible();
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).isVisible();
   });
 });

--- a/ui/admin/tests/acceptance/users/create-test.js
+++ b/ui/admin/tests/acceptance/users/create-test.js
@@ -10,6 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | users | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -135,7 +136,7 @@ module('Acceptance | users | create', function (hooks) {
 
     assert.strictEqual(getUsersCount(), usersCount);
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.dom('[data-test-error-message-name]').hasText('Name is required.');
   });

--- a/ui/admin/tests/acceptance/users/delete-test.js
+++ b/ui/admin/tests/acceptance/users/delete-test.js
@@ -85,7 +85,7 @@ module('Acceptance | users | delete', function (hooks) {
     await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
 
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('Deleted successfully.');
     assert.strictEqual(this.server.db.users.length, usersCount - 1);
     assert.strictEqual(currentURL(), urls.users);
@@ -123,8 +123,6 @@ module('Acceptance | users | delete', function (hooks) {
     await click(`[href="${urls.user}"]`);
     await click(MANAGE_DROPDOWN_SELECTOR);
     await click(DELETE_ACTION_SELECTOR);
-    assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
-      .hasText('Oops.');
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
   });
 });

--- a/ui/admin/tests/acceptance/users/update-test.js
+++ b/ui/admin/tests/acceptance/users/update-test.js
@@ -113,7 +113,7 @@ module('Acceptance | users | update', function (hooks) {
     await click('[type="submit"]');
 
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.dom('[data-test-error-message-name]').hasText('Name is required.');
   });

--- a/ui/admin/tests/acceptance/workers/create-test.js
+++ b/ui/admin/tests/acceptance/workers/create-test.js
@@ -9,6 +9,7 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | workers | create', function (hooks) {
   setupApplicationTest(hooks);
@@ -126,7 +127,7 @@ module('Acceptance | workers | create', function (hooks) {
     await fillIn('[name="worker_auth_registration_request"]', 'token');
     await click('[type="submit"]');
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('rpc error: code = Unknown');
   });
 

--- a/ui/admin/tests/acceptance/workers/delete-test.js
+++ b/ui/admin/tests/acceptance/workers/delete-test.js
@@ -11,6 +11,7 @@ import { Response } from 'miragejs';
 import { resolve, reject } from 'rsvp';
 import sinon from 'sinon';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | workers | delete', function (hooks) {
   setupApplicationTest(hooks);
@@ -105,8 +106,6 @@ module('Acceptance | workers | delete', function (hooks) {
     await visit(urls.worker);
     await click(MANAGE_DROPDOWN_TOGGLE);
     await click(REMOVE_WORKER_BUTTON);
-    assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
-      .hasText('Oops.');
+    assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
   });
 });

--- a/ui/admin/tests/acceptance/workers/update-test.js
+++ b/ui/admin/tests/acceptance/workers/update-test.js
@@ -9,6 +9,7 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Acceptance | workers | update', function (hooks) {
   setupApplicationTest(hooks);
@@ -82,7 +83,7 @@ module('Acceptance | workers | update', function (hooks) {
     await fillIn('[name="name"]', 'Worker Name');
     await click('[type="submit"]');
     assert
-      .dom('[data-test-toast-notification] .hds-alert__description')
+      .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.strictEqual(
       find('[data-test-error-message-name]').textContent.trim(),


### PR DESCRIPTION
# Description
This PR replaces instances of `[data-test-toast-notification] .hds-alert__description` with the common selector `ALERT_TOAST_BODY` from our test helpers file.

<!-- Uncomment line below to manually add link to JIRA ticket -->
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-16376)

## Screenshots (if appropriate)

## How to Test
Tests should pass ✅ 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
