### PR TITLE
chore: 🤖 migrate component helper usage for storage bucket form

### DIFF
--- a/ui/admin/app/components/form/storage-bucket/index.hbs
+++ b/ui/admin/app/components/form/storage-bucket/index.hbs
@@ -3,17 +3,16 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 {{#if @model.type}}
-  {{component
-    (concat 'form/storage-bucket/' @model.compositeType)
-    model=@model
-    submit=@submit
-    cancel=@cancel
-    updateScope=this.updateScope
-    scopes=@scopes
-    pluginTypes=this.pluginTypes
-    changePluginType=@changePluginType
-    changeCredentialType=@changeCredentialType
-    rollbackSecretAttrs=this.rollbackSecretAttrs
-    toggleDisableCredentialRotation=this.toggleDisableCredentialRotation
-  }}
+  <this.storageBucketFormComponent
+    @model={{@model}}
+    @submit={{@submit}}
+    @cancel={{@cancel}}
+    @updateScope={{this.updateScope}}
+    @scopes={{@scopes}}
+    @pluginTypes={{this.pluginTypes}}
+    @changePluginType={{@changePluginType}}
+    @changeCredentialType={{@changeCredentialType}}
+    @rollbackSecretAttrs={{this.rollbackSecretAttrs}}
+    @toggleDisableCredentialRotation={{this.toggleDisableCredentialRotation}}
+  />
 {{/if}}

--- a/ui/admin/app/components/form/storage-bucket/index.js
+++ b/ui/admin/app/components/form/storage-bucket/index.js
@@ -7,11 +7,18 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { set } from '@ember/object';
-
+import { assert } from '@ember/debug';
 import {
   TYPE_CREDENTIAL_DYNAMIC,
   TYPES_STORAGE_BUCKET_PLUGIN,
 } from 'api/models/storage-bucket';
+import awsFormComponent from './aws';
+import minioFormComponent from './minio';
+
+const modelCompositeTypeToComponent = {
+  aws: awsFormComponent,
+  minio: minioFormComponent,
+};
 
 export default class FormStorageBucketComponent extends Component {
   // =attributes
@@ -22,6 +29,19 @@ export default class FormStorageBucketComponent extends Component {
    */
   get pluginTypes() {
     return TYPES_STORAGE_BUCKET_PLUGIN;
+  }
+
+  /**
+   * returns the associated storage bucket form component for the model's composite type
+   */
+  get storageBucketFormComponent() {
+    const component =
+      modelCompositeTypeToComponent[this.args.model.compositeType];
+    assert(
+      `Mapped component must exist for storage bucket composite type: ${this.args.model.compositeType}`,
+      component,
+    );
+    return component;
   }
 
   // =actions


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
This pr continues the migration away from the dynamic `{{component}}` helper. More information in https://github.com/hashicorp/boundary-ui/pull/2880. This pull request focuses on migrating the host-catalog form component.

## How to Test
1. Navigate to the storage bucket form and make sure that it still loads correctly
2. Tests continue to pass

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
