### PR TITLE
PoC no unused services within addons

### DIFF
--- a/addons/api/.eslintrc.js
+++ b/addons/api/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'ember/no-computed-properties-in-native-classes': 'off',
     'ember/no-assignment-of-untracked-properties-used-in-tracking-contexts':
       'off',
+    'ember/no-unused-services': 1,
   },
   overrides: [
     // node files

--- a/addons/api/addon/models/session-recording.js
+++ b/addons/api/addon/models/session-recording.js
@@ -5,7 +5,6 @@
 
 import GeneratedSessionRecordingModel from '../generated/models/session-recording';
 import { hasMany } from '@ember-data/model';
-import { service } from '@ember/service';
 
 export const TYPE_SESSION_RECORDING_SSH = 'ssh';
 export const TYPES_SESSION_RECORDING = Object.freeze([
@@ -22,8 +21,6 @@ export default class SessionRecordingModel extends GeneratedSessionRecordingMode
     inverse: 'session_recording',
   })
   connection_recordings;
-
-  @service store;
 
   /**
    * True if the session recording type is `ssh`.

--- a/addons/auth/.eslintrc.js
+++ b/addons/auth/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'ember/no-computed-properties-in-native-classes': 'off',
     'ember/no-assignment-of-untracked-properties-used-in-tracking-contexts':
       'off',
+    'ember/no-unused-services': 1,
   },
   overrides: [
     // node files

--- a/addons/core/.eslintrc.js
+++ b/addons/core/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'ember/no-computed-properties-in-native-classes': 'off',
     'ember/no-assignment-of-untracked-properties-used-in-tracking-contexts':
       'off',
+    'ember/no-unused-services': 1,
   },
   overrides: [
     // node files

--- a/addons/core/addon/components/pending-confirmations/index.js
+++ b/addons/core/addon/components/pending-confirmations/index.js
@@ -14,7 +14,8 @@ import { action } from '@ember/object';
  */
 export default class PendingConfirmationsComponent extends Component {
   // =services
-
+  // confirm service use within template
+  // eslint-disable-next-line ember/no-unused-services
   @service confirm;
 
   // =actions

--- a/addons/core/tests/dummy/app/controllers/index.js
+++ b/addons/core/tests/dummy/app/controllers/index.js
@@ -4,13 +4,8 @@
  */
 
 import Controller from '@ember/controller';
-import { service } from '@ember/service';
 
 export default class IndexController extends Controller {
-  // =services
-
-  @service clockTick;
-
   // =properties
 
   now = new Date();

--- a/addons/core/tests/dummy/app/templates/index.hbs
+++ b/addons/core/tests/dummy/app/templates/index.hbs
@@ -4,7 +4,6 @@
 }}
 
 <Hds::Text::Display @tag='h2' id='title'>Welcome to Ember</Hds::Text::Display>
-<Hds::Text::Body @tag='p'>{{relative-datetime-live this.now}}</Hds::Text::Body>
 
 <ul>
   <li>{{truncate-list 'actions.more' this.list}}</li>


### PR DESCRIPTION
# Description

This PR is a quick PoC of an old ticket that we discussed within tech time ( March 21 2024). As a result I opened [this ticket](https://hashicorp.atlassian.net/browse/ICU-14874). 

The coverage of this initial PR is addons only, if this is welcome by the team 2 more PR's will follow up, one for Admin other for Desktop.

**For the record, where this will be more useful, simply because there are way more rule matches, is within Admin and Desktop.**

I would like to disscuss: Adding ember/no-unused-services as a rule:
This rule isn't included on the recommended config from eslint because it has limitations, [more info here.](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-unused-services.md) 
In a nutshell, can give false positives, i.e. if a service is included within a route file and not use it within the route file but within the template that renders such route, the linter will mark it as a warning/error but it's not. Because for the template to access, the service should be included.
In that case, the rule becomes "noise" rather than help.

There is a path to avoid the noise, which is disable the eslint rule within the code with a comment `// eslint-disable-next-line ember/no-unused-services`. Not ideal, but a way of not creating noise. [Example here](https://github.com/hashicorp/boundary-ui/compare/icu-14874-no-unused-services-addons?expand=1#diff-c65b190678bd171685ef9d33c57d394b39c1bd65b77547a67b6944e87f636f5eR17).

## Screenshots (if appropriate)

API with rule as warning BEFORE fixing it:
<img width="1103" alt="api-before-fix" src="https://github.com/user-attachments/assets/aacde926-bc34-4604-a801-24b0480cb15e" />

API with rule as warning AFTER the fix:
<img width="1101" alt="api-after-fix" src="https://github.com/user-attachments/assets/791e81c0-280e-4e42-9b9b-2064e118574a" />

Core with rule as warning BEFORE fixing it:
<img width="1102" alt="core-before-fix" src="https://github.com/user-attachments/assets/df33708f-c9b6-432a-ba8e-f1024c86b99a" />


Core with rule as warning After fixing it:
<img width="1101" alt="core-after-fix" src="https://github.com/user-attachments/assets/ca5f12c8-f2a2-493e-b77d-331502c6413e" />


