### PR TITLE
Fix

### DIFF
--- a/ui/desktop/electron-app/src/helpers/app-updater.js
+++ b/ui/desktop/electron-app/src/helpers/app-updater.js
@@ -10,6 +10,7 @@ const semver = require('semver');
 const { parse } = require('node-html-parser');
 const { autoUpdater, dialog, app } = require('electron');
 const { isWindows, isLinux } = require('../helpers/platform.js');
+const isDev = require('electron-is-dev');
 const config = require('../../config/config.js');
 const log = require('electron-log/main');
 const boundaryCli = require('../cli/index.js');
@@ -17,7 +18,8 @@ const boundaryCli = require('../cli/index.js');
 let currentVersion = config.releaseVersion;
 const debug = process.env.DEBUG_APP_UPDATER;
 const releasesUrl = 'https://releases.hashicorp.com/boundary-desktop/';
-if (debug && process.env.APP_UPDATER_CURRENT_VERSION) {
+
+if (isDev && debug && process.env.APP_UPDATER_CURRENT_VERSION) {
   currentVersion = process.env.APP_UPDATER_CURRENT_VERSION;
 }
 
@@ -177,7 +179,7 @@ module.exports = {
     if (!boundaryCli.isBuiltInCli) return;
 
     let latestVersion;
-    if (debug) {
+    if (isDev && debug) {
       latestVersion = process.env.APP_UPDATER_LATEST_VERSION_TAG;
     } else {
       latestVersion = await findLatestVersion(releasesUrl);
@@ -197,14 +199,16 @@ module.exports = {
       return;
     }
 
-    const location = process.env.APP_UPDATER_LATEST_VERSION_LOCATION;
-    if (debug && location) {
-      // Support hosted url and file paths
-      displayDownloadPrompt(
-        latestVersion,
-        location.match(/^http/i) ? location : `file://${location}`,
-      );
-      return;
+    if (isDev) {
+      const location = process.env.APP_UPDATER_LATEST_VERSION_LOCATION;
+      if (debug && location) {
+        // Support hosted url and file paths
+        displayDownloadPrompt(
+          latestVersion,
+          location.match(/^http/i) ? location : `file://${location}`,
+        );
+        return;
+      }
     }
 
     /**


### PR DESCRIPTION
# Description

Add isDev conditional when allowing set `latestVersion` and `location` through environment variables.

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/SECVULN-19529)

## How to Test
- Set `DEBUG_APP_UPDATER` to false while setting values for `APP_UPDATER_LATEST_VERSION_TAG` and `APP_UPDATER_LATEST_VERSION_LOCATION`. You should see no effect, and the values you passed to `APP_UPDATER_LATEST_VERSION_TAG` and `APP_UPDATER_LATEST_VERSION_LOCATION` will be ignore.
- Set `DEBUG_APP_UPDATER` to true while setting values for `APP_UPDATER_LATEST_VERSION_TAG` and `APP_UPDATER_LATEST_VERSION_LOCATION`. The values set for `APP_UPDATER_LATEST_VERSION_TAG` and `APP_UPDATER_LATEST_VERSION_LOCATION` should be used for the appUpdater when on dev mode.
