### PR TITLE
feat: 🎉 add minimum window size for the app

### DIFF
--- a/ui/desktop/electron-app/src/index.js
+++ b/ui/desktop/electron-app/src/index.js
@@ -97,6 +97,8 @@ const createWindow = async (partition, closeWindowCB) => {
   const browserWindowOptions = {
     width: 1280,
     height: 760,
+    minWidth: 812,
+    minHeight: 400,
     frame: showWindowChrome,
     titleBarStyle: showWindowChrome ? 'hiddenInset' : 'none',
     webPreferences: {


### PR DESCRIPTION
# Description
This update sets a minimum width of 812px and a minimum height of 400px for the application window.

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-4430)

## Screenshots
### Before change
No minimum width or height was enforced, which could lead to the app being resized too small to be functional:

<img width="83" alt="image" src="https://github.com/user-attachments/assets/0831c0e4-0bfe-47a0-b2bf-7788c6bf7bf9" />

### After Change
The app now maintains a minimum window size:

<img width="814" alt="image" src="https://github.com/user-attachments/assets/e4099fe6-cd39-453d-ac96-587514dd5501" />

## How to Test

1. Run the app with `yarn start:desktop`.
2. Try resizing the window — it should not shrink below 812px wide or 400px tall.

## Checklist

- [x] I have added before and after screenshots for UI changes
- [ ] ~I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
