### PR TITLE
fix: 🐛 Fix development build for desktop client

### DIFF
--- a/ui/desktop/electron-app/config/desktop.js
+++ b/ui/desktop/electron-app/config/desktop.js
@@ -31,6 +31,7 @@ const createConfig = () => {
   // Take a valid release version in semVer format.
   if (!config.releaseVersion) {
     config.releaseVersion = '0.0.0';
+    config.releaseVersionRaw = '0.0.0';
   } else {
     config.releaseVersion = returnSemVerFromReleaseVersion(
       config.releaseVersion,


### PR DESCRIPTION
# Description
Currently building the DC fails if you don't set the `RELEASE_COMMIT` env which usually happens when building in development. I just also set a dummy `0.0.0` for the raw release version variable.

## How to Test
Building DC works without setting any env variables. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
