### PR TITLE
refactor: 💡 hide manage custom scopes button when using keyword

### DIFF
--- a/ui/admin/app/components/form/role/manage-scopes/index.hbs
+++ b/ui/admin/app/components/form/role/manage-scopes/index.hbs
@@ -77,25 +77,27 @@
     </Hds::Alert>
   {{/if}}
 
-  <Hds::Button
-    @text={{t 'resources.role.scope.actions.manage-custom-scopes.text'}}
-    @color='secondary'
-    @icon={{if @showCheckIcon 'check-circle'}}
-    @route={{if
-      @model.scope.isGlobal
-      'scopes.scope.roles.role.manage-scopes.manage-custom-scopes'
-      'scopes.scope.roles.role.manage-scopes.manage-org-projects'
-    }}
-    @model={{if @model.scope.isOrg @model.scope.id}}
-    data-test-manage-custom-scopes-button
-  />
+  {{#if this.showManageScopesBtn}}
+    <Hds::Button
+      @text={{t 'resources.role.scope.actions.manage-custom-scopes.text'}}
+      @color='secondary'
+      @icon={{if @showCheckIcon 'check-circle'}}
+      @route={{if
+        @model.scope.isGlobal
+        'scopes.scope.roles.role.manage-scopes.manage-custom-scopes'
+        'scopes.scope.roles.role.manage-scopes.manage-org-projects'
+      }}
+      @model={{if @model.scope.isOrg @model.scope.id}}
+      data-test-manage-custom-scopes-button
+    />
 
-  <Hds::Form::HelperText
-    @controlId='for-manage-custom-scopes-button'
-    class='manage-custom-scopes-helper-text'
-  >
-    {{t 'resources.role.scope.actions.manage-custom-scopes.help'}}
-  </Hds::Form::HelperText>
+    <Hds::Form::HelperText
+      @controlId='for-manage-custom-scopes-button'
+      class='manage-custom-scopes-helper-text'
+    >
+      {{t 'resources.role.scope.actions.manage-custom-scopes.help'}}
+    </Hds::Form::HelperText>
+  {{/if}}
 
   <form.actions
     @submitText={{t 'actions.save'}}

--- a/ui/admin/app/components/form/role/manage-scopes/index.js
+++ b/ui/admin/app/components/form/role/manage-scopes/index.js
@@ -33,6 +33,20 @@ export default class FormRoleManageScopesIndexComponent extends Component {
     );
   }
 
+  /**
+   * Returns true if global role does not have "descendants" toggled on
+   * or if org role does not have "children" toggled on.
+   * @type {boolean}
+   */
+  get showManageScopesBtn() {
+    return (
+      (this.args.model.scope.isGlobal &&
+        !this.args.model.grant_scope_ids.includes(GRANT_SCOPE_DESCENDANTS)) ||
+      (this.args.model.scope.isOrg &&
+        !this.args.model.grant_scope_ids.includes(GRANT_SCOPE_CHILDREN))
+    );
+  }
+
   // =actions
 
   /**

--- a/ui/admin/tests/acceptance/roles/global-scope-test.js
+++ b/ui/admin/tests/acceptance/roles/global-scope-test.js
@@ -270,6 +270,20 @@ module('Acceptance | roles | global-scope', function (hooks) {
     assert.dom(selectors.SCOPE_TOGGLE(GRANT_SCOPE_DESCENDANTS)).isVisible();
   });
 
+  test('manage custom scopes button is not visible when "descendants" is toggled on for global level role on manage scopes page', async function (assert) {
+    await visit(urls.role);
+
+    await click(selectors.MANAGE_DROPDOWN_ROLES);
+    await click(selectors.MANAGE_DROPDOWN_ROLES_SCOPES);
+
+    assert.strictEqual(currentURL(), urls.manageScopes);
+    assert.dom(selectors.MANAGE_CUSTOM_SCOPES_BUTTON).isVisible();
+
+    await click(selectors.SCOPE_TOGGLE(GRANT_SCOPE_DESCENDANTS));
+
+    assert.dom(selectors.MANAGE_CUSTOM_SCOPES_BUTTON).doesNotExist();
+  });
+
   test('user can save scope keywords to add on manage scopes page', async function (assert) {
     instances.role.update({ grant_scope_ids: [] });
     await visit(urls.role);

--- a/ui/admin/tests/acceptance/roles/org-scope-test.js
+++ b/ui/admin/tests/acceptance/roles/org-scope-test.js
@@ -224,6 +224,20 @@ module('Acceptance | roles | org-scope', function (hooks) {
     assert.dom(selectors.SCOPE_TOGGLE(GRANT_SCOPE_DESCENDANTS)).doesNotExist();
   });
 
+  test('manage custom scopes button is not visible when "children" is toggled on for org level role on manage scopes page', async function (assert) {
+    await visit(urls.role);
+
+    await click(selectors.MANAGE_DROPDOWN_ROLES);
+    await click(selectors.MANAGE_DROPDOWN_ROLES_SCOPES);
+
+    assert.strictEqual(currentURL(), urls.manageScopes);
+    assert.dom(selectors.MANAGE_CUSTOM_SCOPES_BUTTON).isVisible();
+
+    await click(selectors.SCOPE_TOGGLE(GRANT_SCOPE_CHILDREN));
+
+    assert.dom(selectors.MANAGE_CUSTOM_SCOPES_BUTTON).doesNotExist();
+  });
+
   test('user can save scope keywords to add on manage scopes page', async function (assert) {
     instances.role.update({ grant_scope_ids: [] });
     await visit(urls.role);

--- a/ui/admin/tests/acceptance/roles/selectors.js
+++ b/ui/admin/tests/acceptance/roles/selectors.js
@@ -39,6 +39,8 @@ export const SCOPE_CHECKBOX = (type, id) =>
   `tbody [data-test-${type}-scopes-table-row="${id}"] input`;
 export const MANAGE_CUSTOM_SCOPES_BUTTON_ICON =
   '[data-test-manage-custom-scopes-button] [data-test-icon="check-circle"]';
+export const MANAGE_CUSTOM_SCOPES_BUTTON =
+  '[data-test-manage-custom-scopes-button]';
 export const REMOVE_ORG_MODAL = (name) =>
   `[data-test-manage-scopes-remove-${name}-modal]`;
 export const REMOVE_ORG_ONLY_BTN = (name) =>


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-17195
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-17196

# Description
<!-- Add a brief description of changes here -->
Hide "Manage custom scopes" btn for a global role when using descendants since it includes all org and project scopes.
Hide "Manage custom scopes" btn for a org role when using children since it includes all project scopes.

## Screenshots (if appropriate)
global role after:
![image](https://github.com/user-attachments/assets/92f7f5ea-3047-4774-96b6-f9bbb30662a7)

global role before:
![image](https://github.com/user-attachments/assets/e41418cc-dc0f-4250-a215-73cd80757880)

org role after:
![image](https://github.com/user-attachments/assets/dd9c0073-25fc-456f-be3e-256a10488e45)

org role before:
![image](https://github.com/user-attachments/assets/43a6e3c0-dedd-44a2-bd68-8821d208feb1)


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
1. Go to roles -> role -> manage scopes
2. For global role verify "Manage custom scopes" btn is not visible when "descendants" is toggled on.
3. For org role verify "Manage custom scopes" btn is not visible when "children" is toggled on.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
