### PR TITLE
chore: Always run end-to-end tests

### DIFF
--- a/.github/workflows/test-e2e-admin-ui.yaml
+++ b/.github/workflows/test-e2e-admin-ui.yaml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER_UBUNTU_22) }}
     strategy:
       matrix:
+        boundary_edition: [community, enterprise]
+        browser: [chromium, firefox, webkit]
         include:
           - boundary_edition: community
             github_repo: hashicorp/boundary
@@ -41,6 +43,11 @@ jobs:
             enos_scenario: e2e_ui_docker_ent
             test_command: admin:ent:docker
             boundary_branch: ${{ github.event.inputs.boundary-enterprise-branch || 'main' }}
+        # in boundary-ui-enterprise, only run tests on chromium because playwright dependencies can't
+        # be installed on self-hosted runners due to permission issues
+        exclude:
+          - browser: ${{ github.repository == 'hashicorp/boundary-ui-enterprise' && 'firefox' }}
+          - browser: ${{ github.repository == 'hashicorp/boundary-ui-enterprise' && 'webkit' }}
       fail-fast: false
     env:
       ENOS_VAR_e2e_debug_no_run: true
@@ -210,19 +217,13 @@ jobs:
         run: |
           source <(bash ./support/src/${{matrix.folder_name}}/enos/scripts/test_e2e_env.sh)
           cd e2e-tests
-          if [[ "${{ github.repository }}" == "hashicorp/boundary-ui" ]]; then
-            pnpm run ${{ matrix.test_command }} --reporter=html
-          elif [[ "${{ github.repository }}" == "hashicorp/boundary-ui-enterprise" ]]; then
-            # only run tests on chromium because playwright dependencies can't
-            # be installed to support other browsers
-            pnpm run ${{ matrix.test_command }} --project=chromium --reporter=html
-          fi
+          pnpm run ${{ matrix.test_command }} --project=${{ matrix.browser}} --reporter=html
 
       - name: Upload Playwright report
         if: ${{ failure() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: playwright-report-${{ matrix.boundary_edition }}
+          name: playwright-report-${{ matrix.boundary_edition }}-${{ matrix.browser }}
           path: e2e-tests/playwright-report
 
       - name: Clean up test infra
@@ -242,4 +243,4 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: ":x: admin ui e2e tests failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Branch:* ${{ github.repository }}:${{ github.head_ref || github.ref_name }}"
+            text: ":x: admin ui e2e tests (${{ matrix.boundary_edition }}:${{ matrix.browser }}) failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Branch:* ${{ github.repository }}:${{ github.head_ref || github.ref_name }}"

--- a/.github/workflows/test-e2e-admin-ui.yaml
+++ b/.github/workflows/test-e2e-admin-ui.yaml
@@ -3,13 +3,6 @@ name: Test E2E Admin UI
 on:
   pull_request:
     types: [labeled, opened, synchronize, reopened]
-    paths:
-      - 'ui/admin/**'
-      - 'e2e-tests/*'
-      - 'e2e-tests/api-client/**'
-      - 'e2e-tests/helpers/**'
-      - 'e2e-tests/admin/**'
-      - '.github/workflows/test-e2e-admin-ui.yaml'
   workflow_dispatch:
     inputs:
       boundary-enterprise-branch:
@@ -249,4 +242,4 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: ":x: admin ui e2e tests failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Branch:* ${{ github.repository }}:${{ github.head_ref }}"
+            text: ":x: admin ui e2e tests failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Branch:* ${{ github.repository }}:${{ github.head_ref || github.ref_name }}"

--- a/.github/workflows/test-e2e-desktop.yaml
+++ b/.github/workflows/test-e2e-desktop.yaml
@@ -3,13 +3,6 @@ name: Test E2E Desktop Client
 on:
   pull_request:
     types: [labeled, opened, synchronize, reopened]
-    paths:
-      - 'ui/desktop/**'
-      - 'e2e-tests/*'
-      - 'e2e-tests/api-client/**'
-      - 'e2e-tests/helpers/**'
-      - 'e2e-tests/desktop/**'
-      - '.github/workflows/test-e2e-desktop.yaml'
   workflow_dispatch:
     inputs:
       boundary-enterprise-branch:
@@ -187,4 +180,4 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: ":x: desktop client e2e tests failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Branch:* ${{ github.repository }}:${{ github.head_ref }}"
+            text: ":x: desktop client e2e tests failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Branch:* ${{ github.repository }}:${{ github.head_ref || github.ref_name }}"


### PR DESCRIPTION
# Description
I've noticed in PRs that when a "merge from main" update was done, end-to-end tests may not trigger if the updated files did not fall into one of these paths
```
  pull_request:
    types: [labeled, opened, synchronize, reopened]
    paths:
      - 'ui/admin/**'
      - 'e2e-tests/*'
      - 'e2e-tests/api-client/**'
      - 'e2e-tests/helpers/**'
      - 'e2e-tests/admin/**'
      - '.github/workflows/test-e2e-admin-ui.yaml'
```

To ensure that changes are fully tested alongside any new incoming changes, we should run the end-to-end tests on those updates as well. As a result, the PR is removing the `paths` filter.

This PR also splits up the e2e test job to run a new job per browser type, reducing the overall time for completion.

Before: 
<img width="336" height="248" alt="Screenshot 2026-04-10 at 11 12 38 AM" src="https://github.com/user-attachments/assets/f38110a9-efc3-4785-a507-1faa599ed334" />

After:
<img width="320" height="398" alt="Screenshot 2026-04-10 at 11 17 09 AM" src="https://github.com/user-attachments/assets/f2ef3a2b-6de8-4c43-b9f4-a84e0cd4e2e0" />

Also tested against `boundary-ui-enterprise` to validate that logic: https://github.com/hashicorp/boundary-ui-enterprise/actions/runs/24248679245?pr=1527

<img width="327" height="221" alt="Screenshot 2026-04-10 at 11 14 46 AM" src="https://github.com/user-attachments/assets/f2870780-bc91-4c9e-bd2e-f073d8f9a7ce" />


This PR also includes a fix to a slack message to account for different values based on what triggered the workflow (workflow_dispatch vs pull_request).

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
