### PR TITLE
Icu 17516 use in memory sqlite in non secure contexts

### DIFF
--- a/addons/api/addon/workers/sqlite-worker.js
+++ b/addons/api/addon/workers/sqlite-worker.js
@@ -212,5 +212,8 @@ if (isSecure) {
     initializeOnProviderChange,
   );
 } else {
-  await methods.initializeSQLite();
+  // Production builds error out when using top level awaits so we'll just use an async IIFE
+  (async () => {
+    await methods.initializeSQLite();
+  })();
 }


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-17516

# Description
Add checks to see if we're in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) as the OPFS and weblock APIs require them.

If we're not in a secure context, just start up SQLite in memory so a user still can still get full functionality just without persistence. This would then allow us to remove indexed DB in the future as we wouldn't need to ever fallback.
 
## How to Test
Setup the branch in an http environment that's not localhost. 
You could do this using enos or using a tool like ngrok. If using ngrok, you'd need to force the scheme to be http with something like `ngrok http --scheme=http 4200`. Your browser might also try and force you onto HTTPS with ngrok's urls. For Firefox, I had to set `network.stricttransportsecurity.preloadlist` to false in `about:config`.

Try visiting targets and you should be able to use it like normal, refresh and confirm nothing is persisted. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
