### PR TITLE
test(e2e): Enable Admin UI e2e tests to run against a local branch

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -153,7 +153,7 @@ Using Terminal 1:
 - `eval "$(doormat aws export --account boundary_team_acctest_dev)"`. Exporting AWS env variables from doormat to your terminal.
 - `enos scenario launch e2e_ui_aws builder:local` or `enos scenario launch e2e_ui_aws_ent builder:local` if in enterprise.
   - Launches enos scenario, this will take from 5 to 10 minutes. When its done, you will see a Enos Operations finished! within your terminal. Check out more scenarios [here](https://github.com/hashicorp/boundary/tree/main/enos).
-- `bash scripts/test_e2e_env.sh`. Prints all the env variables within Enos scenario. Copy the output and paste it within your Terminal 2 (Boundary UI). These env variables are need within Boundary UI to run the test against the enos scenario.
+- `bash scripts/test_e2e_env.sh`. Prints all the env variables within Enos scenario. Copy the output and paste it within your Terminal 2 (Boundary UI). These env variables are needed within Boundary UI to run the test against the enos scenario.
 
 Alternatively, you can also redirect the output to an `.env` file that will get picked up by tests automatically which is useful if you're running tests in your IDE:
 ```

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -166,7 +166,7 @@ Using Terminal 1:
 - `eval "$(doormat aws export --account boundary_team_acctest_dev)"`. Exporting AWS env variables from doormat to your terminal.
 - `enos scenario launch e2e_ui_aws builder:local` or `enos scenario launch e2e_ui_aws_ent builder:local` if in enterprise.
   - Launches enos scenario, this will take from 5 to 10 minutes. When its done, you will see a Enos Operations finished! within your terminal. Check out more scenarios [here](https://github.com/hashicorp/boundary/tree/main/enos).
-- `bash scripts/test_e2e_env.sh`. Prints all the env variables within Enos scenario. Copy the output and paste it within your Terminal 2 (Boundary UI). These env variables are need within Boundary UI to run the test against the enos scenario. 
+- `bash scripts/test_e2e_env.sh`. Prints all the env variables within Enos scenario. Copy the output and paste it within your Terminal 2 (Boundary UI). These env variables are need within Boundary UI to run the test against the enos scenario.
 
 Alternatively, you can also redirect the output to an `.env` file that will get picked up by tests automatically which is useful if you're running tests in your IDE:
 ```
@@ -199,6 +199,19 @@ Here are some additional commands to assist with debugging.
 PWDEBUG=console yarn playwright test --headed --config admin/playwright.config.js login.spec.js
 PWDEBUG=console yarn playwright test --headed --config admin/playwright.config.js login.spec.js:13 --debug
 PWDEBUG=console yarn playwright test --headed --config admin/playwright.config.js login.spec.js --debug
+```
+
+##### Admin (Using a Local Branch)
+
+```shell
+# In one terminal, run the `test_e2e_env.sh` script, and then do the following...
+cd boundary-ui/
+ENABLE_MIRAGE=false API_HOST=$BOUNDARY_ADDR yarn workspace admin start
+
+# In another terminal, run the `test_e2e_env.sh` script and then do the following...
+cd boundary-ui/e2e-tests
+export BOUNDARY_ADDR_BRANCH="http://localhost:4200" # This is the URL provided by the first terminal
+yarn run admin:{edition}:{infra} # Example: yarn run admin:ce:aws
 ```
 
 #### Desktop

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -116,19 +116,6 @@ Enos needs some configuration variables to run the scenario successfully. [See t
 
 More documentation about [scenario variables](https://github.com/hashicorp/boundary/tree/main/enos#scenarios-variables).
 
-> [!TIP]
-> To run e2e tests against a local branch for Admin UI, update the UI commit in boundary so it gets picked up when enos builds the binary
-
-By default, enos will build the version of the UI that is specified in the `VERSION` commit for `boundary`. To use a specific branch, update the version first before running the scenario.
-
-In the `boundary` or `boundary-enterprise` repository:
-```bash
-UI_COMMITISH=<commit sha> make update-ui-version
-
-# Alternatively if you want to just be able to run the same command for the most recent commit
-UI_COMMITISH=$(git -C <boundary-ui(-enterprise) repo path> rev-parse HEAD) make update-ui-version
-```
-
 ## Run tests:
 Make sure you followed all the steps within the [Getting started section](#getting-started).
 
@@ -210,8 +197,7 @@ ENABLE_MIRAGE=false API_HOST=$BOUNDARY_ADDR yarn workspace admin start
 
 # In another terminal, run the `test_e2e_env.sh` script and then do the following...
 cd boundary-ui/e2e-tests
-export BOUNDARY_ADDR_BRANCH="http://localhost:4200" # This is the URL provided by the first terminal
-yarn run admin:{edition}:{infra} # Example: yarn run admin:ce:aws
+BOUNDARY_ADDR_BRANCH="http://localhost:4200" yarn run admin:{edition}:{infra} # Example: yarn run admin:ce:aws
 ```
 
 #### Desktop

--- a/e2e-tests/admin/playwright.config.js
+++ b/e2e-tests/admin/playwright.config.js
@@ -4,7 +4,7 @@
  */
 
 import { defineConfig, devices } from '@playwright/test';
-import { authenticatedState } from '../global-setup';
+import { authenticatedState, url } from '../global-setup';
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export default defineConfig({
@@ -13,7 +13,7 @@ export default defineConfig({
   timeout: 90000, // Each test is given 90s to complete
   workers: 1, // Tests need to be run in serial, otherwise there may be conflicts when using the CLI
   use: {
-    baseURL: process.env.BOUNDARY_ADDR,
+    baseURL: url,
     extraHTTPHeaders: {
       // This token is set in global-setup.js
       Authorization: `Bearer ${process.env.E2E_TOKEN}`,

--- a/e2e-tests/admin/playwright.config.js
+++ b/e2e-tests/admin/playwright.config.js
@@ -4,7 +4,7 @@
  */
 
 import { defineConfig, devices } from '@playwright/test';
-import { authenticatedState, url } from '../global-setup';
+import { authenticatedState, baseUrl } from '../global-setup';
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export default defineConfig({
@@ -13,7 +13,7 @@ export default defineConfig({
   timeout: 90000, // Each test is given 90s to complete
   workers: 1, // Tests need to be run in serial, otherwise there may be conflicts when using the CLI
   use: {
-    baseURL: url,
+    baseURL: baseUrl,
     extraHTTPHeaders: {
       // This token is set in global-setup.js
       Authorization: `Bearer ${process.env.E2E_TOKEN}`,

--- a/e2e-tests/admin/tests/alias-ent.spec.js
+++ b/e2e-tests/admin/tests/alias-ent.spec.js
@@ -25,7 +25,7 @@ test.describe('Aliases (Enterprise)', () => {
     { tag: ['@ent', '@aws', '@docker'] },
     async ({
       page,
-      baseURL,
+      controllerAddr,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
@@ -81,7 +81,7 @@ test.describe('Aliases (Enterprise)', () => {
 
         // Connect to target using alias
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -115,7 +115,7 @@ test.describe('Aliases (Enterprise)', () => {
           connect.kill('SIGTERM');
         }
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -138,7 +138,7 @@ test.describe('Aliases (Enterprise)', () => {
     { tag: ['@ent', '@aws', '@docker'] },
     async ({
       page,
-      baseURL,
+      controllerAddr,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
@@ -156,7 +156,7 @@ test.describe('Aliases (Enterprise)', () => {
         const orgsPage = new OrgsPage(page);
         orgName = await orgsPage.createOrg();
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -191,7 +191,7 @@ test.describe('Aliases (Enterprise)', () => {
           connect.kill('SIGTERM');
         }
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -215,7 +215,7 @@ test.describe('Aliases (Enterprise)', () => {
     { tag: ['@ent', '@aws', '@docker'] },
     async ({
       page,
-      baseURL,
+      controllerAddr,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
@@ -253,7 +253,7 @@ test.describe('Aliases (Enterprise)', () => {
 
         // Create new alias from scope page
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -285,7 +285,7 @@ test.describe('Aliases (Enterprise)', () => {
           connect.kill('SIGTERM');
         }
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,

--- a/e2e-tests/admin/tests/alias.spec.js
+++ b/e2e-tests/admin/tests/alias.spec.js
@@ -24,7 +24,7 @@ test.describe('Aliases', () => {
     { tag: ['@ce', '@aws', '@docker'] },
     async ({
       page,
-      baseURL,
+      controllerAddr,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
@@ -64,7 +64,7 @@ test.describe('Aliases', () => {
 
         // Connect to target using alias
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -98,7 +98,7 @@ test.describe('Aliases', () => {
           connect.kill('SIGTERM');
         }
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -121,7 +121,7 @@ test.describe('Aliases', () => {
     { tag: ['@ce', '@aws', '@docker'] },
     async ({
       page,
-      baseURL,
+      controllerAddr,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
@@ -139,7 +139,7 @@ test.describe('Aliases', () => {
         const orgsPage = new OrgsPage(page);
         orgName = await orgsPage.createOrg();
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -163,7 +163,7 @@ test.describe('Aliases', () => {
           connect.kill('SIGTERM');
         }
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -186,7 +186,7 @@ test.describe('Aliases', () => {
     { tag: ['@ce', '@aws', '@docker'] },
     async ({
       page,
-      baseURL,
+      controllerAddr,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
@@ -213,7 +213,7 @@ test.describe('Aliases', () => {
 
         // Create new alias from scope page
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -244,7 +244,7 @@ test.describe('Aliases', () => {
           connect.kill('SIGTERM');
         }
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,

--- a/e2e-tests/admin/tests/auth-method-ldap.spec.js
+++ b/e2e-tests/admin/tests/auth-method-ldap.spec.js
@@ -26,7 +26,7 @@ test(
   { tag: ['@ce', '@ent', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -297,7 +297,7 @@ test(
     } finally {
       if (orgName) {
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,

--- a/e2e-tests/admin/tests/auth-method-oidc-vault.spec.js
+++ b/e2e-tests/admin/tests/auth-method-oidc-vault.spec.js
@@ -33,6 +33,7 @@ test(
     page,
     context,
     baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -263,7 +264,7 @@ test(
 
       if (orgName) {
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,

--- a/e2e-tests/admin/tests/auth-method-password.spec.js
+++ b/e2e-tests/admin/tests/auth-method-password.spec.js
@@ -25,7 +25,7 @@ test(
   { tag: ['@ce', '@ent', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -108,7 +108,7 @@ test(
       ).toBeVisible();
     } finally {
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,

--- a/e2e-tests/admin/tests/credential-store-static-ent.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static-ent.spec.js
@@ -23,7 +23,7 @@ test(
   { tag: ['@ent', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -106,7 +106,7 @@ test(
 
       // Verify credentials
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
@@ -136,7 +136,7 @@ test(
     } finally {
       if (orgName) {
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,

--- a/e2e-tests/admin/tests/credential-store-static.spec.js
+++ b/e2e-tests/admin/tests/credential-store-static.spec.js
@@ -44,7 +44,7 @@ test(
   { tag: ['@ce', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -65,7 +65,7 @@ test(
       );
 
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
@@ -95,7 +95,7 @@ test(
     } finally {
       if (orgName) {
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -114,7 +114,7 @@ test(
   { tag: ['@ce', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -135,7 +135,7 @@ test(
       );
 
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
@@ -161,7 +161,7 @@ test(
     } finally {
       if (orgName) {
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -180,7 +180,7 @@ test(
   { tag: ['@ce', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -224,7 +224,7 @@ test(
       );
 
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
@@ -252,7 +252,7 @@ test(
     } finally {
       if (orgName) {
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -271,7 +271,7 @@ test(
   { tag: ['@ce', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -317,7 +317,7 @@ test(
     } finally {
       if (orgName) {
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,

--- a/e2e-tests/admin/tests/credential-store-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/credential-store-vault-ent.spec.js
@@ -39,7 +39,7 @@ test(
   { tag: ['@ent', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -106,7 +106,7 @@ test(
 
       // Verify that session can be established
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,

--- a/e2e-tests/admin/tests/credential-store-vault.spec.js
+++ b/e2e-tests/admin/tests/credential-store-vault.spec.js
@@ -42,7 +42,7 @@ test(
   { tag: ['@ce', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -120,7 +120,7 @@ test(
 
       // Verify correct credentials are returned after authorizing session
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,

--- a/e2e-tests/admin/tests/delete-resources-ent.spec.js
+++ b/e2e-tests/admin/tests/delete-resources-ent.spec.js
@@ -26,9 +26,14 @@ test.beforeAll(async () => {
 });
 
 test.beforeEach(
-  async ({ baseURL, adminAuthMethodId, adminLoginName, adminPassword }) => {
+  async ({
+    controllerAddr,
+    adminAuthMethodId,
+    adminLoginName,
+    adminPassword,
+  }) => {
     await boundaryCli.authenticateBoundary(
-      baseURL,
+      controllerAddr,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,

--- a/e2e-tests/admin/tests/delete-resources.spec.js
+++ b/e2e-tests/admin/tests/delete-resources.spec.js
@@ -26,9 +26,14 @@ test.beforeAll(async () => {
 });
 
 test.beforeEach(
-  async ({ baseURL, adminAuthMethodId, adminLoginName, adminPassword }) => {
+  async ({
+    controllerAddr,
+    adminAuthMethodId,
+    adminLoginName,
+    adminPassword,
+  }) => {
     await boundaryCli.authenticateBoundary(
-      baseURL,
+      controllerAddr,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,

--- a/e2e-tests/admin/tests/dynamic-host-catalog-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/dynamic-host-catalog-aws-ent.spec.js
@@ -25,7 +25,7 @@ test.describe('AWS', () => {
     { tag: ['@ent', '@aws'] },
     async ({
       page,
-      baseURL,
+      controllerAddr,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
@@ -199,7 +199,7 @@ test.describe('AWS', () => {
 
         // Connect to target
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -222,7 +222,7 @@ test.describe('AWS', () => {
         }
 
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,

--- a/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
+++ b/e2e-tests/admin/tests/dynamic-host-catalog-aws.spec.js
@@ -25,7 +25,7 @@ test.describe('AWS', () => {
     { tag: ['@ce', '@aws'] },
     async ({
       page,
-      baseURL,
+      controllerAddr,
       adminAuthMethodId,
       adminLoginName,
       adminPassword,
@@ -199,7 +199,7 @@ test.describe('AWS', () => {
 
         // Connect to target
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,
@@ -222,7 +222,7 @@ test.describe('AWS', () => {
         }
 
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,

--- a/e2e-tests/admin/tests/global-settings.spec.js
+++ b/e2e-tests/admin/tests/global-settings.spec.js
@@ -15,7 +15,7 @@ test(
   { tag: ['@ent', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -49,7 +49,7 @@ test(
     } finally {
       if (policyName) {
         await boundaryCli.authenticateBoundary(
-          baseURL,
+          controllerAddr,
           adminAuthMethodId,
           adminLoginName,
           adminPassword,

--- a/e2e-tests/admin/tests/group-role.spec.js
+++ b/e2e-tests/admin/tests/group-role.spec.js
@@ -19,7 +19,7 @@ test(
   { tag: ['@ce', '@ent', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -38,7 +38,7 @@ test(
       await rolesPage.addGrantsToRole('ids=*;type=*;actions=read,list');
     } finally {
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,

--- a/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-aws-ent.spec.js
@@ -26,7 +26,7 @@ test(
   { tag: ['@ent', '@aws'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -47,7 +47,7 @@ test(
     let connect;
     try {
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,

--- a/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
+++ b/e2e-tests/admin/tests/session-recording-minio-ent.spec.js
@@ -26,7 +26,7 @@ test(
   { tag: ['@ent', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -49,7 +49,7 @@ test(
     let connect;
     try {
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,

--- a/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-certificate-injection-vault-ent.spec.js
@@ -37,7 +37,7 @@ test(
   { tag: ['@ent', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -122,7 +122,7 @@ test(
 
       // Connect to target
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,

--- a/e2e-tests/admin/tests/ssh-credential-injection-vault-ent.spec.js
+++ b/e2e-tests/admin/tests/ssh-credential-injection-vault-ent.spec.js
@@ -39,7 +39,7 @@ test(
   { tag: ['@ent', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -112,7 +112,7 @@ test(
 
       // Connect to target
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,

--- a/e2e-tests/admin/tests/target-ent.spec.js
+++ b/e2e-tests/admin/tests/target-ent.spec.js
@@ -23,7 +23,7 @@ test(
   { tag: ['@ent', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -47,7 +47,7 @@ test(
       );
 
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
@@ -90,7 +90,7 @@ test(
   { tag: ['@ent', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -125,7 +125,7 @@ test(
       );
 
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
@@ -164,7 +164,7 @@ test(
   { tag: ['@ent', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -231,7 +231,7 @@ test(
 
       // Connect to target
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,

--- a/e2e-tests/admin/tests/target.spec.js
+++ b/e2e-tests/admin/tests/target.spec.js
@@ -23,7 +23,7 @@ test(
   { tag: ['@ce', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -66,7 +66,7 @@ test(
 
       // Connect to target
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
@@ -109,7 +109,7 @@ test(
   { tag: ['@ce', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -133,7 +133,7 @@ test(
       );
 
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,
@@ -176,7 +176,7 @@ test(
   { tag: ['@ce', '@aws', '@docker'] },
   async ({
     page,
-    baseURL,
+    controllerAddr,
     adminAuthMethodId,
     adminLoginName,
     adminPassword,
@@ -239,7 +239,7 @@ test(
       await basePage.dismissSuccessAlert();
     } finally {
       await boundaryCli.authenticateBoundary(
-        baseURL,
+        controllerAddr,
         adminAuthMethodId,
         adminLoginName,
         adminPassword,

--- a/e2e-tests/global-setup.js
+++ b/e2e-tests/global-setup.js
@@ -28,7 +28,7 @@ const authenticateToBoundary = async () => {
   // Log in and save the authenticated state to reuse in tests
   const browser = await chromium.launch();
   const page = await browser.newPage();
-  await page.goto(process.env.BOUNDARY_ADDR);
+  await page.goto(url);
 
   const loginPage = new LoginPage(page);
   await loginPage.login(
@@ -49,6 +49,10 @@ const authenticateToBoundary = async () => {
 
 export default globalSetup;
 
+export const url = process.env.BOUNDARY_ADDR_BRANCH
+  ? process.env.BOUNDARY_ADDR_BRANCH
+  : process.env.BOUNDARY_ADDR;
+
 export const authenticatedState = path.resolve(
   __dirname,
   './.auth/authenticated-state.json',
@@ -65,6 +69,7 @@ export const test = baseTest.extend({
   awsHostSetIps: process.env.E2E_AWS_HOST_SET_IPS,
   awsRegion: process.env.E2E_AWS_REGION,
   awsSecretAccessKey: process.env.E2E_AWS_SECRET_ACCESS_KEY,
+  controllerAddr: process.env.BOUNDARY_ADDR,
   bucketAccessKeyId: process.env.E2E_BUCKET_ACCESS_KEY_ID,
   bucketEndpointUrl: process.env.E2E_BUCKET_ENDPOINT_URL,
   bucketName: process.env.E2E_BUCKET_NAME,

--- a/e2e-tests/global-setup.js
+++ b/e2e-tests/global-setup.js
@@ -28,7 +28,7 @@ const authenticateToBoundary = async () => {
   // Log in and save the authenticated state to reuse in tests
   const browser = await chromium.launch();
   const page = await browser.newPage();
-  await page.goto(url);
+  await page.goto(baseUrl);
 
   const loginPage = new LoginPage(page);
   await loginPage.login(
@@ -49,9 +49,8 @@ const authenticateToBoundary = async () => {
 
 export default globalSetup;
 
-export const url = process.env.BOUNDARY_ADDR_BRANCH
-  ? process.env.BOUNDARY_ADDR_BRANCH
-  : process.env.BOUNDARY_ADDR;
+export const baseUrl =
+  process.env.BOUNDARY_ADDR_BRANCH ?? process.env.BOUNDARY_ADDR;
 
 export const authenticatedState = path.resolve(
   __dirname,


### PR DESCRIPTION
# Description
This PR updates the Admin UI e2e test suite to support running against a local version of the Admin UI independent of the UI that's bundled with a Boundary binary. This required a decoupling of the address used by the browser vs the Boundary CLI. To accomplish this, this PR adds a new environment variable `BOUNDARY_ADDR_BRANCH`. If this is set, the test suite will use that address for the browser. That way, we can run 
```
ember serve 
BOUNDARY_ADDR_BRANCH=http://localhost:4200 yarn run ...
```

The README was updated to include instructions for how to use it.

https://hashicorp.atlassian.net/browse/ICU-16563

## Screenshots (if appropriate)
![Screenshot 2025-02-27 at 12 52 19 PM](https://github.com/user-attachments/assets/e96a39d6-dbcd-4c62-8238-228d882a79c0)

## How to Test
Follow instructions outlined in README updates
```
❯ export BOUNDARY_ADDR_BRANCH="http://localhost:4200" # This is the URL provided by the first terminal
❯ yarn admin:ent:docker tests/target-ent.spec.js  --project=chromium  
yarn run v1.22.22
$ yarn run admin --grep "(?=.*@ent)(?=.*@docker)" tests/target-ent.spec.js --project=chromium
$ yarn playwright test --config admin/playwright.config.js --grep '(?=.*@ent)(?=.*@docker)' tests/target-ent.spec.js --project=chromium
$ /Users/mycow/Developer/boundary-ui/node_modules/.bin/playwright test --config admin/playwright.config.js --grep '(?=.*@ent)(?=.*@docker)' tests/target-ent.spec.js --project=chromium

Running 3 tests using 1 worker

  ✓  1 [chromium] › tests/target-ent.spec.js:21:1 › Verify session created for TCP target @ent @aws @docker (10.2s)

  ✓  2 [chromium] › tests/target-ent.spec.js:88:1 › Verify session created for SSH target @ent @aws @docker (14.1s)

  ✓  3 [chromium] › tests/target-ent.spec.js:162:1 › SSH target with host sources @ent @aws @docker (23.3s)

  Slow test file: [chromium] › tests/target-ent.spec.js (47.5s)
  Consider splitting slow test files to speed up parallel execution
  3 passed (50.6s)
✨  Done in 52.06s.
```

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
