### PR TITLE
refactor: 💅 Add selector to test helpers, implement across test suite

### DIFF
--- a/ui/admin/tests/acceptance/aliases/create-test.js
+++ b/ui/admin/tests/acceptance/aliases/create-test.js
@@ -26,7 +26,6 @@ module('Acceptance | aliases | create', function (hooks) {
   const NAME_FIELD_SELECTOR = '[name="name"]';
   const DESTINATION_ID_SELECTOR = '[name="destination_id"]';
   const HOST_ID_SELECTOR = '[name="authorize_session_arguments"]';
-  const FIELD_ERROR_TEXT_SELECTOR = '.hds-form-error__message';
   const NAME_FIELD_TEXT = 'random string';
 
   const instances = {
@@ -119,7 +118,7 @@ module('Acceptance | aliases | create', function (hooks) {
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
-    assert.dom(FIELD_ERROR_TEXT_SELECTOR).hasText('Name is required.');
+    assert.dom(commonSelectors.FIELD_TEXT_ERROR).hasText('Name is required.');
   });
 
   test('can navigate to new aliases route with proper authorization', async function (assert) {

--- a/ui/admin/tests/acceptance/auth-methods/create-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/create-test.js
@@ -544,7 +544,9 @@ module('Acceptance | auth-methods | create', function (hooks) {
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
-    assert.dom(selectors.FIELD_ERROR).hasText('At least one URL is required.');
+    assert
+      .dom(commonSelectors.FIELD_TEXT_ERROR)
+      .hasText('At least one URL is required.');
   });
 
   test('users cannot directly navigate to new auth method route without proper authorization', async function (assert) {

--- a/ui/admin/tests/acceptance/auth-methods/selectors.js
+++ b/ui/admin/tests/acceptance/auth-methods/selectors.js
@@ -94,7 +94,6 @@ export const FIELD_GROUP_FILTER = '[name=group_filter]';
 export const FIELD_GROUP_FILTER_VALUE = 'Group filter value';
 export const FIELD_ENABLE_GROUPS = '[name=enable_groups]';
 export const FIELD_USE_TOKEN_GROUPS = '[name=use_token_groups]';
-export const FIELD_ERROR = '.hds-form-error__message'; // Selects any error message on the DOM.
 
 export const MANAGE_DROPDOWN = '[data-test-manage-auth-method] button';
 export const MANAGE_DROPDOWN_MAKE_PRIMARY =

--- a/ui/admin/tests/acceptance/auth-methods/update-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/update-test.js
@@ -483,6 +483,6 @@ module('Acceptance | auth-methods | update', function (hooks) {
     await a11yAudit();
 
     assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText(errorMessage);
-    assert.dom(selectors.FIELD_ERROR).hasText(errorDescription);
+    assert.dom(commonSelectors.FIELD_TEXT_ERROR).hasText(errorDescription);
   });
 });

--- a/ui/admin/tests/acceptance/managed-groups/create-test.js
+++ b/ui/admin/tests/acceptance/managed-groups/create-test.js
@@ -29,7 +29,6 @@ module('Acceptance | managed-groups | create', function (hooks) {
   const CANCEL_BTN_SELECTOR = '.rose-form-actions [type="button"]';
   const NAME_INPUT_SELECTOR = '[name="name"]';
   const DESC_INPUT_SELECTOR = '[name="description"]';
-  const FIELD_ERROR_TEXT_SELECTOR = '.hds-form-error__message';
   const MANAGE_DROPDOWN_SELECTOR =
     '[data-test-manage-auth-method] button:first-child';
 
@@ -246,7 +245,7 @@ module('Acceptance | managed-groups | create', function (hooks) {
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
-    assert.dom(FIELD_ERROR_TEXT_SELECTOR).hasText('Name is required.');
+    assert.dom(commonSelectors.FIELD_TEXT_ERROR).hasText('Name is required.');
   });
 
   test('Users cannot directly navigate to a new managed group route without proper authorization', async function (assert) {

--- a/ui/admin/tests/acceptance/policy/create-test.js
+++ b/ui/admin/tests/acceptance/policy/create-test.js
@@ -23,7 +23,6 @@ module('Acceptance | policies | create', function (hooks) {
   const CANCEL_BTN_SELECTOR = '.rose-form-actions [type="button"]';
   const NAME_FIELD_SELECTOR = '[name="name"]';
   const RETAIN_FOR_TEXT_INPUT = '[data-input="retain_for"]';
-  const FIELD_ERROR_TEXT_SELECTOR = '.hds-form-error__message';
   const NAME_FIELD_TEXT = 'random string';
   const DELETE_AFTER_TEXT_INPUT = '[data-input="delete_after"]';
   const RETAIN_OVERRIDE = '[data-toggle="retain_for"]';
@@ -169,7 +168,7 @@ module('Acceptance | policies | create', function (hooks) {
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
-    assert.dom(FIELD_ERROR_TEXT_SELECTOR).hasText('Name is required.');
+    assert.dom(commonSelectors.FIELD_TEXT_ERROR).hasText('Name is required.');
   });
 
   test('users cannot directly navigate to new policy route without proper authorization', async function (assert) {

--- a/ui/admin/tests/acceptance/roles/create-test.js
+++ b/ui/admin/tests/acceptance/roles/create-test.js
@@ -129,7 +129,7 @@ module('Acceptance | roles | create', function (hooks) {
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
-    assert.ok(find('.hds-form-error__message'));
+    assert.ok(find(commonSelectors.FIELD_TEXT_ERROR));
   });
 
   test('users cannot directly navigate to new role route without proper authorization', async function (assert) {

--- a/ui/admin/tests/acceptance/roles/update-test.js
+++ b/ui/admin/tests/acceptance/roles/update-test.js
@@ -108,7 +108,7 @@ module('Acceptance | roles | update', function (hooks) {
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
     assert.strictEqual(
-      find('.hds-form-error__message').textContent.trim(),
+      find(commonSelectors.FIELD_TEXT_ERROR).textContent.trim(),
       'Name is required.',
       'Displays field-level errors.',
     );

--- a/ui/admin/tests/acceptance/scopes-test.js
+++ b/ui/admin/tests/acceptance/scopes-test.js
@@ -216,6 +216,6 @@ module('Acceptance | scopes', function (hooks) {
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
-    assert.dom('.hds-form-error__message').hasText('Name is required.');
+    assert.dom(commonSelectors.FIELD_TEXT_ERROR).hasText('Name is required.');
   });
 });

--- a/ui/admin/tests/acceptance/scopes/update-test.js
+++ b/ui/admin/tests/acceptance/scopes/update-test.js
@@ -126,7 +126,7 @@ module('Acceptance | scopes | update', function (hooks) {
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
-    assert.dom('.hds-form-error__message').hasText('Name is required.');
+    assert.dom(commonSelectors.FIELD_TEXT_ERROR).hasText('Name is required.');
   });
 
   test('can discard unsaved scope changes via dialog', async function (assert) {

--- a/ui/admin/tests/acceptance/targets/create-alias-test.js
+++ b/ui/admin/tests/acceptance/targets/create-alias-test.js
@@ -28,7 +28,6 @@ module('Acceptance | targets | create-alias', function (hooks) {
   const NAME_FIELD_SELECTOR = '[name="name"]';
   const ALIAS_FIELD_SELECTOR = '[name="value"]';
   const DEST_FIELD_SELECTOR = '[name="destination_id"]';
-  const FIELD_ERROR_TEXT_SELECTOR = '.hds-form-error__message';
   const NAME_FIELD_TEXT = 'random string';
   const ALIAS_VALUE_TEXT = 'www.target1.com';
   const ADD_AN_ALIAS_SELECTOR = '.target-sidebar-aliases .hds-button';
@@ -201,6 +200,6 @@ module('Acceptance | targets | create-alias', function (hooks) {
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
-    assert.dom(FIELD_ERROR_TEXT_SELECTOR).hasText('Name is required.');
+    assert.dom(commonSelectors.FIELD_TEXT_ERROR).hasText('Name is required.');
   });
 });

--- a/ui/admin/tests/acceptance/targets/create-test.js
+++ b/ui/admin/tests/acceptance/targets/create-test.js
@@ -280,7 +280,7 @@ module('Acceptance | targets | create', function (hooks) {
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
-    assert.dom('.hds-form-error__message').hasText('Name is required.');
+    assert.dom(commonSelectors.FIELD_TEXT_ERROR).hasText('Name is required.');
   });
 
   test('saving a new SSH target with invalid fields displays error messages', async function (assert) {
@@ -309,7 +309,7 @@ module('Acceptance | targets | create', function (hooks) {
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
-    assert.dom('.hds-form-error__message').hasText('Name is required.');
+    assert.dom(commonSelectors.FIELD_TEXT_ERROR).hasText('Name is required.');
   });
 
   test('can save address', async function (assert) {

--- a/ui/admin/tests/acceptance/targets/enable-session-recording/create-storage-bucket-test.js
+++ b/ui/admin/tests/acceptance/targets/enable-session-recording/create-storage-bucket-test.js
@@ -24,7 +24,6 @@ module(
     const SAVE_BTN_SELECTOR = '[type="submit"]';
     const CANCEL_BTN_SELECTOR = '.rose-form-actions [type="button"]';
     const NAME_FIELD_SELECTOR = '[name="name"]';
-    const FIELD_ERROR_TEXT_SELECTOR = '.hds-form-error__message';
     const NAME_FIELD_TEXT = 'random string';
     const BUCKET_NAME_FIELD_SELECTOR = '[name="bucket_name"]';
     const BUCKET_PREFIX_FIELD_SELECTOR = '[name="bucket_prefix"]';
@@ -167,7 +166,7 @@ module(
       assert
         .dom(commonSelectors.ALERT_TOAST_BODY)
         .hasText('The request was invalid.');
-      assert.dom(FIELD_ERROR_TEXT_SELECTOR).hasText('Name is required.');
+      assert.dom(commonSelectors.FIELD_TEXT_ERROR).hasText('Name is required.');
     });
   },
 );

--- a/ui/admin/tests/acceptance/targets/update-test.js
+++ b/ui/admin/tests/acceptance/targets/update-test.js
@@ -119,7 +119,7 @@ module('Acceptance | targets | update', function (hooks) {
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');
-    assert.dom('.hds-form-error__message').hasText('Name is required.');
+    assert.dom(commonSelectors.FIELD_TEXT_ERROR).hasText('Name is required.');
   });
 
   test('can discard unsaved target changes via dialog', async function (assert) {

--- a/ui/admin/tests/helpers/selectors.js
+++ b/ui/admin/tests/helpers/selectors.js
@@ -10,6 +10,7 @@ export const EDIT_BTN = '.rose-form-actions [type=button]';
 export const FIELD_NAME = '[name=name]';
 export const FIELD_NAME_VALUE = 'Random name';
 export const FIELD_NAME_ERROR = '[data-test-error-message-name]';
+export const FIELD_TEXT_ERROR = '.hds-form-error__message';
 
 export const FIELD_DESCRIPTION = '[name=description]';
 export const FIELD_DESCRIPTION_VALUE = 'description';

--- a/ui/admin/tests/integration/components/form/field/list-wrapper-test.js
+++ b/ui/admin/tests/integration/components/form/field/list-wrapper-test.js
@@ -8,6 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, findAll, render, select } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
+import * as commonSelectors from 'admin/tests/helpers/selectors';
 
 module('Integration | Component | list-wrapper', function (hooks) {
   setupRenderingTest(hooks);
@@ -42,7 +43,7 @@ module('Integration | Component | list-wrapper', function (hooks) {
     assert.dom('legend').exists().hasText('Label');
     assert.dom('.hds-form-helper-text').exists().hasText('Help');
 
-    assert.dom('.hds-form-error__message').exists().hasText('Error!');
+    assert.dom(commonSelectors.FIELD_TEXT_ERROR).exists().hasText('Error!');
     assert.dom('button').exists().hasText('Add');
   });
 


### PR DESCRIPTION
# Description
This PR adds the `FIELD_TEXT_ERROR` to our test helpers file, and replaces all instances of this non-unique err where tests were either selecting `.hds-form-error__message` or exporting a similarly named constant.

<!-- Uncomment line below to manually add link to JIRA ticket -->
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-16379) 

## Screenshots (if appropriate)

## How to Test
Tests should pass ✅ 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
