### PR TITLE
(HACK WEEK 2025) Upload a11y reports in ci

### DIFF
--- a/.github/workflows/a11y-tests.yaml
+++ b/.github/workflows/a11y-tests.yaml
@@ -37,9 +37,9 @@ jobs:
           jq -s 'map(.[])' ./ui/admin/ember-a11y-report/*.json > ember-a11y-reports/admin.json
           jq -s 'map(.[])' ./ui/desktop/ember-a11y-report/*.json > ember-a11y-reports/desktop.json
       # output admin test results
-      - run: cat ember-a11y-reports/admin.json | jq "map({moduleName,testName,routes,urls,violations: .violations | map({id, nodes: .nodes | map({failureSummary, targets: .[].[]?.relatedNodes?.[]?.target? })}) })"
+      - run: 'cat ember-a11y-reports/admin.json | jq "map({moduleName,testName,routes,urls,violations: .violations | map({id, nodes: .nodes | map({failureSummary, targets: .[].[]?.relatedNodes?.[]?.target? })}) })"'
       # output desktop test results
-      - run: cat ember-a11y-reports/desktop.json | jq "map({moduleName,testName,routes,urls,violations: .violations | map({id, nodes: .nodes | map({failureSummary, targets: .[].[]?.relatedNodes?.[]?.target? })}) })"
+      - run: 'cat ember-a11y-reports/desktop.json | jq "map({moduleName,testName,routes,urls,violations: .violations | map({id, nodes: .nodes | map({failureSummary, targets: .[].[]?.relatedNodes?.[]?.target? })}) })"'
       - name: Upload ember a11y reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -49,8 +49,8 @@ jobs:
         if: always()
         # fail CI when the combined array length of admin and desktop a11y reports is not 0
         run: |
-          EMBER_A11y_FAILURE_COUNT=$(jq -s 'map(.[]) | length' ember-a11y-reports/admin.json ember-a11y-reports/desktop.json)
-          echo "$EMBER_A11y_FAILURE_COUNT ember-a11y test failures"
-          if [ "$EMBER_A11y_FAILURE_COUNT" != '0' ] ; then
-            exit -1
+          EMBER_A11Y_FAILURE_COUNT=$(jq -s 'map(.[]) | length' ember-a11y-reports/admin.json ember-a11y-reports/desktop.json)
+          echo "$EMBER_A11Y_FAILURE_COUNT ember-a11y test failures"
+          if [ "$EMBER_A11Y_FAILURE_COUNT" != '0' ]; then
+            exit 1
           fi

--- a/.github/workflows/a11y-tests.yaml
+++ b/.github/workflows/a11y-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Run A11y Tests
     if: contains(github.event.pull_request.labels.*.name, 'a11y-tests')
     runs-on: ${{ fromJSON(vars.RUNNER) }}
-    timeout-minutes: 35
+    timeout-minutes: 40
     steps:
       - uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1.7.3
         with:

--- a/.github/workflows/a11y-tests.yaml
+++ b/.github/workflows/a11y-tests.yaml
@@ -26,4 +26,31 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
       - run: pnpm install
-      - run: pnpm test-a11y
+      - name: Run a11y tests
+        env:
+          # this will generate the test reports but causes tests to pass even when there a11y failures
+          ENABLE_A11Y_MIDDLEWARE_REPORTER: true
+        run: pnpm test-a11y
+      - name: Consolidate ember a11y reports
+        run: |
+          mkdir ember-a11y-reports
+          jq -s 'map(.[])' ./ui/admin/ember-a11y-report/*.json > ember-a11y-reports/admin.json
+          jq -s 'map(.[])' ./ui/desktop/ember-a11y-report/*.json > ember-a11y-reports/desktop.json
+      # output admin test results
+      - run: cat ember-a11y-reports/admin.json | jq
+      # output desktop test results
+      - run: cat ember-a11y-reports/desktop.json | jq
+      - name: Upload ember a11y reports
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ember-a11y-reports
+          path: ./ember-a11y-reports
+      - name: Report a11y test results status
+        if: always()
+        # fail CI when the combined array length of admin and desktop a11y reports is not 0
+        run: |
+          EMBER_A11y_FAILURE_COUNT=$(jq -s 'map(.[]) | length' ember-a11y-reports/admin.json ember-a11y-reports/desktop.json)
+          echo "$EMBER_A11y_FAILURE_COUNT ember-a11y test failures"
+          if [ "$EMBER_A11y_FAILURE_COUNT" != '0' ] ; then
+            exit -1
+          fi

--- a/.github/workflows/a11y-tests.yaml
+++ b/.github/workflows/a11y-tests.yaml
@@ -37,9 +37,9 @@ jobs:
           jq -s 'map(.[])' ./ui/admin/ember-a11y-report/*.json > ember-a11y-reports/admin.json
           jq -s 'map(.[])' ./ui/desktop/ember-a11y-report/*.json > ember-a11y-reports/desktop.json
       # output admin test results
-      - run: cat ember-a11y-reports/admin.json | jq
+      - run: cat ember-a11y-reports/admin.json | jq "map({moduleName,testName,routes,urls,violations: .violations | map({id, nodes: .nodes | map({failureSummary, targets: .[].[]?.relatedNodes?.[]?.target? })}) })"
       # output desktop test results
-      - run: cat ember-a11y-reports/desktop.json | jq
+      - run: cat ember-a11y-reports/desktop.json | jq "map({moduleName,testName,routes,urls,violations: .violations | map({id, nodes: .nodes | map({failureSummary, targets: .[].[]?.relatedNodes?.[]?.target? })}) })"
       - name: Upload ember a11y reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/a11y-tests.yaml
+++ b/.github/workflows/a11y-tests.yaml
@@ -36,10 +36,10 @@ jobs:
           mkdir ember-a11y-reports
           jq -s 'map(.[])' ./ui/admin/ember-a11y-report/*.json > ember-a11y-reports/admin.json
           jq -s 'map(.[])' ./ui/desktop/ember-a11y-report/*.json > ember-a11y-reports/desktop.json
-      # output admin test results
-      - run: 'cat ember-a11y-reports/admin.json | jq "map({moduleName,testName,routes,urls,violations: .violations | map({id, nodes: .nodes | map({failureSummary, targets: .[].[]?.relatedNodes?.[]?.target? })}) })"'
-      # output desktop test results
-      - run: 'cat ember-a11y-reports/desktop.json | jq "map({moduleName,testName,routes,urls,violations: .violations | map({id, nodes: .nodes | map({failureSummary, targets: .[].[]?.relatedNodes?.[]?.target? })}) })"'
+      - name: Output ember a11y test report summary (admin)
+        run: 'cat ember-a11y-reports/admin.json | jq "map({moduleName,testName,routes,urls,violations: .violations | map({id, nodes: .nodes | map({failureSummary, targets: .[].[]?.relatedNodes?.[]?.target? })}) })"'
+      - name: Output ember a11y test report summary (desktop)
+        run: 'cat ember-a11y-reports/desktop.json | jq "map({moduleName,testName,routes,urls,violations: .violations | map({id, nodes: .nodes | map({failureSummary, targets: .[].[]?.relatedNodes?.[]?.target? })}) })"'
       - name: Upload ember a11y reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -32,8 +32,8 @@
     "clean:coverage": "rm -rf coverage_* || true",
     "test": "pnpm clean:coverage && pnpm test:ember && pnpm test:finalize",
     "test-a11y": "concurrently \"pnpm:test-a11y:*\" --names \"test-a11y:\"",
-    "test-a11y:light": "ENABLE_A11Y_AUDIT=true ember test",
-    "test-a11y:dark": "COLOR_THEME=dark pnpm test-a11y:light --test-port=7358",
+    "test-a11y:light": "ENABLE_A11Y_AUDIT=true ember exam --test-port 0 --split=4 --parallel=1",
+    "test-a11y:dark": "COLOR_THEME=dark pnpm test-a11y:light",
     "test:ember": "COVERAGE=true ember exam --test-port 0 --split=4 --parallel=1 --random",
     "test:finalize": "ember coverage-merge && pnpm clean:coverage"
   },

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -32,7 +32,7 @@
     "clean:coverage": "rm -rf coverage_* || true",
     "test": "pnpm clean:coverage && pnpm test:ember && pnpm test:finalize",
     "test-a11y": "concurrently \"pnpm:test-a11y:*\" --names \"test-a11y:\"",
-    "test-a11y:light": "ENABLE_A11Y_AUDIT=true ember exam --test-port 0 --split=4 --parallel=1",
+    "test-a11y:light": "ENABLE_A11Y_AUDIT=true ember exam --test-port 0 --split=4 --parallel=1 --filter='acceptance'",
     "test-a11y:dark": "COLOR_THEME=dark pnpm test-a11y:light",
     "test:ember": "COVERAGE=true ember exam --test-port 0 --split=4 --parallel=1 --random",
     "test:finalize": "ember coverage-merge && pnpm clean:coverage"

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -32,7 +32,7 @@
     "clean:coverage": "rm -rf coverage_* || true",
     "test": "pnpm clean:coverage && pnpm test:ember && pnpm test:finalize",
     "test-a11y": "concurrently \"pnpm:test-a11y:*\" --names \"test-a11y:\"",
-    "test-a11y:light": "ENABLE_A11Y_AUDIT=true ember exam --test-port 0 --split=4 --parallel=1 --filter='acceptance'",
+    "test-a11y:light": "ENABLE_A11Y_AUDIT=true ember test --test-port 0 --filter='acceptance'",
     "test-a11y:dark": "COLOR_THEME=dark pnpm test-a11y:light",
     "test:ember": "COVERAGE=true ember exam --test-port 0 --split=4 --parallel=1 --random",
     "test:finalize": "ember coverage-merge && pnpm clean:coverage"

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -35,7 +35,7 @@
     "test": "pnpm clean:coverage && pnpm test:ember && pnpm test:finalize",
     "test:ember": "cross-env COVERAGE=true ember exam --test-port 0 --split=4 --parallel=1 --random",
     "test-a11y": "concurrently \"pnpm:test-a11y:*\" --names \"test-a11y:\"",
-    "test-a11y:light": "ENABLE_A11Y_AUDIT=true ember exam --test-port 0 --split=4 --parallel=1",
+    "test-a11y:light": "ENABLE_A11Y_AUDIT=true ember exam --test-port 0 --split=4 --parallel=1 --filter='acceptance'",
     "test-a11y:dark": "COLOR_THEME=dark pnpm test-a11y:light",
     "postinstall": "pnpm --dir electron-app install",
     "test:finalize": "ember coverage-merge && pnpm clean:coverage"

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -35,7 +35,7 @@
     "test": "pnpm clean:coverage && pnpm test:ember && pnpm test:finalize",
     "test:ember": "cross-env COVERAGE=true ember exam --test-port 0 --split=4 --parallel=1 --random",
     "test-a11y": "concurrently \"pnpm:test-a11y:*\" --names \"test-a11y:\"",
-    "test-a11y:light": "ENABLE_A11Y_AUDIT=true ember exam --test-port 0 --split=4 --parallel=1 --filter='acceptance'",
+    "test-a11y:light": "ENABLE_A11Y_AUDIT=true ember test --test-port 0 --filter='acceptance'",
     "test-a11y:dark": "COLOR_THEME=dark pnpm test-a11y:light",
     "postinstall": "pnpm --dir electron-app install",
     "test:finalize": "ember coverage-merge && pnpm clean:coverage"

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -35,8 +35,8 @@
     "test": "pnpm clean:coverage && pnpm test:ember && pnpm test:finalize",
     "test:ember": "cross-env COVERAGE=true ember exam --test-port 0 --split=4 --parallel=1 --random",
     "test-a11y": "concurrently \"pnpm:test-a11y:*\" --names \"test-a11y:\"",
-    "test-a11y:light": "ENABLE_A11Y_AUDIT=true ember test --test-port=7359",
-    "test-a11y:dark": "COLOR_THEME=dark pnpm test-a11y:light --test-port=7360",
+    "test-a11y:light": "ENABLE_A11Y_AUDIT=true ember exam --test-port 0 --split=4 --parallel=1",
+    "test-a11y:dark": "COLOR_THEME=dark pnpm test-a11y:light",
     "postinstall": "pnpm --dir electron-app install",
     "test:finalize": "ember coverage-merge && pnpm clean:coverage"
   },


### PR DESCRIPTION
# Description
This pull request does a few things:
* Filters tests ran for a11y purposes to acceptance tests only
* Generates an a11y report
* Outputs the summarized version of the a11y report in CI
* Uploads the a11y report as a github artifact so that it can be downloaded from the workflow summary (and used with the codemod to ignore rules if needed)
* Fails CI if any of the reports contain an a11y violation (see https://github.com/hashicorp/boundary-ui/pull/2949/files#r2246412084 for why this is necessary)

Note: "A11y Tests / Run A11y Tests" should be failing on this PR because there are a11y test failures. Once the current failures are ignored with the codemod from #2946 then we _should_ have a passing a11y workflow in CI

## How to Test
Look at the last run of the "A11y Tests / Run A11y Tests" workflow on this PR and check the steps that were added/changed as part of this PR

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
