### PR TITLE
refactor: 💡 update logic to get preferred rdp client

### DIFF
--- a/ui/desktop/electron-app/src/services/rdp-client-manager.js
+++ b/ui/desktop/electron-app/src/services/rdp-client-manager.js
@@ -78,40 +78,23 @@ class RdpClientManager {
   }
 
   /**
-   * Gets the best default RDP client (first available that's not 'none')
-   * @returns {Promise<string>} Best RDP client value or 'none'
-   */
-  async getBestDefaultRdpClient() {
-    const availableClients = await this.getAvailableRdpClients();
-    const bestClient = availableClients.find(
-      (client) => client !== RDP_CLIENT_NONE,
-    );
-    return bestClient ?? RDP_CLIENT_NONE;
-  }
-
-  /**
    * Gets the user's preferred RDP client, auto-detecting if not set
    * @returns {Promise<string>} Preferred RDP client value
    */
   async getPreferredRdpClient() {
-    // check user stored preference
-    let preferredClient = store.get('preferredRdpClient');
+    const availableClients = await this.getAvailableRdpClients();
+    const installedClients = availableClients.filter(
+      (client) => client !== RDP_CLIENT_NONE,
+    );
 
-    if (!preferredClient) {
-      // Auto-detect and return the best available client
-      preferredClient = await this.getBestDefaultRdpClient();
-      return preferredClient;
-    }
+    if (installedClients.length === 0) return RDP_CLIENT_NONE;
 
-    // Validate preferred client is still available
-    if (preferredClient !== RDP_CLIENT_NONE) {
-      const availableClient = await this.getBestDefaultRdpClient();
-      if (availableClient === RDP_CLIENT_NONE) {
-        preferredClient = RDP_CLIENT_NONE;
-      }
-    }
-
-    return preferredClient;
+    const preferredClient =
+      store.get('preferredRdpClient') ?? installedClients[0];
+    // check if preferred client is still installed
+    return installedClients.includes(preferredClient)
+      ? preferredClient
+      : RDP_CLIENT_NONE;
   }
 
   /**


### PR DESCRIPTION
# Description
Minor improvements for  rdp client launch:

1. No client installed initially
**Issue**: After installing the client, the Settings page still shows “None” as the auto detected preferred client.
**Expected**: The newly installed client should be auto detected and set as the preferred client in the UI
**Fix**: Don’t store the preferred client in the Electron store by default. Only save the value after the user has explicitly changed it in the Settings UI.

2. Client installed initially, then uninstalled
**Issue**: After uninstalling the client, the Settings page updates correctly with recommended client info, but the Targets list and Target details still show an “Open” button instead of “Connect.”
**Fix**: When the preferred client is not “None,” add additional check to verify that the client is actually installed

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

### Before:

#### No client installed

https://github.com/user-attachments/assets/bceba153-5ae8-497f-8c23-a03fbd21ab7b

#### Client installed initially and then uninstalled:

https://github.com/user-attachments/assets/5f7000b8-5b3e-4534-93d9-71cc2130c1b6

### After:

#### No client installed

https://github.com/user-attachments/assets/468c2b00-e656-480c-8f61-d3fcc72ad191

#### Client installed initially and then uninstalled:

https://github.com/user-attachments/assets/909a676a-044b-4a4b-ba29-12cd9516e165

## How to Test
DM for cluster URL
Note: Reset the `~/Library/Application Support/Boundary/config.json` file  prior to testing.

1.  Install Windows App on Mac. Navigate to Settings page and verify Windows App is selected as preferred rdp client.
2.  Navigate to Targets list view and "Open" button should be visible

Uninstall and Install RDP client flow:

1. Uninstall Windows App on Mac. Navigate to Settings page and verify "None detected. We recommend "Windows App" is rendered in preferred client section
2.  Navigate to Targets list view and "Connect" button should be visible.
3. Install Windows App and refresh the window.
4. Navigate to Settings page and verify Windows App is selected as preferred rdp client.
5. Navigate to Targets list view and "Open" button should be visible


## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


