### PR TITLE
Icu 16535 refactor usage of did insert modifiers

### DIFF
--- a/ui/admin/app/components/breadcrumbs/container/index.hbs
+++ b/ui/admin/app/components/breadcrumbs/container/index.hbs
@@ -6,7 +6,7 @@
 <Hds::Breadcrumb
   ...attributes
   data-test-breadcrumbs-container
-  {{did-insert this.registerContainer}}
+  {{this.insertedBreadcrumbContainer}}
 >
   {{yield}}
 </Hds::Breadcrumb>

--- a/ui/admin/app/components/breadcrumbs/container/index.js
+++ b/ui/admin/app/components/breadcrumbs/container/index.js
@@ -5,7 +5,7 @@
 
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { action } from '@ember/object';
+import { modifier } from 'ember-modifier';
 
 /*
   The `containers` property from the `breadcrumbsService` is tracked
@@ -18,20 +18,13 @@ export default class BreadcrumbsContainerComponent extends Component {
 
   container = null;
 
-  @action
-  registerContainer(element) {
-    // A child `ol` is rendered in the Hds::Breadcrumb container and this is
-    // the element that the in-element helper should drop breadcrumbs into.
+  insertedBreadcrumbContainer = modifier((element) => {
     this.container = {
       element: element.querySelector('ol'),
     };
 
     this.breadcrumbsService.registerContainer(this.container);
-  }
 
-  willDestroy() {
-    super.willDestroy(...arguments);
-
-    this.breadcrumbsService.unregisterContainer(this.container);
-  }
+    return () => this.breadcrumbsService.unregisterContainer(this.container);
+  });
 }

--- a/ui/admin/app/components/breadcrumbs/container/index.js
+++ b/ui/admin/app/components/breadcrumbs/container/index.js
@@ -19,6 +19,8 @@ export default class BreadcrumbsContainerComponent extends Component {
   container = null;
 
   insertedBreadcrumbContainer = modifier((element) => {
+    // A child `ol` is rendered in the Hds::Breadcrumb container and this is
+    // the element that the in-element helper should drop breadcrumbs into.
     this.container = {
       element: element.querySelector('ol'),
     };

--- a/ui/admin/app/components/breadcrumbs/item/index.hbs
+++ b/ui/admin/app/components/breadcrumbs/item/index.hbs
@@ -14,7 +14,7 @@
       @model={{@model}}
       @current={{this.current}}
       ...attributes
-      {{did-insert this.registerSelf}}
+      {{this.insertedBreadcrumbItem}}
       data-test-breadcrumbs-item
     />
   {{/in-element}}

--- a/ui/admin/app/components/breadcrumbs/item/index.js
+++ b/ui/admin/app/components/breadcrumbs/item/index.js
@@ -5,8 +5,8 @@
 
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
 
 /*
   `BreadcrumbsItem` inserts the crumbs to an existing container.
@@ -18,10 +18,9 @@ export default class BreadcrumbsItemComponent extends Component {
 
   @tracked element = null;
 
-  @action
-  registerSelf(element) {
+  insertedBreadcrumbItem = modifier((element) => {
     this.element = element;
-  }
+  });
 
   get current() {
     const crumbs = this.breadcrumbsService.containers[0].element.children;


### PR DESCRIPTION
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-16535)

# Description
<!-- Add a brief description of changes here -->
Remove usage of `{{did-insert}}` which is part of [ember-render-modifiers](https://github.com/emberjs/ember-render-modifiers) package. Usage of this was intended only for migrating off of classic ember components. `ember-modifier` can be[ easily used instead](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-at-ember-render-modifiers.md). Our use cases was limited to our breadcrumb components for accessing the dom element.

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
CI tests should be sufficient.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
