### PR TITLE
test: 💍 Fix broken tests after new code editor

### DIFF
--- a/e2e-tests/admin/pages/storage-buckets.js
+++ b/e2e-tests/admin/pages/storage-buckets.js
@@ -98,6 +98,7 @@ export class StorageBucketsPage extends BaseResourcePage {
     await this.page.getByLabel('Region').fill(region);
     await this.page.getByLabel('Access key ID').fill(accessKeyId);
     await this.page.getByLabel('Secret access key').fill(secretAccessKey);
+    await this.page.getByLabel('Worker filter').scrollIntoViewIfNeeded();
     await this.page
       .getByLabel('Worker filter')
       .getByRole('textbox')


### PR DESCRIPTION
# Description
I noticed one test was failing in the grants builder llb for admin e2e tests. It looks it doesn't properly find (or load) the code editor until it's scrolled into view. I believe this is because codemirror has an optimization to not render dom elements unless it's in view so a user has to actually scroll the editor into view before it renders it. 

## How to Test
E2E tests should pass. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- ~[ ] I have added `a11y-tests` label to run a11y audit tests if needed~

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
