### PR TITLE
chore: 🤖 Add chrome for self hosted runners when running tests

### DIFF
--- a/.github/workflows/monorepo-validate.yaml
+++ b/.github/workflows/monorepo-validate.yaml
@@ -62,6 +62,9 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     timeout-minutes: 15
     steps:
+      - uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1.7.3
+        with:
+          install-dependencies: true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-modules-cache


### PR DESCRIPTION
# Description
Our self hosted runner [images](https://github.com/hashicorp/crt-github-runners/releases/tag/ubuntu-22.04-x86_64-78abdae-13654489443) don't include chrome by default so we'll need to manually include it for our tests.
