### PR TITLE
feat: 🎸 Add sqlite support to sessions

### DIFF
--- a/addons/api/addon/services/sqlite.js
+++ b/addons/api/addon/services/sqlite.js
@@ -99,6 +99,16 @@ export const modelMapping = {
     target_scope_name: 'create_time_values.target.scope.name',
     created_time: 'created_time',
   },
+  session: {
+    id: 'id',
+    type: 'type',
+    status: 'status',
+    endpoint: 'endpoint',
+    target_id: 'target_id',
+    user_id: 'user_id',
+    scope_id: 'scope.scope_id',
+    created_time: 'created_time',
+  },
 };
 
 // A list of tables that we support searching using FTS5 in SQLite.
@@ -113,6 +123,7 @@ export const searchTables = new Set([
   'auth-method',
   'host-catalog',
   'session-recording',
+  'session',
 ]);
 
 export default class SqliteDbService extends Service {

--- a/ui/admin/app/routes/scopes/scope/sessions/index.js
+++ b/ui/admin/app/routes/scopes/scope/sessions/index.js
@@ -7,6 +7,13 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { restartableTask, timeout } from 'ember-concurrency';
+import chunk from 'lodash/chunk';
+
+// Maximum expression tree depth is 1000 so
+// we limit the number of expressions in a query.
+// See "Maximum Depth Of An Expression Tree" in
+// https://www.sqlite.org/limits.html
+const MAX_EXPR_NUM = 999;
 
 export default class ScopesScopeSessionsIndexRoute extends Route {
   // =services
@@ -114,10 +121,11 @@ export default class ScopesScopeSessionsIndexRoute extends Route {
       const totalItems = sessions.meta?.totalItems;
 
       const allSessions = await this.getAllSessions(scope_id);
-      const [associatedUsers, associatedTargets] = await Promise.all([
-        this.getAssociatedUsers(scope, allSessions),
-        this.getAssociatedTargets(scope, allSessions),
-      ]);
+      const associatedUsers = await this.getAssociatedUsers(scope, allSessions);
+      const associatedTargets = await this.getAssociatedTargets(
+        scope,
+        allSessions,
+      );
 
       return {
         sessions,
@@ -159,24 +167,27 @@ export default class ScopesScopeSessionsIndexRoute extends Route {
       this.can.can('list model', globalScope, { collection: 'users' }) &&
       this.can.can('list model', orgScope, { collection: 'users' })
     ) {
-      const uniqueSessionUserIds = new Set(
-        allSessions
-          .filter((session) => session.user_id)
-          .map((session) => session.user_id),
+      const uniqueSessionUserIds = [
+        ...new Set(
+          allSessions
+            .filter((session) => session.user_id)
+            .map((session) => session.user_id),
+        ),
+      ];
+      const chunkedUserIds = chunk(uniqueSessionUserIds, MAX_EXPR_NUM);
+      const associatedUsersPromises = chunkedUserIds.map((userIds) =>
+        this.store.query('user', {
+          scope_id: 'global',
+          recursive: true,
+          query: {
+            filters: {
+              id: { values: userIds.map((userId) => ({ equals: userId })) },
+            },
+          },
+        }),
       );
-      const filters = {
-        id: { values: [] },
-      };
-      uniqueSessionUserIds.forEach((userId) => {
-        filters.id.values.push({ equals: userId });
-      });
-      const associatedUsersQuery = {
-        scope_id: 'global',
-        recursive: true,
-        query: { filters },
-      };
-
-      return this.store.query('user', associatedUsersQuery);
+      const usersArray = await Promise.all(associatedUsersPromises);
+      return usersArray.flat();
     }
 
     return [];
@@ -189,21 +200,29 @@ export default class ScopesScopeSessionsIndexRoute extends Route {
    */
   async getAssociatedTargets(scope, allSessions) {
     if (this.can.can('list model', scope, { collection: 'targets' })) {
-      const uniqueSessionTargetIds = new Set(
-        allSessions
-          .filter((session) => session.target_id)
-          .map((session) => session.target_id),
-      );
-      const filters = { id: { values: [] } };
-      uniqueSessionTargetIds.forEach((targetId) => {
-        filters.id.values.push({ equals: targetId });
-      });
-      const associatedTargetsQuery = {
-        scope_id: scope.id,
-        query: { filters },
-      };
+      const uniqueSessionTargetIds = [
+        ...new Set(
+          allSessions
+            .filter((session) => session.target_id)
+            .map((session) => session.target_id),
+        ),
+      ];
 
-      return this.store.query('target', associatedTargetsQuery);
+      const chunkedTargetIds = chunk(uniqueSessionTargetIds, MAX_EXPR_NUM);
+      const associatedTargetsPromises = chunkedTargetIds.map((targetIds) =>
+        this.store.query('target', {
+          scope_id: scope.id,
+          query: {
+            filters: {
+              id: {
+                values: targetIds.map((targetId) => ({ equals: targetId })),
+              },
+            },
+          },
+        }),
+      );
+      const targetsArray = await Promise.all(associatedTargetsPromises);
+      return targetsArray.flat();
     }
 
     return [];


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-17411

# Description
<!-- Add a brief description of changes here -->
Initial sessions load after caching is < 300 ms for 450k sessions.
<img width="1118" height="100" alt="image" src="https://github.com/user-attachments/assets/e2c82f25-efe1-43e3-8bd0-db33ab2c6a94" />
A future improvement could be to remove the need to retrieve all targets by batches for filters.
<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
Use this cluster and navigate to project with 450k sessions.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
