### PR TITLE
Fix SASS deprecation

### DIFF
--- a/addons/rose/app/styles/rose/components/header/_index.scss
+++ b/addons/rose/app/styles/rose/components/header/_index.scss
@@ -17,6 +17,12 @@
   --box-shadow-dark: inset 0 -#{sizing.rems(xxxxs)} 0 var(--ui-border-subtler-1);
   --box-shadow: var(--box-shadow-light);
 
+  display: grid;
+  grid-template-areas: 'brand nav utilities';
+  grid-template-columns: 0.01fr auto 1fr;
+  background: var(--black);
+  box-shadow: var(--box-shadow);
+
   .ember-application.rose-theme-light & {
     --box-shadow: var(--box-shadow-light);
   }
@@ -28,12 +34,6 @@
   .ember-application.rose-theme-dark & {
     --box-shadow: var(--box-shadow-dark);
   }
-
-  display: grid;
-  grid-template-areas: 'brand nav utilities';
-  grid-template-columns: 0.01fr auto 1fr;
-  background: var(--black);
-  box-shadow: var(--box-shadow);
 }
 
 @media (width <= (media.width(small))) {


### PR DESCRIPTION
# Description

Fix a Sass breaking change. [More info about the mixed declarations](https://sass-lang.com/documentation/breaking-changes/mixed-decls/)

## How to Test
- Run Admin and Desktop UI, change to dark mode and check the header still working as expected.

## Screenshots:

Warnings on terminal before the change:
<img width="1094" alt="Screenshot 2025-06-20 at 2 48 02 PM" src="https://github.com/user-attachments/assets/3df6da4c-4bce-4e0f-932c-9a10deb5d8f4" />

Only 1 warning left after the change:
<img width="1094" alt="Screenshot 2025-06-20 at 2 47 30 PM" src="https://github.com/user-attachments/assets/dc226951-56c2-4cee-9f94-f331435786d2" />

