### PR TITLE
[Replace] Rose::Form::Label and <input.field> elements

### DIFF
--- a/ui/admin/app/components/form/role/grants/index.hbs
+++ b/ui/admin/app/components/form/role/grants/index.hbs
@@ -15,15 +15,12 @@
       <list.item as |item|>
         <form.input @contextual={{true}}>
           <item.key>
-            <Hds::Form::Label @controlId='add-grant'>
+            <Hds::Form::Label>
               {{t 'resources.role.grant.actions.create'}}
             </Hds::Form::Label>
           </item.key>
           <item.cell>
-            <Input
-              class='rose-form-input-field'
-              id='add-grant'
-              @type='text'
+            <Hds::Form::TextInput::Field
               name='grant'
               @value={{this.newGrantString}}
             />

--- a/ui/admin/app/components/form/role/grants/index.hbs
+++ b/ui/admin/app/components/form/role/grants/index.hbs
@@ -15,17 +15,18 @@
       <list.item as |item|>
         <form.input @contextual={{true}}>
           <item.key>
-            <Hds::Form::Label>
+            <Hds::Form::Label @controlId='add-grant'>
               {{t 'resources.role.grant.actions.create'}}
             </Hds::Form::Label>
           </item.key>
           <item.cell>
             <Hds::Form::TextInput::Field
-              aria-describedby={{t 'form.grant.help'}}
-              @type='text'
-              name='grant'
-              @value={{this.newGrantString}}
               {{on 'input' this.onInputFieldChanged}}
+              name='grant'
+              @id='add-grant'
+              @type='text'
+              @value={{this.newGrantString}}
+              @extraAriaDescribedBy={{t 'form.grant.help'}}
             />
           </item.cell>
           <item.cell>
@@ -50,22 +51,24 @@
 >
 
   <Rose::List::KeyValue as |list|>
