### PR TITLE
fix(e2e): Fix LDAP test when org name contains the word "New"

### DIFF
--- a/e2e-tests/admin/tests/auth-method-ldap.spec.js
+++ b/e2e-tests/admin/tests/auth-method-ldap.spec.js
@@ -58,7 +58,7 @@ test(
       await expect(
         page.getByRole('heading', { name: 'Auth Methods' }),
       ).toBeVisible();
-      await page.getByRole('button', { name: 'New' }).click();
+      await page.getByRole('button', { name: 'New', exact: true }).click();
       await page.getByRole('link', { name: 'LDAP' }).click();
 
       const ldapAuthMethodName = 'LDAP ' + nanoid();


### PR DESCRIPTION
# Description
Observed an Admin UI e2e test fail: https://github.com/hashicorp/boundary-ui/actions/runs/19443730741/job/55633080274
```
1) [webkit] › admin/tests/auth-method-ldap.spec.js:24:1 › Set up LDAP auth method @ce @ent @docker 

    Test timeout of 90000ms exceeded.

    Error: locator.click: Test timeout of 90000ms exceeded.
    Call log:
      - waiting for getByRole('link', { name: 'LDAP' })


      57 |         .click();
      58 |       await page.getByRole('button', { name: 'New' }).click();
    > 59 |       await page.getByRole('link', { name: 'LDAP' }).click();
         |                                                      ^
      60 |
      61 |       const ldapAuthMethodName = 'LDAP ' + nanoid();
      62 |       await page.getByLabel('Name').fill(ldapAuthMethodName);
        at /home/runner/work/boundary-ui/boundary-ui/e2e-tests/admin/tests/auth-method-ldap.spec.js:59:54

    attachment #1: screenshot (image/png) ──────────────────────────────────────────────────────────
    admin/artifacts/test-failures/tests-auth-method-ldap-Set-up-LDAP-auth-method-webkit/test-failed-1.png
    ────────────────────────────────────────────────────────────────────────────────────────────────

    Error Context: admin/artifacts/test-failures/tests-auth-method-ldap-Set-up-LDAP-auth-method-webkit/error-context.md

    attachment #3: trace (application/zip) ─────────────────────────────────────────────────────────
    admin/artifacts/test-failures/tests-auth-method-ldap-Set-up-LDAP-auth-method-webkit/trace.zip
    Usage:

        pnpm exec playwright show-trace admin/artifacts/test-failures/tests-auth-method-ldap-Set-up-LDAP-auth-method-webkit/trace.zip

    ────────────────────────────────────────────────────────────────────────────────────────────────
```

The test failed because it clicked the org selector on the bottom instead of the "New" button at the top. This was because the randomly generated org name contained the word "New" in it
 
![page@e82e168ac4dc99839e0dd4aa77d51561-1763413434712](https://github.com/user-attachments/assets/530f0546-bf25-4c2b-972b-7aa637ebe395)

This PR makes an update to look for the New button with `exact: true`

## How to Test
Successful run with changes: https://github.com/hashicorp/boundary-ui/actions/runs/19447151630/job/55644209887

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
