### PR TITLE
Enhanced the refresh functionality in targets route

### DIFF
--- a/ui/desktop/app/controllers/scopes/scope/projects/sessions/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/sessions/index.js
@@ -150,7 +150,8 @@ export default class ScopesScopeProjectsSessionsIndexController extends Controll
    * Refreshes the all data for the current page.
    */
   @action
-  refresh() {
-    this.send('refreshAll');
+  async refresh() {
+    // this.send('refreshAll');
+    await this.currentRoute.refreshAll();
   }
 }

--- a/ui/desktop/app/controllers/scopes/scope/projects/sessions/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/sessions/index.js
@@ -151,7 +151,6 @@ export default class ScopesScopeProjectsSessionsIndexController extends Controll
    */
   @action
   async refresh() {
-    // this.send('refreshAll');
     await this.currentRoute.refreshAll();
   }
 }

--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -307,7 +307,7 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
    * Refreshes the all data for the current page.
    */
   @action
-  refresh() {
-    this.send('refreshAll');
+  async refresh() {
+    await this.currentRoute.refreshAll();
   }
 }

--- a/ui/desktop/app/routes/scopes/scope/projects/sessions/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/sessions/index.js
@@ -177,6 +177,11 @@ export default class ScopesScopeProjectsSessionsIndexRoute extends Route {
     });
   }
 
+  setupController(controller, model) {
+    super.setupController(controller, model);
+    controller.currentRoute = this;
+  }
+
   resetController(controller, isExiting, transition) {
     const fromScope = transition.from.find(
       (routeInfo) => routeInfo.name === 'scopes.scope',
@@ -212,6 +217,6 @@ export default class ScopesScopeProjectsSessionsIndexRoute extends Route {
     await this.store.query('scope', {});
 
     // Refresh the proj scopes so our `modelFor` returns accurate data
-    this.router.refresh('scopes.scope.projects');
+    await this.router.refresh('scopes.scope.projects');
   }
 }

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
@@ -243,6 +243,11 @@ export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
     });
   };
 
+  setupController(controller, model) {
+    super.setupController(controller, model);
+    controller.currentRoute = this;
+  }
+
   resetController(controller, isExiting, transition) {
     const fromScope = transition.from.find(
       (routeInfo) => routeInfo.name === 'scopes.scope',
@@ -269,6 +274,6 @@ export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
     await this.store.query('scope', {});
 
     // Refresh the proj scopes so our `modelFor` returns accurate data
-    this.router.refresh('scopes.scope.projects');
+    await this.router.refresh('scopes.scope.projects');
   }
 }


### PR DESCRIPTION
# Description
This PR enhances the user experience of the refresh loading state in the target screen.

Previously, the refresh button would indicate completion while the global linear loader continued, creating user confusion.

With the current solution all refresh operations are awaited in the target route
ensuring the parent and child route refreshes complete before ending loading state.

<!-- Uncomment line below to manually add link to JIRA ticket -->
:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-16235) 

## Screenshots (if appropriate)

### Issue

https://github.com/user-attachments/assets/e1098171-cd4b-41dc-8afd-1db4c035cedd

In the above video, the linear loader on the header is still visible but the circular loader in the button is completed. This is due to internal loading in progress in the target route.

### Fix

https://github.com/user-attachments/assets/4d57b750-172b-4e49-9a0e-17cca31ad19e

## How to Test
Login to the boundary and navigate to the target screen and click on refresh button.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] ~~I have added JSON response output for API changes~~
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
