### PR TITLE
chore: 🤖 use statically referenced components for host catalog

### DIFF
--- a/ui/admin/app/components/form/host-catalog/index.hbs
+++ b/ui/admin/app/components/form/host-catalog/index.hbs
@@ -3,14 +3,13 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-{{component
-  (concat 'form/host-catalog/' @model.compositeType)
-  model=@model
-  submit=@submit
-  cancel=@cancel
-  changeType=@changeType
-  changeCredentialType=@changeCredentialType
-  mapResourceTypeWithIcon=this.mapResourceTypeWithIcon
-  hostCatalogTypes=this.hostCatalogTypes
-  toggleDisableCredentialRotation=this.toggleDisableCredentialRotation
-}}
+<this.hostCatalogFormComponent
+  @model={{@model}}
+  @submit={{@submit}}
+  @cancel={{@cancel}}
+  @changeType={{@changeType}}
+  @changeCredentialType={{@changeCredentialType}}
+  @mapResourceTypeWithIcon={{this.mapResourceTypeWithIcon}}
+  @hostCatalogTypes={{this.hostCatalogTypes}}
+  @toggleDisableCredentialRotation={{this.toggleDisableCredentialRotation}}
+/>

--- a/ui/admin/app/components/form/host-catalog/index.js
+++ b/ui/admin/app/components/form/host-catalog/index.js
@@ -5,11 +5,26 @@
 
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-
+import { assert } from '@ember/debug';
 import {
   TYPES_HOST_CATALOG,
   TYPES_HOST_CATALOG_PLUGIN,
+  TYPE_HOST_CATALOG_PLUGIN_AWS,
+  TYPE_HOST_CATALOG_PLUGIN_AZURE,
+  TYPE_HOST_CATALOG_PLUGIN_GCP,
+  TYPE_HOST_CATALOG_STATIC,
 } from 'api/models/host-catalog';
+import awsHostCatalogFormComponent from './aws';
+import azureHostCatalogFormComponent from './azure';
+import gcpHostCatalogFormComponent from './gcp';
+import staticHostCatalogFormComponent from './static';
+
+const modelCompositeTypeToComponent = {
+  [TYPE_HOST_CATALOG_PLUGIN_AWS]: awsHostCatalogFormComponent,
+  [TYPE_HOST_CATALOG_PLUGIN_AZURE]: azureHostCatalogFormComponent,
+  [TYPE_HOST_CATALOG_PLUGIN_GCP]: gcpHostCatalogFormComponent,
+  [TYPE_HOST_CATALOG_STATIC]: staticHostCatalogFormComponent,
+};
 
 const icons = ['aws-color', 'azure-color', 'gcp-color'];
 
@@ -25,6 +40,20 @@ export default class FormHostCatalogIndexComponent extends Component {
       (obj, plugin, i) => ({ ...obj, [plugin]: icons[i] }),
       {},
     );
+  }
+
+  /**
+   * Returns the host catalog form component associated with the model's composite type
+   * @type {Component}
+   */
+  get hostCatalogFormComponent() {
+    const component =
+      modelCompositeTypeToComponent[this.args.model.compositeType];
+    assert(
+      `Mapped component must exist for host catalog composite type: ${this.args.model.compositeType}`,
+      component,
+    );
+    return component;
   }
 
   // =actions


### PR DESCRIPTION
# Description
This pr continues the migration away from the dynamic `{{component}}` helper. More information in https://github.com/hashicorp/boundary-ui/pull/2880. This pull request focuses on migrating the host-catalog form component.

## How to Test
1. Navigate to the host-catalog form and ensure everything loads correctly
2. Tests continue to pass

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
