### PR TITLE
fix: 🐛 Fix bug that prevents setting cluster URL

### DIFF
--- a/ui/desktop/electron-app/src/models/runtime-settings.js
+++ b/ui/desktop/electron-app/src/models/runtime-settings.js
@@ -51,8 +51,8 @@ class RuntimeSettings {
   /**
    * Sets the clusterUrl to null.
    */
-  resetClusterUrl() {
-    this.clusterUrl = null;
+  async resetClusterUrl() {
+    await this.setClusterUrl(null);
   }
 
   // Quick and dirty event handler pattern to enable the application to respond


### PR DESCRIPTION
# Description
This fixes a bug where a user tries to disconnect if we encountered an error with the cluster URL and are met with another error in trying to disconnect and cannot enter another URL.

## How to Test
Use the default `serve://boundary` and try to disconnect once it fails. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] I have added `a11y-tests` label to run a11y audit tests if needed~

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
