### PR TITLE
fix: 🐛 Pass the addr to CLI when canceling sessions

### DIFF
--- a/ui/desktop/electron-app/src/models/session.js
+++ b/ui/desktop/electron-app/src/models/session.js
@@ -75,12 +75,14 @@ class Session {
         this.#process.on('close', () => resolve());
         this.#process.on('error', (e) => reject(e));
 
-        const sanitizedToken = sanitizer.base62EscapeAndValidate(this.#token);
         // Cancel session before killing process
+        const sanitizedToken = sanitizer.base62EscapeAndValidate(this.#token);
+        const sanitizedAddr = sanitizer.urlValidate(this.#addr);
         const cancelSessionCommand = [
           'sessions',
           'cancel',
           `-id=${this.id}`,
+          `-addr=${sanitizedAddr}`,
           '-token=env://BOUNDARY_TOKEN',
         ];
         spawnSync(cancelSessionCommand, {


### PR DESCRIPTION
# Description
I wasn't passing the boundary address to the CLI when canceling sessions on quit which meant it assumed it was localhost and would 404 if you were on a non localhost address when canceling. 

## Screenshots (if appropriate)

## How to Test
Try connecting with a boundary address that's not localhost and confirm quitting/logging out properly cancels sessions. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] I have added `a11y-tests` label to run a11y audit tests if needed~

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
