### PR TITLE
chore: 🤖 convert rose form to embroider safe component helper

### DIFF
--- a/addons/rose/addon/components/rose/form/index.hbs
+++ b/addons/rose/addon/components/rose/form/index.hbs
@@ -26,16 +26,22 @@
         'rose/form/checkbox/group' disabled=this.disabled
       )
       fieldset=(component 'rose/form/fieldset')
-      actions=(component
-        (if
-          this.showEditToggleButton
+      actions=(if
+        this.showEditToggleButton
+        (component
           'rose/form/actions/edit-toggle'
-          'rose/form/actions'
+          submitDisabled=this.disabled
+          cancelDisabled=(if @showEditToggle @disabled this.disabled)
+          cancel=this.handleCancel
+          enableEdit=this.enableEdit
         )
-        submitDisabled=this.disabled
-        cancelDisabled=(if @showEditToggle @disabled this.disabled)
-        cancel=this.handleCancel
-        enableEdit=this.enableEdit
+        (component
+          'rose/form/actions'
+          submitDisabled=this.disabled
+          cancelDisabled=(if @showEditToggle @disabled this.disabled)
+          cancel=this.handleCancel
+          enableEdit=this.enableEdit
+        )
       )
       isEditable=this.isEditable
       disabled=this.disabled


### PR DESCRIPTION
# Description
Use conditional around the two different `{{component}}` helper usages instead of one where the conditional is for the first string argument to the helper. This results in some redundancy for the args passed in but it makes the first argument for the `{{component}}` helper a static string and can therefore be statically analyzable by ember's build and is embroider-safe, see:
https://github.com/embroider-build/embroider/blob/main/docs/replacing-component-helper.md

## How to Test
1. Navigate to rose forms and ensure that editable forms with `showEditToggle=true`  show the correct `'rose/form/actions/edit-toggle'` component ("Edit Form" button) , otherwise `'rose/form/actions'` is shown ("Save" and "Cancel" button). Many forms use this case `@showEditToggle={{if @model.isNew false true}}` like the [targets detail page](https://boundary-jhnlsqty6-hashicorp.vercel.app/scopes/p_3pr018stno/targets/t_cuaf318g8o).
2. Tests continue to pass

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
