### PR TITLE
test: 💍 Add admin UI test for change passsword flow

### DIFF
--- a/e2e-tests/admin/tests/change-password.spec.js
+++ b/e2e-tests/admin/tests/change-password.spec.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { test } from '../../global-setup.js';
+import { expect } from '@playwright/test';
+import { execSync } from 'child_process';
+
+import * as boundaryCli from '../../helpers/boundary-cli';
+import { LoginPage } from '../pages/login.js';
+import { OrgsPage } from '../pages/orgs.js';
+import { AuthMethodsPage } from '../pages/auth-methods.js';
+import { UsersPage } from '../pages/users.js';
+
+// Reset storage state for this file to avoid being authenticated
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.beforeAll(async () => {
+  await boundaryCli.checkBoundaryCli();
+});
+
+test(
+  'Verify user can change password',
+  // TODO: check test works for each tag
+  { tag: ['@ce', '@ent', '@aws', '@docker'] },
+  async ({
+    page,
+    controllerAddr,
+    adminAuthMethodId,
+    adminLoginName,
+    adminPassword,
+  }) => {
+    await page.goto('/');
+    let orgName;
+    let authMethodName;
+    try {
+      // Log in
+      const loginPage = new LoginPage(page);
+      await loginPage.login(adminLoginName, adminPassword);
+      await expect(
+        page.getByRole('navigation', { name: 'breadcrumbs' }).getByText('Orgs'),
+      ).toBeVisible();
+
+      // Create a new org, password auth method, account, and user
+      const orgsPage = new OrgsPage(page);
+      orgName = await orgsPage.createOrg();
+
+      const authMethodsPage = new AuthMethodsPage(page);
+      authMethodName = await authMethodsPage.createPasswordAuthMethod();
+      const username = 'test-user';
+      const password = 'password';
+      await authMethodsPage.createPasswordAccount(username, password);
+      await authMethodsPage.makeAuthMethodPrimary();
+
+      const usersPage = new UsersPage(page);
+      await usersPage.createUser();
+      await usersPage.addAccountToUser(username);
+
+      // Log in using new account
+      await loginPage.logout(adminLoginName);
+      await console.log(`Logging in as ${username} with password ${password}`);
+      await page.getByText('Choose a different scope').click();
+      await page.getByRole('link', { name: orgName }).click();
+      await page.getByRole('link', { name: authMethodName }).click();
+
+      await loginPage.login(username, password);
+      await expect(
+        page
+          .getByRole('navigation', { name: 'breadcrumbs' })
+          .getByText('Projects'),
+      ).toBeVisible();
+
+      // Change password for user
+      // TODO: move to auth-methods.js page?
+      await page.getByRole('button', { name: username }).click();
+      await page.getByRole('link', { name: 'Change Password' }).click();
+      const newPassword = 'new-password';
+      await page.getByLabel('Current Password').fill(password);
+      await page.getByLabel('New Password').fill(newPassword);
+      await page.getByRole('button', { name: 'Save' }).click();
+      await expect(
+        page.getByRole('alert').getByText('Success', { exact: true }),
+      ).toBeVisible();
+
+      // Confirm user cannot log in with old password
+      await loginPage.logout(username);
+      await page.getByText('Choose a different scope').click();
+      await page.getByRole('link', { name: orgName }).click();
+      await page.getByRole('link', { name: authMethodName }).click();
+      await page.getByLabel('Login Name').fill(username);
+      await page.getByLabel('Password', { exact: true }).fill(password);
+      await page.getByRole('button', { name: 'Sign In' }).click();
+      await expect(page.getByRole('alert').getByText('Error')).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+      await expect(page.getByText(adminLoginName)).toBeHidden();
+
+      // Confirm user can log in with new password
+      await loginPage.login(username, newPassword);
+      await expect(
+        page
+          .getByRole('navigation', { name: 'breadcrumbs' })
+          .getByText('Projects'),
+      ).toBeVisible();
+    } finally {
+      await boundaryCli.authenticateBoundary(
+        controllerAddr,
+        adminAuthMethodId,
+        adminLoginName,
+        adminPassword,
+      );
+
+      if (authMethodName) {
+        const authMethods = JSON.parse(
+          execSync('boundary auth-methods list --recursive -format json'),
+        );
+        const authMethod = authMethods.items.filter(
+          (obj) => obj.name == authMethodName,
+        )[0];
+        if (authMethod) {
+          try {
+            execSync('boundary auth-methods delete -id=' + authMethod.id);
+          } catch (e) {
+            console.log(`${e.stderr}`);
+          }
+        }
+      }
+
+      if (orgName) {
+        const orgId = await boundaryCli.getOrgIdFromName(orgName);
+        if (orgId) {
+          await boundaryCli.deleteScope(orgId);
+        }
+      }
+    }
+  },
+);


### PR DESCRIPTION
This PR adds a test to the Admin UI e2e test suite to validate the workflow of changing user password from settings menu

✅ Closes: https://hashicorp.atlassian.net/browse/ICU-17173

# Description
<!-- Add a brief description of changes here -->
New admin UI e2e test case (`change-password.spec.js`)
Verifies user can update password via change password workflow 
Verifies user cannot login with old password
Verifies user can login with new password 

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
run e2e test
specifically: `/boundary-ui/e2e-tests/admin/tests/change-password.spec.js`

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
