### PR TITLE
fix: 🐛 credential library serializer for SSH certificate

### DIFF
--- a/addons/api/addon/serializers/credential-library.js
+++ b/addons/api/addon/serializers/credential-library.js
@@ -28,6 +28,7 @@ export default class CredentialLibrarySerializer extends ApplicationSerializer {
       case TYPE_CREDENTIAL_LIBRARY_VAULT_GENERIC:
         return this.serializeVaultGeneric(...arguments);
       case TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE:
+        return this.serializeVaultSshCertificate(...arguments);
       default:
         return super.serialize(...arguments);
     }
@@ -57,6 +58,18 @@ export default class CredentialLibrarySerializer extends ApplicationSerializer {
           }
           return obj;
         }, {});
+      }
+      return serialized;
+    }
+  }
+
+  serializeVaultSshCertificate() {
+    const serialized = super.serialize(...arguments);
+    if (serialized.attributes) {
+      const { key_type } = serialized.attributes;
+      if (key_type !== 'rsa' && key_type !== 'ecdsa') {
+        // If the key type is not RSA or ECDSA, set key_bits to null
+        serialized.attributes.key_bits = null;
       }
       return serialized;
     }

--- a/addons/api/tests/unit/serializers/credential-library-test.js
+++ b/addons/api/tests/unit/serializers/credential-library-test.js
@@ -231,4 +231,52 @@ module('Unit | Serializer | credential library', function (hooks) {
       version: 1,
     });
   });
+
+  test('it serializes vault_ssh_certificate correctly when changing type to ed25519', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('credential-library');
+    store.push({
+      data: {
+        id: '1',
+        type: 'credential-library',
+        attributes: {
+          type: TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE,
+          version: 1,
+          name: 'Name',
+          description: 'Description',
+          path: '/vault/path',
+          username: 'user',
+          key_type: 'rsa',
+          key_bits: 100,
+          ttl: '100',
+          key_id: 'id',
+          extensions: [{ key: 'key', value: 'value' }],
+          critical_options: [{ key: 'key', value: 'value' }],
+        },
+      },
+    });
+    const record = store.peekRecord('credential-library', '1');
+    record.key_type = 'ed25519';
+
+    const snapshot = record._createSnapshot();
+    const serializedRecord = serializer.serialize(snapshot);
+
+    assert.deepEqual(serializedRecord, {
+      type: TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE,
+      credential_store_id: null,
+      name: 'Name',
+      description: 'Description',
+      attributes: {
+        path: '/vault/path',
+        username: 'user',
+        key_type: 'ed25519',
+        key_bits: null,
+        ttl: '100',
+        key_id: 'id',
+        extensions: { key: 'value' },
+        critical_options: { key: 'value' },
+      },
+      version: 1,
+    });
+  });
 });


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-16880

# Description
<!-- Add a brief description of changes here -->
A user reported a bug where changing the `key_type` of a Vault SSH Certificate credential library, the update was failing. This was due to the `key_bits` value not being set to null when changing from `rsa` or `ecdsa` to `ed25519`. When using `ed25519` the `key_bits` value needs to be cleared out (set to null).

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

https://github.com/user-attachments/assets/33222aee-4105-4d42-a69a-0946e6c45204


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
Create a Vault Credential Store then a SSH Certificates Credential Library (CL). 
First create the CL with a `key_type` of `ecdsa` and define the `key_bits` to `521`.
Next, change the `key_type` to `ed25519` and click Save. It should successfully update the CL.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
