### PR TITLE
Add chrome flags to keep from backgrounding

### DIFF
--- a/addons/api/testem.js
+++ b/addons/api/testem.js
@@ -17,6 +17,12 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
+        // Disable backgrounding renders for occluded windows
+        '--disable-backgrounding-occluded-windows',
+        // Disable renderer process backgrounding
+        '--disable-renderer-backgrounding',
+        // Disable task throttling of timer tasks from background pages
+        '--disable-background-timer-throttling',
         '--disable-dev-shm-usage',
         '--disable-gpu',
         //'--disable-software-rasterizer',

--- a/addons/auth/testem.js
+++ b/addons/auth/testem.js
@@ -17,6 +17,12 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
+        // Disable backgrounding renders for occluded windows
+        '--disable-backgrounding-occluded-windows',
+        // Disable renderer process backgrounding
+        '--disable-renderer-backgrounding',
+        // Disable task throttling of timer tasks from background pages
+        '--disable-background-timer-throttling',
         '--disable-dev-shm-usage',
         '--disable-gpu',
         //'--disable-software-rasterizer',

--- a/addons/core/testem.js
+++ b/addons/core/testem.js
@@ -17,6 +17,12 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
+        // Disable backgrounding renders for occluded windows
+        '--disable-backgrounding-occluded-windows',
+        // Disable renderer process backgrounding
+        '--disable-renderer-backgrounding',
+        // Disable task throttling of timer tasks from background pages
+        '--disable-background-timer-throttling',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/addons/rose/testem.js
+++ b/addons/rose/testem.js
@@ -17,6 +17,12 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
+        // Disable backgrounding renders for occluded windows
+        '--disable-backgrounding-occluded-windows',
+        // Disable renderer process backgrounding
+        '--disable-renderer-backgrounding',
+        // Disable task throttling of timer tasks from background pages
+        '--disable-background-timer-throttling',
         '--disable-dev-shm-usage',
         '--disable-gpu',
         //'--disable-software-rasterizer',

--- a/ui/admin/testem.js
+++ b/ui/admin/testem.js
@@ -15,6 +15,12 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
+        // Disable backgrounding renders for occluded windows
+        '--disable-backgrounding-occluded-windows',
+        // Disable renderer process backgrounding
+        '--disable-renderer-backgrounding',
+        // Disable task throttling of timer tasks from background pages
+        '--disable-background-timer-throttling',
         '--disable-dev-shm-usage',
         '--disable-gpu',
         //'--disable-software-rasterizer',

--- a/ui/desktop/testem-electron.js
+++ b/ui/desktop/testem-electron.js
@@ -19,6 +19,12 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
+        // Disable backgrounding renders for occluded windows
+        '--disable-backgrounding-occluded-windows',
+        // Disable renderer process backgrounding
+        '--disable-renderer-backgrounding',
+        // Disable task throttling of timer tasks from background pages
+        '--disable-background-timer-throttling',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/ui/desktop/testem.js
+++ b/ui/desktop/testem.js
@@ -17,6 +17,12 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
+        // Disable backgrounding renders for occluded windows
+        '--disable-backgrounding-occluded-windows',
+        // Disable renderer process backgrounding
+        '--disable-renderer-backgrounding',
+        // Disable task throttling of timer tasks from background pages
+        '--disable-background-timer-throttling',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
# Description
There was an issue in tests where `close` events fired in `Hds::FlyOut` and `Hds::Modal` were not being dispatched, but only locally on macbooks with Chrome being ran headless. These close events were depended on by test waiters ([1](https://github.com/hashicorp/design-system/blob/main/packages/components/src/components/hds/flyout/index.ts#L172-L176), [2](https://github.com/hashicorp/design-system/blob/main/packages/components/src/components/hds/modal/index.ts#L188-L192)) to know when the element was removed. In recent versions of chrome, when ran headless and on macos, these events were not firing. This meant the tests waited indefinitely on developers' local machines, until the tests timed out. This issue was seen across multiple macbooks and even within the [hds design sytems repo](https://github.com/hashicorp/design-system).

This issue was *only* experienced in recent chrome versions ran on headless on macos.
It was **not** happening in:
* macos chrome headed locally
* linux chrome headless in CI

This made the issue only impact people running tests locally, getting obscure timeouts. This issue is fixed by the addition of this flag: `--disable-backgrounding-occluded-windows`

The other flags added in this commit are not required for the fix but should help keep a browser "active", which was loosely what researching this bug hinted at in finding the issue fix.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

## How to Test
1. Run tests locally with `yarn test` in any of the projects (no chrome browser should be launched for tests)
2. Tests run successfully

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

~~- [ ] I have added before and after screenshots for UI changes~~
~~- [ ] I have added JSON response output for API changes~~
- [x] I have added steps to reproduce and test for bug fixes in the description
~~- [ ] I have commented on my code, particularly in hard-to-understand areas~~
- [x] My changes generate no new warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
