### PR TITLE
fix: 🐛 fix host source description reference

### DIFF
--- a/ui/admin/app/templates/scopes/scope/targets/target/host-sources.hbs
+++ b/ui/admin/app/templates/scopes/scope/targets/target/host-sources.hbs
@@ -57,7 +57,7 @@
                 {{B.data.model.displayName}}
               {{/if}}
               <Hds::Text::Body @tag='p' class='p'>
-                {{B.data.description}}
+                {{B.data.model.description}}
               </Hds::Text::Body>
             </B.Td>
             <B.Td>


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
While refactoring `p` tags during HDS migration, I missed the `model` portion when referencing the description of our host sources on a target.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
Before:
<img width="1061" alt="Screenshot 2025-05-16 at 4 07 05 PM" src="https://github.com/user-attachments/assets/12af539a-9648-4914-a680-064c3d2bbda1" />

After:
<img width="1061" alt="Screenshot 2025-05-16 at 4 06 52 PM" src="https://github.com/user-attachments/assets/ed05d0d3-8209-4f60-940b-98e1ec4884ec" />


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
Go to the host sources tab on a target and you should see the description of the host source now.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] My changes generate no new warnings
- [ ] I have added JSON response output for API changes
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
