### PR TITLE
fix: 🐛 import codemirror assets correctly

### DIFF
--- a/addons/rose/index.js
+++ b/addons/rose/index.js
@@ -12,16 +12,10 @@ module.exports = {
   included(app) {
     this._super.included.apply(this, arguments);
 
-    app.import(
-      path.resolve(__dirname, 'node_modules/codemirror/lib/codemirror.css'),
-    );
-    app.import(
-      path.resolve(__dirname, 'node_modules/codemirror/theme/monokai.css'),
-    );
-    app.import(
-      path.resolve(__dirname, 'node_modules/codemirror/addon/lint/lint.css'),
-    );
-    app.import(require.resolve('jsonlint'));
+    this.import('node_modules/codemirror/lib/codemirror.css');
+    this.import('node_modules/codemirror/theme/monokai.css');
+    this.import('node_modules/codemirror/addon/lint/lint.css');
+    this.import('node_modules/jsonlint/lib/jsonlint.js');
 
     this.includeHDSStyles(app);
     this.includeFlightIcons(app);


### PR DESCRIPTION
# Description
This a bug that was introduced in the pnpm upgrade PR with [these lines](https://github.com/hashicorp/boundary-ui/pull/2828/files#diff-7fb769f3abadbca53b3275beb5d35ba9b4ff248946ed59ce831f6e21c3e77460R15-R24):
```js
    app.import(
      path.resolve(__dirname, 'node_modules/codemirror/lib/codemirror.css'),
    );
    app.import(
      path.resolve(__dirname, 'node_modules/codemirror/theme/monokai.css'),
    );
    app.import(
      path.resolve(__dirname, 'node_modules/codemirror/addon/lint/lint.css'),
    );
```

While these generate absolute paths that are correctly pointing these assets, they don't get imported, and the `app.import` api fails silently (eg: `app.import('this/does/not/exist.css');` will not fail when the ember build runs). So these files were not imported at their absolute path, there was no warning or errors, and they do not end up in `vendor.css`.

Restoring these lines back to they way they were previously:
```js
    app.import('node_modules/codemirror/lib/codemirror.css');
    app.import('node_modules/codemirror/theme/monokai.css');
    app.import('node_modules/codemirror/addon/lint/lint.css');
```

Results in the build error:
```
Cannot find module 'codemirror/package.json' from '{absolute path}/boundary-ui/ui/admin'
```

The reason why this worked before is that `app.import` when using a path that starts with `node_modules`, uses a [`resolve.sync`](https://www.npmjs.com/package/resolve) which implements the node resolution algorithm in searching for the associated `node_modules` folder:
```js
    let match = assetPath.match(/^node_modules\/((@[^/]+\/)?[^/]+)\//);
    if (match !== null) {
      let basedir = options.resolveFrom || this.project.root;
      let name = match[1];
      let _path = path.dirname(resolve.sync(`${name}/package.json`, { basedir }));
      this._nodeModules.set(_path, { name, path: _path });
    }
```
[_source_](https://github.com/ember-cli/ember-cli/blob/4857a446ba007d3d5ffa8d8a1e79acdbadb87e28/lib/broccoli/ember-app.js#L1109)

Previously with `yarn` this worked because all packages were hoisted. So even though `app.import` is importing relative to the app directory (`admin` in this case) but the `codemirror` dependency exists as a dependency of `rose`, the `codemirror` dependency would end up in `boundary_ui/node_modules` which is up from `boundary-ui/ui/admin` when the node resolution algorithm recursively checks parents `node_modules` starting at `boundary-ui/ui/admin`.

This doesn't work anymore since pnpm installs the `codemirror` dependency in `boundary-ui/addons/rose/node_modules/codemirror`, which is why the error is shown:
```
Cannot find module 'codemirror/package.json' from '{absolute path}/boundary-ui/ui/admin'
```

The code above has the `basedir` that can be used to control where the root directory to begin looking for a node modules following the node resolution algorithm: `let basedir = options.resolveFrom || this.project.root;` either using `options.resolveFrom` or falling back to `this.project.root` (the app's root directory)

## Solution #1: Use `addon.import` (used in this PR)
[The `addon.import` sets the `resolveFrom` option](https://github.com/ember-cli/ember-cli/blob/4857a446ba007d3d5ffa8d8a1e79acdbadb87e28/lib/models/addon.js#L750C1-L756C5):
```
  import(asset, options) {
    options = options || {};
    options.resolveFrom = options.resolveFrom || this.root;

    let app = this._findHost();
    app.import(asset, options);
  }
```

Where the `this.root` is the addon's root. In `rose.index.js` instead of using the `app.import`, the `addon.import` would using the correct `resolveFrom`. This changes `rose/index.js` to (where `this` reference's the `addon`):
```js
    this.import('node_modules/codemirror/lib/codemirror.css');
    this.import('node_modules/codemirror/theme/monokai.css');
    this.import('node_modules/codemirror/addon/lint/lint.css');
```
With the correct `resolveFrom` of the addon starting the node resolution algorithm at `boundary-ui/addons/rose/node_modules` the `codemirror` package is found

## Solution #2: Use `app.import` with `{ resolveFrom }` option explicitly
Specifying the `resolveFrom` option works:
```js
    app.import('node_modules/codemirror/lib/codemirror.css', {
      resolveFrom: __dirname,
    });
    app.import('node_modules/codemirror/theme/monokai.css', {
      resolveFrom: __dirname,
    });
    app.import('node_modules/codemirror/addon/lint/lint.css', {
      resolveFrom: __dirname,
    });
    app.import('node_modules/jsonlint/lib/jsonlint.js', {
      resolveFrom: __dirname,
    });
```
where `__dirname` for `rose/index.js` is `boundary-ui/addons/rose` and as the `basedir` the `boundary-ui/addons/rose/node_modules/codemirror` is found

--- 

The pnpm migration pr also changed this line:
```js
app.import('node_modules/jsonlint/lib/jsonlint.js');
```

to
```js
app.import(require.resolve('jsonlint'));
```
This results in an absolute path similar to the bug caused by changing the css to an absolute path but for some reason this works. Since `app.import` handles `.css` and `.js` differently, it appears absolute paths are _only_ not working with css files. For consistency with the css bug fix above the PR changes the code to:
```js
this.import('node_modules/jsonlint/lib/jsonlint.js');
```

## How to Test
With this PR look the `vendor.css` includes the following selectors from their source respective files:
`node_modules/codemirror/lib/codemirror.css` ➡️ `.CodeMirror-lines`
`node_modules/codemirror/theme/monokai.css` ➡️ `.cm-s-monokai.CodeMirror`
`node_modules/codemirror/addon/lint/lint.css` ➡️ `.CodeMirror-lint-markers`


## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
