### PR TITLE
chore: 🤖 hoist esbuild to consolidate `ember-source` dependencies

### DIFF
--- a/addons/api/package.json
+++ b/addons/api/package.json
@@ -38,6 +38,7 @@
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-mirage": "^3.0.3",
     "ember-data": "~5.3.12",
+    "esbuild": "^0.25.4",
     "miragejs": "^0.1.48",
     "promise-worker-bi": "^5.0.1",
     "tracked-built-ins": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       ember-data:
         specifier: ~5.3.12
         version: 5.3.13(@ember/string@4.0.1)(@ember/test-helpers@5.2.2(@babel/core@7.27.1)(@glint/template@1.5.2))(@ember/test-waiters@4.1.0(@glint/template@1.5.2))(@glint/template@1.5.2)(ember-inflector@4.0.3(ember-source@5.12.0(@glimmer/component@2.0.0)(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.99.8(esbuild@0.25.9))))(ember-source@5.12.0(@glimmer/component@2.0.0)(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.99.8(esbuild@0.25.9)))(qunit@2.24.1)
+      esbuild:
+        specifier: ^0.25.4
+        version: 0.25.9
       miragejs:
         specifier: ^0.1.48
         version: 0.1.48


### PR DESCRIPTION
# Description
This PR is to address an Embroider + Vite build error. The tooling reports the following issue of finding two different `ember-source` resolutions:
```
Some V1 ember addons are resolving as incorrect peer dependencies. This makes it impossible for us to safely convert them to v2 format.

  👇 👇 👇
👉 See https://github.com/embroider-build/embroider/blob/main/docs/peer-dependency-resolution-issues.md for an explanation of the problem and suggestions for fixing it.
  👆 👆 👆

admin@0.0.0 (dev)-> core@0.0.0 -> api@0.0.0
    sees peerDep ember-source@5.12.0
      at boundary-ui/node_modules/.pnpm/ember-source@5.12.0_@glimmer+component@2.0.0_@glint+template@1.5.2_rsvp@4.8.5_webpack@5.99.8_esbuild@0.25.9_/node_modules/ember-source
    but admin@0.0.0 is using ember-source@5.12.0
      at boundary-ui/node_modules/.pnpm/ember-source@5.12.0_@glimmer+component@2.0.0_@glint+template@1.5.2_rsvp@4.8.5_webpack@5.99.8/node_modules/ember-source
```

`pnpm` installs dependencies in its store at `node_modules/.pnpm`.

Currently, looking in the `node_modules/.pnpm` on `main` after a fresh `pnpm install` results in this set up `ember-source` with 2 "installations":
```
boundary-ui/node_modules/.pnpm/ember-source@5.12.0_@glimmer+component@2.0.0_@glint+template@1.5.2_rsvp@4.8.5_webpack@5.99.8
boundary-ui/node_modules/.pnpm/ember-source@5.12.0_@glimmer+component@2.0.0_@glint+template@1.5.2_rsvp@4.8.5_webpack@5.99.8_esbuild@0.25.9
```
The only difference between these two `ember-source` installation sources is `esbuild` being included. pnpm [should try to dedupe them by default](https://pnpm.io/settings#dedupepeerdependents). The example in the documentation is specifically around this scenario: webpack + esbuild. All the versions in the key for `ember-source`, `@glimmer/component`, `@glint/template`, `rsvp`, `webpack` are the same so I believe this should be deduped. The documentation mentions only version mismatches should prevent this dedupe.

This webpack + esbuild scenario arrises from the `api` addon package which has both webpack + esbuild:
* `webpack` has a dependency on `terser-webpack-plugin` which has an optional peer dependency on `esbuild`
* And `ember-source` depends on `ember-auto-import` which depends on `babel-loader` which depends on `webpack` 

If you remove the esbuild from `api` addon, remove `node_modules` and run `pnpm install`, you'll see just one `ember-source` entry (the end goal):
```
boundary-ui/node_modules/.pnpm/ember-source@5.12.0_@glimmer+component@2.0.0_@glint+template@1.5.2_rsvp@4.8.5_webpack@5.99.8
```

While this fixes the issue of just one `ember-source` installation it means that `esbuild` isn't available for the `api` dependency which is needed for our worker builds. Another solution to consolidate the `ember-source` installation is to include `esbuild` anywhere we have `webpack`. This can be done by going to every package and including it explicitly or by hoisting it to the workspace root and then it's available to every workspace implicitly. This results in a single `ember-source` entry:
```
boundary-ui/node_modules/.pnpm/ember-source@5.12.0_@glimmer+component@2.0.0_@glint+template@1.5.2_rsvp@4.8.5_webpack@5.99.8_esbuild@0.25.9
```
As to why the dedupe isn't working, [there may be a bug](https://github.com/pnpm/pnpm/issues/7105)? Based on that [issue](https://github.com/pnpm/pnpm/issues/7105), the workaround is what I've done in this PR:

> This is not high priority right now. You can install @nestjs/microservices and @nestjs/platform-express in the root of the workspace and you'll get a single version of @nestjs/core. 

This PR installs `esbuild` at the root of the workspace and we get a single version of `ember-source`. If this bug gets fixed we can rely on deduping and remove the workspace-level installation of `esbuild`.

## How to Test
### One `ember-source` installation
1. Current state: two `ember-source` entries
From boundary-ui root
```
git checkout main
git pull
rm -rf node_modules
pnpm install
ll node_modules/.pnpm | grep ember-source
```
See that there are two entries _starting with_ `ember-source`, one with `esbuild` and one without

2. This branch: one `ember-source` entry
From boundary-ui root
```
git fetch
git checkout hoist-esbuild
git pull
rm -rf node_modules
pnpm install
ll node_modules/.pnpm | grep ember-source
```
See that there is one entry _starting with_ `ember-source`, it includes `esbuild`

### `esbuild` is still working
The builds should work, and this includes the workers. This should be covered by CI and the vercel builds

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

~~- [ ] I have added before and after screenshots for UI changes~~
~~- [ ] I have added JSON response output for API changes~~
- [X] I have added steps to reproduce and test for bug fixes in the description
~~- [ ] I have commented on my code, particularly in hard-to-understand areas~~
- [X] My changes generate no new warnings
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added `a11y-tests` label to run a11y audit tests if needed~~

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [X] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
