### PR TITLE
Use joins with filters

### DIFF
--- a/addons/api/addon/utils/sqlite-query.js
+++ b/addons/api/addon/utils/sqlite-query.js
@@ -30,12 +30,14 @@ export function generateSQLExpressions(
   const conditions = [];
   const parameters = [];
   const tableName = underscore(resource);
+  const joins = [];
 
-  addFilterConditions({ filters, parameters, conditions });
+  addFilterConditions({ filters, parameters, conditions, joins, tableName });
   addSearchConditions({ search, resource, tableName, parameters, conditions });
 
   const selectClause = constructSelectClause(select, tableName);
-  const orderByClause = constructOrderByClause(resource, sort);
+  const joinClause = constructJoinClause(joins);
+  const orderByClause = constructOrderByClause(resource, tableName, sort);
   const whereClause = conditions.length ? `WHERE ${and(conditions)}` : '';
 
   const paginationClause = page && pageSize ? `LIMIT ? OFFSET ?` : '';
@@ -48,6 +50,7 @@ export function generateSQLExpressions(
     // This is mainly to help us read and test the generated SQL as it has no effect on the actual SQL execution.
     sql: `
       ${selectClause}
+      ${joinClause}
       ${whereClause}
       ${orderByClause}
       ${paginationClause}`
@@ -57,7 +60,13 @@ export function generateSQLExpressions(
   };
 }
 
-function addFilterConditions({ filters, parameters, conditions }) {
+function addFilterConditions({
+  filters,
+  parameters,
+  conditions,
+  joins,
+  tableName,
+}) {
   if (!filters) {
     return;
   }
@@ -68,7 +77,7 @@ function addFilterConditions({ filters, parameters, conditions }) {
       ? filterArrayOrObject
       : filterArrayOrObject.values;
 
-    if (!filterValueArray || !filterValueArray.length || key === 'subqueries') {
+    if (!filterValueArray || !filterValueArray.length || key === 'joins') {
       continue;
     }
 
@@ -85,8 +94,13 @@ function addFilterConditions({ filters, parameters, conditions }) {
       allOperatorsEqual
     ) {
       const operation = firstOperator === 'equals' ? 'in' : 'notIn';
+      const nullOperator =
+        firstOperator === 'equals' ? 'IS NULL' : 'IS NOT NULL';
       const values = filterValueArray
-        .filter((f) => f)
+        .filter(
+          (filterObjValue) =>
+            filterObjValue && Object.values(filterObjValue)[0] !== null,
+        )
         .map((filterObjValue) => {
           let value = Object.values(filterObjValue)[0];
           if (typeOf(value) === 'date') {
@@ -95,7 +109,14 @@ function addFilterConditions({ filters, parameters, conditions }) {
           parameters.push(value);
           return value;
         });
-      const filterCondition = `${key}${OPERATORS[operation](values)}`;
+
+      // Add a check for null values as an IN clause will mistakenly use `=` for null values.
+      // We'll add an extra OR clause to handle nulls separately.
+      const isNullValue = filterValueArray.some(
+        (filterObjValue) => Object.values(filterObjValue)[0] === null,
+      );
+
+      const filterCondition = `"${tableName}".${key}${OPERATORS[operation](values)}${isNullValue ? ` OR "${tableName}".${key} ${nullOperator}` : ''}`;
       conditions.push(parenthetical(filterCondition));
       continue;
     }
@@ -104,6 +125,16 @@ function addFilterConditions({ filters, parameters, conditions }) {
       .filter((f) => f)
       .map((filterObjValue) => {
         let [operation, value] = Object.entries(filterObjValue)[0];
+
+        // Handle null values: convert equals/notEquals to IS NULL or IS NOT NULL
+        if (value === null) {
+          if (operation === 'equals') {
+            return `"${tableName}".${key} IS NULL`;
+          }
+          if (operation === 'notEquals') {
+            return `"${tableName}".${key} IS NOT NULL`;
+          }
+        }
 
         // SQLite needs to be working with ISO strings
         if (typeOf(value) === 'date') {
@@ -117,7 +148,7 @@ function addFilterConditions({ filters, parameters, conditions }) {
           parameters.push(value);
         }
 
-        return `${key}${OPERATORS[operation]}`;
+        return `"${tableName}".${key}${OPERATORS[operation]}`;
       });
 
     const { logicalOperator } = filterArrayOrObject;
@@ -131,19 +162,34 @@ function addFilterConditions({ filters, parameters, conditions }) {
     );
   }
 
-  if (filters.subqueries?.length > 0) {
-    filters.subqueries.forEach((subquery) => {
-      const { resource, query, select } = subquery;
-      const { sql, parameters: subqueryParams } = generateSQLExpressions(
-        resource,
-        query,
-        {
-          select,
-        },
-      );
+  if (filters.joins?.length > 0) {
+    const tableNameIndex = {};
 
-      conditions.push(`id IN (${sql})`);
-      parameters.push(...subqueryParams);
+    filters.joins.forEach((join) => {
+      const { resource, query, joinOn, joinType = 'INNER' } = join;
+      const joinTableName = underscore(resource);
+      tableNameIndex[resource] ??= 1;
+      // Alias in the possible scenario we join the same table more than once
+      const alias = `${joinTableName}${tableNameIndex[resource]}`;
+
+      joins.push({
+        type: joinType,
+        table: joinTableName,
+        alias,
+        condition: `"${tableName}".id = ${alias}.${joinOn}`,
+      });
+
+      // Add the conditions from the join query
+      if (query?.filters) {
+        addFilterConditions({
+          filters: query.filters,
+          parameters,
+          conditions,
+          tableName: alias,
+        });
+      }
+
+      tableNameIndex[resource]++;
     });
   }
 }
@@ -176,7 +222,7 @@ function addSearchConditions({
   // much more efficient with FTS queries when using rowids or MATCH (or both).
   // We could have also used a join here but a subquery is simpler.
   conditions.push(
-    `rowid IN (SELECT rowid FROM ${tableName}_fts WHERE ${tableName}_fts MATCH ?)`,
+    `"${tableName}".rowid IN (SELECT rowid FROM ${tableName}_fts WHERE ${tableName}_fts MATCH ?)`,
   );
 }
 
@@ -188,11 +234,11 @@ function constructSelectClause(select = [{ field: '*' }], tableName) {
   // We're only handling simple use cases as anything more complicated
   // like windows/CTEs can be custom SQL.
   if (distinctColumns.length > 0) {
-    selectColumns = `DISTINCT ${distinctColumns.map(({ field }) => field).join(', ')}`;
+    selectColumns = `DISTINCT ${distinctColumns.map(({ field }) => (field === '*' ? field : `"${tableName}".${field}`)).join(', ')}`;
   } else {
     selectColumns = select
       .map(({ field, isCount, alias }) => {
-        let column = field;
+        let column = field === '*' ? field : `"${tableName}".${field}`;
 
         if (isCount) {
           column = `count(${column})`;
@@ -209,11 +255,27 @@ function constructSelectClause(select = [{ field: '*' }], tableName) {
   return `SELECT ${selectColumns} FROM "${tableName}"`;
 }
 
-function constructOrderByClause(resource, sort) {
-  const defaultOrderByClause = 'ORDER BY created_time DESC';
+function constructJoinClause(joins) {
+  if (!joins || joins.length === 0) {
+    return '';
+  }
+
+  return joins
+    .map(
+      ({ type, table, alias, condition }) =>
+        `${type} JOIN "${table}" ${alias} ON ${condition}`,
+    )
+    .join(' ');
+}
+
+function constructOrderByClause(resource, tableName, sort) {
+  const defaultOrderByClause = `ORDER BY "${tableName}".created_time DESC`;
 
   const { attributes, customSort, direction, isCoalesced } = sort;
   const sortDirection = direction === 'desc' ? 'DESC' : 'ASC';
+  const attributesWithTableName = attributes?.map(
+    (attribute) => `"${tableName}".${attribute}`,
+  );
 
   // We have to check if the attributes are valid for the resource
   // as we can't use parameterized queries for ORDER BY
@@ -229,21 +291,21 @@ function constructOrderByClause(resource, sort) {
       },
       '',
     );
-    return `ORDER BY CASE ${attributes.join(', ')} ${whenClauses}END ${sortDirection}`;
+    return `ORDER BY CASE ${attributesWithTableName.join(', ')} ${whenClauses}END ${sortDirection}`;
   } else if (attributes?.length > 0) {
-    const commaSeparatedVals = attributes.join(', ');
+    const commaSeparatedVals = attributesWithTableName.join(', ');
 
     // In places where `collate nocase` is used, it is to ensure case is ignored on the initial sort.
     // Then, a sort on the same condition is performed to ensure upper-case strings are given preference in a tie.
     if (isCoalesced) {
-      return `ORDER BY COALESCE(${attributes.join(', ')}) COLLATE NOCASE ${sortDirection}, COALESCE(${commaSeparatedVals}) ${sortDirection}`;
+      return `ORDER BY COALESCE(${commaSeparatedVals}) COLLATE NOCASE ${sortDirection}, COALESCE(${commaSeparatedVals}) ${sortDirection}`;
     }
 
     const attributesWithNoCollate = attributes
-      .map((attr) => `${attr} COLLATE NOCASE ${sortDirection}`)
+      .map((attr) => `"${tableName}".${attr} COLLATE NOCASE ${sortDirection}`)
       .join(', ');
     const attributesWithDirection = attributes
-      .map((attr) => `${attr} ${sortDirection}`)
+      .map((attr) => `"${tableName}".${attr} ${sortDirection}`)
       .join(', ');
     return `ORDER BY ${attributesWithNoCollate}, ${attributesWithDirection}`;
   } else if (modelMapping[resource]?.created_time) {

--- a/addons/api/addon/utils/sqlite-query.js
+++ b/addons/api/addon/utils/sqlite-query.js
@@ -68,7 +68,7 @@ function addFilterConditions({ filters, parameters, conditions }) {
       ? filterArrayOrObject
       : filterArrayOrObject.values;
 
-    if (!filterValueArray || !filterValueArray.length) {
+    if (!filterValueArray || !filterValueArray.length || key === 'subqueries') {
       continue;
     }
 
@@ -130,6 +130,22 @@ function addFilterConditions({ filters, parameters, conditions }) {
       ),
     );
   }
+
+  if (filters.subqueries?.length > 0) {
+    filters.subqueries.forEach((subquery) => {
+      const { resource, query, select } = subquery;
+      const { sql, parameters: subqueryParams } = generateSQLExpressions(
+        resource,
+        query,
+        {
+          select,
+        },
+      );
+
+      conditions.push(`id IN (${sql})`);
+      parameters.push(...subqueryParams);
+    });
+  }
 }
 
 function addSearchConditions({
@@ -163,6 +179,7 @@ function addSearchConditions({
     `rowid IN (SELECT rowid FROM ${tableName}_fts WHERE ${tableName}_fts MATCH ?)`,
   );
 }
+
 function constructSelectClause(select = [{ field: '*' }], tableName) {
   const distinctColumns = select.filter(({ isDistinct }) => isDistinct);
   let selectColumns;

--- a/addons/api/tests/unit/utils/sqlite-query-test.js
+++ b/addons/api/tests/unit/utils/sqlite-query-test.js
@@ -325,6 +325,48 @@ module('Unit | Utility | sqlite-query', function (hooks) {
     ]);
   });
 
+  test('it generates subqueries with filters', function (assert) {
+    const query = {
+      filters: {
+        type: [{ equals: 'ssh' }],
+        subqueries: [
+          {
+            resource: 'session',
+            query: {
+              filters: {
+                status: [{ equals: 'active' }],
+              },
+            },
+            select: [{ field: 'target_id' }],
+          },
+          {
+            resource: 'session-recording',
+            query: {
+              filters: {
+                state: [{ equals: 'available' }],
+              },
+            },
+            select: [{ field: 'target_id' }],
+          },
+        ],
+      },
+    };
+
+    const { sql, parameters } = generateSQLExpressions('target', query);
+    assert.strictEqual(
+      sql,
+      `
+        SELECT * FROM "target"
+        WHERE (type = ?) AND id IN (SELECT target_id FROM "session"
+                                    WHERE (status = ?)
+                                    ORDER BY created_time DESC) AND id IN (SELECT target_id FROM "session_recording"
+                                                                            WHERE (state = ?)
+                                                                            ORDER BY created_time DESC)
+        ORDER BY created_time DESC`.removeExtraWhiteSpace(),
+    );
+    assert.deepEqual(parameters, ['ssh', 'active', 'available']);
+  });
+
   test('it generates SQL with all clauses combined', function (assert) {
     const query = {
       search: 'favorite',

--- a/addons/api/tests/unit/utils/sqlite-query-test.js
+++ b/addons/api/tests/unit/utils/sqlite-query-test.js
@@ -30,7 +30,7 @@ module('Unit | Utility | sqlite-query', function (hooks) {
       sql,
       `
         SELECT * FROM "token"
-        WHERE (id = ?)`.removeExtraWhiteSpace(),
+        WHERE ("token".id = ?)`.removeExtraWhiteSpace(),
     );
     assert.deepEqual(parameters, ['tokenKey']);
   });
@@ -45,7 +45,7 @@ module('Unit | Utility | sqlite-query', function (hooks) {
       sql,
       `
       SELECT count(*) as total FROM "target"
-      ORDER BY created_time DESC`.removeExtraWhiteSpace(),
+      ORDER BY "target".created_time DESC`.removeExtraWhiteSpace(),
     );
     assert.deepEqual(parameters, []);
   });
@@ -55,14 +55,14 @@ module('Unit | Utility | sqlite-query', function (hooks) {
     [
       {
         select: [{ field: 'type', isDistinct: true }],
-        expectedSelect: 'type',
+        expectedSelect: '"target".type',
       },
       {
         select: [
           { field: 'type', isDistinct: true },
           { field: 'status', isDistinct: true },
         ],
-        expectedSelect: 'type, status',
+        expectedSelect: '"target".type, "target".status',
       },
     ],
     function (assert, { select, expectedSelect }) {
@@ -76,7 +76,7 @@ module('Unit | Utility | sqlite-query', function (hooks) {
         sql,
         `
         SELECT DISTINCT ${expectedSelect} FROM "target"
-        ORDER BY created_time DESC`.removeExtraWhiteSpace(),
+        ORDER BY "target".created_time DESC`.removeExtraWhiteSpace(),
       );
       assert.deepEqual(parameters, []);
     },
@@ -91,7 +91,7 @@ module('Unit | Utility | sqlite-query', function (hooks) {
             type: [{ equals: 'ssh' }],
           },
         },
-        expectedWhereClause: 'WHERE (type = ?)',
+        expectedWhereClause: 'WHERE ("target".type = ?)',
         expectedParams: ['ssh'],
       },
       notEquals: {
@@ -100,7 +100,7 @@ module('Unit | Utility | sqlite-query', function (hooks) {
             type: [{ notEquals: 'ssh' }],
           },
         },
-        expectedWhereClause: 'WHERE (type != ?)',
+        expectedWhereClause: 'WHERE ("target".type != ?)',
         expectedParams: ['ssh'],
       },
       contains: {
@@ -109,7 +109,7 @@ module('Unit | Utility | sqlite-query', function (hooks) {
             type: [{ contains: 'ssh' }],
           },
         },
-        expectedWhereClause: 'WHERE (type LIKE ?)',
+        expectedWhereClause: 'WHERE ("target".type LIKE ?)',
         expectedParams: ['%ssh%'],
       },
       greaterThan: {
@@ -119,7 +119,8 @@ module('Unit | Utility | sqlite-query', function (hooks) {
             numberField: [{ gt: 10 }],
           },
         },
-        expectedWhereClause: 'WHERE (created_time > ?) AND (numberField > ?)',
+        expectedWhereClause:
+          'WHERE ("target".created_time > ?) AND ("target".numberField > ?)',
         expectedParams: [isoDateString, 10],
       },
       lessThan: {
@@ -129,7 +130,8 @@ module('Unit | Utility | sqlite-query', function (hooks) {
             numberField: [{ lt: 10 }],
           },
         },
-        expectedWhereClause: 'WHERE (created_time < ?) AND (numberField < ?)',
+        expectedWhereClause:
+          'WHERE ("target".created_time < ?) AND ("target".numberField < ?)',
         expectedParams: [isoDateString, 10],
       },
       greaterThanOrEqual: {
@@ -139,7 +141,8 @@ module('Unit | Utility | sqlite-query', function (hooks) {
             numberField: [{ gte: 10 }],
           },
         },
-        expectedWhereClause: 'WHERE (created_time >= ?) AND (numberField >= ?)',
+        expectedWhereClause:
+          'WHERE ("target".created_time >= ?) AND ("target".numberField >= ?)',
         expectedParams: [isoDateString, 10],
       },
       lessThanOrEqual: {
@@ -149,7 +152,8 @@ module('Unit | Utility | sqlite-query', function (hooks) {
             numberField: [{ lte: 10 }],
           },
         },
-        expectedWhereClause: 'WHERE (created_time <= ?) AND (numberField <= ?)',
+        expectedWhereClause:
+          'WHERE ("target".created_time <= ?) AND ("target".numberField <= ?)',
         expectedParams: [isoDateString, 10],
       },
       logicalOperators: {
@@ -167,8 +171,41 @@ module('Unit | Utility | sqlite-query', function (hooks) {
           },
         },
         expectedWhereClause:
-          'WHERE (id NOT IN (?, ?)) AND (status IN (?, ?)) AND (type = ?)',
+          'WHERE ("target".id NOT IN (?, ?)) AND ("target".status IN (?, ?)) AND ("target".type = ?)',
         expectedParams: ['id1', 'id2', 'active', 'pending', 'ssh'],
+      },
+      equalsNull: {
+        query: {
+          filters: {
+            description: [{ equals: null }],
+          },
+        },
+        expectedWhereClause: 'WHERE ("target".description IS NULL)',
+        expectedParams: [],
+      },
+      notEqualsNull: {
+        query: {
+          filters: {
+            description: [{ notEquals: null }],
+          },
+        },
+        expectedWhereClause: 'WHERE ("target".description IS NOT NULL)',
+        expectedParams: [],
+      },
+      mixedNullAndValues: {
+        query: {
+          filters: {
+            status: [
+              { equals: 'active' },
+              { equals: 'pending' },
+              { equals: null },
+            ],
+            type: [{ notEquals: null }, { notEquals: 'ssh' }],
+          },
+        },
+        expectedWhereClause:
+          'WHERE ("target".status IN (?, ?) OR "target".status IS NULL) AND ("target".type NOT IN (?) OR "target".type IS NOT NULL)',
+        expectedParams: ['active', 'pending', 'ssh'],
       },
     },
 
@@ -179,7 +216,7 @@ module('Unit | Utility | sqlite-query', function (hooks) {
         `
         SELECT * FROM "target"
         ${expectedWhereClause}
-        ORDER BY created_time DESC`.removeExtraWhiteSpace(),
+        ORDER BY "target".created_time DESC`.removeExtraWhiteSpace(),
       );
       assert.deepEqual(parameters, expectedParams);
     },
@@ -201,7 +238,7 @@ module('Unit | Utility | sqlite-query', function (hooks) {
         sql,
         `
         SELECT * FROM "target"
-        ORDER BY name COLLATE NOCASE ${expectedDirection}, name ${expectedDirection}`.removeExtraWhiteSpace(),
+        ORDER BY "target".name COLLATE NOCASE ${expectedDirection}, "target".name ${expectedDirection}`.removeExtraWhiteSpace(),
       );
       assert.deepEqual(parameters, []);
     },
@@ -215,20 +252,20 @@ module('Unit | Utility | sqlite-query', function (hooks) {
           attributes: ['name', 'id'],
           isCoalesced: true,
         },
-        expectedOrderByClause: `ORDER BY COALESCE(name, id) COLLATE NOCASE DESC, COALESCE(name, id) DESC`,
+        expectedOrderByClause: `ORDER BY COALESCE("target".name, "target".id) COLLATE NOCASE DESC, COALESCE("target".name, "target".id) DESC`,
       },
       'sort on multiple attributes': {
         sort: {
           attributes: ['name', 'id'],
         },
-        expectedOrderByClause: `ORDER BY name COLLATE NOCASE DESC, id COLLATE NOCASE DESC, name DESC, id DESC`,
+        expectedOrderByClause: `ORDER BY "target".name COLLATE NOCASE DESC, "target".id COLLATE NOCASE DESC, "target".name DESC, "target".id DESC`,
       },
       'sort on mapped attributes': {
         sort: {
           attributes: ['type'],
           customSort: { attributeMap: { ssh: 'SSH', tcp: 'Generic TCP' } },
         },
-        expectedOrderByClause: `ORDER BY CASE type WHEN 'ssh' THEN 'SSH' WHEN 'tcp' THEN 'Generic TCP' END DESC`,
+        expectedOrderByClause: `ORDER BY CASE "target".type WHEN 'ssh' THEN 'SSH' WHEN 'tcp' THEN 'Generic TCP' END DESC`,
       },
     },
     function (assert, { sort, expectedOrderByClause }) {
@@ -264,108 +301,130 @@ module('Unit | Utility | sqlite-query', function (hooks) {
         sql,
         `
         SELECT * FROM "target"
-        ORDER BY created_time DESC
+        ORDER BY "target".created_time DESC
         LIMIT ? OFFSET ?`.removeExtraWhiteSpace(),
       );
       assert.deepEqual(parameters, expectedParams);
     },
   );
 
-  test('it generates FTS5 search with filters', function (assert) {
-    const query = {
-      search: 'favorite',
-      filters: {
-        id: {
-          logicalOperator: 'and',
-          values: [{ notEquals: 'id1' }, { notEquals: 'id2' }],
+  test.each(
+    'it generates FTS5 search correctly',
+    {
+      'string search with filters': {
+        query: {
+          search: 'favorite',
         },
-        status: [{ equals: 'active' }, { equals: 'pending' }],
+        expectedSql: `
+          SELECT * FROM "target"
+          WHERE "target".rowid IN (SELECT rowid FROM target_fts WHERE target_fts MATCH ?)
+          ORDER BY "target".created_time DESC`,
+        expectedParams: ['"favorite"*'],
       },
-    };
-
-    const { sql, parameters } = generateSQLExpressions('target', query);
-    assert.strictEqual(
-      sql,
-      `
-        SELECT * FROM "target"
-        WHERE (id NOT IN (?, ?)) AND (status IN (?, ?)) AND rowid IN (SELECT rowid FROM target_fts WHERE target_fts MATCH ?)
-        ORDER BY created_time DESC`.removeExtraWhiteSpace(),
-    );
-    assert.deepEqual(parameters, [
-      'id1',
-      'id2',
-      'active',
-      'pending',
-      '"favorite"*',
-    ]);
-  });
-
-  test('it generates FTS5 search with object parameter', function (assert) {
-    const query = {
-      search: {
-        text: 'favorite',
-        fields: ['name', 'description'],
-      },
-      filters: {
-        type: [{ equals: 'ssh' }],
-      },
-    };
-
-    const { sql, parameters } = generateSQLExpressions('target', query);
-    assert.strictEqual(
-      sql,
-      `
-        SELECT * FROM "target"
-        WHERE (type = ?) AND rowid IN (SELECT rowid FROM target_fts WHERE target_fts MATCH ?)
-        ORDER BY created_time DESC`.removeExtraWhiteSpace(),
-    );
-    assert.deepEqual(parameters, [
-      'ssh',
-      'name:"favorite"* OR description:"favorite"*',
-    ]);
-  });
-
-  test('it generates subqueries with filters', function (assert) {
-    const query = {
-      filters: {
-        type: [{ equals: 'ssh' }],
-        subqueries: [
-          {
-            resource: 'session',
-            query: {
-              filters: {
-                status: [{ equals: 'active' }],
-              },
-            },
-            select: [{ field: 'target_id' }],
+      'object search with field-specific searches': {
+        query: {
+          search: {
+            text: 'favorite',
+            fields: ['name', 'description'],
           },
-          {
-            resource: 'session-recording',
-            query: {
-              filters: {
-                state: [{ equals: 'available' }],
-              },
-            },
-            select: [{ field: 'target_id' }],
-          },
-        ],
+        },
+        expectedSql: `
+          SELECT * FROM "target"
+          WHERE "target".rowid IN (SELECT rowid FROM target_fts WHERE target_fts MATCH ?)
+          ORDER BY "target".created_time DESC`,
+        expectedParams: ['name:"favorite"* OR description:"favorite"*'],
       },
-    };
+    },
+    function (assert, { query, expectedSql, expectedParams }) {
+      const { sql, parameters } = generateSQLExpressions('target', query);
+      assert.strictEqual(sql, expectedSql.removeExtraWhiteSpace());
+      assert.deepEqual(parameters, expectedParams);
+    },
+  );
 
-    const { sql, parameters } = generateSQLExpressions('target', query);
-    assert.strictEqual(
-      sql,
-      `
-        SELECT * FROM "target"
-        WHERE (type = ?) AND id IN (SELECT target_id FROM "session"
-                                    WHERE (status = ?)
-                                    ORDER BY created_time DESC) AND id IN (SELECT target_id FROM "session_recording"
-                                                                            WHERE (state = ?)
-                                                                            ORDER BY created_time DESC)
-        ORDER BY created_time DESC`.removeExtraWhiteSpace(),
-    );
-    assert.deepEqual(parameters, ['ssh', 'active', 'available']);
-  });
+  test.each(
+    'it generates joins with filters',
+    {
+      'basic joins with filters': {
+        query: {
+          filters: {
+            type: [{ equals: 'ssh' }],
+            joins: [
+              {
+                resource: 'session',
+                query: {
+                  filters: {
+                    status: [{ equals: 'active' }],
+                  },
+                },
+                joinOn: 'target_id',
+                joinType: 'INNER',
+              },
+              {
+                resource: 'session-recording',
+                query: {
+                  filters: {
+                    state: [{ equals: 'available' }],
+                  },
+                },
+                joinOn: 'target_id',
+                joinType: 'LEFT',
+              },
+            ],
+          },
+        },
+        select: [{ field: 'data' }],
+        expectedSql: `
+          SELECT "target".data FROM "target"
+          INNER JOIN "session" session1 ON "target".id = session1.target_id LEFT JOIN "session_recording" session_recording1 ON "target".id = session_recording1.target_id
+          WHERE ("target".type = ?) AND ("session1".status = ?) AND ("session_recording1".state = ?)
+          ORDER BY "target".created_time DESC`,
+        expectedParams: ['ssh', 'active', 'available'],
+      },
+      'multiple joins same table': {
+        query: {
+          filters: {
+            joins: [
+              {
+                resource: 'session',
+                query: {
+                  filters: {
+                    status: [{ equals: 'active' }],
+                  },
+                },
+                joinOn: 'target_id',
+                joinType: 'INNER',
+              },
+              {
+                resource: 'session',
+                query: {
+                  filters: {
+                    status: [{ equals: 'pending' }],
+                  },
+                },
+                joinOn: 'host_id',
+                joinType: 'LEFT',
+              },
+            ],
+          },
+        },
+        select: [{ field: 'id' }],
+        expectedSql: `
+          SELECT "target".id FROM "target"
+          INNER JOIN "session" session1 ON "target".id = session1.target_id LEFT JOIN "session" session2 ON "target".id = session2.host_id
+          WHERE ("session1".status = ?) AND ("session2".status = ?)
+          ORDER BY "target".created_time DESC`,
+        expectedParams: ['active', 'pending'],
+      },
+    },
+    function (assert, { query, select, expectedSql, expectedParams }) {
+      const { sql, parameters } = generateSQLExpressions('target', query, {
+        select,
+      });
+      assert.strictEqual(sql, expectedSql.removeExtraWhiteSpace());
+      assert.deepEqual(parameters, expectedParams);
+    },
+  );
 
   test('it generates SQL with all clauses combined', function (assert) {
     const query = {
@@ -390,9 +449,9 @@ module('Unit | Utility | sqlite-query', function (hooks) {
     assert.strictEqual(
       sql,
       `
-      SELECT data FROM "target"
-      WHERE (type = ?) AND (status IN (?, ?)) AND (created_time >= ?) AND rowid IN (SELECT rowid FROM target_fts WHERE target_fts MATCH ?)
-      ORDER BY name COLLATE NOCASE DESC, name DESC
+      SELECT "target".data FROM "target"
+      WHERE ("target".type = ?) AND ("target".status IN (?, ?)) AND ("target".created_time >= ?) AND "target".rowid IN (SELECT rowid FROM target_fts WHERE target_fts MATCH ?)
+      ORDER BY "target".name COLLATE NOCASE DESC, "target".name DESC
       LIMIT ? OFFSET ?`.removeExtraWhiteSpace(),
     );
 
@@ -434,7 +493,7 @@ module('Unit | Utility | sqlite-query', function (hooks) {
         targetSql,
         `
         SELECT * FROM "target"
-        ORDER BY created_time DESC`.removeExtraWhiteSpace(),
+        ORDER BY "target".created_time DESC`.removeExtraWhiteSpace(),
       );
       assert.deepEqual(targetParameters, []);
 

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/index.js
@@ -195,14 +195,6 @@ export default class ScopesScopeSessionRecordingsIndexController extends Control
       await this.retrieveFilterOptions('targetFilters');
   });
 
-  // async loadItems() {
-  //   this.userFilters.options = await this.retrieveFilterOptions('userFilters');
-  //   this.scopeFilters.options =
-  //     await this.retrieveFilterOptions('scopeFilters');
-  //   this.targetFilters.options =
-  //     await this.retrieveFilterOptions('targetFilters');
-  // }
-
   // =actions
 
   /**


### PR DESCRIPTION
# Description
Added support for joins with filters. Added an example using the targets table where I join with sessions to grab the active sessions instead of passing in a list of target IDs from the sessions. This removes the need to grab and return _all_ sessions which can be very slow (and even cause browser errors) with big enough data sets and is where the bulk of the time loading is spent if there's a lot of data.

## Screenshots (if appropriate)

## How to Test
Try using the active sessions filter on the targets page. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- ~[ ] I have added `a11y-tests` label to run a11y audit tests if needed~

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
