### PR TITLE
(HACK WEEK 2025) Fix `a11y-tests` label

### DIFF
--- a/.github/workflows/a11y-tests.yaml
+++ b/.github/workflows/a11y-tests.yaml
@@ -9,7 +9,7 @@ jobs:
 
   a11y-test:
     name: Run A11y Tests
-    if: contains(github.event.pull_request.labels.*.name, 'a11y-test')
+    if: contains(github.event.pull_request.labels.*.name, 'a11y-tests')
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     timeout-minutes: 35
     steps:


### PR DESCRIPTION
# Description
Update the label to trigger a11y tests from `a11y-test` to `a11y-tests`

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
