### PR TITLE
Deprecate import inject from @ember/service

### DIFF
--- a/addons/api/addon/abilities/channel-recording.js
+++ b/addons/api/addon/abilities/channel-recording.js
@@ -4,7 +4,7 @@
  */
 
 import ModelAbility from './model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * Provides abilities for channel recordings.

--- a/addons/api/addon/abilities/credential-store.js
+++ b/addons/api/addon/abilities/credential-store.js
@@ -4,7 +4,7 @@
  */
 
 import ModelAbility from './model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 /**
  * Provides abilities for credential store.
  */

--- a/addons/api/addon/abilities/role.js
+++ b/addons/api/addon/abilities/role.js
@@ -4,7 +4,7 @@
  */
 
 import ModelAbility from './model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 class InvalidRolePrincipalTypeError extends Error {
   name = 'InvalidRolePrincipalTypeError';

--- a/addons/api/addon/handlers/cache-daemon-handler.js
+++ b/addons/api/addon/handlers/cache-daemon-handler.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { getOwner, setOwner } from '@ember/application';
 import { generateMQLExpression } from '../utils/mql-query';
 import { paginateResults } from '../utils/paginate-results';

--- a/addons/api/addon/handlers/indexed-db-handler.js
+++ b/addons/api/addon/handlers/indexed-db-handler.js
@@ -4,7 +4,7 @@
  */
 
 import { modelIndexes } from 'api/services/indexed-db';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { getOwner, setOwner } from '@ember/application';
 import { queryIndexedDb } from '../utils/indexed-db-query';
 import { paginateResults } from '../utils/paginate-results';

