### PR TITLE
[Desktop] Conditionally render separator in nav org dropdown

### DIFF
--- a/ui/desktop/app/templates/scopes/scope.hbs
+++ b/ui/desktop/app/templates/scopes/scope.hbs
@@ -20,7 +20,9 @@
       <dd.Interactive @route='scopes.scope' @model='global'>
         {{t 'titles.global'}}
       </dd.Interactive>
-      <dd.Separator />
+      {{#if this.scopes.orgs.length}}
+        <dd.Separator />
+      {{/if}}
       {{#each this.scopes.orgs as |scope|}}
         <dd.Interactive @route='scopes.scope' @model={{scope.id}}>
           {{scope.displayName}}


### PR DESCRIPTION
# Description
This PR adds logic to conditionally render the [separator](https://helios.hashicorp.design/components/separator) component, only when non-global orgs exist.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
Before:
<img width="398" alt="before" src="https://github.com/user-attachments/assets/32c2d01d-6f9c-42b4-a5dc-69248c05b5fa" />

After:
<img width="398" alt="after" src="https://github.com/user-attachments/assets/d4dee2c7-5cf3-40d1-9a0c-beb494020279" />


## How to Test
When only the global org exists, the separator should not render. The inverse being it should render when non-global orgs exist.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
