### PR TITLE
feat: Conditionally display 'Check for Updates' menu item based on built-in CLI

### DIFF
--- a/ui/desktop/electron-app/src/config/menu.js
+++ b/ui/desktop/electron-app/src/config/menu.js
@@ -2,7 +2,7 @@ const { shell, dialog } = require('electron');
 const appUpdater = require('../helpers/app-updater.js');
 const { isMac, isWindows } = require('../helpers/platform.js');
 const config = require('../../config/config.js');
-const { version } = require('../cli/index.js');
+const { isBuiltInCli, version } = require('../cli/index.js');
 
 const generateMenuTemplate = () => {
   const aboutDialog = () => {
@@ -30,11 +30,15 @@ const generateMenuTemplate = () => {
                 label: `About ${config.productName}`,
                 click: aboutDialog,
               },
-              {
-                id: 'update',
-                label: 'Check for Updates',
-                click: async () => appUpdater.run(),
-              },
+              ...(isBuiltInCli
+                ? [
+                    {
+                      id: 'update',
+                      label: 'Check for Updates',
+                      click: async () => appUpdater.run(),
+                    },
+                  ]
+                : []),
               { type: 'separator' },
               { role: 'services' },
               { type: 'separator' },


### PR DESCRIPTION

# Description
This change ensures that the "Check for Updates" menu is only displayed if the CLI exists.

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-15297)

## Screenshots

Before Changes:
![image](https://github.com/user-attachments/assets/720804c2-527c-40b4-b43f-534b571d7180)

After Changes:
![image](https://github.com/user-attachments/assets/03a14860-c561-40da-8e22-15feef1a9d2a)

## How to Test
As mentioned, the "Check for Updates" menu will only be visible if the built-in CLI is included.

The CLI is included based on the build command. By default, the CLI is not included. To include the CLI, use the following command:
`SETUP_CLI=true yarn build:desktop`

After building, navigate to the build folder and run the **Boundary** app from the following location:
`<your_repo_path>/boundary-ui/ui/desktop/electron-app/out/Boundary-darwin-arm64/Boundary.app`

The CLI folder can be found at:

`<your_repo_path>/boundary-ui/ui/desktop/electron-app/out/Boundary-darwin-arm64/Boundary.app/Contents/Resources`

The "Check for Updates" button will appear when the CLI folder exists. If the folder is missing, the button will not be visible. There are two ways to remove the CLI folder:

1. **Exclude the CLI during the build process** by running the following command: `yarn build:desktop`
3. **Manually delete the CLI folder** if it exists. Afterward, quit and restart the application to see the changes.

## Checklist

- [x] I have added before and after screenshots for UI changes
- [ ] ~~I have added JSON response output for API changes~~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
