### PR TITLE
Add sorting to Groups in boundary admin

### DIFF
--- a/ui/admin/app/controllers/scopes/scope/groups/index.js
+++ b/ui/admin/app/controllers/scopes/scope/groups/index.js
@@ -20,11 +20,19 @@ export default class ScopesScopeGroupsIndexController extends Controller {
 
   // =attributes
 
-  queryParams = ['search', 'page', 'pageSize'];
+  queryParams = [
+    'search',
+    'page',
+    'pageSize',
+    'sortAttribute',
+    'sortDirection',
+  ];
 
   @tracked search;
   @tracked page = 1;
   @tracked pageSize = 10;
+  @tracked sortAttribute;
+  @tracked sortDirection;
 
   /**
    * If can list (at least): return default welcome message.
@@ -122,6 +130,13 @@ export default class ScopesScopeGroupsIndexController extends Controller {
   handleSearchInput(event) {
     const { value } = event.target;
     this.search = value;
+    this.page = 1;
+  }
+
+  @action
+  sortBy(attribute, direction) {
+    this.sortAttribute = attribute;
+    this.sortDirection = direction;
     this.page = 1;
   }
 }

--- a/ui/admin/app/routes/scopes/scope/groups/index.js
+++ b/ui/admin/app/routes/scopes/scope/groups/index.js
@@ -26,6 +26,14 @@ export default class ScopesScopeGroupsIndexRoute extends Route {
     pageSize: {
       refreshModel: true,
     },
+    sortAttribute: {
+      refreshModel: true,
+      replace: true,
+    },
+    sortDirection: {
+      refreshModel: true,
+      replace: true,
+    },
   };
 
   // =methods
@@ -41,7 +49,14 @@ export default class ScopesScopeGroupsIndexRoute extends Route {
   }
 
   retrieveData = restartableTask(
-    async ({ search, page, pageSize, useDebounce }) => {
+    async ({
+      search,
+      page,
+      pageSize,
+      sortAttribute,
+      sortDirection,
+      useDebounce,
+    }) => {
       if (useDebounce) {
         await timeout(250);
       }
@@ -52,11 +67,15 @@ export default class ScopesScopeGroupsIndexRoute extends Route {
       let totalItems = 0;
       let doGroupsExist = false;
       const filters = { scope_id: [{ equals: scope_id }] };
+      const sort = {
+        attribute: sortAttribute,
+        direction: sortDirection,
+      };
 
       if (this.can.can('list model', scope, { collection: 'groups' })) {
         groups = await this.store.query('group', {
           scope_id,
-          query: { filters, search },
+          query: { filters, search, sort },
           page,
           pageSize,
         });

--- a/ui/admin/app/templates/scopes/scope/groups/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/groups/index.hbs
@@ -46,15 +46,26 @@
       </Hds::SegmentedGroup>
       {{#if @model.groups}}
 
-        <Hds::Table @valign='middle'>
+        <Hds::Table
+          @valign='middle'
+          @sortBy={{this.sortAttribute}}
+          @sortOrder={{this.sortDirection}}
+          @onSort={{this.sortBy}}
+        >
           <:head as |H|>
             <H.Tr>
-              <H.Th>
+              <H.ThSort
+                @onClickSort={{fn H.setSortBy 'name'}}
+                @sortOrder={{if (eq 'name' H.sortBy) H.sortOrder}}
+              >
                 {{t 'form.name.label'}}
-              </H.Th>
-              <H.Th>
+              </H.ThSort>
+              <H.ThSort
+                @onClickSort={{fn H.setSortBy 'id'}}
+                @sortOrder={{if (eq 'id' H.sortBy) H.sortOrder}}
+              >
                 {{t 'form.id.label'}}
-              </H.Th>
+              </H.ThSort>
             </H.Tr>
           </:head>
 

--- a/ui/admin/app/templates/scopes/scope/groups/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/groups/index.hbs
@@ -46,38 +46,44 @@
       </Hds::SegmentedGroup>
       {{#if @model.groups}}
 
-        <Hds::Table
-          @model={{@model.groups}}
-          @columns={{array
-            (hash label=(t 'form.name.label'))
-            (hash label=(t 'form.id.label'))
-          }}
-          @valign='middle'
-        >
+        <Hds::Table @valign='middle'>
+          <:head as |H|>
+            <H.Tr>
+              <H.Th>
+                {{t 'form.name.label'}}
+              </H.Th>
+              <H.Th>
+                {{t 'form.id.label'}}
+              </H.Th>
+            </H.Tr>
+          </:head>
+
           <:body as |B|>
-            <B.Tr>
-              <B.Td>
-                {{#if (can 'read group' B.data)}}
-                  <LinkTo
-                    @route='scopes.scope.groups.group'
-                    @model={{B.data.id}}
-                  >
-                    {{B.data.displayName}}
-                  </LinkTo>
-                {{else}}
-                  {{B.data.displayName}}
-                {{/if}}
-                <Hds::Text::Body @tag='p'>
-                  {{B.data.description}}
-                </Hds::Text::Body>
-              </B.Td>
-              <B.Td>
-                <Hds::Copy::Snippet
-                  @textToCopy={{B.data.id}}
-                  @color='secondary'
-                />
-              </B.Td>
-            </B.Tr>
+            {{#each @model.groups as |data|}}
+              <B.Tr>
+                <B.Td>
+                  {{#if (can 'read group' data)}}
+                    <LinkTo
+                      @route='scopes.scope.groups.group'
+                      @model={{data.id}}
+                    >
+                      {{data.displayName}}
+                    </LinkTo>
+                  {{else}}
+                    {{data.displayName}}
+                  {{/if}}
+                  <Hds::Text::Body @tag='p'>
+                    {{data.description}}
+                  </Hds::Text::Body>
+                </B.Td>
+                <B.Td>
+                  <Hds::Copy::Snippet
+                    @textToCopy={{data.id}}
+                    @color='secondary'
+                  />
+                </B.Td>
+              </B.Tr>
+            {{/each}}
           </:body>
         </Hds::Table>
         <Rose::Pagination


### PR DESCRIPTION
# Description
This pull request adds sorting to the groups table in Boundary Admin.

## Before
<img width="986" alt="image" src="https://github.com/user-attachments/assets/fbc2d82d-e4c1-41d4-9823-0878b9187d52" />

## After
<img width="977" alt="image" src="https://github.com/user-attachments/assets/550a1caf-8971-46ca-8a16-55fd02051798" />

_Name and ID headers are sortable_

<!-- Uncomment line below to manually add link to JIRA ticket -->
[Jira ticket](https://hashicorp.atlassian.net/browse/ICU-16783)

## How to Test
1. Pull down this branch
2. `boundary dev`
3. API_HOST=http://localhost:9200 ENABLE_MIRAGE=false yarn start
4. Open a browser at the url of the running local ember server, and navigate to the path `/scopes/global/groups`
5. Create a few groups via the "New Group" button with varying data 
6. Click through the name and id headers to sort the data

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [X] I have added before and after screenshots for UI changes
~~- [ ] I have added JSON response output for API changes~~
~~- [ ] I have added steps to reproduce and test for bug fixes in the description~~
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
