### PR TITLE
Migrate away from component helper in credential library form component

### DIFF
--- a/ui/admin/app/components/form/credential-library/index.hbs
+++ b/ui/admin/app/components/form/credential-library/index.hbs
@@ -4,12 +4,11 @@
 }}
 
 {{#if @model.type}}
-  {{component
-    (concat 'form/credential-library/' @model.type)
-    model=@model
-    submit=@submit
-    cancel=@cancel
-    changeType=@changeType
-    edit=@edit
-  }}
+  <this.credentialLibraryFormComponent
+    @model={{@model}}
+    @submit={{@submit}}
+    @cancel={{@cancel}}
+    @changeType={{@changeType}}
+    @edit={{@edit}}
+  />
 {{/if}}

--- a/ui/admin/app/components/form/credential-library/index.js
+++ b/ui/admin/app/components/form/credential-library/index.js
@@ -1,0 +1,28 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+import {
+  TYPE_CREDENTIAL_LIBRARY_VAULT_GENERIC,
+  TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE,
+  TYPE_CREDENTIAL_LIBRARY_VAULT_LDAP,
+} from 'api/models/credential-library';
+import VaultGenericFormComponent from './vault-generic';
+import VaultSshCertificateFormComponent from './vault-ssh-certificate';
+import VaultLdapFormComponent from './vault-ldap';
+
+const modelTypeToComponent = {
+  [TYPE_CREDENTIAL_LIBRARY_VAULT_GENERIC]: VaultGenericFormComponent,
+  [TYPE_CREDENTIAL_LIBRARY_VAULT_SSH_CERTIFICATE]:
+    VaultSshCertificateFormComponent,
+  [TYPE_CREDENTIAL_LIBRARY_VAULT_LDAP]: VaultLdapFormComponent,
+};
+
+export default class FormCredentialLibraryIndex extends Component {
+  get credentialLibraryFormComponent() {
+    const component = modelTypeToComponent[this.args.model.type];
+    assert(
+      `Mapped component must exist for credential library type: ${this.args.model.type}`,
+      component,
+    );
+    return component;
+  }
+}

--- a/ui/admin/app/components/form/credential-library/index.js
+++ b/ui/admin/app/components/form/credential-library/index.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import {


### PR DESCRIPTION
# Description
This pr continues the migration away from the dynamic `{{component}}` helper. More information in https://github.com/hashicorp/boundary-ui/pull/2880. This pull request focuses on migrating the credential-library form component.

:tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/ICU-17285) 

## How to Test
* Tests should pass
* Navigate to `/scopes/:project_id/credential-stores/:credential_store_id/credential-libraries` and create or edit credential libraries. The forms for all credential types should load correctly

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