--- a/addons/api/addon/models/base.js
+++ b/addons/api/addon/models/base.js
@@ -6,7 +6,7 @@
 import Model from '@ember-data/model';
 import { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * Base model class provides common functionality for all models.

--- a/addons/api/addon/models/group.js
+++ b/addons/api/addon/models/group.js
@@ -7,7 +7,7 @@ import GeneratedGroupModel from '../generated/models/group';
 import { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 import { A } from '@ember/array';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class GroupModel extends GeneratedGroupModel {
   // =services

--- a/addons/api/addon/models/role.js
+++ b/addons/api/addon/models/role.js
@@ -5,7 +5,7 @@
 
 import GeneratedRoleModel from '../generated/models/role';
 import { attr } from '@ember-data/model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export const GRANT_SCOPE_THIS = 'this';
 export const GRANT_SCOPE_CHILDREN = 'children';

--- a/addons/api/addon/models/session-recording.js
+++ b/addons/api/addon/models/session-recording.js
@@ -5,7 +5,7 @@
 
 import GeneratedSessionRecordingModel from '../generated/models/session-recording';
 import { hasMany } from '@ember-data/model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export const TYPE_SESSION_RECORDING_SSH = 'ssh';
 export const TYPES_SESSION_RECORDING = Object.freeze([

--- a/addons/api/addon/models/session.js
+++ b/addons/api/addon/models/session.js
@@ -7,7 +7,7 @@ import GeneratedSessionModel from '../generated/models/session';
 import { equal } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { flattenObject } from '../utils/flatten-nested-object';
 import { TYPES_CREDENTIAL_LIBRARY } from 'api/models/credential-library';
 import { TYPE_CREDENTIAL_JSON } from 'api/models/credential';

--- a/addons/api/addon/models/target.js
+++ b/addons/api/addon/models/target.js
@@ -5,7 +5,7 @@
 
 import GeneratedTargetModel from '../generated/models/target';
 import { attr } from '@ember-data/model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export const TYPE_TARGET_TCP = 'tcp';
 export const TYPE_TARGET_SSH = 'ssh';

--- a/addons/api/addon/services/resource-filter-store.js
+++ b/addons/api/addon/services/resource-filter-store.js
@@ -4,7 +4,7 @@
  */
 
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * Takes a POJO representing a query and converts it to a boolean expression

--- a/addons/api/addon/services/storage.js
+++ b/addons/api/addon/services/storage.js
@@ -56,7 +56,7 @@ class MemoryStorage {
  *
  * @example
  *   import Route from '@ember/routing/route';
- *   import { inject as service } from '@ember/service';
+ *   import { service } from '@ember/service';
  *   export default class ApplicationRoute extends Route {
  *     @service storage;
  *     afterModel() {

--- a/addons/api/tests/dummy/app/routes/application.js
+++ b/addons/api/tests/dummy/app/routes/application.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ApplicationRoute extends Route {
   // =services

--- a/addons/auth/addon/authenticators/oidc.js
+++ b/addons/auth/addon/authenticators/oidc.js
@@ -4,7 +4,7 @@
  */
 
 import BaseAuthenticator from './base';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { reject } from 'rsvp';
 import { waitForPromise } from '@ember/test-waiters';
 

--- a/addons/auth/addon/session-stores/cookie.js
+++ b/addons/auth/addon/session-stores/cookie.js
@@ -6,7 +6,7 @@
 import BaseSessionStore from 'ember-simple-auth/session-stores/base';
 import { resolve, reject } from 'rsvp';
 import { get } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  *

--- a/addons/core/README.md
+++ b/addons/core/README.md
@@ -121,7 +121,7 @@ This addon exposes a service to hold all active scopes (org and project where av
 To make use of the service, import it and initialize it using service injection.
 
 ```js
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ExampleRoute extends Route {
   @service scope;

--- a/addons/core/addon/authenticators/oidc.js
+++ b/addons/core/addon/authenticators/oidc.js
@@ -4,7 +4,7 @@
  */
 
 import BaseOIDCAuthenticator from 'auth/authenticators/oidc';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * An OIDC authenticator that handles flow kick-off and polling.

--- a/addons/core/addon/authenticators/password.js
+++ b/addons/core/addon/authenticators/password.js
@@ -4,7 +4,7 @@
  */
 
 import BasePasswordAuthenticator from 'auth/authenticators/password';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * A username/password authenticator that authenticates with

--- a/addons/core/addon/components/filter-tags/index.js
+++ b/addons/core/addon/components/filter-tags/index.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 

--- a/addons/core/addon/components/pending-confirmations/index.js
+++ b/addons/core/addon/components/pending-confirmations/index.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 /**

--- a/addons/core/addon/helpers/format-day-year.js
+++ b/addons/core/addon/helpers/format-day-year.js
@@ -4,7 +4,7 @@
  */
 
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * Takes a `Day` instance and returns in year format if there are no remainders,

--- a/addons/core/addon/helpers/format-time-duration.js
+++ b/addons/core/addon/helpers/format-time-duration.js
@@ -4,7 +4,7 @@
  */
 
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { DurationFormat } from '@formatjs/intl-durationformat';
 import { secondsToDuration } from 'core/utils/seconds-to-duration';
 

--- a/addons/core/addon/helpers/has-resource-filter-selections.js
+++ b/addons/core/addon/helpers/has-resource-filter-selections.js
@@ -4,7 +4,7 @@
  */
 
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 

--- a/addons/core/addon/helpers/is-loading.js
+++ b/addons/core/addon/helpers/is-loading.js
@@ -4,7 +4,7 @@
  */
 
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * This helper returns true or false based on the state of the ember-loading

--- a/addons/core/addon/helpers/relative-datetime-live.js
+++ b/addons/core/addon/helpers/relative-datetime-live.js
@@ -4,7 +4,7 @@
  */
 
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const MILLISECOND = 1;
 const SECOND = MILLISECOND * 1000;

--- a/addons/core/addon/helpers/resource-filter.js
+++ b/addons/core/addon/helpers/resource-filter.js
@@ -4,7 +4,7 @@
  */
 
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 

--- a/addons/core/addon/helpers/reverse-indexed-display-name.js
+++ b/addons/core/addon/helpers/reverse-indexed-display-name.js
@@ -4,7 +4,7 @@
  */
 
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export function reverseIndexedDisplayName(intl, translation, array, item) {
   const length = array.length;

--- a/addons/core/addon/helpers/time-remaining.js
+++ b/addons/core/addon/helpers/time-remaining.js
@@ -4,7 +4,7 @@
  */
 
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { DurationFormat } from '@formatjs/intl-durationformat';
 import { secondsToDuration } from 'core/utils/seconds-to-duration';
 

--- a/addons/core/addon/helpers/truncate-list.js
+++ b/addons/core/addon/helpers/truncate-list.js
@@ -12,7 +12,7 @@
  */
 
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class extends Helper {
   // =services

--- a/addons/core/tests/dummy/app/controllers/index.js
+++ b/addons/core/tests/dummy/app/controllers/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IndexController extends Controller {
   // =services

--- a/addons/core/tests/dummy/app/routes/application.js
+++ b/addons/core/tests/dummy/app/routes/application.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ApplicationRoute extends Route {
   @service intl;

--- a/addons/rose/addon/components/rose/pagination/index.js
+++ b/addons/rose/addon/components/rose/pagination/index.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class RosePaginationComponent extends Component {

--- a/ui/admin/app/abilities/auth-method.js
+++ b/ui/admin/app/abilities/auth-method.js
@@ -4,7 +4,7 @@
  */
 
 import AuthMethodAbility from 'api/abilities/auth-method';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OverrideAuthMethodAbility extends AuthMethodAbility {
   //service

--- a/ui/admin/app/abilities/channel-recording.js
+++ b/ui/admin/app/abilities/channel-recording.js
@@ -4,7 +4,7 @@
  */
 
 import ChannelRecordingAbility from 'api/abilities/channel-recording';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OverrideChannelRecordingAbility extends ChannelRecordingAbility {
   // =service

--- a/ui/admin/app/abilities/credential-library.js
+++ b/ui/admin/app/abilities/credential-library.js
@@ -4,7 +4,7 @@
  */
 
 import CredentialLibraryAbility from 'api/abilities/credential-library';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OverrideCredentialLibraryAbility extends CredentialLibraryAbility {
   // =service

--- a/ui/admin/app/abilities/credential.js
+++ b/ui/admin/app/abilities/credential.js
@@ -4,7 +4,7 @@
  */
 
 import CredentialAbility from 'api/abilities/credential';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OverrideCredentialAbility extends CredentialAbility {
   // =service

--- a/ui/admin/app/abilities/scope.js
+++ b/ui/admin/app/abilities/scope.js
@@ -4,7 +4,7 @@
  */
 
 import OverrideModelAbility from './model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OverrideScopeAbility extends OverrideModelAbility {
   // =services

--- a/ui/admin/app/abilities/session-recording.js
+++ b/ui/admin/app/abilities/session-recording.js
@@ -4,7 +4,7 @@
  */
 
 import SessionRecordingAbility from 'api/abilities/session-recording';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OverrideSessionRecordingAbility extends SessionRecordingAbility {
   // =service

--- a/ui/admin/app/abilities/storage-bucket.js
+++ b/ui/admin/app/abilities/storage-bucket.js
@@ -4,7 +4,7 @@
  */
 
 import StorageBucketAbility from 'api/abilities/storage-bucket';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OverrideStorageBucketAbility extends StorageBucketAbility {
   // =service

--- a/ui/admin/app/abilities/user.js
+++ b/ui/admin/app/abilities/user.js
@@ -4,7 +4,7 @@
  */
 
 import UserAbility from 'api/abilities/user';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OverrideUserAbility extends UserAbility {
   // =service

--- a/ui/admin/app/components/breadcrumbs/container/index.js
+++ b/ui/admin/app/components/breadcrumbs/container/index.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 /*

--- a/ui/admin/app/components/breadcrumbs/item/index.js
+++ b/ui/admin/app/components/breadcrumbs/item/index.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/ui/admin/app/components/form/credential/index.js
+++ b/ui/admin/app/components/form/credential/index.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TYPES_CREDENTIAL } from 'api/models/credential';
 
 export default class FormCredentialComponent extends Component {

--- a/ui/admin/app/components/form/storage-bucket/index.js
+++ b/ui/admin/app/components/form/storage-bucket/index.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { set } from '@ember/object';
 
 import {

--- a/ui/admin/app/components/form/target/add-host-sets/index.js
+++ b/ui/admin/app/components/form/target/add-host-sets/index.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { loading } from 'ember-loading';
 import { notifyError } from 'core/decorators/notify';
 

--- a/ui/admin/app/components/form/target/details/index.js
+++ b/ui/admin/app/components/form/target/details/index.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { TYPES_TARGET } from 'api/models/target';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 // NOTE: this is all a temporary solution till we have a resource type helper.
 const types = [...TYPES_TARGET].reverse();

--- a/ui/admin/app/components/form/user/add-accounts/index.js
+++ b/ui/admin/app/components/form/user/add-accounts/index.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class FormUserAddAccountsComponent extends Component {
   // =properties

--- a/ui/admin/app/components/form/worker/create-tags/index.js
+++ b/ui/admin/app/components/form/worker/create-tags/index.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import Tag from '../tag';
 

--- a/ui/admin/app/components/form/worker/create-worker-led/index.js
+++ b/ui/admin/app/components/form/worker/create-worker-led/index.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
 import Tag from '../tag';

--- a/ui/admin/app/components/header-nav/index.js
+++ b/ui/admin/app/components/header-nav/index.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class HeaderNavComponent extends Component {
   // =services

--- a/ui/admin/app/components/session-recording/status/index.js
+++ b/ui/admin/app/components/session-recording/status/index.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import {
   STATE_SESSION_RECORDING_STARTED,
   STATE_SESSION_RECORDING_AVAILABLE,

--- a/ui/admin/app/controllers/account/change-password.js
+++ b/ui/admin/app/controllers/account/change-password.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { notifySuccess, notifyError } from 'core/decorators/notify';
 

--- a/ui/admin/app/controllers/application.js
+++ b/ui/admin/app/controllers/application.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 

--- a/ui/admin/app/controllers/onboarding/index.js
+++ b/ui/admin/app/controllers/onboarding/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/onboarding/success.js
+++ b/ui/admin/app/controllers/onboarding/success.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class OnboardingSuccessController extends Controller {

--- a/ui/admin/app/controllers/scopes/index.js
+++ b/ui/admin/app/controllers/scopes/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesIndexController extends Controller {
   // =services

--- a/ui/admin/app/controllers/scopes/scope.js
+++ b/ui/admin/app/controllers/scopes/scope.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeController extends Controller {
   // =services

--- a/ui/admin/app/controllers/scopes/scope/add-storage-policy/create.js
+++ b/ui/admin/app/controllers/scopes/scope/add-storage-policy/create.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { notifySuccess, notifyError } from 'core/decorators/notify';
 import { loading } from 'ember-loading';

--- a/ui/admin/app/controllers/scopes/scope/add-storage-policy/index.js
+++ b/ui/admin/app/controllers/scopes/scope/add-storage-policy/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/aliases/index.js
+++ b/ui/admin/app/controllers/scopes/scope/aliases/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { loading } from 'ember-loading';

--- a/ui/admin/app/controllers/scopes/scope/auth-methods/auth-method/accounts/account/set-password.js
+++ b/ui/admin/app/controllers/scopes/scope/auth-methods/auth-method/accounts/account/set-password.js
@@ -5,7 +5,7 @@
 
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';
 

--- a/ui/admin/app/controllers/scopes/scope/auth-methods/auth-method/accounts/index.js
+++ b/ui/admin/app/controllers/scopes/scope/auth-methods/auth-method/accounts/index.js
@@ -5,7 +5,7 @@
 
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { loading } from 'ember-loading';
 import { confirm } from 'core/decorators/confirm';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/auth-methods/auth-method/managed-groups/index.js
+++ b/ui/admin/app/controllers/scopes/scope/auth-methods/auth-method/managed-groups/index.js
@@ -5,7 +5,7 @@
 
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { loading } from 'ember-loading';
 import { confirm } from 'core/decorators/confirm';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/auth-methods/index.js
+++ b/ui/admin/app/controllers/scopes/scope/auth-methods/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { confirm } from 'core/decorators/confirm';

--- a/ui/admin/app/controllers/scopes/scope/authenticate/method/index.js
+++ b/ui/admin/app/controllers/scopes/scope/authenticate/method/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';

--- a/ui/admin/app/controllers/scopes/scope/authenticate/method/oidc.js
+++ b/ui/admin/app/controllers/scopes/scope/authenticate/method/oidc.js
@@ -4,7 +4,7 @@
  */
 
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class ScopesScopeAuthenticateMethodOidcController extends Controller {

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/index.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credential-libraries/index.js
@@ -8,7 +8,7 @@ import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { confirm } from 'core/decorators/confirm';
 import { notifySuccess, notifyError } from 'core/decorators/notify';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrariesIndexController extends Controller {
   @controller('scopes/scope/credential-stores/index') credentialStores;

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credentials/index.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/credential-store/credentials/index.js
@@ -8,7 +8,7 @@ import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { confirm } from 'core/decorators/confirm';
 import { notifySuccess, notifyError } from 'core/decorators/notify';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialsIndexController extends Controller {
   @controller('scopes/scope/credential-stores/index') credentialStores;

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/index.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { loading } from 'ember-loading';

--- a/ui/admin/app/controllers/scopes/scope/groups/group/add-members.js
+++ b/ui/admin/app/controllers/scopes/scope/groups/group/add-members.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/groups/index.js
+++ b/ui/admin/app/controllers/scopes/scope/groups/index.js
@@ -5,7 +5,7 @@
 
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { confirm } from 'core/decorators/confirm';

--- a/ui/admin/app/controllers/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/add-hosts.js
+++ b/ui/admin/app/controllers/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/add-hosts.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/create-and-add-host.js
+++ b/ui/admin/app/controllers/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/create-and-add-host.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/host-catalogs/host-catalog/host-sets/index.js
+++ b/ui/admin/app/controllers/scopes/scope/host-catalogs/host-catalog/host-sets/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { confirm } from 'core/decorators/confirm';

--- a/ui/admin/app/controllers/scopes/scope/host-catalogs/host-catalog/hosts/index.js
+++ b/ui/admin/app/controllers/scopes/scope/host-catalogs/host-catalog/hosts/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { confirm } from 'core/decorators/confirm';

--- a/ui/admin/app/controllers/scopes/scope/host-catalogs/index.js
+++ b/ui/admin/app/controllers/scopes/scope/host-catalogs/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { debounce } from 'core/decorators/debounce';

--- a/ui/admin/app/controllers/scopes/scope/index.js
+++ b/ui/admin/app/controllers/scopes/scope/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { confirm } from 'core/decorators/confirm';

--- a/ui/admin/app/controllers/scopes/scope/policies/index.js
+++ b/ui/admin/app/controllers/scopes/scope/policies/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { confirm } from 'core/decorators/confirm';

--- a/ui/admin/app/controllers/scopes/scope/roles/index.js
+++ b/ui/admin/app/controllers/scopes/scope/roles/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { tracked } from '@glimmer/tracking';

--- a/ui/admin/app/controllers/scopes/scope/roles/role/add-principals.js
+++ b/ui/admin/app/controllers/scopes/scope/roles/role/add-principals.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/roles/role/grants.js
+++ b/ui/admin/app/controllers/scopes/scope/roles/role/grants.js
@@ -4,7 +4,7 @@
  */
 
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/roles/role/manage-scopes/index.js
+++ b/ui/admin/app/controllers/scopes/scope/roles/role/manage-scopes/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/roles/role/manage-scopes/manage-custom-scopes.js
+++ b/ui/admin/app/controllers/scopes/scope/roles/role/manage-scopes/manage-custom-scopes.js
@@ -4,7 +4,7 @@
  */
 
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { tracked } from '@glimmer/tracking';

--- a/ui/admin/app/controllers/scopes/scope/roles/role/manage-scopes/manage-org-projects.js
+++ b/ui/admin/app/controllers/scopes/scope/roles/role/manage-scopes/manage-org-projects.js
@@ -4,7 +4,7 @@
  */
 
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { tracked } from '@glimmer/tracking';

--- a/ui/admin/app/controllers/scopes/scope/roles/role/scopes.js
+++ b/ui/admin/app/controllers/scopes/scope/roles/role/scopes.js
@@ -4,7 +4,7 @@
  */
 
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { debounce } from 'core/decorators/debounce';

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
@@ -7,7 +7,7 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { debounce } from 'core/decorators/debounce';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeSessionRecordingsIndexController extends Controller {
   // =services

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { confirm } from 'core/decorators/confirm';

--- a/ui/admin/app/controllers/scopes/scope/sessions/index.js
+++ b/ui/admin/app/controllers/scopes/scope/sessions/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import {
   STATUS_SESSION_ACTIVE,

--- a/ui/admin/app/controllers/scopes/scope/storage-buckets/index.js
+++ b/ui/admin/app/controllers/scopes/scope/storage-buckets/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { confirm } from 'core/decorators/confirm';

--- a/ui/admin/app/controllers/scopes/scope/storage-buckets/new.js
+++ b/ui/admin/app/controllers/scopes/scope/storage-buckets/new.js
@@ -4,7 +4,7 @@
  */
 
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeStorageBucketsNewController extends Controller {
   @controller('scopes/scope/storage-buckets/index')

--- a/ui/admin/app/controllers/scopes/scope/targets/index.js
+++ b/ui/admin/app/controllers/scopes/scope/targets/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { debounce } from 'core/decorators/debounce';

--- a/ui/admin/app/controllers/scopes/scope/targets/target/add-brokered-credential-sources.js
+++ b/ui/admin/app/controllers/scopes/scope/targets/target/add-brokered-credential-sources.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/targets/target/add-host-sources.js
+++ b/ui/admin/app/controllers/scopes/scope/targets/target/add-host-sources.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/targets/target/add-injected-application-credential-sources.js
+++ b/ui/admin/app/controllers/scopes/scope/targets/target/add-injected-application-credential-sources.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/targets/target/enable-session-recording/create-storage-bucket.js
+++ b/ui/admin/app/controllers/scopes/scope/targets/target/enable-session-recording/create-storage-bucket.js
@@ -4,7 +4,7 @@
  */
 
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { notifySuccess, notifyError } from 'core/decorators/notify';
 import { loading } from 'ember-loading';

--- a/ui/admin/app/controllers/scopes/scope/targets/target/enable-session-recording/index.js
+++ b/ui/admin/app/controllers/scopes/scope/targets/target/enable-session-recording/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class ScopesScopeTargetsTargetEnableSessionRecordingIndexController extends Controller {

--- a/ui/admin/app/controllers/scopes/scope/targets/target/index.js
+++ b/ui/admin/app/controllers/scopes/scope/targets/target/index.js
@@ -5,7 +5,7 @@
 
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class ScopesScopeTargetsTargetIndexController extends Controller {

--- a/ui/admin/app/controllers/scopes/scope/users/index.js
+++ b/ui/admin/app/controllers/scopes/scope/users/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { debounce } from 'core/decorators/debounce';

--- a/ui/admin/app/controllers/scopes/scope/users/user/add-accounts.js
+++ b/ui/admin/app/controllers/scopes/scope/users/user/add-accounts.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/workers/index.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { tracked } from '@glimmer/tracking';

--- a/ui/admin/app/controllers/scopes/scope/workers/new.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/new.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/workers/worker/create-tags.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/worker/create-tags.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifySuccess, notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/controllers/scopes/scope/workers/worker/tags.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/worker/tags.js
@@ -4,7 +4,7 @@
  */
 
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';

--- a/ui/admin/app/helpers/can.js
+++ b/ui/admin/app/helpers/can.js
@@ -4,7 +4,7 @@
  */
 
 import CanHelper from 'ember-can/helpers/can';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import config from 'admin/config/environment';
 
 const isDevelopment = config.environment === 'development';

--- a/ui/admin/app/routes/account.js
+++ b/ui/admin/app/routes/account.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AccountRoute extends Route {
   // =services

--- a/ui/admin/app/routes/account/change-password.js
+++ b/ui/admin/app/routes/account/change-password.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * The change password flow is associated only with password-type auth methods.

--- a/ui/admin/app/routes/application.js
+++ b/ui/admin/app/routes/application.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
 import { formatDbName } from 'api/services/indexed-db';

--- a/ui/admin/app/routes/authentication-error.js
+++ b/ui/admin/app/routes/authentication-error.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticationErrorRoute extends Route {
   // =services

--- a/ui/admin/app/routes/index.js
+++ b/ui/admin/app/routes/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/onboarding.js
+++ b/ui/admin/app/routes/onboarding.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TYPE_TARGET_TCP } from 'api/models/target';
 
 export default class OnboardingRoute extends Route {

--- a/ui/admin/app/routes/onboarding/success.js
+++ b/ui/admin/app/routes/onboarding/success.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OnboardingSuccessRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes.js
+++ b/ui/admin/app/routes/scopes.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { A } from '@ember/array';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/index.js
+++ b/ui/admin/app/routes/scopes/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { get } from '@ember/object';
 
 export default class ScopesIndexRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope.js
+++ b/ui/admin/app/routes/scopes/scope.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { A } from '@ember/array';
 import { TYPE_SCOPE_GLOBAL, TYPE_SCOPE_ORG } from 'api/models/scope';
 

--- a/ui/admin/app/routes/scopes/scope/add-storage-policy/create.js
+++ b/ui/admin/app/routes/scopes/scope/add-storage-policy/create.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TYPE_POLICY } from 'api/models/policy';
 
 export default class ScopesScopeAddStoragePolicyCreateRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
+++ b/ui/admin/app/routes/scopes/scope/add-storage-policy/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAddStoragePolicyIndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/aliases.js
+++ b/ui/admin/app/routes/scopes/scope/aliases.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAliasesRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/aliases/alias.js
+++ b/ui/admin/app/routes/scopes/scope/aliases/alias.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAliasesAliasRoute extends Route {
   @service store;

--- a/ui/admin/app/routes/scopes/scope/aliases/index.js
+++ b/ui/admin/app/routes/scopes/scope/aliases/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 
 export default class ScopesScopeAliasesIndexRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/aliases/new.js
+++ b/ui/admin/app/routes/scopes/scope/aliases/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TYPE_ALIAS_TARGET } from 'api/models/alias';
 
 export default class ScopesScopeAliasesNewRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/auth-methods.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthMethodsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { paramValueFinder } from 'admin/utils/param-value-finder';
 
 export default class ScopesScopeAuthMethodsAuthMethodRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/accounts.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/accounts.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthMethodsAuthMethodAccountsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/accounts/account.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/accounts/account.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthMethodsAuthMethodAccountsAccountRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/accounts/new.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/accounts/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthMethodsAuthMethodAccountsNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthMethodsAuthMethodManagedGroupsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthMethodsAuthMethodManagedGroupsManagedGroupRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group/members.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups/managed-group/members.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthMethodsAuthMethodManagedGroupsManagedGroupMembersRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups/new.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/auth-method/managed-groups/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthMethodsAuthMethodManagedGroupsNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/auth-methods/index.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthMethodsIndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/auth-methods/new.js
+++ b/ui/admin/app/routes/scopes/scope/auth-methods/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthMethodsNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/authenticate.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthenticateRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/authenticate/index.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthenticateIndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/authenticate/method.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate/method.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthenticateMethodRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/authenticate/method/oidc.js
+++ b/ui/admin/app/routes/scopes/scope/authenticate/method/oidc.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { getOwner } from '@ember/application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
 import { notifyError } from 'core/decorators/notify';

--- a/ui/admin/app/routes/scopes/scope/credential-stores.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { paramValueFinder } from 'admin/utils/param-value-finder';
 
 export default class ScopesScopeCredentialStoresCredentialStoreRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrariesRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/credential-library.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrariesCredentialLibraryRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/new.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credential-libraries/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TYPE_CREDENTIAL_LIBRARY_VAULT_GENERIC } from 'api/models/credential-library';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialLibrariesNewRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials/credential.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials/credential.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialsCredentialRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials/new.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/credential-store/credentials/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresCredentialStoreCredentialsNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/credential-stores/index.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresIndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/credential-stores/new.js
+++ b/ui/admin/app/routes/scopes/scope/credential-stores/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeCredentialStoresNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/edit.js
+++ b/ui/admin/app/routes/scopes/scope/edit.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeEditRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/groups.js
+++ b/ui/admin/app/routes/scopes/scope/groups.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeGroupsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/groups/group.js
+++ b/ui/admin/app/routes/scopes/scope/groups/group.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeGroupsGroupRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/groups/group/add-members.js
+++ b/ui/admin/app/routes/scopes/scope/groups/group/add-members.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { resourceFilter } from 'core/decorators/resource-filter';
 

--- a/ui/admin/app/routes/scopes/scope/groups/group/members.js
+++ b/ui/admin/app/routes/scopes/scope/groups/group/members.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeGroupsGroupMembersRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/groups/index.js
+++ b/ui/admin/app/routes/scopes/scope/groups/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeGroupsIndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/groups/new.js
+++ b/ui/admin/app/routes/scopes/scope/groups/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeGroupsNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/host-catalogs.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeHostCatalogsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { paramValueFinder } from 'admin/utils/param-value-finder';
 
 export default class ScopesScopeHostCatalogsHostCatalogRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeHostCatalogsHostCatalogHostSetsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { paramValueFinder } from 'admin/utils/param-value-finder';
 
 export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/add-hosts.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/add-hosts.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash } from 'rsvp';
 
 export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetAddHostsRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/create-and-add-host.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/create-and-add-host.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetCreateAndAddHostRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { hash, all } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetHostsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/host-set/hosts/host.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeHostCatalogsHostCatalogHostSetsHostSetHostsHostRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/new.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/host-sets/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeHostCatalogsHostCatalogHostSetsNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeHostCatalogsHostCatalogHostsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts/host.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts/host.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeHostCatalogsHostCatalogHostsHostRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts/new.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/host-catalog/hosts/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeHostCatalogsHostCatalogHostsNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/index.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeHostCatalogsIndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
+++ b/ui/admin/app/routes/scopes/scope/host-catalogs/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeHostCatalogsNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/index.js
+++ b/ui/admin/app/routes/scopes/scope/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeIndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/policies.js
+++ b/ui/admin/app/routes/scopes/scope/policies.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopePoliciesRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/policies/new.js
+++ b/ui/admin/app/routes/scopes/scope/policies/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopePoliciesNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/policies/policy.js
+++ b/ui/admin/app/routes/scopes/scope/policies/policy.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopePoliciesPolicyRoute extends Route {
   @service store;

--- a/ui/admin/app/routes/scopes/scope/roles.js
+++ b/ui/admin/app/routes/scopes/scope/roles.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeRolesRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/roles/index.js
+++ b/ui/admin/app/routes/scopes/scope/roles/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeRolesIndexRoute extends Route {
   // =attributes

--- a/ui/admin/app/routes/scopes/scope/roles/new.js
+++ b/ui/admin/app/routes/scopes/scope/roles/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeRolesNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/roles/role.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class ScopesScopeRolesRoleRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/roles/role/add-principals.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/add-principals.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { resourceFilter } from 'core/decorators/resource-filter';
 import {

--- a/ui/admin/app/routes/scopes/scope/roles/role/index.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeRolesRoleIndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/roles/role/manage-scopes/manage-custom-scopes.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/manage-scopes/manage-custom-scopes.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TrackedObject } from 'tracked-built-ins';
 import { TYPE_SCOPE_PROJECT } from 'api/models/scope';
 

--- a/ui/admin/app/routes/scopes/scope/roles/role/manage-scopes/manage-org-projects.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/manage-scopes/manage-org-projects.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeRolesRoleManageScopesManageOrgProjectsRoute extends Route {
   // =attributes

--- a/ui/admin/app/routes/scopes/scope/roles/role/principals.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/principals.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import {
   TYPE_AUTH_METHOD_OIDC,
   TYPE_AUTH_METHOD_LDAP,

--- a/ui/admin/app/routes/scopes/scope/roles/role/scopes.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/scopes.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeRolesRoleScopesRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/scopes.js
+++ b/ui/admin/app/routes/scopes/scope/scopes.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * The scopes route lists subscopes under the currently active scope.

--- a/ui/admin/app/routes/scopes/scope/scopes/index.js
+++ b/ui/admin/app/routes/scopes/scope/scopes/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeScopesIndexRoute extends Route {
   // =attributes

--- a/ui/admin/app/routes/scopes/scope/scopes/new.js
+++ b/ui/admin/app/routes/scopes/scope/scopes/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeScopesNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/session-recordings.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeSessionRecordingsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class ScopesScopeSessionRecordingsIndexRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { paramValueFinder } from 'admin/utils/param-value-finder';
 
 export default class ScopesScopeSessionRecordingsSessionRecordingRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConnectionRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConnectionChannelRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/channels-by-connection/channel/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConnectionChannelIndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/index.js
+++ b/ui/admin/app/routes/scopes/scope/session-recordings/session-recording/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeSessionRecordingsSessionRecordingIndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/sessions.js
+++ b/ui/admin/app/routes/scopes/scope/sessions.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeSessionsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/sessions/index.js
+++ b/ui/admin/app/routes/scopes/scope/sessions/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class ScopesScopeSessionsIndexRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/storage-buckets.js
+++ b/ui/admin/app/routes/scopes/scope/storage-buckets.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeStorageBucketsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/storage-buckets/new.js
+++ b/ui/admin/app/routes/scopes/scope/storage-buckets/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import {
   TYPE_STORAGE_BUCKET_PLUGIN,
   TYPE_STORAGE_BUCKET_PLUGIN_AWS_S3,

--- a/ui/admin/app/routes/scopes/scope/storage-buckets/storage-bucket.js
+++ b/ui/admin/app/routes/scopes/scope/storage-buckets/storage-bucket.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeStorageBucketsStorageBucketRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/storage-buckets/storage-bucket/index.js
+++ b/ui/admin/app/routes/scopes/scope/storage-buckets/storage-bucket/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeStorageBucketsStorageBucketIndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/targets.js
+++ b/ui/admin/app/routes/scopes/scope/targets.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeTargetsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/targets/index.js
+++ b/ui/admin/app/routes/scopes/scope/targets/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import {
   STATUS_SESSION_ACTIVE,
   STATUS_SESSION_PENDING,

--- a/ui/admin/app/routes/scopes/scope/targets/new.js
+++ b/ui/admin/app/routes/scopes/scope/targets/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TYPE_TARGET_TCP, TYPE_TARGET_SSH } from 'api/models/target';
 
 export default class ScopesScopeTargetsNewRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/targets/target.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeTargetsTargetRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/targets/target/add-brokered-credential-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/add-brokered-credential-sources.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeTargetsTargetAddBrokeredCredentialSourcesRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/targets/target/add-host-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/add-host-sources.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeTargetsTargetAddHostSourcesRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/targets/target/add-injected-application-credential-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/add-injected-application-credential-sources.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeTargetsTargetAddInjectedApplicationCredentialSourcesRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/targets/target/brokered-credential-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/brokered-credential-sources.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { all } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeTargetsTargetBrokeredCredentialSourcesRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/targets/target/create-alias.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/create-alias.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TYPE_ALIAS_TARGET } from 'api/models/alias';
 
 export default class ScopesScopeTargetsTargetCreateAliasRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/targets/target/enable-session-recording/create-storage-bucket.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/enable-session-recording/create-storage-bucket.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import {
   TYPE_STORAGE_BUCKET_PLUGIN,
   TYPE_STORAGE_BUCKET_PLUGIN_AWS_S3,

--- a/ui/admin/app/routes/scopes/scope/targets/target/enable-session-recording/index.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/enable-session-recording/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeTargetsTargetEnableSessionRecordingIndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/targets/target/host-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/host-sources.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { all, hash } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeTargetsTargetHostSourcesRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/targets/target/index.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeTargetsTargetIndexRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/targets/target/injected-application-credential-sources.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/injected-application-credential-sources.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { all } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeTargetsTargetInjectedApplicationCredentialSourcesRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/targets/target/manage-alias.js
+++ b/ui/admin/app/routes/scopes/scope/targets/target/manage-alias.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeTargetsTargetManageAliasRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/users.js
+++ b/ui/admin/app/routes/scopes/scope/users.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeUsersRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/users/index.js
+++ b/ui/admin/app/routes/scopes/scope/users/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeUsersIndexRoute extends Route {
   // =attributes

--- a/ui/admin/app/routes/scopes/scope/users/new.js
+++ b/ui/admin/app/routes/scopes/scope/users/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeUsersNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/users/user.js
+++ b/ui/admin/app/routes/scopes/scope/users/user.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeUsersUserRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/users/user/accounts.js
+++ b/ui/admin/app/routes/scopes/scope/users/user/accounts.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { hash, all } from 'rsvp';
 
 export default class ScopesScopeUsersUserAccountsRoute extends Route {

--- a/ui/admin/app/routes/scopes/scope/users/user/add-accounts.js
+++ b/ui/admin/app/routes/scopes/scope/users/user/add-accounts.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeUsersUserAddAccountsRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/workers.js
+++ b/ui/admin/app/routes/scopes/scope/workers.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeWorkersRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/workers/new.js
+++ b/ui/admin/app/routes/scopes/scope/workers/new.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeWorkersNewRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/workers/worker.js
+++ b/ui/admin/app/routes/scopes/scope/workers/worker.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeWorkersWorkerRoute extends Route {
   // =services

--- a/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
+++ b/ui/admin/app/routes/scopes/scope/workers/worker/create-tags.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TrackedArray } from 'tracked-built-ins';
 
 export default class ScopesScopeWorkersWorkerCreateTagsRoute extends Route {

--- a/ui/admin/app/services/feature-edition.js
+++ b/ui/admin/app/services/feature-edition.js
@@ -4,7 +4,7 @@
  */
 
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import config from 'admin/config/environment';
 

--- a/ui/admin/app/services/session.js
+++ b/ui/admin/app/services/session.js
@@ -4,7 +4,7 @@
  */
 
 import BaseSessionService from 'ember-simple-auth/services/session';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { formatDbName } from 'api/services/indexed-db';
 
 export default class SessionService extends BaseSessionService {

--- a/ui/admin/app/services/window-manager.js
+++ b/ui/admin/app/services/window-manager.js
@@ -4,7 +4,7 @@
  */
 
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * The window manager service enables browser windows to open and close

--- a/ui/desktop/app/components/session/proxy-url/index.js
+++ b/ui/desktop/app/components/session/proxy-url/index.js
@@ -6,7 +6,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SessionProxyUrlComponent extends Component {
   @service intl;

--- a/ui/desktop/app/components/session/tabs/index.js
+++ b/ui/desktop/app/components/session/tabs/index.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { CanvasAddon } from '@xterm/addon-canvas';

--- a/ui/desktop/app/components/settings-card/application/index.js
+++ b/ui/desktop/app/components/settings-card/application/index.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const THEMES = [
   {

--- a/ui/desktop/app/components/settings-card/client-agent/index.js
+++ b/ui/desktop/app/components/settings-card/client-agent/index.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifyError } from 'core/decorators/notify';

--- a/ui/desktop/app/components/settings-card/logs/index.js
+++ b/ui/desktop/app/components/settings-card/logs/index.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SettingsCardLogsComponent extends Component {
   // =services

--- a/ui/desktop/app/components/settings-card/server/index.js
+++ b/ui/desktop/app/components/settings-card/server/index.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SettingsCardServerComponent extends Component {
   // =services

--- a/ui/desktop/app/components/settings-card/user/index.js
+++ b/ui/desktop/app/components/settings-card/user/index.js
@@ -4,7 +4,7 @@
  */
 
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class SettingsUserInfoComponent extends Component {

--- a/ui/desktop/app/controllers/application.js
+++ b/ui/desktop/app/controllers/application.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 export default class ApplicationController extends Controller {

--- a/ui/desktop/app/controllers/cluster-url.js
+++ b/ui/desktop/app/controllers/cluster-url.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { notifyError } from 'core/decorators/notify';

--- a/ui/desktop/app/controllers/scopes/scope.js
+++ b/ui/desktop/app/controllers/scopes/scope.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeController extends Controller {
   // =services

--- a/ui/desktop/app/controllers/scopes/scope/authenticate.js
+++ b/ui/desktop/app/controllers/scopes/scope/authenticate.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthenticateController extends Controller {
   // =services

--- a/ui/desktop/app/controllers/scopes/scope/authenticate/method/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/authenticate/method/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';

--- a/ui/desktop/app/controllers/scopes/scope/authenticate/method/oidc.js
+++ b/ui/desktop/app/controllers/scopes/scope/authenticate/method/oidc.js
@@ -5,7 +5,7 @@
 
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthenticateMethodOidcController extends Controller {
   @controller('scopes/scope/authenticate/method/index') authenticateMethod;

--- a/ui/desktop/app/controllers/scopes/scope/projects/sessions/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/sessions/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -4,7 +4,7 @@
  */
 
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { loading } from 'ember-loading';
 import { tracked } from '@glimmer/tracking';

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
@@ -4,7 +4,7 @@
  */
 
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 

--- a/ui/desktop/app/helpers/is-loading.js
+++ b/ui/desktop/app/helpers/is-loading.js
@@ -4,7 +4,7 @@
  */
 
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * This helper returns true or false based on the state of the ember-loading

--- a/ui/desktop/app/routes/application.js
+++ b/ui/desktop/app/routes/application.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
 import { notifyError } from 'core/decorators/notify';

--- a/ui/desktop/app/routes/cluster-url.js
+++ b/ui/desktop/app/routes/cluster-url.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import config from '../config/environment';
 
 export default class ClusterUrlRoute extends Route {

--- a/ui/desktop/app/routes/index.js
+++ b/ui/desktop/app/routes/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route {
   // =services

--- a/ui/desktop/app/routes/scopes.js
+++ b/ui/desktop/app/routes/scopes.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { A } from '@ember/array';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesRoute extends Route {
   // =services

--- a/ui/desktop/app/routes/scopes/index.js
+++ b/ui/desktop/app/routes/scopes/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { get } from '@ember/object';
 
 export default class ScopesIndexRoute extends Route {

--- a/ui/desktop/app/routes/scopes/scope.js
+++ b/ui/desktop/app/routes/scopes/scope.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { A } from '@ember/array';
 
 export default class ScopesScopeRoute extends Route {

--- a/ui/desktop/app/routes/scopes/scope/authenticate.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthenticateRoute extends Route {
   // =services

--- a/ui/desktop/app/routes/scopes/scope/authenticate/index.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthenticateIndexRoute extends Route {
   // =services

--- a/ui/desktop/app/routes/scopes/scope/authenticate/method.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate/method.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeAuthenticateMethodRoute extends Route {
   // =services

--- a/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
@@ -5,7 +5,7 @@
 
 import Route from '@ember/routing/route';
 import { getOwner } from '@ember/application';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
 import { notifyError } from 'core/decorators/notify';

--- a/ui/desktop/app/routes/scopes/scope/index.js
+++ b/ui/desktop/app/routes/scopes/scope/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeIndexRoute extends Route {
   // =services

--- a/ui/desktop/app/routes/scopes/scope/projects.js
+++ b/ui/desktop/app/routes/scopes/scope/projects.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { restartableTask, timeout } from 'ember-concurrency';
 import config from '../../../config/environment';
 

--- a/ui/desktop/app/routes/scopes/scope/projects/sessions.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeProjectsSessionsRoute extends Route {
   // =services

--- a/ui/desktop/app/routes/scopes/scope/projects/sessions/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import {
   STATUS_SESSION_ACTIVE,

--- a/ui/desktop/app/routes/scopes/scope/projects/sessions/session.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions/session.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const { __electronLog } = globalThis;
 

--- a/ui/desktop/app/routes/scopes/scope/projects/settings/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/settings/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeProjectsSettingsIndexRoute extends Route {
   // =services

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import {
   STATUS_SESSION_ACTIVE,
   STATUS_SESSION_PENDING,

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/target.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class ScopesScopeProjectsTargetsTargetRoute extends Route {

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/target/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/target/index.js
@@ -4,7 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ScopesScopeProjectsTargetsTargetIndexRoute extends Route {
   // =services

--- a/ui/desktop/app/services/cluster-url.js
+++ b/ui/desktop/app/services/cluster-url.js
@@ -5,7 +5,7 @@
 
 import Service from '@ember/service';
 import { assert } from '@ember/debug';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { notifyError } from 'core/decorators/notify';
 
 export default class ClusterUrlService extends Service {

--- a/ui/desktop/app/services/ipc.js
+++ b/ui/desktop/app/services/ipc.js
@@ -4,7 +4,7 @@
  */
 
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { Promise } from 'rsvp';
 
 /**

--- a/ui/desktop/app/services/session.js
+++ b/ui/desktop/app/services/session.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import BaseSessionService from 'ember-simple-auth/services/session';
 import { notifyError } from 'core/decorators/notify';
 


### PR DESCRIPTION
# Description

[As per deprecation guide](https://deprecations.emberjs.com/id/importing-inject-from-ember-service/), deprecate import from @ember/service, import service instead.

[Jira ticket](https://hashicorp.atlassian.net/browse/ICU-16538)

## How to Test
- Admin UI: Run `e2e_ui_aws` CE.
- Desktop UI: Run `e2e_ui_aws_ent` ENT.
