### PR TITLE
(HACK WEEK 2025) a11y desktop test helper

### DIFF
--- a/ui/desktop/.gitignore
+++ b/ui/desktop/.gitignore
@@ -21,3 +21,6 @@
 
 # broccoli-debug
 /DEBUG/
+
+# a11y audit
+/ember-a11y-report/

--- a/ui/desktop/config/environment.js
+++ b/ui/desktop/config/environment.js
@@ -7,6 +7,7 @@
 
 const APP_NAME = process.env.APP_NAME || 'Boundary';
 const locationType = process.env.EMBER_CLI_ELECTRON ? 'hash' : 'history';
+const ENABLE_A11Y_AUDIT = process.env.ENABLE_A11Y_AUDIT || false;
 
 module.exports = function (environment) {
   const ENV = {
@@ -80,6 +81,8 @@ module.exports = function (environment) {
     ENV['ember-cli-mirage'].enabled = process.env.ENABLE_MIRAGE
       ? JSON.parse(process.env.ENABLE_MIRAGE)
       : true;
+
+    ENV.ENABLE_A11Y_AUDIT = ENABLE_A11Y_AUDIT;
   }
 
   if (environment === 'test') {
@@ -107,7 +110,7 @@ module.exports = function (environment) {
       memory: true,
     };
 
-    // Enable tests for development features
+    ENV.ENABLE_A11Y_AUDIT = ENABLE_A11Y_AUDIT;
   }
 
   if (environment === 'production') {

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -32,7 +32,7 @@
     "init:desktop": "pnpm --dir electron-app build:all",
     "start:desktop": "pnpm init:desktop && ember electron",
     "clean:coverage": "rm -rf coverage_* || true",
-    "test": "pnpm clean:coverage && concurrently \"npm:test:*\" --names \"test:\" && pnpm test:finalize",
+    "test": "pnpm clean:coverage && pnpm test:ember && pnpm test:finalize",
     "test:ember": "cross-env COVERAGE=true ember exam --test-port 0 --split=4 --parallel=1 --random",
     "test-a11y": "ENABLE_A11Y_AUDIT=true ember test",
     "test-a11y:dark": "COLOR_THEME=dark pnpm test-a11y",

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -34,6 +34,8 @@
     "clean:coverage": "rm -rf coverage_* || true",
     "test": "pnpm clean:coverage && concurrently \"npm:test:*\" --names \"test:\" && pnpm test:finalize",
     "test:ember": "cross-env COVERAGE=true ember exam --test-port 0 --split=4 --parallel=1 --random",
+    "test-a11y": "ENABLE_A11Y_AUDIT=true ember test",
+    "test-a11y:dark": "COLOR_THEME=dark pnpm test-a11y",
     "postinstall": "pnpm --dir electron-app install",
     "test:finalize": "ember coverage-merge && pnpm clean:coverage"
   },

--- a/ui/desktop/testem.js
+++ b/ui/desktop/testem.js
@@ -5,6 +5,14 @@
 
 'use strict';
 
+const COLOR_THEME = process.env.COLOR_THEME ?? 'light';
+
+if (!['dark', 'light'].includes(COLOR_THEME)) {
+  throw new Error(
+    `Only values of "dark" and "light" are allowed for environment variable COLOR_THEME`,
+  );
+}
+
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
@@ -14,8 +22,10 @@ module.exports = {
   browser_args: {
     Chrome: {
       all: [
-        process.env.DARK_MODE ? '--enable-features=WebContentsForceDark' : null,
-        process.env.DARK_MODE ? '--force-dark-mode' : null,
+        COLOR_THEME === 'dark'
+          ? '--enable-features=WebContentsForceDark'
+          : null,
+        COLOR_THEME === 'dark' ? '--force-dark-mode' : '--force-light-mode',
       ].filter(Boolean),
       ci: [
         // --no-sandbox is needed when running Chrome inside a container

--- a/ui/desktop/tests/test-helper.js
+++ b/ui/desktop/tests/test-helper.js
@@ -9,8 +9,73 @@ import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
 import start from 'ember-exam/test-support/start';
+import {
+  DEFAULT_A11Y_TEST_HELPER_NAMES,
+  setRunOptions,
+  setupGlobalA11yHooks,
+  setupQUnitA11yAuditToggle,
+  shouldForceAudit,
+  setEnableA11yAudit,
+  useMiddlewareReporter,
+  setupMiddlewareReporter,
+} from 'ember-a11y-testing/test-support';
 
 setApplication(Application.create(config.APP));
+
+setupGlobalA11yHooks(() => true, {
+  helpers: [
+    ...DEFAULT_A11Y_TEST_HELPER_NAMES,
+    'fillIn',
+    'render',
+    'tab',
+    'focus',
+    'select',
+  ],
+});
+
+setupQUnitA11yAuditToggle(QUnit);
+
+setRunOptions({
+  runOnly: {
+    type: 'tag',
+    values: [
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22aa',
+      'best-practice',
+    ],
+  },
+  include: [['#ember-testing-container']],
+  exclude: [['.flight-sprite-container']],
+});
+
+// This will be used by developers to run the tests locally
+// Either with the `enableA11yAudit` as a query param in the URL
+// or `pnpm test:a11y` in the CLI
+// Note: if you want to filter what test is run from the start, use the --filter flag: `pnpm test-a11y --filter="alert"`
+// Docs: https://guides.emberjs.com/release/testing/#toc_how-to-filter-tests
+console.log('config a11y tests: ', config.ENABLE_A11Y_AUDIT);
+console.log('Running accessibility tests...');
+console.log(
+  'To run accessibility tests, use the `enableA11yAudit` query param in the URL or the `ENABLE_A11Y_AUDIT` environment variable.',
+);
+console.log(
+  shouldForceAudit()
+    ? 'Accessibility audits are enabled.'
+    : 'Accessibility audits are disabled.',
+);
+
+if (shouldForceAudit()) {
+  setEnableA11yAudit(true);
+}
+
+// Note, as a convenience, useMiddlewareReporter automatically forces audits, thus explicitly specifying the enableA11yAudit query param or the ENABLE_A11Y_AUDIT environment variable is unnecessary.
+if (useMiddlewareReporter()) {
+  // Only runs if `enableA11yMiddlewareReporter` is set in URL
+  setupMiddlewareReporter();
+}
 
 setup(QUnit.assert);
 

--- a/ui/desktop/tests/test-helper.js
+++ b/ui/desktop/tests/test-helper.js
@@ -53,20 +53,9 @@ setRunOptions({
 
 // This will be used by developers to run the tests locally
 // Either with the `enableA11yAudit` as a query param in the URL
-// or `pnpm test:a11y` in the CLI
+// or `pnpm test-a11y` in the CLI
 // Note: if you want to filter what test is run from the start, use the --filter flag: `pnpm test-a11y --filter="alert"`
 // Docs: https://guides.emberjs.com/release/testing/#toc_how-to-filter-tests
-console.log('config a11y tests: ', config.ENABLE_A11Y_AUDIT);
-console.log('Running accessibility tests...');
-console.log(
-  'To run accessibility tests, use the `enableA11yAudit` query param in the URL or the `ENABLE_A11Y_AUDIT` environment variable.',
-);
-console.log(
-  shouldForceAudit()
-    ? 'Accessibility audits are enabled.'
-    : 'Accessibility audits are disabled.',
-);
-
 if (shouldForceAudit()) {
   setEnableA11yAudit(true);
 }


### PR DESCRIPTION
# Description
This pull request sets up the `ui/desktop` for improved a11y testing for dark and light mode:
`pnpm test-a11y` for light and `pnpm test-a11y:dark` for dark.

Also within a regular ember test the a11y can be toggled on within testem to include a11y tests.

## How to Test
1. Check `pnpm test-a11y` (add `-s` to launch chrome so it's not headless) (ui should be in light even in system preferences is dark)
2. 1. Check `pnpm test-a11y:dark` (add `-s` to launch chrome so it's not headless) (ui should be in dark even in system preferences is light)
3. Try `pnpm ember s`, go to `localhost:4200/tests`, and toggle the a11y checkbox toggle included a11y tests
4. Try `pnpm ember test -s`, chrome browser should launch, and toggle the a11y checkbox toggle included a11y tests

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
