### PR TITLE
Upgrade electron forge from 7.5.0 to 7.7.0

### DIFF
--- a/ui/desktop/electron-app/package.json
+++ b/ui/desktop/electron-app/package.json
@@ -36,11 +36,11 @@
     "which": "^4.0.0"
   },
   "devDependencies": {
-    "@electron-forge/cli": "^7.5.0",
-    "@electron-forge/maker-deb": "^7.5.0",
-    "@electron-forge/maker-dmg": "^7.5.0",
-    "@electron-forge/maker-squirrel": "^7.5.0",
-    "@electron-forge/maker-zip": "^7.5.0",
+    "@electron-forge/cli": "^7.7.0",
+    "@electron-forge/maker-deb": "^7.7.0",
+    "@electron-forge/maker-dmg": "^7.7.0",
+    "@electron-forge/maker-squirrel": "^7.7.0",
+    "@electron-forge/maker-zip": "^7.7.0",
     "electron": "31.0.1",
     "unzipper": "^0.11.5"
   },

--- a/ui/desktop/electron-app/yarn.lock
+++ b/ui/desktop/electron-app/yarn.lock
@@ -5,7 +5,7 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@electron-forge/cli@npm:^7.5.0":
+"@electron-forge/cli@npm:^7.7.0":
   version: 7.7.0
   resolution: "@electron-forge/cli@npm:7.7.0"
   dependencies:
@@ -96,7 +96,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron-forge/maker-deb@npm:^7.5.0":
+"@electron-forge/maker-deb@npm:^7.7.0":
   version: 7.7.0
   resolution: "@electron-forge/maker-deb@npm:7.7.0"
   dependencies:
@@ -110,7 +110,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron-forge/maker-dmg@npm:^7.5.0":
+"@electron-forge/maker-dmg@npm:^7.7.0":
   version: 7.7.0
   resolution: "@electron-forge/maker-dmg@npm:7.7.0"
   dependencies:
@@ -125,7 +125,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron-forge/maker-squirrel@npm:^7.5.0":
+"@electron-forge/maker-squirrel@npm:^7.7.0":
   version: 7.7.0
   resolution: "@electron-forge/maker-squirrel@npm:7.7.0"
   dependencies:
@@ -140,7 +140,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron-forge/maker-zip@npm:^7.5.0":
+"@electron-forge/maker-zip@npm:^7.7.0":
   version: 7.7.0
   resolution: "@electron-forge/maker-zip@npm:7.7.0"
   dependencies:
@@ -903,11 +903,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "boundary-desktop@workspace:."
   dependencies:
-    "@electron-forge/cli": "npm:^7.5.0"
-    "@electron-forge/maker-deb": "npm:^7.5.0"
-    "@electron-forge/maker-dmg": "npm:^7.5.0"
-    "@electron-forge/maker-squirrel": "npm:^7.5.0"
-    "@electron-forge/maker-zip": "npm:^7.5.0"
+    "@electron-forge/cli": "npm:^7.7.0"
+    "@electron-forge/maker-deb": "npm:^7.7.0"
+    "@electron-forge/maker-dmg": "npm:^7.7.0"
+    "@electron-forge/maker-squirrel": "npm:^7.7.0"
+    "@electron-forge/maker-zip": "npm:^7.7.0"
     electron: "npm:31.0.1"
     electron-devtools-installer: "npm:^3.2.0"
     electron-is-dev: "npm:^2.0.0"


### PR DESCRIPTION
# Description

Upgrade electron-forge to latest in preparation for electron upgrade.

[Pipeline test run](https://github.com/hashicorp/boundary-desktop-releases/actions/runs/13975391991)
