### PR TITLE
Fix locationType deprecations.

### DIFF
--- a/addons/rose/tests/dummy/config/environment.js
+++ b/addons/rose/tests/dummy/config/environment.js
@@ -10,7 +10,7 @@ module.exports = function (environment) {
     modulePrefix: 'dummy',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     EmberENV: {
       EXTEND_PROTOTYPES: false,
       FEATURES: {

--- a/ui/desktop/config/environment.js
+++ b/ui/desktop/config/environment.js
@@ -6,13 +6,14 @@
 'use strict';
 
 const APP_NAME = process.env.APP_NAME || 'Boundary';
+const locationType = process.env.EMBER_CLI_ELECTRON ? 'hash' : 'history';
 
 module.exports = function (environment) {
   const ENV = {
     modulePrefix: 'desktop',
     environment,
     rootURL: process.env.EMBER_CLI_ELECTRON ? '' : '/',
-    locationType: process.env.EMBER_CLI_ELECTRON ? 'hash' : 'auto',
+    locationType,
     EmberENV: {
       EXTEND_PROTOTYPES: false,
       FEATURES: {


### PR DESCRIPTION
# Description

Within Desktop Client, we never deprecated auto location, [more info about this deprecation here](https://deprecations.emberjs.com/id/deprecate-auto-location). Therefore, when running the DC in the browser we were seeing 2 deprecations messages:
1. Using `auto` as value has been deprecated. So only `hash` or `history` are accepted.
2. Using detection code at `locationType` setting.

To solve 1, we decide to change `auto` to use `history`. [As per documentation](https://guides.emberjs.com/release/configuring-ember/specifying-url-type/), `auto` will uses `history` if supported by the browsers and fallback to `hash` if not. Since we are pretty sure the browser used by electron supports `history`, is safe to directly uses `history`.

To solve 2, we decide to set a const with the value before we are setting the environment config, therefore at setting time the variable has already a value.

## Screenshots:

Before, showing deprecation messages:
<img width="1678" alt="Screenshot 2025-03-11 at 1 56 19 PM" src="https://github.com/user-attachments/assets/1d1e237b-0dfe-4123-993d-c836ed7c67dd" />

After, showing no deprecation messages
<img width="1676" alt="Screenshot 2025-03-11 at 1 57 52 PM" src="https://github.com/user-attachments/assets/36faebc5-d83d-4a1c-ba12-2a4852671cb2" />
