### PR TITLE
feat: Clear flash messages during login

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
@@ -18,8 +18,6 @@ export default class ScopesScopeAuthenticateMethodOidcRoute extends Route {
 
   @service session;
   @service router;
-  @service flashMessages;
-  @service intl;
 
   // =attributes
 

--- a/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
@@ -19,6 +19,7 @@ export default class ScopesScopeAuthenticateMethodOidcRoute extends Route {
   @service session;
   @service router;
   @service flashMessages;
+  @service intl;
 
   // =attributes
 
@@ -55,7 +56,11 @@ export default class ScopesScopeAuthenticateMethodOidcRoute extends Route {
    * When this route is activated (entered), start polling for authentication.
    */
   activate() {
-    this.flashMessages.clearMessages(); // clear any ui messages during login
+    const prevAuthFailedMessage = this.flashMessages.queue.find(
+      (flash) =>
+        flash.message === this.intl.t('errors.authentication-failed.title'),
+    );
+    prevAuthFailedMessage?.destroyMessage();
     this.poller.perform();
   }
 

--- a/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
@@ -56,11 +56,6 @@ export default class ScopesScopeAuthenticateMethodOidcRoute extends Route {
    * When this route is activated (entered), start polling for authentication.
    */
   activate() {
-    const prevAuthFailedMessage = this.flashMessages.queue.find(
-      (flash) =>
-        flash.message === this.intl.t('errors.authentication-failed.title'),
-    );
-    prevAuthFailedMessage?.destroyMessage();
     this.poller.perform();
   }
 
@@ -77,7 +72,10 @@ export default class ScopesScopeAuthenticateMethodOidcRoute extends Route {
    * notified and returned to the index.
    */
   @action
-  @notifyError(() => 'errors.authentication-failed.title', { catch: true })
+  @notifyError(() => 'errors.authentication-failed.title', {
+    catch: true,
+    sticky: false,
+  })
   error(e) {
     this.router.transitionTo('scopes.scope.authenticate.method.index');
     // rethrow the error to activate the notifyError decorator

--- a/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
@@ -18,6 +18,7 @@ export default class ScopesScopeAuthenticateMethodOidcRoute extends Route {
 
   @service session;
   @service router;
+  @service flashMessages;
 
   // =attributes
 
@@ -46,6 +47,7 @@ export default class ScopesScopeAuthenticateMethodOidcRoute extends Route {
    */
   setupController(controller) {
     super.setupController(...arguments);
+    this.flashMessages.clearMessages(); // clear any ui messages during login
     const authMethod = this.modelFor('scopes.scope.authenticate.method');
     controller.authMethod = authMethod;
   }

--- a/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
+++ b/ui/desktop/app/routes/scopes/scope/authenticate/method/oidc.js
@@ -47,7 +47,6 @@ export default class ScopesScopeAuthenticateMethodOidcRoute extends Route {
    */
   setupController(controller) {
     super.setupController(...arguments);
-    this.flashMessages.clearMessages(); // clear any ui messages during login
     const authMethod = this.modelFor('scopes.scope.authenticate.method');
     controller.authMethod = authMethod;
   }
@@ -56,6 +55,7 @@ export default class ScopesScopeAuthenticateMethodOidcRoute extends Route {
    * When this route is activated (entered), start polling for authentication.
    */
   activate() {
+    this.flashMessages.clearMessages(); // clear any ui messages during login
     this.poller.perform();
   }
 

--- a/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
+++ b/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';

--- a/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
+++ b/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
@@ -5,129 +5,17 @@
 
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import sinon from 'sinon';
 
 module(
   'Unit | Route | scopes/scope/authenticate/method/oidc',
   function (hooks) {
     setupTest(hooks);
 
-    let route, flashMessagesService, intlService;
-    let originalQueue;
-
-    function createFlashMessage(message, type = 'danger') {
-      return {
-        message,
-        type,
-        // Add destroyMessage method to the flash message object
-        // This is needed because we're using a simplified mock queue in tests rather than
-        // the actual flash messages implementation. In production, flash messages would have
-        // this method natively, but we need to add it manually for testing purposes.
-        destroyMessage() {
-          const index = flashMessagesService.queue.indexOf(this);
-          if (index !== -1) {
-            flashMessagesService.queue.splice(index, 1);
-          }
-        },
-      };
-    }
-
-    hooks.beforeEach(function () {
-      route = this.owner.lookup('route:scopes/scope/authenticate/method/oidc');
-      flashMessagesService = this.owner.lookup('service:flashMessages');
-      intlService = this.owner.lookup('service:intl');
-
-      sinon
-        .stub(intlService, 't')
-        .withArgs('errors.authentication-failed.title')
-        .returns('Authentication Failed');
-
-      // Need to stub the exists method to avoid "Cannot read properties of undefined (reading 'some')" error
-      sinon.stub(intlService, 'exists').returns(true);
-
-      // Store original queue and create a mock queue
-      originalQueue = flashMessagesService.queue;
-      flashMessagesService.queue = [];
-      flashMessagesService.queue.clear = function () {
-        this.length = 0;
-      };
-
-      sinon
-        .stub(flashMessagesService, 'danger')
-        .callsFake(function (message, opts) {
-          const flashMessage = createFlashMessage(message);
-          this.queue.push({ ...flashMessage, ...opts });
-        });
-
-      // Stub refresh method that is called by the poller task
-      // Without this stub, the route.activate() call would trigger the poller which attempts
-      // to call refresh(), causing "Cannot read properties of undefined" errors since the
-      // actual refresh implementation relies on router and model hooks not available in unit tests
-      route.refresh = () => {};
-    });
-
-    hooks.afterEach(function () {
-      flashMessagesService.queue = originalQueue;
-      sinon.restore();
-    });
-
-    test('it shows and clears flash message on error and activate', async function (assert) {
-      assert.expect(4);
-
-      const error = new Error('Authentication Failed');
-      const expectedErrorMessage = 'Authentication Failed';
-
-      route.router = { transitionTo: sinon.stub() };
-
-      await route.error(error);
-
-      assert.ok(
-        route.router.transitionTo.calledWith(
-          'scopes.scope.authenticate.method.index',
-        ),
-        'Router transition was triggered',
+    test('it exists', function (assert) {
+      let route = this.owner.lookup(
+        'route:scopes/scope/authenticate/method/oidc',
       );
-
-      assert.strictEqual(
-        flashMessagesService.queue.length,
-        1,
-        'Flash message was added by notifyError',
-      );
-
-      assert.strictEqual(
-        flashMessagesService.queue[0].message,
-        expectedErrorMessage,
-        'Correct error message is displayed',
-      );
-
-      route.activate();
-
-      assert.strictEqual(
-        flashMessagesService.queue.length,
-        0,
-        'Flash message was cleared by activate hook',
-      );
-    });
-
-    test('it does not clear non-authentication-error flash messages during activate', function (assert) {
-      assert.expect(2);
-
-      const otherErrorMessage = 'Some other error';
-      flashMessagesService.queue.push(createFlashMessage(otherErrorMessage));
-
-      assert.strictEqual(
-        flashMessagesService.queue.length,
-        1,
-        'Flash message was added',
-      );
-
-      route.activate();
-
-      assert.strictEqual(
-        flashMessagesService.queue.length,
-        1,
-        'Non-authentication flash messages are preserved after activate hook',
-      );
+      assert.ok(route);
     });
   },
 );

--- a/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
+++ b/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) HashiCorp, Inc.
- * SPDX-License-Identifier: BUSL-1.1
- */
-
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
@@ -12,39 +7,121 @@ module(
   function (hooks) {
     setupTest(hooks);
 
-    let route;
+    let route, flashMessagesService, intlService;
+    let originalQueue;
+
+    function createFlashMessage(message, type = 'danger') {
+      return {
+        message,
+        type,
+        // Add destroyMessage method to the flash message object
+        // This is needed because we're using a simplified mock queue in tests rather than
+        // the actual flash messages implementation. In production, flash messages would have
+        // this method natively, but we need to add it manually for testing purposes.
+        destroyMessage() {
+          const index = flashMessagesService.queue.indexOf(this);
+          if (index !== -1) {
+            flashMessagesService.queue.splice(index, 1);
+          }
+        },
+      };
+    }
+
     hooks.beforeEach(function () {
       route = this.owner.lookup('route:scopes/scope/authenticate/method/oidc');
-    });
-
-    test('it exists', function (assert) {
-      assert.ok(route);
-    });
-
-    test('setupController clears UI messages and sets authMethod on the controller', function (assert) {
-      assert.expect(2);
-
-      const fakeAuthMethod = { name: 'OIDC', type: 'oidc' };
-
-      const flashMessagesService = this.owner.lookup('service:flash-messages');
-      const clearMessagesSpy = sinon.spy(flashMessagesService, 'clearMessages');
-      route.flashMessages = flashMessagesService;
+      flashMessagesService = this.owner.lookup('service:flashMessages');
+      intlService = this.owner.lookup('service:intl');
 
       sinon
-        .stub(route, 'modelFor')
-        .withArgs('scopes.scope.authenticate.method')
-        .returns(fakeAuthMethod);
+        .stub(intlService, 't')
+        .withArgs('errors.authentication-failed.title')
+        .returns('Authentication Failed');
 
-      const controller = this.owner.lookup(
-        'controller:scopes/scope/authenticate/method/oidc',
+      // Need to stub the exists method to avoid "Cannot read properties of undefined (reading 'some')" error
+      sinon.stub(intlService, 'exists').returns(true);
+
+      // Store original queue and create a mock queue
+      originalQueue = flashMessagesService.queue;
+      flashMessagesService.queue = [];
+      flashMessagesService.queue.clear = function () {
+        this.length = 0;
+      };
+
+      sinon
+        .stub(flashMessagesService, 'danger')
+        .callsFake(function (message, opts) {
+          const flashMessage = createFlashMessage(message);
+          this.queue.push({ ...flashMessage, ...opts });
+        });
+
+      // Stub refresh method that is called by the poller task
+      // Without this stub, the route.activate() call would trigger the poller which attempts
+      // to call refresh(), causing "Cannot read properties of undefined" errors since the
+      // actual refresh implementation relies on router and model hooks not available in unit tests
+      route.refresh = () => {};
+    });
+
+    hooks.afterEach(function () {
+      flashMessagesService.queue = originalQueue;
+      sinon.restore();
+    });
+
+    test('it shows and clears flash message on error and activate', async function (assert) {
+      assert.expect(4);
+
+      const error = new Error('Authentication Failed');
+      const expectedErrorMessage = 'Authentication Failed';
+
+      route.router = { transitionTo: sinon.stub() };
+
+      await route.error(error);
+
+      assert.ok(
+        route.router.transitionTo.calledWith(
+          'scopes.scope.authenticate.method.index',
+        ),
+        'Router transition was triggered',
       );
-      route.setupController(controller);
 
-      assert.ok(clearMessagesSpy.calledOnce, 'clearMessages was called');
-      assert.deepEqual(
-        controller.authMethod,
-        fakeAuthMethod,
-        'controller.authMethod was set correctly',
+      assert.strictEqual(
+        flashMessagesService.queue.length,
+        1,
+        'Flash message was added by notifyError',
+      );
+
+      assert.strictEqual(
+        flashMessagesService.queue[0].message,
+        expectedErrorMessage,
+        'Correct error message is displayed',
+      );
+
+      route.activate();
+
+      assert.strictEqual(
+        flashMessagesService.queue.length,
+        0,
+        'Flash message was cleared by activate hook',
+      );
+    });
+
+    test('it does not clear non-authentication-error flash messages during activate', function (assert) {
+      assert.expect(2);
+
+      const otherErrorMessage = 'Some other error';
+      flashMessagesService.queue.push(createFlashMessage(otherErrorMessage));
+
+      assert.strictEqual(
+        flashMessagesService.queue.length,
+        1,
+        'Flash message was added',
+      );
+
+      route.activate();
+
+      assert.strictEqual(
+        flashMessagesService.queue.length,
+        1,
+        'Non-authentication flash messages are preserved after activate hook',
       );
     });
   },

--- a/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
+++ b/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
@@ -5,6 +5,9 @@
 
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+import Controller from '@ember/controller';
+import sinon from 'sinon';
 
 module(
   'Unit | Route | scopes/scope/authenticate/method/oidc',
@@ -16,6 +19,73 @@ module(
         'route:scopes/scope/authenticate/method/oidc',
       );
       assert.ok(route);
+    });
+
+    test('setupController clears UI messages and sets authMethod on the controller', function (assert) {
+      assert.expect(2);
+
+      class FlashMessagesStub extends Service {
+        clearMessages() {
+          assert.ok(true, 'flashMessages.clearMessages was called');
+        }
+      }
+
+      this.owner.register('service:flash-messages', FlashMessagesStub);
+
+      const controller = new (class extends Controller {})();
+      const route = this.owner.lookup(
+        'route:scopes/scope/authenticate/method/oidc',
+      );
+
+      const fakeAuthMethod = { name: 'OIDC', type: 'oidc' };
+      route.modelFor = () => fakeAuthMethod;
+
+      route.setupController(controller);
+
+      assert.deepEqual(
+        controller.authMethod,
+        fakeAuthMethod,
+        'controller.authMethod was set correctly',
+      );
+    });
+
+    test('setupController clears flash messages', function (assert) {
+      assert.expect(2);
+
+      // Get the route instance
+      const route = this.owner.lookup(
+        'route:scopes/scope/authenticate/method/oidc',
+      );
+
+      // Mock the flashMessages service
+      const flashMessages = {
+        clearMessages: sinon.spy(),
+      };
+      route.flashMessages = flashMessages;
+
+      // Mock the controller and model
+      const controller = {};
+      const authMethod = { id: 'test-auth-method' };
+      sinon
+        .stub(route, 'modelFor')
+        .withArgs('scopes.scope.authenticate.method')
+        .returns(authMethod);
+
+      // Call setupController
+      route.setupController(controller);
+
+      // Assert that clearMessages was called
+      assert.ok(
+        flashMessages.clearMessages.calledOnce,
+        'clearMessages was called',
+      );
+
+      // Assert that the authMethod was set on the controller
+      assert.strictEqual(
+        controller.authMethod,
+        authMethod,
+        'authMethod was set on the controller',
+      );
     });
   },
 );

--- a/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
+++ b/ui/desktop/tests/unit/routes/scopes/scope/authenticate/method/oidc-test.js
@@ -5,7 +5,6 @@
 
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import Controller from '@ember/controller';
 import sinon from 'sinon';
 
 module(
@@ -13,9 +12,10 @@ module(
   function (hooks) {
     setupTest(hooks);
 
-    let route = this.owner.lookup(
-      'route:scopes/scope/authenticate/method/oidc',
-    );
+    let route;
+    hooks.beforeEach(function () {
+      route = this.owner.lookup('route:scopes/scope/authenticate/method/oidc');
+    });
 
     test('it exists', function (assert) {
       assert.ok(route);
@@ -24,16 +24,20 @@ module(
     test('setupController clears UI messages and sets authMethod on the controller', function (assert) {
       assert.expect(2);
 
-      let flashMessagesService, clearMessagesSpy;
       const fakeAuthMethod = { name: 'OIDC', type: 'oidc' };
 
-      flashMessagesService = this.owner.lookup('service:flash-messages');
-      clearMessagesSpy = sinon.spy(flashMessagesService, 'clearMessages');
+      const flashMessagesService = this.owner.lookup('service:flash-messages');
+      const clearMessagesSpy = sinon.spy(flashMessagesService, 'clearMessages');
       route.flashMessages = flashMessagesService;
 
-      sinon.stub(route, 'modelFor').returns(fakeAuthMethod);
+      sinon
+        .stub(route, 'modelFor')
+        .withArgs('scopes.scope.authenticate.method')
+        .returns(fakeAuthMethod);
 
-      const controller = new (class extends Controller {})();
+      const controller = this.owner.lookup(
+        'controller:scopes/scope/authenticate/method/oidc',
+      );
       route.setupController(controller);
 
       assert.ok(clearMessagesSpy.calledOnce, 'clearMessages was called');


### PR DESCRIPTION
# Description
Display of incorrect UI error message when the user tries to login after unsuccessful attempt.

## Short Summary of the Issue
A [ticket](https://hashicorp.atlassian.net/browse/ICU-16227) has been raised with the issue where the user encounter an error message after attempting to log in to Boundary using OpenID Connect (OIDC) with Vault as the authentication provider. While the login flow works as expected when the token is valid, user experienced unexpected behavior once the token expires - despite re-authenticating successfully, an error is displayed.

## RCA Details  
**1. Handling Expiry of Tokens**

When a user's OIDC token (from Vault) expires, they are redirected to the Vault login page for re-authentication. However, Vault fails to return a valid token back to Boundary after this process. As a result, Boundary receives an invalid token and responds with a 500 error.

- **Root Cause:** Vault does not return a fresh or valid token ID to Boundary after re-authentication. This causes Boundary to treat the session as invalid.
- **Note:** This issue has been [confirmed](https://hashicorp.slack.com/archives/C04L34UGZ/p1743579285190629) and is [tracked](https://hashicorp.atlassian.net/browse/VAULT-32519) separately

**2. Sticky Error Message on UI**

Once the 500 error is received due to the invalid token, an error message is shown in the UI. If the user subsequently logs in successfully (e.g., by manually authenticating through Vault in another tab), the previous error message still persists.

- **Root Cause:** Error messages are not automatically cleared when the login button is clicked again, resulting in stale messages being shown post-successful login.

Solution provided for Issue 2 (Sticky Error Message)
To resolve the sticky error message, considered the below solution:

**Message Reset on Login**

Clear all existing success or error messages when the user initiates a new login attempt. This ensures that only the most recent status message is shown.

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-16227) 

## Screenshots (if appropriate)
Before:
<img width="728" alt="image" src="https://github.com/user-attachments/assets/141bf953-83b9-480b-9279-e46641faa987" />

After:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/502a3d10-1614-41d3-9f1f-c10123c77749" />

## How to Test

1. **Set Up Vault as an OIDC Provider**
To get started, create a Vault as an OIDC provider for the login, you can refer the [documentation](https://developer.hashicorp.com/vault/tutorials/auth-methods/oidc-identity-provider) for the setup process and use "HCP Vault Dedicated" because token has expiry time here.
Note: Use HCP Vault Dedicated, as tokens here have an expiration time, which is essential for testing.

2. **Run the UI with Mirage Disabled**
Ensure that ENABLE_MIRAGE flag is set to false and run the below command: 
`ENABLE_MIRAGE=false yarn start:desktop`

3. **Login via Vault**
Select the Vault as the login provide and login. If the token is valid, it should take you to the home page of the boundary.

4. **Test Invalid Token Scenario**
If the token is invalid, you will be redirected to Vault's login UI page to re-authenticate. Currently the vault's UI has a known issue of not passing the correct token and the [ticket](https://hashicorp.atlassian.net/browse/VAULT-32519) is open. After few minutes the API server will return a 500 error indicating an invalid token, and an error message will be displayed to the user.
![image](https://github.com/user-attachments/assets/dd4a1436-2bc7-4587-b9e8-f65177e5fa07)
<img width="670" alt="image" src="https://github.com/user-attachments/assets/0a70e30b-a1e5-44ce-94c2-bfb94cef03d3" />

5. **Workaround for Vault UI Issue**
We can bypass the above issue from Vault's UI by re-authenticating the vault from the browser by navigating to the HCP Vault Dedicated's page from the [HCP portal](https://portal.cloud.hashicorp.com/) - (configured in the step 1 above)

6. **Verify Successful Re-authentication**
After successful attempt, repeat the step 3 to login the error message should no longer be displayed.

7. **Reference Video**
A video demonstrating both the issue and the fix is attached for reference.

Before Fix:
https://github.com/user-attachments/assets/b73238f3-d118-41eb-91a1-c549ff181df9

After Fix:
https://github.com/user-attachments/assets/a04a8fd2-772d-4a34-9597-49bc00fc87c1

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] ~~I have added JSON response output for API changes~~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
