### PR TITLE
Fix auto commit

### DIFF
--- a/.github/workflows/copyright-validate.yaml
+++ b/.github/workflows/copyright-validate.yaml
@@ -7,6 +7,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        # Ref and repository aren't normally needed, this is a workaround for a bug in auto commit
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3
       - name: Add missing Copyright Headers
         run: copywrite headers

--- a/ui/admin/newfile.js
+++ b/ui/admin/newfile.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-unused-vars
+const test = 'wow';


### PR DESCRIPTION
# Description
It looks like there was a regression in v6 of `git-auto-commit-action`. We can either revert to v5 or use this workaround outlined [here](https://github.com/stefanzweifel/git-auto-commit-action/issues/383) 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
