### PR TITLE
fix: 🐛 Pass in session time out when creating session

### DIFF
--- a/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/controllers/scopes/scope/projects/targets/index.js
@@ -190,6 +190,7 @@ export default class ScopesScopeProjectsTargetsIndexController extends Controlle
     const options = {
       target_id: target.id,
       token: this.session.data.authenticated.token,
+      session_max_seconds: target.session_max_seconds,
     };
 
     if (host) options.host_id = host.id;

--- a/ui/desktop/electron-app/src/helpers/spawn-promise.js
+++ b/ui/desktop/electron-app/src/helpers/spawn-promise.js
@@ -32,14 +32,14 @@ module.exports = {
    * @param {number} timeout Duration in seconds
    * @return {Promise}
    */
-  spawnAsyncJSONPromise(command, token, timeout = 0) {
+  spawnAsyncJSONPromise(command, token, timeout) {
     return new Promise((resolve, reject) => {
       const childProcess = spawn(path, command, {
         env: {
           ...process.env,
           BOUNDARY_TOKEN: token,
         },
-        timeout: timeout * 1000,
+        timeout: timeout ? timeout * 1000 : undefined,
       });
       let outputStream = '';
       let errorStream = '';

--- a/ui/desktop/electron-app/src/helpers/spawn-promise.js
+++ b/ui/desktop/electron-app/src/helpers/spawn-promise.js
@@ -27,16 +27,19 @@ module.exports = {
    * data on either stdout or stderr.  The process is allowed to continue
    * running after the promise resolves.  This function is intended to launch
    * the local proxy.
-   * @param {string} command
+   * @param {string[]} command
+   * @param {string} token
+   * @param {number} timeout Duration in seconds
    * @return {Promise}
    */
-  spawnAsyncJSONPromise(command, token) {
+  spawnAsyncJSONPromise(command, token, timeout = 0) {
     return new Promise((resolve, reject) => {
       const childProcess = spawn(path, command, {
         env: {
           ...process.env,
           BOUNDARY_TOKEN: token,
         },
+        timeout: timeout * 1000,
       });
       let outputStream = '';
       let errorStream = '';

--- a/ui/desktop/electron-app/src/ipc/handlers.js
+++ b/ui/desktop/electron-app/src/ipc/handlers.js
@@ -71,8 +71,14 @@ handle('cliExists', () => boundaryCli.exists());
 /**
  * Establishes a boundary session and returns session details.
  */
-handle('connect', ({ target_id, token, host_id }) =>
-  sessionManager.start(runtimeSettings.clusterUrl, target_id, token, host_id),
+handle('connect', ({ target_id, token, host_id, session_max_seconds }) =>
+  sessionManager.start(
+    runtimeSettings.clusterUrl,
+    target_id,
+    token,
+    host_id,
+    session_max_seconds,
+  ),
 );
 
 /**

--- a/ui/desktop/electron-app/src/models/session-manager.js
+++ b/ui/desktop/electron-app/src/models/session-manager.js
@@ -23,9 +23,16 @@ class SessionManager {
    * @param {string} target_id
    * @param {string} token
    * @param {string} host_id
+   * @param {number} session_max_seconds
    */
-  start(addr, target_id, token, host_id) {
-    const session = new Session(addr, target_id, token, host_id);
+  start(addr, target_id, token, host_id, session_max_seconds) {
+    const session = new Session(
+      addr,
+      target_id,
+      token,
+      host_id,
+      session_max_seconds,
+    );
     this.#sessions.push(session);
     return session.start();
   }


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-17701

# Description
Currently if a session expires, we don't keep track if it's still valid or not. This means if a session has expired our session manager will still think it's a valid session and prompt the user if they try to logout or quit the app. 

## How to Test
Make a target with a short session duration (e.g. 15s). Connect to the target and confirm you get prompted still. Wait until the session goes past the max session duration and try to logout and quit the app. You should not get prompted anymore.

Confirm this works in all 3 OS environments.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] I have added `a11y-tests` label to run a11y audit tests if needed~

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
