### PR TITLE
(HACK WEEK 2025) refactor: 💡 remove explicit a11yAudit usage

### DIFF
--- a/ui/admin/README.md
+++ b/ui/admin/README.md
@@ -93,8 +93,6 @@ of testing".  Use test coverage as a guide to help you identify untested
 high-value code.
 
 We rely on `ember-a11y-testing` to validate accessibility in acceptance tests.
-If you write acceptance tests, please ensure at least one validation per
-route using `await a11yAudit();`.
 
 ### Deploying
 

--- a/ui/admin/tests/acceptance/accounts/change-password-test.js
+++ b/ui/admin/tests/acceptance/accounts/change-password-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import {
   authenticateSession,
@@ -60,7 +59,6 @@ module('Acceptance | accounts | change password', function (hooks) {
 
     await click(commonSelectors.SIDEBAR_USER_DROPDOWN);
     await click(commonSelectors.HREF(urls.changePassword));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.changePassword);
   });
@@ -102,8 +100,6 @@ module('Acceptance | accounts | change password', function (hooks) {
       selectors.FIELD_NEW_PASSWORD_VALUE,
     );
     await click(commonSelectors.SAVE_BTN);
-
-    await a11yAudit();
   });
 
   test('can cancel password change', async function (assert) {
@@ -147,7 +143,6 @@ module('Acceptance | accounts | change password', function (hooks) {
       selectors.FIELD_NEW_PASSWORD_VALUE,
     );
     await click(commonSelectors.SAVE_BTN);
-    await a11yAudit();
 
     assert.dom(commonSelectors.ALERT_TOAST).isVisible();
   });

--- a/ui/admin/tests/acceptance/accounts/create-test.js
+++ b/ui/admin/tests/acceptance/accounts/create-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click, find, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as selectors from './selectors';
@@ -67,7 +66,7 @@ module('Acceptance | accounts | create', function (hooks) {
 
   test('visiting accounts', async function (assert) {
     await visit(urls.accounts);
-    await a11yAudit();
+
     assert.strictEqual(currentURL(), urls.accounts);
   });
 
@@ -205,7 +204,6 @@ module('Acceptance | accounts | create', function (hooks) {
     await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
     await click(commonSelectors.SAVE_BTN);
 
-    await a11yAudit();
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');

--- a/ui/admin/tests/acceptance/accounts/delete-test.js
+++ b/ui/admin/tests/acceptance/accounts/delete-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, click, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as selectors from './selectors';
@@ -101,7 +100,6 @@ module('Acceptance | accounts | delete', function (hooks) {
     await click(selectors.MANAGE_DROPDOWN_ACCOUNT);
     await click(selectors.MANAGE_DROPDOWN_DELETE_ACCOUNT);
 
-    await a11yAudit();
     assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
   });
 });

--- a/ui/admin/tests/acceptance/accounts/read-test.js
+++ b/ui/admin/tests/acceptance/accounts/read-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 
@@ -55,7 +54,6 @@ module('Acceptance | accounts | read', function (hooks) {
     await visit(urls.accounts);
     await click(commonSelectors.TABLE_RESOURCE_LINK(urls.account));
 
-    await a11yAudit();
     assert.strictEqual(currentURL(), urls.account);
   });
 

--- a/ui/admin/tests/acceptance/accounts/set-password-test.js
+++ b/ui/admin/tests/acceptance/accounts/set-password-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -55,7 +54,6 @@ module('Acceptance | accounts | set password', function (hooks) {
   test('visiting account set password', async function (assert) {
     await visit(urls.setPassword);
 
-    await a11yAudit();
     assert.strictEqual(currentURL(), urls.setPassword);
   });
 
@@ -96,7 +94,6 @@ module('Acceptance | accounts | set password', function (hooks) {
 
     await fillIn(commonSelectors.FIELD_PASSWORD, 'update password');
     await click(commonSelectors.SAVE_BTN);
-    await a11yAudit();
   });
 
   test('can cancel setting new password by navigating away', async function (assert) {
@@ -132,6 +129,5 @@ module('Acceptance | accounts | set password', function (hooks) {
     await click(commonSelectors.SAVE_BTN);
 
     assert.dom(commonSelectors.ALERT_TOAST).isVisible();
-    await a11yAudit();
   });
 });

--- a/ui/admin/tests/acceptance/accounts/update-test.js
+++ b/ui/admin/tests/acceptance/accounts/update-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -125,7 +124,6 @@ module('Acceptance | accounts | update', function (hooks) {
     await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
     await click(commonSelectors.SAVE_BTN);
 
-    await a11yAudit();
     assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
   });
 
@@ -155,7 +153,6 @@ module('Acceptance | accounts | update', function (hooks) {
     await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
     await click(commonSelectors.SAVE_BTN);
 
-    await a11yAudit();
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
       .hasText('The request was invalid.');

--- a/ui/admin/tests/acceptance/aliases/create-test.js
+++ b/ui/admin/tests/acceptance/aliases/create-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
@@ -107,7 +106,6 @@ module('Acceptance | aliases | create', function (hooks) {
     });
     await visit(urls.newAlias);
     await click(commonSelectors.SAVE_BTN);
-    await a11yAudit();
 
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)

--- a/ui/admin/tests/acceptance/aliases/read-test.js
+++ b/ui/admin/tests/acceptance/aliases/read-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -51,12 +50,9 @@ module('Acceptance | aliases | read', function (hooks) {
 
   test('visiting an alias', async function (assert) {
     await visit(urls.globalScope);
-    await a11yAudit();
 
     await click(commonSelectors.HREF(urls.aliases));
-    await a11yAudit();
     await click(commonSelectors.HREF(urls.alias));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.alias);
   });
@@ -73,7 +69,6 @@ module('Acceptance | aliases | read', function (hooks) {
 
   test('visiting an unknown alias displays 404 message', async function (assert) {
     await visit(urls.unknownAlias);
-    await a11yAudit();
 
     assert
       .dom(commonSelectors.RESOURCE_NOT_FOUND_SUBTITLE)

--- a/ui/admin/tests/acceptance/auth-methods/delete-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/delete-test.js
@@ -8,7 +8,6 @@ import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { TYPE_AUTH_METHOD_LDAP } from 'api/models/auth-method';
@@ -104,7 +103,6 @@ module('Acceptance | auth-methods | delete', function (hooks) {
     await click(commonSelectors.HREF(urls.authMethod));
     await click(selectors.MANAGE_DROPDOWN);
     await click(selectors.MANAGE_DROPDOWN_DELETE);
-    await a11yAudit();
 
     assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
   });
@@ -127,7 +125,6 @@ module('Acceptance | auth-methods | delete', function (hooks) {
     await click(commonSelectors.HREF(urls.ldapAuthMethod));
     await click(selectors.MANAGE_DROPDOWN);
     await click(selectors.MANAGE_DROPDOWN_DELETE);
-    await a11yAudit();
 
     assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
   });

--- a/ui/admin/tests/acceptance/auth-methods/oidc-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/oidc-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { TYPE_AUTH_METHOD_OIDC } from 'api/models/auth-method';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -49,7 +48,6 @@ module('Acceptance | auth-methods | oidc', function (hooks) {
 
   test('visiting oidc auth method', async function (assert) {
     await visit(urls.authMethod);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.authMethod);
   });

--- a/ui/admin/tests/acceptance/auth-methods/read-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/read-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
   TYPE_AUTH_METHOD_LDAP,
@@ -71,7 +70,6 @@ module('Acceptance | auth-methods | read', function (hooks) {
     await visit(urls.orgScope);
 
     await click(commonSelectors.HREF(urls.orgAuthMethods));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.orgAuthMethods);
   });
@@ -80,7 +78,6 @@ module('Acceptance | auth-methods | read', function (hooks) {
     await visit(urls.globalScope);
 
     await click(commonSelectors.HREF(urls.globalAuthMethods));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.globalAuthMethods);
   });
@@ -100,7 +97,6 @@ module('Acceptance | auth-methods | read', function (hooks) {
     await click(
       selectors.TABLE_ROW_NAME_LINK(instances.passwordAuthMethodOrg.id),
     );
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.passwordAuthMethodOrg);
   });
@@ -120,7 +116,6 @@ module('Acceptance | auth-methods | read', function (hooks) {
     await click(
       selectors.TABLE_ROW_NAME_LINK(instances.oidcAuthMethodGlobal.id),
     );
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.oidcAuthMethodGlobal);
   });

--- a/ui/admin/tests/acceptance/auth-methods/update-test.js
+++ b/ui/admin/tests/acceptance/auth-methods/update-test.js
@@ -8,7 +8,6 @@ import { visit, click, fillIn, select, findAll } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -445,7 +444,6 @@ module('Acceptance | auth-methods | update', function (hooks) {
     await click(commonSelectors.EDIT_BTN);
     await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
     await click(commonSelectors.SAVE_BTN);
-    await a11yAudit();
 
     assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText(errorMessage);
     assert.dom(commonSelectors.FIELD_NAME_ERROR).hasText(errorDescription);
@@ -480,7 +478,6 @@ module('Acceptance | auth-methods | update', function (hooks) {
     await click(commonSelectors.EDIT_BTN);
     await fillIn(selectors.FIELD_URLS, '');
     await click(commonSelectors.SAVE_BTN);
-    await a11yAudit();
 
     assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText(errorMessage);
     assert.dom(commonSelectors.FIELD_ERROR).hasText(errorDescription);

--- a/ui/admin/tests/acceptance/authentication-test.js
+++ b/ui/admin/tests/acceptance/authentication-test.js
@@ -16,7 +16,6 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import { setupIntl } from 'ember-intl/test-support';
 import { Response } from 'miragejs';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import {
   currentSession,
   authenticateSession,
@@ -136,7 +135,6 @@ module('Acceptance | authentication', function (hooks) {
 
   test('visiting auth methods authenticate route redirects to first auth method', async function (assert) {
     await visit(authenticateURL);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), authMethodAuthenticateURL);
   });
@@ -146,7 +144,6 @@ module('Acceptance | authentication', function (hooks) {
       return new Response(404);
     });
     await visit(authMethodAuthenticateURL);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), authMethodAuthenticateURL);
   });
@@ -249,7 +246,6 @@ module('Acceptance | authentication', function (hooks) {
   test('visiting auth method authenticate route', async function (assert) {
     await visit(authMethodAuthenticateURL);
 
-    await a11yAudit();
     assert.strictEqual(currentURL(), authMethodAuthenticateURL);
   });
 

--- a/ui/admin/tests/acceptance/credential-library/create-test.js
+++ b/ui/admin/tests/acceptance/credential-library/create-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, click, fillIn, currentURL, select } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { Response } from 'miragejs';
 import { TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE } from 'api/models/credential-library';
@@ -77,12 +76,10 @@ module('Acceptance | credential-libraries | create', function (hooks) {
 
   test('visiting credential libraries', async function (assert) {
     await visit(urls.credentialLibraries);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.credentialLibraries);
 
     await visit(urls.credentialLibrary);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.credentialLibrary);
   });

--- a/ui/admin/tests/acceptance/credential-library/read-test.js
+++ b/ui/admin/tests/acceptance/credential-library/read-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE } from 'api/models/credential-library';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -72,7 +71,6 @@ module('Acceptance | credential-libraries | read', function (hooks) {
     await visit(urls.credentialLibraries);
 
     await click(commonSelectors.TABLE_RESOURCE_LINK(urls.credentialLibrary));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.credentialLibrary);
   });
@@ -110,7 +108,7 @@ module('Acceptance | credential-libraries | read', function (hooks) {
 
   test('visiting an unknown credential library displays 404 message', async function (assert) {
     await visit(urls.unknownCredentialLibrary);
-    await a11yAudit();
+
     assert
       .dom(commonSelectors.RESOURCE_NOT_FOUND_SUBTITLE)
       .hasText(commonSelectors.RESOURCE_NOT_FOUND_VALUE);

--- a/ui/admin/tests/acceptance/credential-store/credentials/read-test.js
+++ b/ui/admin/tests/acceptance/credential-store/credentials/read-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, find, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 
@@ -84,12 +83,10 @@ module('Acceptance | credential-stores | credentials | read', function (hooks) {
   test('visiting username & password credential', async function (assert) {
     await visit(urls.staticCredentialStore);
     await click(commonSelectors.HREF(urls.credentials));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.credentials);
 
     await click(commonSelectors.HREF(urls.usernamePasswordCredential));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.usernamePasswordCredential);
   });
@@ -97,12 +94,10 @@ module('Acceptance | credential-stores | credentials | read', function (hooks) {
   test('visiting username & key pair credential', async function (assert) {
     await visit(urls.staticCredentialStore);
     await click(commonSelectors.HREF(urls.credentials));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.credentials);
 
     await click(commonSelectors.HREF(urls.usernameKeyPairCredential));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.usernameKeyPairCredential);
   });
@@ -111,12 +106,10 @@ module('Acceptance | credential-stores | credentials | read', function (hooks) {
     featuresService.enable('json-credentials');
     await visit(urls.staticCredentialStore);
     await click(commonSelectors.HREF(urls.credentials));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.credentials);
 
     await click(commonSelectors.HREF(urls.jsonCredential));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.jsonCredential);
   });
@@ -180,7 +173,6 @@ module('Acceptance | credential-stores | credentials | read', function (hooks) {
 
   test('visiting an unknown credential displays 404 message', async function (assert) {
     await visit(urls.unknownCredential);
-    await a11yAudit();
 
     assert
       .dom(commonSelectors.RESOURCE_NOT_FOUND_SUBTITLE)

--- a/ui/admin/tests/acceptance/credential-store/read-test.js
+++ b/ui/admin/tests/acceptance/credential-store/read-test.js
@@ -8,7 +8,6 @@ import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 
@@ -71,12 +70,10 @@ module('Acceptance | credential-stores | read', function (hooks) {
     featuresService.enable('static-credentials');
     await visit(urls.credentialStores);
 
-    await a11yAudit();
     assert.strictEqual(currentURL(), urls.credentialStores);
 
     await click(commonSelectors.HREF(urls.staticCredentialStore));
 
-    await a11yAudit();
     assert.strictEqual(currentURL(), urls.staticCredentialStore);
   });
 
@@ -87,7 +84,6 @@ module('Acceptance | credential-stores | read', function (hooks) {
 
     await click(commonSelectors.HREF(urls.vaultCredentialStore));
 
-    await a11yAudit();
     assert.strictEqual(currentURL(), urls.vaultCredentialStore);
   });
 
@@ -129,7 +125,6 @@ module('Acceptance | credential-stores | read', function (hooks) {
   test('visiting an unknown credential store displays 404 message', async function (assert) {
     await visit(urls.unknownCredentialStore);
 
-    await a11yAudit();
     assert
       .dom(commonSelectors.RESOURCE_NOT_FOUND_SUBTITLE)
       .hasText(commonSelectors.RESOURCE_NOT_FOUND_VALUE);

--- a/ui/admin/tests/acceptance/groups/members-test.js
+++ b/ui/admin/tests/acceptance/groups/members-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -58,7 +57,6 @@ module('Acceptance | groups | members', function (hooks) {
 
   test('visiting group members', async function (assert) {
     await visit(urls.members);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.members);
     assert.dom(commonSelectors.TABLE_ROWS).exists({ count: membersCount });
@@ -112,7 +110,7 @@ module('Acceptance | groups | members', function (hooks) {
 
   test('visiting member selection', async function (assert) {
     await visit(urls.addMembers);
-    await a11yAudit();
+
     assert.strictEqual(currentURL(), urls.addMembers);
   });
 

--- a/ui/admin/tests/acceptance/groups/read-test.js
+++ b/ui/admin/tests/acceptance/groups/read-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 
@@ -49,7 +48,6 @@ module('Acceptance | groups | read', function (hooks) {
   test('visiting a group', async function (assert) {
     await visit(urls.newGroup);
 
-    await a11yAudit();
     assert.strictEqual(currentURL(), urls.newGroup);
   });
 

--- a/ui/admin/tests/acceptance/host-catalogs/host-sets/hosts-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/host-sets/hosts-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -80,7 +79,6 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
   test('visiting host set hosts', async function (assert) {
     const count = getHostSetHostCount();
     await visit(urls.hostSetHosts);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.hostSetHosts);
     assert.dom(commonSelectors.TABLE_ROWS).exists({ count });
@@ -136,7 +134,6 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
 
   test('visiting add hosts', async function (assert) {
     await visit(urls.addHosts);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.addHosts);
   });
@@ -228,7 +225,6 @@ module('Acceptance | host-catalogs | host-sets | hosts', function (hooks) {
 
   test('visiting host creation from a host set', async function (assert) {
     await visit(urls.createAndAddHost);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.createAndAddHost);
   });

--- a/ui/admin/tests/acceptance/host-catalogs/host-sets/read-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/host-sets/read-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 
@@ -69,12 +68,10 @@ module('Acceptance | host-catalogs | host-sets | read', function (hooks) {
 
   test('visiting host sets', async function (assert) {
     await visit(urls.hostSets);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.hostSets);
 
     await click(commonSelectors.HREF(urls.hostSet));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.hostSet);
   });
@@ -93,7 +90,6 @@ module('Acceptance | host-catalogs | host-sets | read', function (hooks) {
 
   test('visiting an unknown host set displays 404 message', async function (assert) {
     await visit(urls.unknownHostSet);
-    await a11yAudit();
 
     assert
       .dom(commonSelectors.RESOURCE_NOT_FOUND_SUBTITLE)

--- a/ui/admin/tests/acceptance/host-catalogs/hosts/read-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/hosts/read-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 
@@ -69,11 +68,10 @@ module('Acceptance | host-catalogs | hosts | read', function (hooks) {
 
   test('visiting hosts', async function (assert) {
     await visit(urls.hosts);
-    await a11yAudit();
+
     assert.strictEqual(currentURL(), urls.hosts);
 
     await click(commonSelectors.HREF(urls.host));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.host);
   });
@@ -90,7 +88,6 @@ module('Acceptance | host-catalogs | hosts | read', function (hooks) {
 
   test('visiting an unknown host displays 404 message', async function (assert) {
     await visit(urls.unknownHost);
-    await a11yAudit();
 
     assert
       .dom(commonSelectors.RESOURCE_NOT_FOUND_SUBTITLE)

--- a/ui/admin/tests/acceptance/host-catalogs/read-test.js
+++ b/ui/admin/tests/acceptance/host-catalogs/read-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -61,12 +60,10 @@ module('Acceptance | host-catalogs | read', function (hooks) {
 
   test('visiting host catalogs', async function (assert) {
     await visit(urls.hostCatalogs);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.hostCatalogs);
 
     await click(commonSelectors.HREF(urls.hostCatalog));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.hostCatalog);
   });
@@ -87,7 +84,6 @@ module('Acceptance | host-catalogs | read', function (hooks) {
 
   test('visiting an unknown host catalog displays 404 message', async function (assert) {
     await visit(urls.unknownHostCatalog);
-    await a11yAudit();
 
     assert
       .dom(commonSelectors.RESOURCE_NOT_FOUND_SUBTITLE)

--- a/ui/admin/tests/acceptance/managed-groups/create-test.js
+++ b/ui/admin/tests/acceptance/managed-groups/create-test.js
@@ -9,7 +9,6 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import {
   TYPE_AUTH_METHOD_OIDC,
@@ -216,7 +215,6 @@ module('Acceptance | managed-groups | create', function (hooks) {
 
     await click(commonSelectors.HREF(urls.newManagedGroup));
     await click(commonSelectors.SAVE_BTN);
-    await a11yAudit();
 
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)
@@ -249,7 +247,6 @@ module('Acceptance | managed-groups | create', function (hooks) {
 
     await click(commonSelectors.HREF(urls.newLdapManagedGroup));
     await click(commonSelectors.SAVE_BTN);
-    await a11yAudit();
 
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)

--- a/ui/admin/tests/acceptance/managed-groups/delete-test.js
+++ b/ui/admin/tests/acceptance/managed-groups/delete-test.js
@@ -8,7 +8,6 @@ import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import {
   TYPE_AUTH_METHOD_OIDC,
@@ -145,7 +144,6 @@ module('Acceptance | managed-groups | delete', function (hooks) {
     await click(commonSelectors.HREF(urls.managedGroup));
     await click(selectors.MANAGE_DROPDOWN_MANAGED_GROUPS);
     await click(selectors.MANAGE_DROPDOWN_MANAGED_GROUP_DELETE);
-    await a11yAudit();
 
     assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
     assert.strictEqual(currentURL(), urls.managedGroup);
@@ -168,7 +166,6 @@ module('Acceptance | managed-groups | delete', function (hooks) {
     await click(commonSelectors.HREF(urls.ldapManagedGroup));
     await click(selectors.MANAGE_DROPDOWN_MANAGED_GROUPS);
     await click(selectors.MANAGE_DROPDOWN_MANAGED_GROUP_DELETE);
-    await a11yAudit();
 
     assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText('Oops.');
     assert.strictEqual(currentURL(), urls.ldapManagedGroup);

--- a/ui/admin/tests/acceptance/managed-groups/members-test.js
+++ b/ui/admin/tests/acceptance/managed-groups/members-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { TYPE_AUTH_METHOD_OIDC } from 'api/models/auth-method';
 
@@ -61,7 +60,6 @@ module('Acceptance | managed-groups | members', function (hooks) {
     const membersCount = instances.managedGroup.memberIds.length;
     await visit(urls.managedGroupMembers);
 
-    await a11yAudit();
     assert.strictEqual(currentURL(), urls.managedGroupMembers);
     assert.ok(membersCount);
     assert.dom('tbody tr').exists({ count: membersCount });

--- a/ui/admin/tests/acceptance/managed-groups/read-test.js
+++ b/ui/admin/tests/acceptance/managed-groups/read-test.js
@@ -8,7 +8,6 @@ import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import {
   TYPE_AUTH_METHOD_OIDC,
   TYPE_AUTH_METHOD_LDAP,
@@ -78,7 +77,6 @@ module('Acceptance | managed-groups | read', function (hooks) {
     await visit(urls.managedGroups);
 
     await click(commonSelectors.HREF(urls.managedGroup));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.managedGroup);
   });
@@ -87,7 +85,6 @@ module('Acceptance | managed-groups | read', function (hooks) {
     await visit(urls.ldapManagedGroups);
 
     await click(commonSelectors.HREF(urls.ldapManagedGroup));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.ldapManagedGroup);
   });

--- a/ui/admin/tests/acceptance/policy/create-test.js
+++ b/ui/admin/tests/acceptance/policy/create-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click, fillIn, select } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -161,7 +160,6 @@ module('Acceptance | policies | create', function (hooks) {
 
     await click(commonSelectors.HREF(urls.newPolicy));
     await click(commonSelectors.SAVE_BTN);
-    await a11yAudit();
 
     assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText(errorMessage);
   });

--- a/ui/admin/tests/acceptance/policy/read-test.js
+++ b/ui/admin/tests/acceptance/policy/read-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 
@@ -55,12 +54,9 @@ module('Acceptance | policies | read', function (hooks) {
 
   test('visiting a policy', async function (assert) {
     await visit(urls.globalScope);
-    await a11yAudit();
 
     await click(commonSelectors.HREF(urls.policies));
-    await a11yAudit();
     await click(commonSelectors.HREF(urls.policy));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.policy);
   });
@@ -77,7 +73,6 @@ module('Acceptance | policies | read', function (hooks) {
 
   test('visiting an unknown policy displays 404 message', async function (assert) {
     await visit(urls.unknownPolicy);
-    await a11yAudit();
 
     assert
       .dom(commonSelectors.RESOURCE_NOT_FOUND_SUBTITLE)

--- a/ui/admin/tests/acceptance/roles/create-test.js
+++ b/ui/admin/tests/acceptance/roles/create-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as selectors from './selectors';
@@ -140,7 +139,6 @@ module('Acceptance | roles | create', function (hooks) {
 
     await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
     await click(commonSelectors.SAVE_BTN);
-    await a11yAudit();
 
     assert.dom(commonSelectors.ALERT_TOAST_BODY).hasText(errorMsg);
   });

--- a/ui/admin/tests/acceptance/roles/global-scope-test.js
+++ b/ui/admin/tests/acceptance/roles/global-scope-test.js
@@ -16,7 +16,6 @@ import {
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
   GRANT_SCOPE_THIS,
@@ -81,16 +80,9 @@ module('Acceptance | roles | global-scope', function (hooks) {
   });
 
   test('visiting role scopes', async function (assert) {
-    // TODO: address issue with ICU-15021
-    // Failing due to a11y violation while in dark mode.
-    // Investigating issue with styles not properly
-    // being applied during test.
-    const session = this.owner.lookup('service:session');
-    session.set('data.theme', 'light');
     await visit(urls.role);
 
     await click(commonSelectors.HREF(urls.roleScopes));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.roleScopes);
     assert
@@ -295,7 +287,6 @@ module('Acceptance | roles | global-scope', function (hooks) {
 
     await click(selectors.MANAGE_DROPDOWN_ROLES);
     await click(selectors.MANAGE_DROPDOWN_ROLES_SCOPES);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.manageScopes);
 
@@ -410,7 +401,6 @@ module('Acceptance | roles | global-scope', function (hooks) {
     assert.strictEqual(currentURL(), urls.manageScopes);
 
     await click(commonSelectors.HREF(urls.manageCustomScopes));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.manageCustomScopes);
 
@@ -839,7 +829,6 @@ module('Acceptance | roles | global-scope', function (hooks) {
     await click(selectors.MANAGE_DROPDOWN_ROLES_SCOPES);
     await click(commonSelectors.HREF(urls.manageCustomScopes));
     await click(commonSelectors.TABLE_RESOURCE_LINK(urls.manageScopesOrg));
-    await a11yAudit();
 
     // Click three times to select, unselect, then reselect (for coverage)
     await click(

--- a/ui/admin/tests/acceptance/roles/grants-test.js
+++ b/ui/admin/tests/acceptance/roles/grants-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as selectors from './selectors';
@@ -54,7 +53,6 @@ module('Acceptance | roles | grants', function (hooks) {
 
   test('visiting role grants', async function (assert) {
     await visit(urls.grants);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.grants);
     assert.dom(selectors.FIELD_GRANT).exists({ count: grantsCount() });

--- a/ui/admin/tests/acceptance/roles/org-scope-test.js
+++ b/ui/admin/tests/acceptance/roles/org-scope-test.js
@@ -15,7 +15,6 @@ import {
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as selectors from './selectors';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -87,7 +86,6 @@ module('Acceptance | roles | org-scope', function (hooks) {
     await visit(urls.role);
 
     await click(commonSelectors.HREF(urls.roleScopes));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.roleScopes);
     assert
@@ -248,7 +246,6 @@ module('Acceptance | roles | org-scope', function (hooks) {
 
     await click(selectors.MANAGE_DROPDOWN_ROLES);
     await click(selectors.MANAGE_DROPDOWN_ROLES_SCOPES);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.manageScopes);
 
@@ -354,7 +351,6 @@ module('Acceptance | roles | org-scope', function (hooks) {
     await click(selectors.MANAGE_DROPDOWN_ROLES);
     await click(selectors.MANAGE_DROPDOWN_ROLES_SCOPES);
     await click(commonSelectors.HREF(urls.manageOrgProjects));
-    await a11yAudit();
 
     // Click three times to select, unselect, then reselect (for coverage)
     await click(
@@ -388,7 +384,6 @@ module('Acceptance | roles | org-scope', function (hooks) {
     await click(selectors.MANAGE_DROPDOWN_ROLES);
     await click(selectors.MANAGE_DROPDOWN_ROLES_SCOPES);
     await click(commonSelectors.HREF(urls.manageOrgProjects));
-    await a11yAudit();
 
     // Click three times to select, unselect, then reselect (for coverage)
     await click(

--- a/ui/admin/tests/acceptance/roles/principals-test.js
+++ b/ui/admin/tests/acceptance/roles/principals-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click, findAll } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as selectors from './selectors';
@@ -61,7 +60,6 @@ module('Acceptance | roles | principals', function (hooks) {
 
   test('visiting role principals', async function (assert) {
     await visit(urls.rolePrincipals);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.rolePrincipals);
     assert.strictEqual(findAll('tbody tr').length, principalsCount);

--- a/ui/admin/tests/acceptance/roles/project-scope-test.js
+++ b/ui/admin/tests/acceptance/roles/project-scope-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { GRANT_SCOPE_THIS } from 'api/models/role';
 import * as selectors from './selectors';
@@ -56,7 +55,6 @@ module('Acceptance | roles | project-scope', function (hooks) {
     await visit(urls.role);
 
     await click(commonSelectors.HREF(urls.roleScopes));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.roleScopes);
     assert.dom(selectors.GRANT_SCOPE_ROW(GRANT_SCOPE_THIS)).isVisible();

--- a/ui/admin/tests/acceptance/roles/read-test.js
+++ b/ui/admin/tests/acceptance/roles/read-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 
@@ -61,7 +60,6 @@ module('Acceptance | roles | read', function (hooks) {
 
   test('visiting roles', async function (assert) {
     await visit(urls.roles);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.roles);
   });
@@ -71,7 +69,6 @@ module('Acceptance | roles | read', function (hooks) {
 
     await click(commonSelectors.HREF(urls.roles));
     await click(commonSelectors.TABLE_RESOURCE_LINK(urls.role));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.role);
   });
@@ -94,7 +91,6 @@ module('Acceptance | roles | read', function (hooks) {
     await visit(urls.roles);
 
     await click(commonSelectors.TABLE_RESOURCE_LINK(urls.role));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.role);
   });

--- a/ui/admin/tests/acceptance/scopes-test.js
+++ b/ui/admin/tests/acceptance/scopes-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -85,7 +84,6 @@ module('Acceptance | scopes', function (hooks) {
 
   test('visiting global scope', async function (assert) {
     await visit(urls.globalScope);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.globalScope);
   });
@@ -107,14 +105,12 @@ module('Acceptance | scopes', function (hooks) {
 
   test('visiting org scope', async function (assert) {
     await visit(urls.orgScopes);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.orgScopes);
   });
 
   test('can navigate among org scopes via side-nav', async function (assert) {
     await visit(urls.globalScope);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.globalScope);
 
@@ -130,7 +126,6 @@ module('Acceptance | scopes', function (hooks) {
 
   test('can navigate among project scopes via side-nav', async function (assert) {
     await visit(urls.projectScope);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.projectTargets);
 

--- a/ui/admin/tests/acceptance/scopes/add-storage-policy-test.js
+++ b/ui/admin/tests/acceptance/scopes/add-storage-policy-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import select from '@ember/test-helpers/dom/select';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -72,7 +71,6 @@ module('Acceptance | scope | add storage policy', function (hooks) {
     assert.false(featuresService.isEnabled('ssh-session-recording'));
 
     await visit(urls.orgScopeEdit);
-    await a11yAudit();
 
     assert.dom(selectors.STORAGE_POLICY_SIDEBAR).doesNotExist();
   });

--- a/ui/admin/tests/acceptance/scopes/read-test.js
+++ b/ui/admin/tests/acceptance/scopes/read-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 import * as selectors from './selectors';
@@ -53,10 +52,8 @@ module('Acceptance | scopes | read', function (hooks) {
 
   test('visiting org scope edit', async function (assert) {
     await visit(urls.orgScope);
-    await a11yAudit();
 
     await click(commonSelectors.HREF(urls.orgScopeEdit));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.orgScopeEdit);
     assert.dom(commonSelectors.FORM).isVisible();
@@ -64,18 +61,10 @@ module('Acceptance | scopes | read', function (hooks) {
   });
 
   test('visiting global scope settings when feature flag is enabled', async function (assert) {
-    // TODO: address issue with ICU-15021
-    // Failing due to a11y violation while in dark mode.
-    // Investigating issue with styles not properly
-    // being applied during test.
-    const session = this.owner.lookup('service:session');
-    session.set('data.theme', 'light');
     features.enable('ssh-session-recording');
     await visit(urls.globalScope);
-    await a11yAudit();
 
     await click(commonSelectors.HREF(urls.globalScopeEdit));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.globalScopeEdit);
     assert.dom(commonSelectors.FORM).isVisible();

--- a/ui/admin/tests/acceptance/session-recordings/read-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/read-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import { setupIntl } from 'ember-intl/test-support';
@@ -72,21 +71,13 @@ module('Acceptance | session-recordings | read', function (hooks) {
   });
 
   test('visiting a session recording', async function (assert) {
-    // TODO: address issue with ICU-15021
-    // Failing due to a11y violation while in dark mode.
-    // Investigating issue with styles not properly
-    // being applied during test.
-    const session = this.owner.lookup('service:session');
-    session.set('data.theme', 'light');
     featuresService.enable('ssh-session-recording');
     await visit(urls.globalScope);
 
     // Visit session recordings
     await click(commonSelectors.HREF(urls.sessionRecordings));
-    await a11yAudit();
     // Click a session recording and check it navigates properly
     await click(selectors.TABLE_FIRST_ROW_ACTION_LINK);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.sessionRecording);
   });

--- a/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/session-recording/channels-by-connection/channel-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { Response } from 'miragejs';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
@@ -89,7 +88,6 @@ module(
 
       // Visit channel
       await click(commonSelectors.HREF(urls.channelRecording));
-      await a11yAudit();
 
       assert.strictEqual(currentURL(), urls.channelRecording);
     });

--- a/ui/admin/tests/acceptance/sessions/list-test.js
+++ b/ui/admin/tests/acceptance/sessions/list-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click, fillIn, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { faker } from '@faker-js/faker';
@@ -114,10 +113,8 @@ module('Acceptance | sessions | list', function (hooks) {
 
   test('visiting sessions', async function (assert) {
     await visit(urls.projectScope);
-    await a11yAudit();
 
     await click(commonSelectors.HREF(urls.sessions));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.sessions);
     assert
@@ -127,7 +124,6 @@ module('Acceptance | sessions | list', function (hooks) {
 
   test('users cannot navigate to sessions tab without proper authorization', async function (assert) {
     await visit(urls.orgScope);
-    await a11yAudit();
     instances.scopes.project.authorized_collection_actions.sessions =
       instances.scopes.project.authorized_collection_actions.sessions.filter(
         (item) => item !== 'list',

--- a/ui/admin/tests/acceptance/storage-buckets/read-test.js
+++ b/ui/admin/tests/acceptance/storage-buckets/read-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 
@@ -57,7 +56,6 @@ module('Acceptance | storage-buckets | read', function (hooks) {
     await visit(urls.storageBuckets);
 
     await click(commonSelectors.HREF(urls.storageBucket));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.storageBucket);
   });
@@ -78,7 +76,6 @@ module('Acceptance | storage-buckets | read', function (hooks) {
 
   test('visiting an unknown storage bucket displays 404 message', async function (assert) {
     await visit(urls.unknownStorageBucket);
-    await a11yAudit();
 
     assert
       .dom(commonSelectors.RESOURCE_NOT_FOUND_SUBTITLE)

--- a/ui/admin/tests/acceptance/targets/brokered-credential-sources-test.js
+++ b/ui/admin/tests/acceptance/targets/brokered-credential-sources-test.js
@@ -8,7 +8,6 @@ import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 import * as selectors from './selectors';
@@ -126,7 +125,6 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
 
   test('visiting target brokered credential sources', async function (assert) {
     await visit(urls.brokeredCredentialSources);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.brokeredCredentialSources);
     assert
@@ -138,7 +136,6 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
     await visit(urls.brokeredCredentialSources);
 
     await click(commonSelectors.TABLE_RESOURCE_LINK(urls.credentialLibrary));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.credentialLibrary);
   });
@@ -150,7 +147,6 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
     await visit(urls.brokeredCredentialSources);
 
     await click(commonSelectors.TABLE_RESOURCE_LINK(urls.credential));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.credential);
   });
@@ -169,7 +165,6 @@ module('Acceptance | targets | brokered credential sources', function (hooks) {
 
   test('visiting add brokered credential sources', async function (assert) {
     await visit(urls.addBrokeredCredentialSources);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.addBrokeredCredentialSources);
   });

--- a/ui/admin/tests/acceptance/targets/create-alias-test.js
+++ b/ui/admin/tests/acceptance/targets/create-alias-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, click, fillIn, getContext } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
@@ -181,7 +180,6 @@ module('Acceptance | targets | create-alias', function (hooks) {
     await click(commonSelectors.HREF(urls.target));
     await click(selectors.ALIASES_ADD_BTN);
     await click(commonSelectors.SAVE_BTN);
-    await a11yAudit();
 
     assert
       .dom(commonSelectors.ALERT_TOAST_BODY)

--- a/ui/admin/tests/acceptance/targets/enable-session-recording-test.js
+++ b/ui/admin/tests/acceptance/targets/enable-session-recording-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, find, click, currentURL, select } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 import * as selectors from './selectors';
@@ -84,7 +83,6 @@ module('Acceptance | targets | enable session recording', function (hooks) {
 
   test('cannot enable session recording for a target without proper authorization', async function (assert) {
     await visit(urls.target);
-    await a11yAudit();
 
     assert.false(featuresService.isEnabled('ssh-session-recording'));
     assert.dom(selectors.ENABLE_RECORDING_BTN).doesNotExist();

--- a/ui/admin/tests/acceptance/targets/enable-session-recording/index-test.js
+++ b/ui/admin/tests/acceptance/targets/enable-session-recording/index-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, find, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { TYPE_TARGET_SSH } from 'api/models/target';
 import select from '@ember/test-helpers/dom/select';
@@ -93,7 +92,6 @@ module(
       assert.false(featuresService.isEnabled('ssh-session-recording'));
 
       await visit(urls.target);
-      await a11yAudit();
 
       assert.dom(SESSION_RECORDING_ENABLE_BTN).doesNotExist();
     });

--- a/ui/admin/tests/acceptance/targets/host-sources-test.js
+++ b/ui/admin/tests/acceptance/targets/host-sources-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -88,7 +87,6 @@ module('Acceptance | targets | host-sources', function (hooks) {
     await visit(urls.target);
 
     await click(commonSelectors.HREF(urls.targetHostSources));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.targetHostSources);
     assert
@@ -100,7 +98,6 @@ module('Acceptance | targets | host-sources', function (hooks) {
     await visit(urls.targetHostSources);
 
     await click(commonSelectors.HREF(urls.hostSet));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.hostSet);
   });

--- a/ui/admin/tests/acceptance/targets/injected-application-credential-sources-test.js
+++ b/ui/admin/tests/acceptance/targets/injected-application-credential-sources-test.js
@@ -8,7 +8,6 @@ import { visit, click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { TYPE_TARGET_SSH } from 'api/models/target';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -125,7 +124,6 @@ module(
 
     test('visiting target injected application credential sources', async function (assert) {
       await visit(urls.injectedApplicationCredentialSources);
-      await a11yAudit();
 
       assert.strictEqual(
         currentURL(),
@@ -140,7 +138,6 @@ module(
       await visit(urls.injectedApplicationCredentialSources);
 
       await click(commonSelectors.TABLE_RESOURCE_LINK(urls.credentialLibrary));
-      await a11yAudit();
 
       assert.strictEqual(currentURL(), urls.credentialLibrary);
     });
@@ -154,14 +151,12 @@ module(
       await visit(urls.injectedApplicationCredentialSources);
 
       await click(commonSelectors.TABLE_RESOURCE_LINK(urls.credential));
-      await a11yAudit();
 
       assert.strictEqual(currentURL(), urls.credential);
     });
 
     test('visiting add injected application credential sources', async function (assert) {
       await visit(urls.addInjectedApplicationCredentialSources);
-      await a11yAudit();
 
       assert.strictEqual(
         currentURL(),

--- a/ui/admin/tests/acceptance/targets/manage-alias-test.js
+++ b/ui/admin/tests/acceptance/targets/manage-alias-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { TYPE_TARGET_TCP, TYPE_TARGET_SSH } from 'api/models/target';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -93,7 +92,6 @@ module('Acceptance | targets | manage-alias', function (hooks) {
     await click(selectors.LINK_LIST_ITEM);
 
     assert.strictEqual(currentURL(), urls.tcpAlias);
-    await a11yAudit();
   });
 
   test('clicking on `clear alias` from the dropdown should remove the destination ID and alias should disapper from the target sidebar', async function (assert) {

--- a/ui/admin/tests/acceptance/targets/read-test.js
+++ b/ui/admin/tests/acceptance/targets/read-test.js
@@ -9,7 +9,6 @@ import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
 import { setupIntl } from 'ember-intl/test-support';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { TYPE_TARGET_TCP, TYPE_TARGET_SSH } from 'api/models/target';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -92,12 +91,10 @@ module('Acceptance | targets | read', function (hooks) {
     await visit(urls.projectScope);
 
     await click(commonSelectors.HREF(urls.targets));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.targets);
 
     await click(commonSelectors.HREF(urls.sshTarget));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.sshTarget);
   });
@@ -109,7 +106,6 @@ module('Acceptance | targets | read', function (hooks) {
     assert.strictEqual(currentURL(), urls.targets);
 
     await click(commonSelectors.HREF(urls.tcpTarget));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.tcpTarget);
   });
@@ -142,7 +138,6 @@ module('Acceptance | targets | read', function (hooks) {
 
   test('visiting an unknown target displays 404 message', async function (assert) {
     await visit(urls.unknownTarget);
-    await a11yAudit();
 
     assert
       .dom(commonSelectors.RESOURCE_NOT_FOUND_SUBTITLE)

--- a/ui/admin/tests/acceptance/targets/workers-test.js
+++ b/ui/admin/tests/acceptance/targets/workers-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 import * as selectors from './selectors';
@@ -72,16 +71,9 @@ module('Acceptance | targets | workers', function (hooks) {
   });
 
   test('visiting target workers', async function (assert) {
-    // TODO: address issue with ICU-15021
-    // Failing due to a11y violation while in dark mode.
-    // Investigating issue with styles not properly
-    // being applied during test.
-    const session = this.owner.lookup('service:session');
-    session.set('data.theme', 'light');
     await visit(urls.target);
 
     await click(commonSelectors.HREF(urls.targetWorkers));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.targetWorkers);
   });

--- a/ui/admin/tests/acceptance/users/accounts-test.js
+++ b/ui/admin/tests/acceptance/users/accounts-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { Response } from 'miragejs';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -69,7 +68,6 @@ module('Acceptance | users | accounts', function (hooks) {
     await visit(urls.user);
 
     await click(commonSelectors.HREF(urls.accounts));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.accounts);
     assert.dom(commonSelectors.TABLE_ROWS).exists({ count: accountsCount });
@@ -171,7 +169,6 @@ module('Acceptance | users | accounts', function (hooks) {
 
     await click(selectors.MANAGE_DROPDOWN_USER);
     await click(selectors.MANAGE_DROPDOWN_USER_ADD_ACCOUNTS);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.addAccounts);
   });

--- a/ui/admin/tests/acceptance/users/read-test.js
+++ b/ui/admin/tests/acceptance/users/read-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 
@@ -48,10 +47,8 @@ module('Acceptance | users | read', function (hooks) {
 
   test('visiting users', async function (assert) {
     await visit(urls.orgScope);
-    await a11yAudit();
 
     await click(commonSelectors.HREF(urls.users));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.users);
   });
@@ -60,7 +57,6 @@ module('Acceptance | users | read', function (hooks) {
     await visit(urls.users);
 
     await click(commonSelectors.HREF(urls.user));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.user);
   });

--- a/ui/admin/tests/acceptance/workers/create-tags-test.js
+++ b/ui/admin/tests/acceptance/workers/create-tags-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 import * as selectors from './selectors';
@@ -51,7 +50,6 @@ module('Acceptance | workers | worker | create-tags', function (hooks) {
 
     await click(selectors.MANAGE_DROPDOWN_WORKER);
     await click(selectors.MANAGE_DROPDOWN_WORKER_CREATE_TAGS);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.createTags);
   });

--- a/ui/admin/tests/acceptance/workers/read-test.js
+++ b/ui/admin/tests/acceptance/workers/read-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupIndexedDb } from 'api/test-support/helpers/indexed-db';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
 
@@ -54,14 +53,7 @@ module('Acceptance | workers | read', function (hooks) {
   });
 
   test('visiting worker', async function (assert) {
-    // TODO: address issue with ICU-15021
-    // Failing due to a11y violation while in dark mode.
-    // Investigating issue with styles not properly
-    // being applied during test.
-    const session = this.owner.lookup('service:session');
-    session.set('data.theme', 'light');
     await visit(urls.workers);
-    await a11yAudit();
 
     await click(commonSelectors.HREF(urls.worker));
 

--- a/ui/admin/tests/acceptance/workers/tags-test.js
+++ b/ui/admin/tests/acceptance/workers/tags-test.js
@@ -14,7 +14,6 @@ import {
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { HCP_MANAGED_KEY } from 'api/models/worker';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -53,7 +52,6 @@ module('Acceptance | workers | worker | tags', function (hooks) {
     await visit(urls.worker);
 
     await click(commonSelectors.HREF(urls.tags));
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.tags);
     assert.dom(commonSelectors.TABLE_ROWS).exists({ count: 11 });

--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -107,7 +107,7 @@ These environment variables may be used to customized the build.
 ### Building for Production
 
 Before executing a build, be sure to set any environment variables necessary
-for your target [environment](#environment-variables-prod) and you have full permissions in the environment you want to build in. 
+for your target [environment](#environment-variables-prod) and you have full permissions in the environment you want to build in.
 To build this UI for production, run the following commands from this folder:
 
 ```bash
@@ -149,8 +149,6 @@ of testing".  Use test coverage as a guide to help you identify untested
 high-value code.
 
 We rely on `ember-a11y-testing` to validate accessibility in acceptance tests.
-If you write acceptance tests, please ensure at least one validation per
-route using `await a11yAudit();`.
 
 ### Running end to end Tests
 

--- a/ui/desktop/tests/acceptance/authentication-test.js
+++ b/ui/desktop/tests/acceptance/authentication-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, fillIn, click, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import {
   currentSession,
   authenticateSession,
@@ -131,7 +130,7 @@ module('Acceptance | authentication', function (hooks) {
   test('visiting index while unauthenticated redirects to global authenticate method', async function (assert) {
     assert.expect(2);
     await visit(urls.index);
-    await a11yAudit();
+
     assert.notOk(currentSession().isAuthenticated);
     assert.strictEqual(currentURL(), urls.authenticate.methods.global);
   });
@@ -140,7 +139,7 @@ module('Acceptance | authentication', function (hooks) {
     assert.expect(1);
     this.owner.lookup('service:clusterUrl').rendererClusterUrl = null;
     await visit(urls.authenticate.global);
-    await a11yAudit();
+
     assert.strictEqual(currentURL(), urls.clusterUrl);
   });
 
@@ -150,7 +149,7 @@ module('Acceptance | authentication', function (hooks) {
       return new Response(404);
     });
     await visit(urls.authenticate.global);
-    await a11yAudit();
+
     assert.strictEqual(currentURL(), urls.authenticate.methods.global);
   });
 

--- a/ui/desktop/tests/acceptance/cluster-url-test.js
+++ b/ui/desktop/tests/acceptance/cluster-url-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL, fillIn, click, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import sinon from 'sinon';
 import { invalidateSession } from 'ember-simple-auth/test-support';
 import { setupBrowserFakes } from 'ember-browser-services/test-support';
@@ -109,7 +108,7 @@ module('Acceptance | clusterUrl', function (hooks) {
   test('visiting index', async function (assert) {
     assert.expect(1);
     await visit(urls.clusterUrl);
-    await a11yAudit();
+
     assert.strictEqual(currentURL(), urls.clusterUrl);
   });
 
@@ -117,7 +116,7 @@ module('Acceptance | clusterUrl', function (hooks) {
     assert.expect(2);
     setupMockIpc(this);
     await visit(urls.index);
-    await a11yAudit();
+
     assert.notOk(mockIPC.clusterUrl);
     assert.strictEqual(currentURL(), urls.clusterUrl);
   });

--- a/ui/desktop/tests/acceptance/projects-test.js
+++ b/ui/desktop/tests/acceptance/projects-test.js
@@ -7,7 +7,6 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import {
   currentSession,
   authenticateSession,
@@ -105,7 +104,7 @@ module('Acceptance | projects', function (hooks) {
     await invalidateSession();
     assert.expect(2);
     await visit(urls.projects);
-    await a11yAudit();
+
     assert.notOk(currentSession().isAuthenticated);
     assert.strictEqual(currentURL(), urls.authenticate.methods.global);
   });
@@ -113,7 +112,7 @@ module('Acceptance | projects', function (hooks) {
   test('visiting index', async function (assert) {
     assert.expect(1);
     await visit(urls.projects);
-    await a11yAudit();
+
     assert.strictEqual(currentURL(), urls.projects);
   });
 });

--- a/ui/desktop/tests/acceptance/projects/sessions/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/index-test.js
@@ -8,7 +8,6 @@ import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import WindowMockIPC from '../../../helpers/window-mock-ipc';
 import {
   currentSession,
@@ -170,7 +169,6 @@ module('Acceptance | projects | sessions | index', function (hooks) {
     this.stubCacheDaemonSearch();
 
     await visit(urls.sessions);
-    await a11yAudit();
 
     assert.notOk(currentSession().isAuthenticated);
     assert.strictEqual(currentURL(), urls.authenticate.methods.global);
@@ -193,24 +191,16 @@ module('Acceptance | projects | sessions | index', function (hooks) {
     await visit(urls.projects);
 
     await click(`[href="${urls.sessions}"]`);
-    await a11yAudit();
 
     assert.dom(APP_STATE_TITLE).hasText('No Sessions Available');
   });
 
   test('visiting sessions without targets is OK', async function (assert) {
-    // TODO: address issue with ICU-15021
-    // Failing due to a11y violation while in dark mode.
-    // Investigating issue with styles not properly
-    // being applied during test.
-    const session = this.owner.lookup('service:session');
-    session.set('data.theme', 'light');
     instances.session.update({ targetId: undefined });
     const sessionsCount = this.server.schema.sessions.all().models.length;
     await visit(urls.projects);
 
     await click(`[href="${urls.sessions}"]`);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.sessions);
     assert.dom('tbody tr').exists({ count: sessionsCount });

--- a/ui/desktop/tests/acceptance/projects/sessions/session-test.js
+++ b/ui/desktop/tests/acceptance/projects/sessions/session-test.js
@@ -10,7 +10,6 @@ import { visit, currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import WindowMockIPC from '../../../helpers/window-mock-ipc';
 import { STATUS_SESSION_ACTIVE } from 'api/models/session';
@@ -129,7 +128,6 @@ module('Acceptance | projects | sessions | session', function (hooks) {
     assert.expect(1);
 
     await visit(urls.session);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.session);
   });

--- a/ui/desktop/tests/acceptance/projects/targets/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/index-test.js
@@ -12,7 +12,6 @@ import {
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import WindowMockIPC from '../../../helpers/window-mock-ipc';
 import {
   authenticateSession,
@@ -168,24 +167,16 @@ module('Acceptance | projects | targets | index', function (hooks) {
     await invalidateSession();
     this.stubCacheDaemonSearch();
     await visit(urls.targets);
-    await a11yAudit();
 
     assert.notOk(currentSession().isAuthenticated);
     assert.strictEqual(currentURL(), urls.authenticate.methods.global);
   });
 
   test('visiting targets index', async function (assert) {
-    // TODO: address issue with ICU-15021
-    // Failing due to a11y violation while in dark mode.
-    // Investigating issue with styles not properly
-    // being applied during test.
-    const session = this.owner.lookup('service:session');
-    session.set('data.theme', 'light');
     const targetsCount = getTargetCount();
     await visit(urls.projects);
 
     await click(`[href="${urls.targets}"]`);
-    await a11yAudit();
 
     assert.dom('.hds-segmented-group').exists();
     assert.strictEqual(currentURL(), urls.targets);

--- a/ui/desktop/tests/acceptance/scopes-test.js
+++ b/ui/desktop/tests/acceptance/scopes-test.js
@@ -15,7 +15,6 @@ import {
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { Response } from 'miragejs';
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import {
   currentSession,
   authenticateSession,
@@ -157,16 +156,9 @@ module('Acceptance | scopes', function (hooks) {
   });
 
   test('visiting global scope', async function (assert) {
-    // TODO: address issue with ICU-15021
-    // Failing due to a11y violation while in dark mode.
-    // Investigating issue with styles not properly
-    // being applied during test.
-    const session = this.owner.lookup('service:session');
-    session.set('data.theme', 'light');
     assert.expect(1);
 
     await visit(urls.scopes.global);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.globalTargets);
   });
@@ -176,12 +168,6 @@ module('Acceptance | scopes', function (hooks) {
   // In order to resolve this, we might hoist authentication routes up from
   // under scopes.
   test('visiting global scope is not successful when the global scope cannot be fetched', async function (assert) {
-    // TODO: address issue with ICU-15021
-    // Failing due to a11y violation while in dark mode.
-    // Investigating issue with styles not properly
-    // being applied during test.
-    const session = this.owner.lookup('service:session');
-    session.set('data.theme', 'light');
     assert.expect(1);
     this.server.get('/scopes/:id', ({ scopes }, { params: { id } }) => {
       const scope = scopes.find(id);
@@ -190,22 +176,14 @@ module('Acceptance | scopes', function (hooks) {
     });
 
     await visit(urls.scopes.global);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.globalTargets);
   });
 
   test('visiting org scope', async function (assert) {
-    // TODO: address issue with ICU-15021
-    // Failing due to a11y violation while in dark mode.
-    // Investigating issue with styles not properly
-    // being applied during test.
-    const session = this.owner.lookup('service:session');
-    session.set('data.theme', 'light');
     assert.expect(1);
 
     await visit(urls.scopes.org);
-    await a11yAudit();
 
     assert.strictEqual(currentURL(), urls.targets);
   });
@@ -249,7 +227,6 @@ module('Acceptance | scopes', function (hooks) {
     this.stubCacheDaemonSearch();
 
     await visit(urls.targets);
-    await a11yAudit();
 
     assert.notOk(currentSession().isAuthenticated);
     assert.strictEqual(currentURL(), urls.authenticate.methods.global);


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
With our new test-helper config, we do not need to explicitly call `a11yAudit`. This removes all usages in admin and desktop acceptance tests.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
