### PR TITLE
refactor: 💡 remove dynamic `component` helper from `Form::Account` component

### DIFF
--- a/ui/admin/app/components/form/account/index.hbs
+++ b/ui/admin/app/components/form/account/index.hbs
@@ -4,10 +4,9 @@
 }}
 
 {{#if @model.type}}
-  {{component
-    (concat 'form/account/' @model.type)
-    model=@model
-    submit=@submit
-    cancel=@cancel
-  }}
+  <this.accountFormComponent
+    @model={{@model}}
+    @submit={{@submit}}
+    @cancel={{@cancel}}
+  />
 {{/if}}

--- a/ui/admin/app/components/form/account/index.js
+++ b/ui/admin/app/components/form/account/index.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+import oidc from './oidc';
+import ldap from './ldap';
+import password from './password';
+
+const modelTypeToComponent = {
+  ldap,
+  password,
+  oidc,
+};
+
+export default class FormAccountIndex extends Component {
+  get accountFormComponent() {
+    const component = modelTypeToComponent[this.args.model.type];
+    assert(
+      `Mapped component must exist for account type: ${this.args.model.type}`,
+      component,
+    );
+    return component;
+  }
+}


### PR DESCRIPTION
# Description
The dynamic `{{component}}` template helper allows to load a component dynamically with arguments. This makes it impossible for ember to know which components are being used:

> Using the {{component}} helper in traditional loose handlebars template can prevent your app or addon from being statically analyzed, which will prevent you from taking advantage of staticComponents and splitAtRoutes.

- [Embroider docs](https://github.com/embroider-build/embroider/blob/6801c113faf737a5a0276b768925b63fb9fe745b/docs/replacing-component-helper.md)

Static analysis of imports is an important step in our move to vite. What prevents static analysis specifically is the the technique we use (`{{component (concat 'some/component/path' @type)}}`) where `@type` can be anything.

It should been possible to use [this technique](https://github.com/embroider-build/embroider/blob/6801c113faf737a5a0276b768925b63fb9fe745b/docs/replacing-component-helper.md#when-youre-matching-a-large-set-of-possible-components) as a migration path but it didn't appear to work.

As a simple test:
```js
import password from './password';
const password1 = importSync('./password');
const type = 'password'
const dynamicPassword = importSync(`./${type}`);
console.log({ password, password1, dynamicPassword });
```
And the result was:
![image](https://github.com/user-attachments/assets/089df622-ded0-4dc7-930c-3dec8ca6d88a)

The `importSync('./password');` works, but `const dynamicPassword = importSync(``./${type}``);` is undefined. The interpolated `type` would have allowed a simpler approach to migration as [described in the guides](https://github.com/embroider-build/embroider/blob/6801c113faf737a5a0276b768925b63fb9fe745b/docs/replacing-component-helper.md#when-youre-matching-a-large-set-of-possible-components). The `undefined` behavior in `dynamicPassword` might be related to this bug https://github.com/embroider-build/embroider/issues/1410. The mapping alternative does work though and is a bit more explicit and since we only have a few imports to switch between maybe this okay.

This is PR will serve as the template for the remaining dynamic `{{component}}` helpers that will need to be migrated:
- addons/core/addon/components/form/authenticate/index
- addons/core/app/components/form/authenticate/index
- app/components/form/auth-method/index
- app/components/form/credential-library/index
- app/components/form/credential-store/index
- app/components/form/host-set/index
- app/components/form/host/index
- app/components/form/managed-group/index
- app/components/form/target/index

## How to Test
1. Check out the accounts form under an auth method at `/scopes/global/auth-methods`
2. The form should render for the various types

This is a good case where the test suite should exercise the loading of each of these forms

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

~~- [ ] I have added before and after screenshots for UI changes~~
~~- [ ] I have added JSON response output for API changes~~
~~- [ ] I have added steps to reproduce and test for bug fixes in the description~~
~~- [ ] I have commented on my code, particularly in hard-to-understand areas~~
- [X] My changes generate no new warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
