### PR TITLE
fix: 🐛 Fix sanitizing of tokens when logging

### DIFF
--- a/ui/desktop/electron-app/src/services/cache-daemon-manager.js
+++ b/ui/desktop/electron-app/src/services/cache-daemon-manager.js
@@ -177,7 +177,7 @@ const searchCliCommand = (requestData) => {
 
   // Log request data and response, but clean up token from log
   const requestCopy = { ...requestData };
-  delete requestData.token;
+  delete requestCopy.token;
   log.error(`searchCliCommand(${JSON.stringify(requestCopy)}):`, stderr);
 
   return generateErrorPromise(stderr);


### PR DESCRIPTION
# Description
I noticed in a log message that token was still being logged when it shouldn't have been. It looks like we were deleting from the wrong object. 

## Screenshots (if appropriate)

## How to Test
On windows, force an error to be thrown from the cache search and confirm that no tokens are being logged

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- [x] I have added steps to reproduce and test for bug fixes in the description
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] I have added `a11y-tests` label to run a11y audit tests if needed~

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