-    {{#each this.grants as |grant|}}
+    {{#each this.grants as |grant index|}}
       <list.item as |item|>
         <form.input @contextual={{true}}>
           <item.key>
-            <Hds::Form::Label>
+            <Hds::Form::Label @controlId='update-grant-{{index}}'>
               {{t 'form.grant.label'}}
             </Hds::Form::Label>
           </item.key>
           <item.cell>
             <Hds::Form::TextInput::Field
-              aria-describedby={{t 'form.grant.help'}}
-              @type='text'
+              {{on 'input' (fn this.onUpdateGrant grant)}}
               name='grant'
+              disabled={{if (can 'setGrants role' @model) false true}}
+              @id='update-grant-{{index}}'
+              @type='text'
               @value={{grant.value}}
-              @disabled={{if (can 'setGrants role' @model) false true}}
               @error={{@model.errors.grant_strings}}
+              @extraAriaDescribedBy={{t 'form.grant.help'}}
             />
           </item.cell>
         </form.input>

--- a/ui/admin/app/components/form/role/grants/index.hbs
+++ b/ui/admin/app/components/form/role/grants/index.hbs
@@ -8,36 +8,32 @@
     @onSubmit={{fn this.createGrant @addGrant}}
     @cancel={{@cancel}}
     @disabled={{@model.isSaving}}
-    as |form|
   >
     <Rose::List::KeyValue as |list|>
       {{! Add grant field (only one per form) }}
       <list.item as |item|>
-        <form.input @contextual={{true}}>
-          <item.key>
-            <Hds::Form::Label @controlId='add-grant'>
-              {{t 'resources.role.grant.actions.create'}}
-            </Hds::Form::Label>
-          </item.key>
-          <item.cell>
-            <Hds::Form::TextInput::Field
-              {{on 'input' (set-from-event this 'newGrantString')}}
-              name='grant'
-              @id='add-grant'
-              @type='text'
-              @value={{this.newGrantString}}
-              @extraAriaDescribedBy={{t 'form.grant.help'}}
-            />
-          </item.cell>
-          <item.cell>
-            <Hds::Button
-              disabled={{this.cannotSave}}
-              type='submit'
-              @color='secondary'
-              @text={{t 'actions.add'}}
-            />
-          </item.cell>
-        </form.input>
+        <item.key>
+          <Hds::Form::Label @controlId='add-grant'>
+            {{t 'resources.role.grant.actions.create'}}
+          </Hds::Form::Label>
+        </item.key>
+        <item.cell>
+          <Hds::Form::TextInput::Field
+            {{on 'input' (set-from-event this 'newGrantString')}}
+            name='grant'
+            @id='add-grant'
+            @type='text'
+            @value={{this.newGrantString}}
+          />
+        </item.cell>
+        <item.cell>
+          <Hds::Button
+            disabled={{this.cannotSave}}
+            type='submit'
+            @color='secondary'
+            @text={{t 'actions.add'}}
+          />
+        </item.cell>
       </list.item>
     </Rose::List::KeyValue>
   </Rose::Form>
@@ -53,25 +49,22 @@
   <Rose::List::KeyValue as |list|>
     {{#each this.grants as |grant index|}}
       <list.item as |item|>
-        <form.input @contextual={{true}}>
-          <item.key>
-            <Hds::Form::Label @controlId='update-grant-{{index}}'>
-              {{t 'form.grant.label'}}
-            </Hds::Form::Label>
-          </item.key>
-          <item.cell>
-            <Hds::Form::TextInput::Field
-              {{on 'input' (set-from-event grant 'value')}}
-              name='grant'
-              disabled={{if (can 'setGrants role' @model) false true}}
-              @id='update-grant-{{index}}'
-              @type='text'
-              @value={{grant.value}}
-              @error={{@model.errors.grant_strings}}
-              @extraAriaDescribedBy={{t 'form.grant.help'}}
-            />
-          </item.cell>
-        </form.input>
+        <item.key>
+          <Hds::Form::Label @controlId='update-grant-{{index}}'>
+            {{t 'form.grant.label'}}
+          </Hds::Form::Label>
+        </item.key>
+        <item.cell>
+          <Hds::Form::TextInput::Field
+            {{on 'input' (set-from-event grant 'value')}}
+            name='grant'
+            disabled={{if (can 'setGrants role' @model) false true}}
+            @id='update-grant-{{index}}'
+            @type='text'
+            @value={{grant.value}}
+            @error={{@model.errors.grant_strings}}
+          />
+        </item.cell>
         <item.cell>
           {{#if (can 'setGrants role' @model)}}
             <Hds::Button

--- a/ui/admin/app/components/form/role/grants/index.hbs
+++ b/ui/admin/app/components/form/role/grants/index.hbs
@@ -21,8 +21,11 @@
           </item.key>
           <item.cell>
             <Hds::Form::TextInput::Field
+              aria-describedby={{t 'form.grant.help'}}
+              @type='text'
               name='grant'
               @value={{this.newGrantString}}
+              {{on 'input' this.onInputFieldChanged}}
             />
           </item.cell>
           <item.cell>
@@ -46,16 +49,6 @@
   as |form|
 >
 
-  {{!--
-  {{#if @model.errors.grants}}
-    <input.errors as |errors|>
-      {{#each @model.errors.grants as |error|}}
-        <errors.message>{{error.message}}</errors.message>
-      {{/each}}
-    </input.errors>
-  {{/if}}
-  --}}
-
   <Rose::List::KeyValue as |list|>
     {{#each this.grants as |grant|}}
       <list.item as |item|>
@@ -74,7 +67,10 @@
             </Hds::Form::Label>
           </item.key>
           <item.cell>
-            <input.field title={{t 'form.grant.help'}} />
+            <input.field
+              title={{t 'form.grant.help'}}
+              aria-label={{t 'form.grant.help'}}
+            />
           </item.cell>
         </form.input>
         <item.cell>

--- a/ui/admin/app/components/form/role/grants/index.hbs
+++ b/ui/admin/app/components/form/role/grants/index.hbs
@@ -21,6 +21,7 @@
           <Hds::Form::TextInput::Field
             {{on 'input' (set-from-event this 'newGrantString')}}
             name='grant'
+            title={{t 'form.grant.help'}}
             @id='add-grant'
             @type='text'
             @value={{this.newGrantString}}
@@ -58,6 +59,7 @@
           <Hds::Form::TextInput::Field
             {{on 'input' (set-from-event grant 'value')}}
             name='grant'
+            title={{t 'form.grant.help'}}
             disabled={{if (can 'setGrants role' @model) false true}}
             @id='update-grant-{{index}}'
             @type='text'

--- a/ui/admin/app/components/form/role/grants/index.hbs
+++ b/ui/admin/app/components/form/role/grants/index.hbs
@@ -21,7 +21,7 @@
           </item.key>
           <item.cell>
             <Hds::Form::TextInput::Field
-              {{on 'input' this.onInputFieldChanged}}
+              {{on 'input' (set-from-event this 'newGrantString')}}
               name='grant'
               @id='add-grant'
               @type='text'
@@ -31,8 +31,8 @@
           </item.cell>
           <item.cell>
             <Hds::Button
-              type='submit'
               disabled={{this.cannotSave}}
+              type='submit'
               @color='secondary'
               @text={{t 'actions.add'}}
             />
@@ -61,7 +61,7 @@
           </item.key>
           <item.cell>
             <Hds::Form::TextInput::Field
-              {{on 'input' (fn this.onUpdateGrant grant)}}
+              {{on 'input' (set-from-event grant 'value')}}
               name='grant'
               disabled={{if (can 'setGrants role' @model) false true}}
               @id='update-grant-{{index}}'
@@ -75,12 +75,12 @@
         <item.cell>
           {{#if (can 'setGrants role' @model)}}
             <Hds::Button
+              {{on 'click' (fn @removeGrant grant.value)}}
+              type='button'
               @color='secondary'
               @icon='trash'
               @isIconOnly={{true}}
               @text={{t 'actions.remove'}}
-              type='button'
-              {{on 'click' (fn @removeGrant grant.value)}}
             />
           {{/if}}
         </item.cell>

--- a/ui/admin/app/components/form/role/grants/index.hbs
+++ b/ui/admin/app/components/form/role/grants/index.hbs
@@ -52,24 +52,20 @@
   <Rose::List::KeyValue as |list|>
     {{#each this.grants as |grant|}}
       <list.item as |item|>
-        <form.input
-          @contextual={{true}}
-          @name='grant'
-          @type='text'
-          @value={{grant.value}}
-          @disabled={{if (can 'setGrants role' @model) false true}}
-          @error={{@model.errors.grant_strings}}
-          as |input|
-        >
+        <form.input @contextual={{true}}>
           <item.key>
             <Hds::Form::Label>
               {{t 'form.grant.label'}}
             </Hds::Form::Label>
           </item.key>
           <item.cell>
-            <input.field
-              title={{t 'form.grant.help'}}
-              aria-label={{t 'form.grant.help'}}
+            <Hds::Form::TextInput::Field
+              aria-describedby={{t 'form.grant.help'}}
+              @type='text'
+              name='grant'
+              @value={{grant.value}}
+              @disabled={{if (can 'setGrants role' @model) false true}}
+              @error={{@model.errors.grant_strings}}
             />
           </item.cell>
         </form.input>

--- a/ui/admin/app/components/form/role/grants/index.hbs
+++ b/ui/admin/app/components/form/role/grants/index.hbs
@@ -13,20 +13,20 @@
     <Rose::List::KeyValue as |list|>
       {{! Add grant field (only one per form) }}
       <list.item as |item|>
-        <form.input
-          @contextual={{true}}
-          @name='grant'
-          @type='text'
-          @value={{this.newGrantString}}
-          as |input|
-        >
+        <form.input @contextual={{true}}>
           <item.key>
-            <input.label>{{t
-                'resources.role.grant.actions.create'
-              }}</input.label>
+            <Hds::Form::Label @controlId='add-grant'>
+              {{t 'resources.role.grant.actions.create'}}
+            </Hds::Form::Label>
           </item.key>
           <item.cell>
-            <input.field title={{t 'form.grant.help'}} />
+            <Input
+              class='rose-form-input-field'
+              id='add-grant'
+              @type='text'
+              name='grant'
+              @value={{this.newGrantString}}
+            />
           </item.cell>
           <item.cell>
             <Hds::Button
@@ -72,7 +72,9 @@
           as |input|
         >
           <item.key>
-            <input.label>{{t 'form.grant.label'}}</input.label>
+            <Hds::Form::Label>
+              {{t 'form.grant.label'}}
+            </Hds::Form::Label>
           </item.key>
           <item.cell>
             <input.field title={{t 'form.grant.help'}} />

--- a/ui/admin/app/components/form/role/grants/index.js
+++ b/ui/admin/app/components/form/role/grants/index.js
@@ -44,6 +44,15 @@ export default class FormRoleGrantsComponent extends Component {
   // =actions
 
   /**
+   * Input event updates newGrantString tracked prop
+   * @param {string} event
+   */
+  @action
+  onInputFieldChanged(event) {
+    this.newGrantString = event.target.value;
+  }
+
+  /**
    * Calls the passed function with the grant string as an argument and then
    * clears the value of the grant string field.
    * `@addGrant` should be passed by the context calling this component.

--- a/ui/admin/app/components/form/role/grants/index.js
+++ b/ui/admin/app/components/form/role/grants/index.js
@@ -48,25 +48,6 @@ export default class FormRoleGrantsComponent extends Component {
   // =actions
 
   /**
-   * Listens on user input and populates newGrantString tracked prop
-   * @param {string} event
-   */
-  @action
-  onInputFieldChanged(event) {
-    this.newGrantString = event.target.value;
-  }
-
-  /**
-   * Listens on user input and updates existing grants
-   * @param {string} grant
-   * @param {string} event
-   */
-  @action
-  onUpdateGrant(grant, event) {
-    grant.value = event.target.value;
-  }
-
-  /**
    * Calls the passed function with the grant string as an argument and then
    * clears the value of the grant string field.
    * `@addGrant` should be passed by the context calling this component.

--- a/ui/admin/app/components/form/role/grants/index.js
+++ b/ui/admin/app/components/form/role/grants/index.js
@@ -48,12 +48,22 @@ export default class FormRoleGrantsComponent extends Component {
   // =actions
 
   /**
-   * Input event updates newGrantString tracked prop
+   * Listens on user input and populates newGrantString tracked prop
    * @param {string} event
    */
   @action
   onInputFieldChanged(event) {
     this.newGrantString = event.target.value;
+  }
+
+  /**
+   * Listens on user input and updates existing grants
+   * @param {string} grant
+   * @param {string} event
+   */
+  @action
+  onUpdateGrant(grant, event) {
+    grant.value = event.target.value;
   }
 
   /**

--- a/ui/admin/app/components/form/role/grants/index.js
+++ b/ui/admin/app/components/form/role/grants/index.js
@@ -16,7 +16,10 @@ export default class FormRoleGrantsComponent extends Component {
   @tracked newGrantString = '';
 
   /**
-   * @type {[object]}
+   * Returns grants currently on model, in addition to
+   * grants added (or deleted) interactively by user -
+   * before form submission
+   * @return {[string]}
    */
   @computed('args.model.grant_strings.[]')
   get grants() {
@@ -24,7 +27,8 @@ export default class FormRoleGrantsComponent extends Component {
   }
 
   /**
-   * @type {[string]}
+   * Returns grants after form submission
+   * @return {[object]}
    */
   @computed('grants.@each.value')
   get grantStrings() {

--- a/ui/admin/tests/acceptance/accounts/delete-test.js
+++ b/ui/admin/tests/acceptance/accounts/delete-test.js
@@ -63,16 +63,13 @@ module('Acceptance | accounts | delete', function (hooks) {
   });
 
   test('can delete an account', async function (assert) {
-    const accountsCount = this.server.schema.accounts.all().models.length;
+    const accountsCount = this.server.db.accounts.length;
     await visit(urls.account);
 
     await click(selectors.MANAGE_DROPDOWN_ACCOUNT);
     await click(selectors.MANAGE_DROPDOWN_DELETE_ACCOUNT);
 
-    assert.strictEqual(
-      this.server.schema.accounts.all().models.length,
-      accountsCount - 1,
-    );
+    assert.strictEqual(this.server.db.accounts.length, accountsCount - 1);
   });
 
   test('cannot delete an account without proper authorization', async function (assert) {

--- a/ui/admin/tests/acceptance/accounts/delete-test.js
+++ b/ui/admin/tests/acceptance/accounts/delete-test.js
@@ -63,13 +63,16 @@ module('Acceptance | accounts | delete', function (hooks) {
   });
 
   test('can delete an account', async function (assert) {
-    const accountsCount = this.server.db.accounts.length;
+    const accountsCount = this.server.schema.accounts.all().models.length;
     await visit(urls.account);
 
     await click(selectors.MANAGE_DROPDOWN_ACCOUNT);
     await click(selectors.MANAGE_DROPDOWN_DELETE_ACCOUNT);
 
-    assert.strictEqual(this.server.db.accounts.length, accountsCount - 1);
+    assert.strictEqual(
+      this.server.schema.accounts.all().models.length,
+      accountsCount - 1,
+    );
   });
 
   test('cannot delete an account without proper authorization', async function (assert) {


### PR DESCRIPTION
# Description
This PR replaces instances of `<input.label>` with `Hds::Form::Label`, and those instances only exist on our role/grants form.

Update:
Usage of `input.field` cause a11y violations, so we agreed to expand the scope of this ticket to also refactor the input field.

<!-- Uncomment line below to manually add link to JIRA ticket -->
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-16831)

## Screenshots (if appropriate)
Before 👇 
<img width="1392" alt="Screenshot 2025-04-18 at 12 43 13 PM" src="https://github.com/user-attachments/assets/816b36ba-ac47-44b3-96fd-b338fdc320c7" />

After 👇 
<img width="1270" alt="Screenshot 2025-04-29 at 2 45 20 PM" src="https://github.com/user-attachments/assets/bc50a4ea-41ea-4b7a-8e42-bf5a9babbf87" />

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
