### PR TITLE
style: 💄 fix formatting for long credential names & description

### DIFF
--- a/ui/desktop/app/components/credentials-panel/index.hbs
+++ b/ui/desktop/app/components/credentials-panel/index.hbs
@@ -48,16 +48,20 @@
   {{else}}
     <div class='credential-panel-body'>
       <div class='credential-header'>
-        <div class='credential-name hds-typography-display-200'>
+        <Hds::Text::Display class='credential-name' @weight='semibold'>
           {{#if credential.source.name}}
             {{credential.source.name}}
           {{else}}
             {{credential.source.id}}
           {{/if}}
-        </div>
-        <div class='hds-typography-body-100'>
+        </Hds::Text::Display>
+        <Hds::Text::Body
+          class='credential-description'
+          @size='100'
+          @weight='semibold'
+        >
           {{credential.source.description}}
-        </div>
+        </Hds::Text::Body>
       </div>
 
       <ul class='credential-secret'>

--- a/ui/desktop/app/styles/app.scss
+++ b/ui/desktop/app/styles/app.scss
@@ -479,8 +479,9 @@
   }
 }
 
-.credential-name {
-  font-weight: var(--token-typography-font-weight-semibold);
+.credential-name,
+.credential-description {
+  overflow-wrap: break-word;
 }
 
 .raw-credential-panel-body {


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-16869

# Description
<!-- Add a brief description of changes here -->
Fix overlapping elements when viewing credentials.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
Before:
![image](https://github.com/user-attachments/assets/b5fcaa65-6fa8-4487-aa9c-41d72a3f3c4e)

After:
![image](https://github.com/user-attachments/assets/25642d1d-1750-44bb-ae58-c7a4431a753a)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
1. Attach a brokered credential to a target. The credential has to have a long name with no spaces.
2. Connect to that target using the DC.
3. Validate there are no overlapping elements in the session details page.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
