### PR TITLE
fix: 🐛 transition aborted error when deleting or saving

### DIFF
--- a/ui/admin/app/controllers/scopes/scope/aliases/index.js
+++ b/ui/admin/app/controllers/scopes/scope/aliases/index.js
@@ -87,7 +87,7 @@ export default class ScopesScopeAliasesIndexController extends Controller {
     if (this.can.can('read model', alias)) {
       await this.router.transitionTo('scopes.scope.aliases.alias', alias);
     } else {
-      await this.router.transitionTo('scopes.scope.aliases');
+      this.router.transitionTo('scopes.scope.aliases');
     }
     await this.router.refresh();
   }
@@ -118,7 +118,7 @@ export default class ScopesScopeAliasesIndexController extends Controller {
   @notifySuccess('notifications.delete-success')
   async deleteAlias(alias) {
     await alias.destroyRecord();
-    await this.router.replaceWith('scopes.scope.aliases');
+    this.router.replaceWith('scopes.scope.aliases');
     await this.router.refresh();
   }
 

--- a/ui/admin/app/controllers/scopes/scope/auth-methods/index.js
+++ b/ui/admin/app/controllers/scopes/scope/auth-methods/index.js
@@ -154,7 +154,7 @@ export default class ScopesScopeAuthMethodsIndexController extends Controller {
         authMethod,
       );
     } else {
-      await this.router.transitionTo('scopes.scope.auth-methods');
+      this.router.transitionTo('scopes.scope.auth-methods');
     }
     await this.router.refresh();
   }

--- a/ui/admin/app/controllers/scopes/scope/credential-stores/index.js
+++ b/ui/admin/app/controllers/scopes/scope/credential-stores/index.js
@@ -94,7 +94,7 @@ export default class ScopesScopeCredentialStoresIndexController extends Controll
         credentialStore,
       );
     } else {
-      await this.router.transitionTo('scopes.scope.credential-stores');
+      this.router.transitionTo('scopes.scope.credential-stores');
     }
     await this.router.refresh();
   }

--- a/ui/admin/app/controllers/scopes/scope/groups/index.js
+++ b/ui/admin/app/controllers/scopes/scope/groups/index.js
@@ -87,7 +87,7 @@ export default class ScopesScopeGroupsIndexController extends Controller {
     if (this.can.can('read model', group)) {
       await this.router.transitionTo('scopes.scope.groups.group', group);
     } else {
-      await this.router.transitionTo('scopes.scope.groups');
+      this.router.transitionTo('scopes.scope.groups');
     }
     await this.router.refresh();
   }

--- a/ui/admin/app/controllers/scopes/scope/host-catalogs/index.js
+++ b/ui/admin/app/controllers/scopes/scope/host-catalogs/index.js
@@ -107,7 +107,7 @@ export default class ScopesScopeHostCatalogsIndexController extends Controller {
         hostCatalog,
       );
     } else {
-      await this.router.transitionTo('scopes.scope.host-catalogs');
+      this.router.transitionTo('scopes.scope.host-catalogs');
     }
     await this.router.refresh();
   }

--- a/ui/admin/app/controllers/scopes/scope/roles/index.js
+++ b/ui/admin/app/controllers/scopes/scope/roles/index.js
@@ -101,7 +101,7 @@ export default class ScopesScopeRolesIndexController extends Controller {
     if (this.can.can('read model', role)) {
       await this.router.transitionTo('scopes.scope.roles.role', role);
     } else {
-      await this.router.transitionTo('scopes.scope.roles');
+      this.router.transitionTo('scopes.scope.roles');
     }
     await this.router.refresh();
   }

--- a/ui/admin/app/controllers/scopes/scope/targets/index.js
+++ b/ui/admin/app/controllers/scopes/scope/targets/index.js
@@ -151,7 +151,7 @@ export default class ScopesScopeTargetsIndexController extends Controller {
     if (this.can.can('read model', target)) {
       await this.router.transitionTo('scopes.scope.targets.target', target);
     } else {
-      await this.router.transitionTo('scopes.scope.targets');
+      this.router.transitionTo('scopes.scope.targets');
     }
     await this.router.refresh();
   }

--- a/ui/admin/app/controllers/scopes/scope/users/index.js
+++ b/ui/admin/app/controllers/scopes/scope/users/index.js
@@ -101,7 +101,7 @@ export default class ScopesScopeUsersIndexController extends Controller {
     if (this.can.can('read model', user)) {
       await this.router.transitionTo('scopes.scope.users.user', user);
     } else {
-      await this.router.transitionTo('scopes.scope.users');
+      this.router.transitionTo('scopes.scope.users');
     }
     await this.router.refresh();
   }

--- a/ui/admin/app/controllers/scopes/scope/workers/index.js
+++ b/ui/admin/app/controllers/scopes/scope/workers/index.js
@@ -162,7 +162,7 @@ export default class ScopesScopeWorkersIndexController extends Controller {
     if (this.can.can('read model', worker)) {
       await this.router.transitionTo('scopes.scope.workers.worker', worker);
     } else {
-      await this.router.transitionTo('scopes.scope.workers');
+      this.router.transitionTo('scopes.scope.workers');
     }
     await this.router.refresh();
   }
@@ -178,7 +178,7 @@ export default class ScopesScopeWorkersIndexController extends Controller {
   @notifySuccess('notifications.delete-success')
   async delete(worker) {
     await worker.destroyRecord();
-    await this.router.replaceWith('scopes.scope.workers');
+    this.router.replaceWith('scopes.scope.workers');
     await this.router.refresh();
   }
 


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
When awaiting a transition to a resource list view that implements search/filtering the original transition gets aborted since there is some sort of reload going on.
For example when saving a resource that does not have `read` permissions a user is redirected to resource list view by default and in some resources the transition was erroring out via alert toast.
Additionally when deleting a user is also redirected to list view and in some resources this transition was also erroring out.
<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
Example of buggy behavior w/ User resource.
Before:

https://github.com/user-attachments/assets/944fbe04-eb64-41c9-a2cf-419c04c15837


After:


https://github.com/user-attachments/assets/03570fed-6910-45aa-bb92-9231d7763ead



## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
To test delete action for aliases, and workers:
1. Navigate to existing resource.
2. Click on manage dropdown and click "Delete"
3. Delete action should result in success alert msg.

To test save action for workers, users, targets, roles, host-catalogs, groups, cred-stores, auth-methods, & aliases
1. Login to admin ui using an account that only allows create or list actions on the specified resource (no read action).
2. Navigate to list view of the resource & click on "New".
3. Fill in information and click "Save"
4. User should be redirected to list view & should see green success alert msg.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [x] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
