### PR TITLE
feat: 🎸 add logging to notifyError decorator

### DIFF
--- a/addons/api/addon/handlers/cache-daemon-handler.js
+++ b/addons/api/addon/handlers/cache-daemon-handler.js
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-/* global __electronLog */
 import { inject as service } from '@ember/service';
 import { getOwner, setOwner } from '@ember/application';
 import { generateMQLExpression } from '../utils/mql-query';
 import { paginateResults } from '../utils/paginate-results';
 import { underscore } from '@ember/string';
+
+const { __electronLog } = globalThis;
 
 /**
  * Not all types are yet supported by the cache daemon so we'll

--- a/addons/core/.eslintrc.js
+++ b/addons/core/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
   env: {
     browser: true,
   },
+  globals: { __electronLog: 'true' },
   rules: {
     'ember/no-get': 'off',
     'ember/no-get-with-default': 'off',

--- a/addons/core/.eslintrc.js
+++ b/addons/core/.eslintrc.js
@@ -25,7 +25,6 @@ module.exports = {
   env: {
     browser: true,
   },
-  globals: { __electronLog: 'true' },
   rules: {
     'ember/no-get': 'off',
     'ember/no-get-with-default': 'off',

--- a/addons/core/addon/decorators/notify.js
+++ b/addons/core/addon/decorators/notify.js
@@ -61,10 +61,12 @@ export function notifySuccess(notification) {
  *                              electron logging service
  * @param {string} options.log.origin - defaults to undefined, the origin that
  *                                     triggered the error
+ * @param {string} options.log.level - defaults to undefined, the log level that
+ *                                     our electron logging service should use
  */
 export function notifyError(
   notification,
-  options = { catch: false, sticky: true, log: undefined },
+  options = { catch: false, sticky: true },
 ) {
   return function (_target, _propertyKey, desc) {
     const method = desc.value;
@@ -77,11 +79,8 @@ export function notifyError(
         return await method.apply(this, arguments);
       } catch (error) {
         if (options.log) {
-          const { origin } = options.log;
-          __electronLog?.error(
-            `Error triggered in '${origin}':`,
-            error.message,
-          );
+          const { origin, level = 'error' } = options.log;
+          __electronLog?.[level](`${origin}:`, error.message);
         }
         const candidateKey =
           typeof notification === 'function'

--- a/addons/core/addon/decorators/notify.js
+++ b/addons/core/addon/decorators/notify.js
@@ -54,10 +54,12 @@ export function notifySuccess(notification) {
  *                                  the notification until user dismissal
  * @param {object} options.catch - defaults to false, whether or not to catch
  *                                 and squelch the error
+ * @param {object} options.log - defaults to false, whether or not to log
+ *                                 the error to our electron logging service
  */
 export function notifyError(
   notification,
-  options = { catch: false, sticky: true },
+  options = { catch: false, sticky: true, log: false },
 ) {
   return function (_target, _propertyKey, desc) {
     const method = desc.value;
@@ -69,6 +71,9 @@ export function notifyError(
       try {
         return await method.apply(this, arguments);
       } catch (error) {
+        if (options.log) {
+          __electronLog?.error('notifyError', error.message);
+        }
         const candidateKey =
           typeof notification === 'function'
             ? notification.apply(this, [error])

--- a/addons/core/addon/decorators/notify.js
+++ b/addons/core/addon/decorators/notify.js
@@ -5,6 +5,8 @@
 
 import { getOwner } from '@ember/application';
 
+const { __electronLog } = globalThis;
+
 /**
  * Decorates a method and, if the method does not error, shows a success
  * notification via the notify service.  The text of the notification is derived

--- a/addons/core/addon/decorators/notify.js
+++ b/addons/core/addon/decorators/notify.js
@@ -52,16 +52,19 @@ export function notifySuccess(notification) {
  *
  * @param {string|function} notification
  * @param {object} options
- * @param {object} options.sticky - defaults to true, whether or not to persist
+ * @param {boolean} options.sticky - defaults to true, whether or not to persist
  *                                  the notification until user dismissal
- * @param {object} options.catch - defaults to false, whether or not to catch
+ * @param {boolean} options.catch - defaults to false, whether or not to catch
  *                                 and squelch the error
- * @param {object} options.log - defaults to false, whether or not to log
- *                                 the error to our electron logging service
+ * @param {object} options.log - defaults to undefined, object with unique
+ *                              information about the error to send to our
+ *                              electron logging service
+ * @param {string} options.log.origin - defaults to undefined, the origin that
+ *                                     triggered the error
  */
 export function notifyError(
   notification,
-  options = { catch: false, sticky: true, log: false },
+  options = { catch: false, sticky: true, log: undefined },
 ) {
   return function (_target, _propertyKey, desc) {
     const method = desc.value;
@@ -74,7 +77,11 @@ export function notifyError(
         return await method.apply(this, arguments);
       } catch (error) {
         if (options.log) {
-          __electronLog?.error('notifyError', error.message);
+          const { origin } = options.log;
+          __electronLog?.error(
+            `Error triggered in '${origin}':`,
+            error.message,
+          );
         }
         const candidateKey =
           typeof notification === 'function'

--- a/ui/desktop/.eslintrc.js
+++ b/ui/desktop/.eslintrc.js
@@ -25,7 +25,6 @@ module.exports = {
   env: {
     browser: true,
   },
-  globals: { __electronLog: 'true' },
   rules: {
     'ember/no-get': 'off',
     'ember/no-get-with-default': 'off',

--- a/ui/desktop/app/controllers/cluster-url.js
+++ b/ui/desktop/app/controllers/cluster-url.js
@@ -26,7 +26,7 @@ export default class ClusterUrlController extends Controller {
   @loading
   @notifyError(() => 'errors.cluster-url-verification-failed.description', {
     catch: true,
-    log: true,
+    log: { origin: 'setClusterUrl' },
   })
   async setClusterUrl(clusterUrl) {
     await this.clusterUrlService.setClusterUrl(clusterUrl);

--- a/ui/desktop/app/controllers/cluster-url.js
+++ b/ui/desktop/app/controllers/cluster-url.js
@@ -26,6 +26,7 @@ export default class ClusterUrlController extends Controller {
   @loading
   @notifyError(() => 'errors.cluster-url-verification-failed.description', {
     catch: true,
+    log: true,
   })
   async setClusterUrl(clusterUrl) {
     await this.clusterUrlService.setClusterUrl(clusterUrl);

--- a/ui/desktop/app/routes/application.js
+++ b/ui/desktop/app/routes/application.js
@@ -29,7 +29,10 @@ export default class ApplicationRoute extends Route {
    * reported by the main process.  If they differ, update the main process
    * clusterUrl so that the renderer's CSP can be rewritten to allow requests.
    */
-  @notifyError(({ message }) => message, { catch: true, log: true })
+  @notifyError(({ message }) => message, {
+    catch: true,
+    log: { origin: 'ApplicationRoute:beforeModel' },
+  })
   async beforeModel() {
     this.intl.setLocale(['en-us']);
     await this.session.setup();

--- a/ui/desktop/app/routes/application.js
+++ b/ui/desktop/app/routes/application.js
@@ -29,7 +29,7 @@ export default class ApplicationRoute extends Route {
    * reported by the main process.  If they differ, update the main process
    * clusterUrl so that the renderer's CSP can be rewritten to allow requests.
    */
-  @notifyError(({ message }) => message, { catch: true })
+  @notifyError(({ message }) => message, { catch: true, log: true })
   async beforeModel() {
     this.intl.setLocale(['en-us']);
     await this.session.setup();

--- a/ui/desktop/app/routes/scopes/scope/projects.js
+++ b/ui/desktop/app/routes/scopes/scope/projects.js
@@ -6,6 +6,8 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
+const { __electronLog } = globalThis;
+
 /**
  * TODO:  This route is now vestigial.  Desktop does not provide project-based
  * navigation.  This route formerly provided a way to aggregate

--- a/ui/desktop/app/routes/scopes/scope/projects/sessions/session.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions/session.js
@@ -6,6 +6,8 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
+const { __electronLog } = globalThis;
+
 export default class ScopesScopeProjectsSessionsSessionRoute extends Route {
   // =services
 

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
@@ -11,6 +11,8 @@ import {
 } from 'api/models/session';
 import { action } from '@ember/object';
 
+const { __electronLog } = globalThis;
+
 export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
   // =services
 

--- a/ui/desktop/app/services/cluster-url.js
+++ b/ui/desktop/app/services/cluster-url.js
@@ -88,7 +88,7 @@ export default class ClusterUrlService extends Service {
   /**
    * Resets the clusterUrl.
    */
-  @notifyError(({ message }) => message, { catch: true })
+  @notifyError(({ message }) => message, { catch: true, log: true })
   async resetClusterUrl() {
     this.rendererClusterUrl = null;
     await this.ipc.invoke('resetClusterUrl');

--- a/ui/desktop/app/services/cluster-url.js
+++ b/ui/desktop/app/services/cluster-url.js
@@ -88,7 +88,10 @@ export default class ClusterUrlService extends Service {
   /**
    * Resets the clusterUrl.
    */
-  @notifyError(({ message }) => message, { catch: true, log: true })
+  @notifyError(({ message }) => message, {
+    catch: true,
+    log: { origin: 'resetClusterUrl' },
+  })
   async resetClusterUrl() {
     this.rendererClusterUrl = null;
     await this.ipc.invoke('resetClusterUrl');


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-16334

# Description
<!-- Add a brief description of changes here -->

I took this approach to make adding error logs for desktop client easier. The plan is if we need add logs, we can simply add `log: true` to the options object of the `notifyError` decorator. 

The scope of this PR is just to add this logging. I am reaching out to product about which errors we show in the desktop compared to the logs. They likely should be the same now and if product is good with that I will update this specific instance to show the error to the user and record it to the log file.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
