### PR TITLE
feat: 🎸 add pagination to host source table

### DIFF
--- a/addons/api/mirage/factories/target.js
+++ b/addons/api/mirage/factories/target.js
@@ -103,6 +103,27 @@ export default factory.extend({
     },
   }),
 
+  withManyHosts: trait({
+    afterCreate(target, server) {
+      const { scope } = target;
+      const hostCatalog = server.create('host-catalog', { scope });
+      const hosts = server.createList('host', 15, {
+        scope,
+        hostCatalog,
+        type: hostCatalog.type,
+      });
+      const hostSets = [
+        server.create('host-set', {
+          scope,
+          hostCatalog,
+          hosts,
+          type: hostCatalog.type,
+        }),
+      ];
+      target.update({ hostSets });
+    },
+  }),
+
   withTwoHosts: trait({
     afterCreate(target, server) {
       const { scope } = target;

--- a/e2e-tests/desktop/tests/pagination.spec.js
+++ b/e2e-tests/desktop/tests/pagination.spec.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { expect, test } from '../fixtures/baseTest.js';
+import * as boundaryHttp from '../../helpers/boundary-http.js';
+
+let hosts = [];
+let org;
+let targetWithManyHosts;
+
+test.beforeEach(async ({ request, targetAddress, targetPort }) => {
+  org = await boundaryHttp.createOrg(request);
+  const project = await boundaryHttp.createProject(request, org.id);
+
+  // Create host set
+  const hostCatalog = await boundaryHttp.createStaticHostCatalog(
+    request,
+    project.id,
+  );
+
+  // Create hosts
+  const hostCount = 15;
+  for (let i = 0; i < hostCount; i++) {
+    const host = await boundaryHttp.createHost(request, {
+      hostCatalogId: hostCatalog.id,
+      address: targetAddress,
+      name: `Host ${i + 1}`,
+    });
+    hosts.push(host);
+  }
+
+  const hostSet = await boundaryHttp.createHostSet(request, hostCatalog.id);
+  await boundaryHttp.addHostToHostSet(request, {
+    hostSet,
+    hostIds: hosts.map((host) => host.id),
+  });
+
+  // Create target
+  targetWithManyHosts = await boundaryHttp.createTarget(request, {
+    scopeId: project.id,
+    type: 'tcp',
+    port: targetPort,
+  });
+  targetWithManyHosts = await boundaryHttp.addHostSource(request, {
+    target: targetWithManyHosts,
+    hostSourceIds: [hostSet.id],
+  });
+});
+
+test.afterEach(async ({ request }) => {
+  if (org) {
+    await boundaryHttp.deleteOrg(request, org.id);
+  }
+});
+
+test.describe('Target with many hosts', () => {
+  // TODO: Add tests for searching host sources
+  test('should display all hosts in the target', async ({ authedPage }) => {
+    await authedPage
+      .getByRole('link', { name: targetWithManyHosts.name })
+      .click();
+
+    // Check pagination
+    await expect(
+      authedPage.getByRole('cell', { name: hosts[0].name, exact: true }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole('cell', {
+        name: hosts[hosts.length - 1].name,
+        exact: true,
+      }),
+    ).toBeHidden();
+
+    // Navigate to the second page. The last host should now be visible.
+    await authedPage
+      .getByRole('navigation', { name: 'pagination' })
+      .getByRole('button', { name: 'page 2' })
+      .click();
+    await expect(
+      authedPage.getByRole('cell', { name: hosts[0].name, exact: true }),
+    ).toBeHidden();
+    await expect(
+      authedPage.getByRole('cell', {
+        name: hosts[hosts.length - 1].name,
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    // Use the "previous page" button to navigate back to the first page.
+    await authedPage
+      .getByRole('navigation', { name: 'pagination' })
+      .getByRole('button', { name: 'Previous page' })
+      .click();
+    await expect(
+      authedPage.getByRole('cell', { name: hosts[0].name, exact: true }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole('cell', {
+        name: hosts[hosts.length - 1].name,
+        exact: true,
+      }),
+    ).toBeHidden();
+
+    // Use the "next page" button to navigate to the second page again.
+    await authedPage
+      .getByRole('navigation', { name: 'pagination' })
+      .getByRole('button', { name: 'Next page' })
+      .click();
+    await expect(
+      authedPage.getByRole('cell', { name: hosts[0].name, exact: true }),
+    ).toBeHidden();
+    await expect(
+      authedPage.getByRole('cell', {
+        name: hosts[hosts.length - 1].name,
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    // Use the "Items per page" options to show 30 items per page.
+    await authedPage
+      .getByRole('combobox', { name: 'Items per page' })
+      .selectOption('30');
+    await expect(
+      authedPage.getByRole('cell', { name: hosts[0].name, exact: true }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole('cell', {
+        name: hosts[hosts.length - 1].name,
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    // Use the "Items per page" options to show 10 items per page again.
+    await authedPage
+      .getByRole('combobox', { name: 'Items per page' })
+      .selectOption('10');
+    await expect(
+      authedPage.getByRole('cell', { name: hosts[0].name, exact: true }),
+    ).toBeVisible();
+    await expect(
+      authedPage.getByRole('cell', {
+        name: hosts[hosts.length - 1].name,
+        exact: true,
+      }),
+    ).toBeHidden();
+  });
+});
+
+// TODO: Add tests for pagination of targets and sessions

--- a/e2e-tests/desktop/tests/pagination.spec.js
+++ b/e2e-tests/desktop/tests/pagination.spec.js
@@ -123,28 +123,20 @@ test.describe('Target with many hosts', () => {
       .getByRole('combobox', { name: 'Items per page' })
       .selectOption('30');
     await expect(
-      authedPage.getByRole('cell', { name: hosts[0].name, exact: true }),
-    ).toBeVisible();
-    await expect(
-      authedPage.getByRole('cell', {
-        name: hosts[hosts.length - 1].name,
-        exact: true,
-      }),
-    ).toBeVisible();
+      authedPage
+        .getByRole('row')
+        .filter({ hasNot: authedPage.getByRole('columnheader') }),
+    ).toHaveCount(15);
 
     // Use the "Items per page" options to show 10 items per page again.
     await authedPage
       .getByRole('combobox', { name: 'Items per page' })
       .selectOption('10');
     await expect(
-      authedPage.getByRole('cell', { name: hosts[0].name, exact: true }),
-    ).toBeVisible();
-    await expect(
-      authedPage.getByRole('cell', {
-        name: hosts[hosts.length - 1].name,
-        exact: true,
-      }),
-    ).toBeHidden();
+      authedPage
+        .getByRole('row')
+        .filter({ hasNot: authedPage.getByRole('columnheader') }),
+    ).toHaveCount(10);
   });
 });
 

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
@@ -23,14 +23,14 @@ export default class ScopesScopeProjectsTargetsTargetController extends Controll
   @tracked page = 1;
   @tracked pageSize = 10;
   @tracked totalItems = this.model.hosts.length;
-  @tracked paginatedHosts = this.paginateHosts();
+  @tracked paginatedHosts = this.paginateHosts;
 
   @tracked isConnecting = false;
   isConnectionError = false;
 
   // =methods
 
-  paginateHosts() {
+  get paginateHosts() {
     return this.model.hosts.slice(
       (this.page - 1) * this.pageSize,
       this.page * this.pageSize,
@@ -65,7 +65,7 @@ export default class ScopesScopeProjectsTargetsTargetController extends Controll
   async handlePageChange(page) {
     this.page = page;
 
-    this.paginatedHosts = this.paginateHosts();
+    this.paginatedHosts = this.paginateHosts;
   }
 
   @action
@@ -73,6 +73,6 @@ export default class ScopesScopeProjectsTargetsTargetController extends Controll
     this.page = 1;
     this.pageSize = pageSize;
 
-    this.paginatedHosts = this.paginateHosts();
+    this.paginatedHosts = this.paginateHosts;
   }
 }

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
@@ -20,10 +20,22 @@ export default class ScopesScopeProjectsTargetsTargetController extends Controll
 
   queryParams = [{ isConnecting: { type: 'boolean' } }];
 
+  @tracked page = 1;
+  @tracked pageSize = 10;
+  @tracked totalItems = this.model.hosts.length;
+  @tracked paginatedHosts = this.paginateHosts();
+
   @tracked isConnecting = false;
   isConnectionError = false;
 
   // =methods
+
+  paginateHosts() {
+    return this.model.hosts.slice(
+      (this.page - 1) * this.pageSize,
+      this.page * this.pageSize,
+    );
+  }
 
   /**
    * Connect method that calls parent connect method and handles
@@ -47,5 +59,20 @@ export default class ScopesScopeProjectsTargetsTargetController extends Controll
           this.isConnectionError = false;
         });
     }
+  }
+
+  @action
+  async handlePageChange(page) {
+    this.page = page;
+
+    this.paginatedHosts = this.paginateHosts();
+  }
+
+  @action
+  async handlePageSizeChange(pageSize) {
+    this.page = 1;
+    this.pageSize = pageSize;
+
+    this.paginatedHosts = this.paginateHosts();
   }
 }

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/target.js
@@ -23,14 +23,13 @@ export default class ScopesScopeProjectsTargetsTargetController extends Controll
   @tracked page = 1;
   @tracked pageSize = 10;
   @tracked totalItems = this.model.hosts.length;
-  @tracked paginatedHosts = this.paginateHosts;
 
   @tracked isConnecting = false;
   isConnectionError = false;
 
   // =methods
 
-  get paginateHosts() {
+  get paginatedHosts() {
     return this.model.hosts.slice(
       (this.page - 1) * this.pageSize,
       this.page * this.pageSize,
@@ -64,15 +63,11 @@ export default class ScopesScopeProjectsTargetsTargetController extends Controll
   @action
   async handlePageChange(page) {
     this.page = page;
-
-    this.paginatedHosts = this.paginateHosts;
   }
 
   @action
   async handlePageSizeChange(pageSize) {
     this.page = 1;
     this.pageSize = pageSize;
-
-    this.paginatedHosts = this.paginateHosts;
   }
 }

--- a/ui/desktop/app/templates/scopes/scope/projects/targets/target.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/targets/target.hbs
@@ -39,7 +39,7 @@
       <bc.Body class='target-details-body'>
         {{#if (gt @model.hosts.length 1)}}
           <Hds::Table
-            @model={{@model.hosts}}
+            @model={{this.paginatedHosts}}
             @columns={{array
               (hash label=(t 'resources.target.host-source.title_plural'))
               (hash label=(t 'form.address.label'))
@@ -77,6 +77,14 @@
               </B.Tr>
             </:body>
           </Hds::Table>
+          <Hds::Pagination::Numbered
+            data-test-pagination
+            @totalItems={{this.totalItems}}
+            @currentPage={{this.page}}
+            @currentPageSize={{this.pageSize}}
+            @onPageChange={{this.handlePageChange}}
+            @onPageSizeChange={{this.handlePageSizeChange}}
+          />
         {{else}}
           <Hds::ApplicationState as |A|>
             <A.Header

--- a/ui/desktop/tests/acceptance/projects/targets/target-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/target-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { visit, currentURL, click, find } from '@ember/test-helpers';
+import { visit, currentURL, click, find, select } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateSession } from 'ember-simple-auth/test-support';
@@ -29,6 +29,7 @@ module('Acceptance | projects | targets | target', function (hooks) {
     '.hds-modal__footer .hds-button--color-primary';
   const HDS_DIALOG_CANCEL_BUTTON =
     '.hds-modal__footer .hds-button--color-secondary';
+  const TABLE_ROWS = 'tbody tr';
 
   const instances = {
     scopes: {
@@ -43,6 +44,7 @@ module('Acceptance | projects | targets | target', function (hooks) {
     target: null,
     targetWithOneHost: null,
     targetWithTwoHosts: null,
+    targetWithManyHosts: null,
     alias: null,
   };
 
@@ -57,6 +59,7 @@ module('Acceptance | projects | targets | target', function (hooks) {
     target: null,
     targetWithOneHost: null,
     targetWithTwoHosts: null,
+    targetWithManyHosts: null,
   };
 
   const setDefaultClusterUrl = (test) => {
@@ -107,6 +110,11 @@ module('Acceptance | projects | targets | target', function (hooks) {
       { scope: instances.scopes.project },
       'withTwoHosts',
     );
+    instances.targetWithManyHosts = this.server.create(
+      'target',
+      { scope: instances.scopes.project },
+      'withManyHosts',
+    );
     instances.alias = this.server.create('alias', {
       scope: instances.scopes.global,
       destination_id: instances.targetWithOneHost.id,
@@ -128,6 +136,7 @@ module('Acceptance | projects | targets | target', function (hooks) {
     urls.target = `${urls.targets}/${instances.target.id}`;
     urls.targetWithOneHost = `${urls.targets}/${instances.targetWithOneHost.id}`;
     urls.targetWithTwoHosts = `${urls.targets}/${instances.targetWithTwoHosts.id}`;
+    urls.targetWithManyHosts = `${urls.targets}/${instances.targetWithManyHosts.id}`;
 
     // Mock the postMessage interface used by IPC.
     this.owner.register('service:browser/window', WindowMockIPC);
@@ -237,7 +246,7 @@ module('Acceptance | projects | targets | target', function (hooks) {
     await visit(urls.targets);
     await click(TARGET_RESOURCE_LINK(targetId));
 
-    assert.dom('tbody tr').exists({ count: 2 });
+    assert.dom(TABLE_ROWS).exists({ count: 2 });
   });
 
   test('user can see host source table when visiting a target via connect button', async function (assert) {
@@ -246,7 +255,7 @@ module('Acceptance | projects | targets | target', function (hooks) {
     await visit(urls.targets);
     await click(TARGET_TABLE_CONNECT_BUTTON(targetId));
 
-    assert.dom('tbody tr').exists({ count: 2 });
+    assert.dom(TABLE_ROWS).exists({ count: 2 });
   });
 
   test('user can connect to a target with two hosts using host source table', async function (assert) {
@@ -265,7 +274,7 @@ module('Acceptance | projects | targets | target', function (hooks) {
 
     await click(`[href="${urls.targetWithTwoHosts}"]`);
 
-    assert.dom('tbody tr').exists({ count: 2 });
+    assert.dom(TABLE_ROWS).exists({ count: 2 });
 
     await click(TARGET_HOST_SOURCE_CONNECT_BUTTON(hostId));
 
@@ -293,6 +302,29 @@ module('Acceptance | projects | targets | target', function (hooks) {
       assert.dom(TARGET_CONNECT_BUTTON).hasText(input.expectedText);
     },
   );
+
+  test('user can use table pagination to see more hosts', async function (assert) {
+    await visit(urls.targets);
+    await click(`[href="${urls.targetWithManyHosts}"]`);
+
+    assert.dom(TABLE_ROWS).exists({ count: 10 });
+    assert.dom('[data-test-pagination]').isVisible();
+
+    await click('button[aria-label="Next page"]');
+
+    assert.dom(TABLE_ROWS).exists({ count: 5 });
+  });
+
+  test('user can change page size', async function (assert) {
+    await visit(urls.targets);
+    await click(`[href="${urls.targetWithManyHosts}"]`);
+
+    assert.dom(TABLE_ROWS).exists({ count: 10 });
+
+    await select('[data-test-pagination] select', '30');
+
+    assert.dom(TABLE_ROWS).exists({ count: 15 });
+  });
 
   test('user can visit target details screen without read permissions for host-set', async function (assert) {
     assert.expect(1);


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-17093

# Description
<!-- Add a brief description of changes here -->
This PR adds the ability to display a portion of the host sources (10 by default) and allow the user to click to the next page(s) if needed. Along with selecting different options for items per page.

**Note: This feature is not using `<Rose::Pagination />` because that component is tied to the API and utilized queryParams from the route. So I use the `<Hds::Pagination::Numbered />` component directly and the page and pageSize handling lives in the controller. This work will be removed and replaced by `<Rose::Pagination />` once the backend supports host source search and filtering.** 

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

https://github.com/user-attachments/assets/0540c44b-11fe-436e-b981-47f58e62b1c2



## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
Spin up the desktop client and visit a target that has more than 2 host sources. To better test, find a target with more than 10 host sources (typically the first target in a vercel build) to test the page change and "items per page" change.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
