### PR TITLE
fix: 🐛 fix bug with the `apiClientTestAfter` noop fixture hanging and update e2e label username, password locators with required text

### DIFF
--- a/e2e-tests/admin/pages/credential-stores.js
+++ b/e2e-tests/admin/pages/credential-stores.js
@@ -153,7 +153,9 @@ export class CredentialStoresPage extends BaseResourcePage {
       .getByRole('group', { name: 'Type' })
       .getByLabel('Username & Key Pair')
       .click();
-    await this.page.getByLabel('Username', { exact: true }).fill(username);
+    await this.page
+      .getByLabel('Username Required', { exact: true })
+      .fill(username);
     const keyData = await readFile(keyPath, {
       encoding: 'utf-8',
     });
@@ -211,8 +213,12 @@ export class CredentialStoresPage extends BaseResourcePage {
       .getByRole('group', { name: 'Type' })
       .getByLabel('Username & Password')
       .click();
-    await this.page.getByLabel('Username', { exact: true }).fill(username);
-    await this.page.getByLabel('Password', { exact: true }).fill(password);
+    await this.page
+      .getByLabel('Username Required', { exact: true })
+      .fill(username);
+    await this.page
+      .getByLabel('Password Required', { exact: true })
+      .fill(password);
     await this.page.getByRole('button', { name: 'Save' }).click();
     await this.dismissSuccessAlert();
     await expect(

--- a/e2e-tests/admin/pages/targets.js
+++ b/e2e-tests/admin/pages/targets.js
@@ -70,8 +70,33 @@ export class TargetsPage extends BaseResourcePage {
    * @param {string} alias alias used for the target
    * @returns Name of the target
    */
-  async createTargetWithAddressAndAlias(address, port, alias) {
+  async createTargetWithAddressAndAlias(
+    address,
+    port,
+    alias,
+    targetType = 'tcp',
+  ) {
     const targetName = 'Target ' + nanoid();
+    let targetTypeLabel;
+
+    switch (targetType) {
+      case 'ssh': {
+        targetTypeLabel = 'SSH';
+        break;
+      }
+      case 'rdp': {
+        targetTypeLabel = 'RDP';
+        break;
+      }
+      case 'tcp': {
+        targetTypeLabel = 'Generic TCP';
+        break;
+      }
+      default: {
+        throw new Error(`Unexpected target type passed ${targetType}`);
+      }
+    }
+
     await this.page
       .getByRole('navigation', { name: 'Application local navigation' })
       .getByRole('link', { name: 'Targets' })
@@ -79,6 +104,7 @@ export class TargetsPage extends BaseResourcePage {
     await this.page.getByRole('link', { name: 'New', exact: true }).click();
     await this.page.getByLabel('Name').fill(targetName);
     await this.page.getByLabel('Description').fill('This is an automated test');
+    await this.page.getByLabel(targetTypeLabel).click();
     await this.page.getByLabel('Target Address').fill(address);
     await this.page.getByLabel('Default Port').fill(port);
     await this.page

--- a/e2e-tests/admin/tests/alias-ent.spec.js
+++ b/e2e-tests/admin/tests/alias-ent.spec.js
@@ -169,6 +169,7 @@ test.describe('Aliases (Enterprise)', () => {
           targetAddress,
           targetPort,
           alias,
+          'ssh',
         );
         const credentialStoresPage = new CredentialStoresPage(page);
         await credentialStoresPage.createStaticCredentialStore();

--- a/e2e-tests/helpers/boundary-api-client.ts
+++ b/e2e-tests/helpers/boundary-api-client.ts
@@ -244,11 +244,13 @@ class BoundaryApi {
 export const boundaryApiClientTest = base.extend<{
   apiClient: BoundaryApi;
   controllerAddr?: string;
-  apiClientTestAfter?: () => {};
+  apiClientTestAfter?: () => void;
 }>({
-  // this is a noop so that the `apiClient` fixture doesn't fail for other tests,
-  // the `apiClientTestAfter` fixture is used in api-client tests to provide a hook for assertions
-  apiClientTestAfter: () => {},
+  apiClientTestAfter: async ({}, use) => {
+    // this is a noop so that the `apiClient` fixture doesn't fail for other tests,
+    // the `apiClientTestAfter` fixture is used in api-client tests to provide a hook for assertions
+    await use(() => {});
+  },
   apiClient: async ({ controllerAddr, apiClientTestAfter }, use) => {
     // by destructuring the `apiClientTestAfter` fixture it creates a dependency on that fixture which
     // controls the setup/teardown order and allows `api-client.spec.js` to test the teardown cleanup


### PR DESCRIPTION
# Description
The `apiClientTestAfter` noop fixture wasn't set up properly in #2964. The noop helped in one case but not when the the api client was actually used outside of the `api-client.spec.js`, and would end up waiting indefinitely because the noop didn't call `use` (this affected the pagination and sorting e2e tests).

There are a few tests that are failing in `credential-store-static.spec` because the username and password labels now have "Required" included (see [comment](https://github.com/hashicorp/boundary-ui/pull/2994/files#r2334116745)).

## `desktop:dev`
```
  1 skipped
  17 passed (1.4m)
```

## `admin:ce:docker`
```
boundary-ui/e2e-tests on  fix-api-client-fixture-noop-dependency [$!] via  v20.19.0
🍕 pnpm admin:ce:docker --project chromium --headed

Running 28 tests using 1 worker

  ✓  1 [chromium] › admin/tests/alias.spec.js:22:3 › Aliases › Set up alias from target details page @ce @aws @docker (10.6s)

  ✓  2 [chromium] › admin/tests/alias.spec.js:119:3 › Aliases › Set up alias from new target page @ce @aws @docker (8.1s)

  ✓  3 [chromium] › admin/tests/alias.spec.js:184:3 › Aliases › Set up alias from aliases page @ce @aws @docker (10.1s)

  ✓  4 [chromium] › admin/tests/api-client.spec.js:36:1 › resources can be created (example: alias) @ce @ent @aws @docker (60ms)
  ✓  5 [chromium] › admin/tests/api-client.spec.js:98:1 › it logs the response when an error is returned from an api call @ce @ent @aws @docker (3ms)
  ✓  6 [chromium] › admin/tests/api-client.spec.js:124:1 › it throws when #skipCleanup is given an object without an id @ce @ent @aws @docker (1ms)
  ✓  7 [chromium] › admin/tests/auth-method-ldap.spec.js:24:1 › Set up LDAP auth method @ce @ent @docker (16.2s)

  ✓  8 [chromium] › admin/tests/auth-method-oidc-vault.spec.js:29:1 › Set up OIDC auth method @ce @ent @aws @docker (18.6s)

  ✓  9 [chromium] › admin/tests/auth-method-password.spec.js:23:1 › Verify new auth-method can be created and assigned to users @ce @ent @aws @docker (14.0s)

  ✓  10 [chromium] › admin/tests/change-password.spec.js:20:1 › Verify user can change password @ce @ent @aws @docker (3.7s)

  ✓  11 [chromium] › admin/tests/credential-store-static.spec.js:42:1 › Static Credential Store (User & Key Pair) @ce @aws @docker (10.3s)

  ✓  12 [chromium] › admin/tests/credential-store-static.spec.js:112:1 › Static Credential Store (Username & Password) @ce @aws @docker (9.9s)

  ✓  13 [chromium] › admin/tests/credential-store-static.spec.js:178:1 › Static Credential Store (JSON) @ce @aws @docker (10.2s)

  ✓  14 [chromium] › admin/tests/credential-store-static.spec.js:269:1 › Multiple Credential Stores (CE) @ce @aws @docker (12.4s)

  ✓  15 [chromium] › admin/tests/credential-store-vault.spec.js:40:1 › Vault Credential Store (User & Key Pair) @ce @aws @docker (10.4s)

  ✓  16 [chromium] › admin/tests/group-role.spec.js:17:1 › Verify a new role can be created and associated with a group @ce @ent @aws @docker (8.4s)

  ✓  17 [chromium] › admin/tests/login.spec.js:14:1 › Log in, log out, and then log back in @ce @ent @aws @docker (2.1s)
  ✓  18 [chromium] › admin/tests/login.spec.js:44:3 › Failure Cases › Log in with invalid password @ce @ent @aws @docker (1.1s)
  ✓  19 [chromium] › admin/tests/login.spec.js:57:3 › Failure Cases › Log in with only username @ce @ent @aws @docker (642ms)
  ✓  20 [chromium] › admin/tests/login.spec.js:69:3 › Failure Cases › Log in with only password @ce @ent @aws @docker (631ms)
  ✓  21 [chromium] › admin/tests/pagination.spec.js:10:1 › Search and Pagination (Targets) @ce @ent @aws @docker (3.1s)
  ✓  22 [chromium] › admin/tests/scope.spec.js:12:1 › Session picker @ce @ent @aws @docker (1.6s)
  ✓  23 [chromium] › admin/tests/sorting.spec.js:63:1 › Sorting works @ce @ent @aws @docker (1.8s)
  ✓  24 [chromium] › admin/tests/target.spec.js:21:1 › Verify session created to target with host, then cancel the session @ce @aws @docker (15.8s)

  ✓  25 [chromium] › admin/tests/target.spec.js:107:1 › Verify session created to target with address, then cancel the session @ce @aws @docker (7.8s)

  ✓  26 [chromium] › admin/tests/target.spec.js:174:1 › Verify TCP target is updated @ce @aws @docker (8.6s)

  ✓  27 [chromium] › admin/tests/worker-tags.spec.js:12:1 › Worker Tags @ce @ent @aws @docker (4.9s)
  ✓  28 [chromium] › admin/tests/worker.spec.js:9:1 › Create a worker @ce @aws @docker (2.1s)

  28 passed (3.3m)
```

## `admin:ent:docker`
```
Running 32 tests using 1 worker

  ✓  1 [chromium] › admin/tests/alias-ent.spec.js:23:3 › Aliases (Enterprise) › Set up alias from target details page @ent @aws @docker (15.3s)

  ✓  2 [chromium] › admin/tests/alias-ent.spec.js:136:3 › Aliases (Enterprise) › Set up alias from new target page @ent @aws @docker (12.5s)

  ✓  3 [chromium] › admin/tests/alias-ent.spec.js:214:3 › Aliases (Enterprise) › Set up alias from aliases page @ent @aws @docker (14.4s)

  ✓  4 [chromium] › admin/tests/api-client.spec.js:36:1 › resources can be created (example: alias) @ce @ent @aws @docker (49ms)
  ✓  5 [chromium] › admin/tests/api-client.spec.js:98:1 › it logs the response when an error is returned from an api call @ce @ent @aws @docker (3ms)
  ✓  6 [chromium] › admin/tests/api-client.spec.js:124:1 › it throws when #skipCleanup is given an object without an id @ce @ent @aws @docker (0ms)
  ✓  7 [chromium] › admin/tests/api-client.spec.js:139:1 › Storage buckets can be cleaned up after a session is manually cancelled and session recordings are manually deleted @ent @docker (6.4s)

  ✓  8 [chromium] › admin/tests/auth-method-ldap.spec.js:24:1 › Set up LDAP auth method @ce @ent @docker (17.3s)

  ✓  9 [chromium] › admin/tests/auth-method-oidc-vault.spec.js:29:1 › Set up OIDC auth method @ce @ent @aws @docker (18.6s)

  ✓  10 [chromium] › admin/tests/auth-method-password.spec.js:23:1 › Verify new auth-method can be created and assigned to users @ce @ent @aws @docker (13.9s)

  ✓  11 [chromium] › admin/tests/change-password.spec.js:20:1 › Verify user can change password @ce @ent @aws @docker (3.5s)

  ✓  12 [chromium] › admin/tests/credential-store-static-ent.spec.js:21:1 › Multiple Credential Stores (ENT) @ent @aws @docker (19.5s)

  ✓  13 [chromium] › admin/tests/credential-store-vault-ent.spec.js:38:1 › Vault Credential Store (User & Key Pair) @ent @aws @docker (13.1s)

  ✓  14 [chromium] › admin/tests/credential-store-vault-ent.spec.js:122:1 › Vault Credential Store - Username, Password & Domain credential type @ent @aws @docker (6.3s)

  ✓  15 [chromium] › admin/tests/global-settings.spec.js:13:1 › Global Settings @ent @aws @docker (4.9s)

  ✓  16 [chromium] › admin/tests/group-role.spec.js:17:1 › Verify a new role can be created and associated with a group @ce @ent @aws @docker (8.8s)

  ✓  17 [chromium] › admin/tests/login.spec.js:14:1 › Log in, log out, and then log back in @ce @ent @aws @docker (2.0s)
  ✓  18 [chromium] › admin/tests/login.spec.js:44:3 › Failure Cases › Log in with invalid password @ce @ent @aws @docker (845ms)
  ✓  19 [chromium] › admin/tests/login.spec.js:57:3 › Failure Cases › Log in with only username @ce @ent @aws @docker (460ms)
  ✓  20 [chromium] › admin/tests/login.spec.js:69:3 › Failure Cases › Log in with only password @ce @ent @aws @docker (465ms)
  ✓  21 [chromium] › admin/tests/pagination.spec.js:10:1 › Search and Pagination (Targets) @ce @ent @aws @docker (2.7s)
  ✓  22 [chromium] › admin/tests/scope.spec.js:12:1 › Session picker @ce @ent @aws @docker (1.3s)
  ✓  23 [chromium] › admin/tests/session-recording-minio-ent.spec.js:24:1 › Session Recording Test (MinIO) @ent @docker (31.2s)

  ✓  24 [chromium] › admin/tests/sorting.spec.js:63:1 › Sorting works @ce @ent @aws @docker (1.6s)
  ✓  25 [chromium] › admin/tests/ssh-certificate-injection-vault-ent.spec.js:35:1 › SSH Certificate Injection @ent @docker (12.9s)

  ✓  26 [chromium] › admin/tests/ssh-credential-injection-vault-ent.spec.js:37:1 › SSH Credential Injection (Vault User & Key Pair) @ent @docker (12.7s)

  ✓  27 [chromium] › admin/tests/target-ent.spec.js:21:1 › Verify session created for TCP target @ent @aws @docker (7.9s)

  ✓  28 [chromium] › admin/tests/target-ent.spec.js:88:1 › Verify session created for SSH target @ent @aws @docker (12.0s)

  ✓  29 [chromium] › admin/tests/target-ent.spec.js:162:1 › SSH target with host sources @ent @aws @docker (22.0s)

  ✓  30 [chromium] › admin/tests/target-ent.spec.js:263:1 › Verify RDP target creation @ent @aws @docker (7.9s)
  ✓  31 [chromium] › admin/tests/worker-ent.spec.js:9:1 › Create a worker (enterprise) @ent @aws @docker (2.1s)
  ✓  32 [chromium] › admin/tests/worker-tags.spec.js:12:1 › Worker Tags @ce @ent @aws @docker (4.9s)

  32 passed (4.7m)
```


## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
