### PR TITLE
ICU-16787 sort admin users

### DIFF
--- a/ui/admin/app/controllers/scopes/scope/users/index.js
+++ b/ui/admin/app/controllers/scopes/scope/users/index.js
@@ -17,10 +17,18 @@ export default class ScopesScopeUsersIndexController extends Controller {
   @service can;
   @service intl;
   @service router;
+  @tracked sortAttribute;
+  @tracked sortDirection;
 
   // =attributes
 
-  queryParams = ['search', 'page', 'pageSize'];
+  queryParams = [
+    'search',
+    'page',
+    'pageSize',
+    'sortAttribute',
+    'sortDirection',
+  ];
 
   @tracked search;
   @tracked page = 1;
@@ -125,5 +133,13 @@ export default class ScopesScopeUsersIndexController extends Controller {
   async removeAccount(user, account) {
     await user.removeAccount(account.id);
     await this.router.refresh();
+  }
+
+  @action
+  sortBy(attribute, direction) {
+    this.sortAttribute = attribute;
+    this.sortDirection = direction;
+    // Reset to the first page when changing sort
+    this.page = 1;
   }
 }

--- a/ui/admin/app/routes/scopes/scope/users/index.js
+++ b/ui/admin/app/routes/scopes/scope/users/index.js
@@ -21,6 +21,14 @@ export default class ScopesScopeUsersIndexRoute extends Route {
     pageSize: {
       refreshModel: true,
     },
+    sortAttribute: {
+      refreshModel: true,
+      replace: true,
+    },
+    sortDirection: {
+      refreshModel: true,
+      replace: true,
+    },
   };
 
   // =services
@@ -41,7 +49,14 @@ export default class ScopesScopeUsersIndexRoute extends Route {
   }
 
   retrieveData = restartableTask(
-    async ({ search, page, pageSize, useDebounce }) => {
+    async ({
+      search,
+      page,
+      pageSize,
+      sortAttribute,
+      sortDirection,
+      useDebounce,
+    }) => {
       if (useDebounce) {
         await timeout(250);
       }
@@ -53,13 +68,18 @@ export default class ScopesScopeUsersIndexRoute extends Route {
         scope_id: [{ equals: scope_id }],
       };
 
+      const sort = {
+        attribute: sortAttribute,
+        direction: sortDirection,
+      };
+
       let users;
       let totalItems = 0;
       let doUsersExist = false;
       if (this.can.can('list model', scope, { collection: 'users' })) {
         users = await this.store.query('user', {
           scope_id,
-          query: { search, filters },
+          query: { search, filters, sort },
           page,
           pageSize,
         });

--- a/ui/admin/app/templates/scopes/scope/users/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/users/index.hbs
@@ -44,15 +44,26 @@
         />
       </Hds::SegmentedGroup>
       {{#if @model.users}}
-        <Hds::Table @valign='middle'>
+        <Hds::Table
+          @valign='middle'
+          @sortBy={{this.sortAttribute}}
+          @sortOrder={{this.sortDirection}}
+          @onSort={{this.sortBy}}
+        >
           <:head as |H|>
             <H.Tr>
-              <H.Th>
+              <H.ThSort
+                @onClickSort={{fn H.setSortBy 'name'}}
+                @sortOrder={{if (eq 'name' H.sortBy) H.sortOrder}}
+              >
                 {{t 'form.name.label'}}
-              </H.Th>
-              <H.Th>
+              </H.ThSort>
+              <H.ThSort
+                @onClickSort={{fn H.setSortBy 'id'}}
+                @sortOrder={{if (eq 'id' H.sortBy) H.sortOrder}}
+              >
                 {{t 'form.id.label'}}
-              </H.Th>
+              </H.ThSort>
             </H.Tr>
           </:head>
           <:body as |B|>

--- a/ui/admin/app/templates/scopes/scope/users/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/users/index.hbs
@@ -44,38 +44,43 @@
         />
       </Hds::SegmentedGroup>
       {{#if @model.users}}
-        <Hds::Table
-          @model={{@model.users}}
-          @columns={{array
-            (hash label=(t 'form.name.label'))
-            (hash label=(t 'form.id.label'))
-          }}
-          @valign='middle'
-        >
+        <Hds::Table @valign='middle'>
+          <:head as |H|>
+            <H.Tr>
+              <H.Th>
+                {{t 'form.name.label'}}
+              </H.Th>
+              <H.Th>
+                {{t 'form.id.label'}}
+              </H.Th>
+            </H.Tr>
+          </:head>
           <:body as |B|>
-            <B.Tr>
-              <B.Td>
-                {{#if (can 'read user' B.data)}}
-                  <LinkTo @route='scopes.scope.users.user' @model={{B.data.id}}>
-                    {{B.data.displayName}}
-                  </LinkTo>
-                {{else}}
-                  {{B.data.displayName}}
-                {{/if}}
-                {{#if B.data.accountName}}
-                  <br /><Hds::Badge @text={{B.data.accountName}} />
-                {{/if}}
-                <Hds::Text::Body @tag='p'>
-                  {{B.data.description}}
-                </Hds::Text::Body>
-              </B.Td>
-              <B.Td>
-                <Hds::Copy::Snippet
-                  @textToCopy={{B.data.id}}
-                  @color='secondary'
-                />
-              </B.Td>
-            </B.Tr>
+            {{#each @model.users as |data|}}
+              <B.Tr>
+                <B.Td>
+                  {{#if (can 'read user' data)}}
+                    <LinkTo @route='scopes.scope.users.user' @model={{data.id}}>
+                      {{data.displayName}}
+                    </LinkTo>
+                  {{else}}
+                    {{data.displayName}}
+                  {{/if}}
+                  {{#if data.accountName}}
+                    <br /><Hds::Badge @text={{data.accountName}} />
+                  {{/if}}
+                  <Hds::Text::Body @tag='p'>
+                    {{data.description}}
+                  </Hds::Text::Body>
+                </B.Td>
+                <B.Td>
+                  <Hds::Copy::Snippet
+                    @textToCopy={{data.id}}
+                    @color='secondary'
+                  />
+                </B.Td>
+              </B.Tr>
+            {{/each}}
           </:body>
         </Hds::Table>
         <Rose::Pagination


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
This pull request adds sorting for the list of users in Boundary Admin

<!-- Uncomment line below to manually add link to JIRA ticket -->
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-16787)

## Screenshots (if appropriate)
<img width="1175" alt="image" src="https://github.com/user-attachments/assets/1863f753-19c4-4ac2-8675-c6f6be433c4b" />

## How to Test
1. Navigate to the `/scopes/global/users`
2. Create some users
3. Click on the _Name_ or _ID_ column headers and the table should sort accordingly. Each time a column is initially sorted, the page number should reset to the first page.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
~~- [ ] I have added JSON response output for API changes~~
~~- [ ] I have added steps to reproduce and test for bug fixes in the description~~
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
