### PR TITLE
fix: 🐛 Fix schema for sqlite inserts

### DIFF
--- a/addons/api/addon/workers/utils/schema.js
+++ b/addons/api/addon/workers/utils/schema.js
@@ -44,9 +44,9 @@ CREATE VIRTUAL TABLE IF NOT EXISTS target_fts USING fts5(
 -- which replaces the row and doesn't execute an UPDATE trigger.
 CREATE TRIGGER IF NOT EXISTS target_ai AFTER INSERT ON target BEGIN
     INSERT INTO target_fts(
-        id, type, name, description, address, scope_id, created_time
+        rowid, id, type, name, description, address, scope_id, created_time
     ) VALUES (
-        new.id, new.type, new.name, new.description, new.address, new.scope_id, new.created_time
+        new.rowid, new.id, new.type, new.name, new.description, new.address, new.scope_id, new.created_time
     );
 END;
 
@@ -83,9 +83,9 @@ CREATE VIRTUAL TABLE IF NOT EXISTS alias_fts USING fts5(
 
 CREATE TRIGGER IF NOT EXISTS alias_ai AFTER INSERT ON alias BEGIN
     INSERT INTO alias_fts(
-        id, type, name, description, destination_id, value, scope_id, created_time
+        rowid, id, type, name, description, destination_id, value, scope_id, created_time
     ) VALUES (
-        new.id, new.type, new.name, new.description, new.destination_id, new.value, new.scope_id, new.created_time
+        new.rowid, new.id, new.type, new.name, new.description, new.destination_id, new.value, new.scope_id, new.created_time
     );
 END;
 
@@ -116,9 +116,9 @@ CREATE VIRTUAL TABLE IF NOT EXISTS group_fts USING fts5(
 
 CREATE TRIGGER IF NOT EXISTS group_ai AFTER INSERT ON "group" BEGIN
     INSERT INTO group_fts(
-        id, name, description, scope_id, created_time
+        rowid, id, name, description, scope_id, created_time
     ) VALUES (
-        new.id, new.name, new.description, new.scope_id, new.created_time
+        new.rowid, new.id, new.name, new.description, new.scope_id, new.created_time
     );
 END;
 
@@ -149,9 +149,9 @@ CREATE VIRTUAL TABLE IF NOT EXISTS role_fts USING fts5(
 
 CREATE TRIGGER IF NOT EXISTS role_ai AFTER INSERT ON role BEGIN
     INSERT INTO role_fts(
-        id, name, description, scope_id, created_time
+        rowid, id, name, description, scope_id, created_time
     ) VALUES (
-        new.id, new.name, new.description, new.scope_id, new.created_time
+        new.rowid, new.id, new.name, new.description, new.scope_id, new.created_time
     );
 END;
 
@@ -182,9 +182,9 @@ CREATE VIRTUAL TABLE IF NOT EXISTS user_fts USING fts5(
 
 CREATE TRIGGER IF NOT EXISTS user_ai AFTER INSERT ON user BEGIN
     INSERT INTO user_fts(
-        id, name, description, scope_id, created_time
+        rowid, id, name, description, scope_id, created_time
     ) VALUES (
-        new.id, new.name, new.description, new.scope_id, new.created_time
+        new.rowid, new.id, new.name, new.description, new.scope_id, new.created_time
     );
 END;
 
@@ -217,9 +217,9 @@ CREATE VIRTUAL TABLE IF NOT EXISTS credential_store_fts USING fts5(
 
 CREATE TRIGGER IF NOT EXISTS credential_store_ai AFTER INSERT ON credential_store BEGIN
     INSERT INTO credential_store_fts(
-        id, type, name, description, scope_id, created_time
+        rowid, id, type, name, description, scope_id, created_time
     ) VALUES (
-        new.id, new.type, new.name, new.description, new.scope_id, new.created_time
+        new.rowid, new.id, new.type, new.name, new.description, new.scope_id, new.created_time
     );
 END;
 
@@ -252,9 +252,9 @@ CREATE VIRTUAL TABLE IF NOT EXISTS scope_fts USING fts5(
 
 CREATE TRIGGER IF NOT EXISTS scope_ai AFTER INSERT ON scope BEGIN
     INSERT INTO scope_fts(
-        id, type, name, description, scope_id, created_time
+        rowid, id, type, name, description, scope_id, created_time
     ) VALUES (
-        new.id, new.type, new.name, new.description, new.scope_id, new.created_time
+        new.rowid, new.id, new.type, new.name, new.description, new.scope_id, new.created_time
     );
 END;
 
@@ -289,9 +289,9 @@ CREATE VIRTUAL TABLE IF NOT EXISTS auth_method_fts USING fts5(
 
 CREATE TRIGGER IF NOT EXISTS auth_method_ai AFTER INSERT ON auth_method BEGIN
     INSERT INTO auth_method_fts(
-        id, type, name, description, is_primary, scope_id, created_time
+        rowid, id, type, name, description, is_primary, scope_id, created_time
     ) VALUES (
-        new.id, new.type, new.name, new.description, new.is_primary, new.scope_id, new.created_time
+        new.rowid, new.id, new.type, new.name, new.description, new.is_primary, new.scope_id, new.created_time
     );
 END;
 
@@ -326,9 +326,9 @@ CREATE VIRTUAL TABLE IF NOT EXISTS host_catalog_fts USING fts5(
 
 CREATE TRIGGER IF NOT EXISTS host_catalog_ai AFTER INSERT ON host_catalog BEGIN
     INSERT INTO host_catalog_fts(
-        id, type, name, description, plugin_name, scope_id, created_time
+        rowid, id, type, name, description, plugin_name, scope_id, created_time
     ) VALUES (
-        new.id, new.type, new.name, new.description, new.plugin_name, new.scope_id, new.created_time
+        new.rowid, new.id, new.type, new.name, new.description, new.plugin_name, new.scope_id, new.created_time
     );
 END;
 
@@ -377,9 +377,9 @@ CREATE VIRTUAL TABLE IF NOT EXISTS session_recording_fts USING fts5(
 
 CREATE TRIGGER IF NOT EXISTS session_recording_ai AFTER INSERT ON session_recording BEGIN
     INSERT INTO session_recording_fts(
-        id, type, state, start_time, end_time, duration, scope_id, user_id, user_name, target_id, target_name, target_scope_id, target_scope_name, created_time
+        rowid, id, type, state, start_time, end_time, duration, scope_id, user_id, user_name, target_id, target_name, target_scope_id, target_scope_name, created_time
     ) VALUES (
-        new.id, new.type, new.state, new.start_time, new.end_time, new.duration, new.scope_id, new.user_id, new.user_name, new.target_id, new.target_name, new.target_scope_id, new.target_scope_name, new.created_time
+        new.rowid, new.id, new.type, new.state, new.start_time, new.end_time, new.duration, new.scope_id, new.user_id, new.user_name, new.target_id, new.target_name, new.target_scope_id, new.target_scope_name, new.created_time
     );
 END;
 
@@ -416,9 +416,9 @@ CREATE VIRTUAL TABLE IF NOT EXISTS session_fts USING fts5(
 
 CREATE TRIGGER IF NOT EXISTS session_ai AFTER INSERT ON session BEGIN
     INSERT INTO session_fts(
-        id, type, status, endpoint, target_id, user_id, scope_id, created_time
+        rowid, id, type, status, endpoint, target_id, user_id, scope_id, created_time
     ) VALUES (
-        new.id, new.type, new.status, new.endpoint, new.target_id, new.user_id, new.scope_id, new.created_time
+        new.rowid, new.id, new.type, new.status, new.endpoint, new.target_id, new.user_id, new.scope_id, new.created_time
     );
 END;
 


### PR DESCRIPTION
# Description

Currently there's a bug where after deleting and inserting resources into sqlite, sometimes the search will have undefined behavior and either show the wrong rows or no rows. This is because the triggers to maintain the FTS5 tables were missing the rowid on inserts from the original table and instead using the automatic autoincremented rowids which happened to match the original as long as rows weren't deleted and re-inserted.

If they were deletions and insertions, what ends up happening is sometimes the rowids might get [re-used](https://www.sqlite.org/autoinc.html#:~:text=If%20you%20ever%20delete%20rows%20or%20if%20you%20ever%20create%20a%20row%20with%20the%20maximum%20possible%20ROWID%2C%20then%20ROWIDs%20from%20previously%20deleted%20rows%20might%20be%20reused%20when%20creating%20new%20rows%20and%20newly%20created%20ROWIDs%20might%20not%20be%20in%20strictly%20ascending%20order.) and the deletes after may also be [unpredictable](https://www.sqlite.org/fts5.html#the_delete_command:~:text=If%20the%20values%20%22inserted%22%20into%20the%20text%20columns%20as%20part%20of%20a%20%27delete%27%20command%20are%20not%20the%20same%20as%20those%20currently%20stored%20within%20the%20table%2C%20the%20results%20may%20be%20unpredictable.) and not actually delete. 

## How to Test
This is most obvious on the scopes resource (but can be reproducible with any resource) due to the fact adding or deleting a scope causes an invalid list token and we clear out the table and re-fetch.

On `main`, goto scopes and try adding a new scope. This should cause a list token invalidation and re-fetch of scopes. Try searching for different IDs and you should see that you get the wrong results or no results back.

On this branch, delete your old sqlite DB by clearing the cache (since the schema was updated and I didn't increment the version yet since we haven't released) and try the same thing as before. It should now return the right search results. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] I have added `a11y-tests` label to run a11y audit tests if needed~

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
