### PR TITLE
chore(e2e): Update desktop e2e test workflow to use new environment variable

### DIFF
--- a/.github/workflows/test-e2e-desktop.yaml
+++ b/.github/workflows/test-e2e-desktop.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    if: ${{contains(github.event.pull_request.labels.*.name, 'desktop')}}
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'desktop') }}
     name: Run Desktop E2E Tests
     runs-on: ${{ fromJSON(vars.RUNNER_UBUNTU_22) }}
     env:

--- a/.github/workflows/test-e2e-desktop.yaml
+++ b/.github/workflows/test-e2e-desktop.yaml
@@ -13,7 +13,6 @@ jobs:
     env:
       ENOS_VAR_boundary_edition: "ent"
       ENOS_VAR_e2e_debug_no_run: true
-      ENOS_VAR_boundary_license_path: "./license.hclic"
       SETUP_CLI: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -72,15 +71,14 @@ jobs:
           docker pull hashicorp/boundary-enterprise:latest
           docker save hashicorp/boundary-enterprise:latest | gzip > /tmp/boundary-enterprise.zip
 
-        # TODO: Set up license in a better way? Use directly rather than writing to file and pull from secrets manager
       - name: Set up test infra
         id: infra
         run: |
-          echo "${{ secrets.BOUNDARY_ENT_LICENSE }}" > ./support/src/boundary-enterprise/enos/license.hclic
           ssh-keygen -N '' -t ed25519 -f ~/.ssh/github_enos
           mkdir -p ./enos/terraform-plugin-cache
           export ENOS_VAR_enos_user=$GITHUB_ACTOR && \
           export ENOS_VAR_aws_ssh_private_key_path=~/.ssh/github_enos && \
+          export ENOS_VAR_boundary_license="${{ secrets.BOUNDARY_ENT_LICENSE }}" && \
           export ENOS_VAR_boundary_docker_image_name=hashicorp/boundary-enterprise:latest && \
           export ENOS_VAR_boundary_docker_image_file=/tmp/boundary-enterprise.zip && \
           enos scenario launch --timeout 60m0s --chdir ./support/src/boundary-enterprise/enos e2e_ui_docker_ent builder:crt


### PR DESCRIPTION
# Description
This PR updates the Desktop e2e tests github action workflow to use an environment variable to pass the boundary license information as opposed to needing to create an intermediary file.

This PR also includes a change to the workflow to allow it to run on any manual invocation to allow for easier testing of changes to this workflow.

Here is an example run with these changes: https://github.com/hashicorp/boundary-ui/actions/runs/18134805881/job/51610638515

https://hashicorp.atlassian.net/browse/ICU-17175

## How to Test
Run desktop e2e tests using this branch: https://github.com/hashicorp/boundary-ui/actions/workflows/test-e2e-desktop.yaml

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
