### PR TITLE
chore(e2e): Log in via CLI during global setup to update cache

### DIFF
--- a/.github/workflows/test-e2e-desktop.yaml
+++ b/.github/workflows/test-e2e-desktop.yaml
@@ -155,7 +155,7 @@ jobs:
 
           export DISPLAY=:99
           Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-          pnpm run desktop
+          pnpm run desktop:ci
 
       - name: Upload Playwright report
         if: ${{ failure() }}

--- a/.github/workflows/test-e2e-desktop.yaml
+++ b/.github/workflows/test-e2e-desktop.yaml
@@ -155,7 +155,7 @@ jobs:
 
           export DISPLAY=:99
           Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-          pnpm run desktop:ci
+          pnpm run desktop
 
       - name: Upload Playwright report
         if: ${{ failure() }}

--- a/e2e-tests/desktop/global-setup.js
+++ b/e2e-tests/desktop/global-setup.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright IBM Corp. 2021, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import * as boundaryCli from '../helpers/boundary-cli.js';
+import baseGlobalSetup from '../global-setup.js';
+
+export default async function globalSetup() {
+  await baseGlobalSetup();
+
+  // when running locally, there's a chance that the cache could be running an
+  // older version.
+  // stop the cache if it's running, and the desktop client will automatically
+  // start the cache after logging in .
+  await boundaryCli.checkBoundaryCli();
+  await boundaryCli.stopCache();
+}

--- a/e2e-tests/desktop/playwright.config.js
+++ b/e2e-tests/desktop/playwright.config.js
@@ -6,7 +6,7 @@ import { defineConfig } from '@playwright/test';
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export default defineConfig({
-  globalSetup: '../global-setup',
+  globalSetup: './global-setup',
   outputDir: './artifacts',
   workers: 1, // Tests need to be run in serial, otherwise there may be conflicts when using the CLI
   use: {

--- a/e2e-tests/global-setup.js
+++ b/e2e-tests/global-setup.js
@@ -4,6 +4,8 @@
  */
 
 import { chromium, test as baseTest, mergeTests } from '@playwright/test';
+
+import * as boundaryCli from './helpers/boundary-cli';
 import { checkEnv } from './helpers/general.js';
 import { boundaryApiClientTest } from './helpers/boundary-api-client.js';
 import { LoginPage } from './admin/pages/login.js';
@@ -23,6 +25,17 @@ async function globalSetup() {
     'E2E_PASSWORD_AUTH_METHOD_ID',
   ]);
   await authenticateToBoundary();
+
+  // log in via CLI to ensure cache is running the correct version.
+  // when running locally, there's a chance that the cache could have an older
+  // version running. logging in via the CLI will update the cache to the latest version
+  await boundaryCli.checkBoundaryCli();
+  await boundaryCli.authenticateBoundary(
+    process.env.BOUNDARY_ADDR,
+    process.env.E2E_PASSWORD_AUTH_METHOD_ID,
+    process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
+    process.env.E2E_PASSWORD_ADMIN_PASSWORD,
+  );
 }
 
 const authenticateToBoundary = async () => {

--- a/e2e-tests/global-setup.js
+++ b/e2e-tests/global-setup.js
@@ -5,7 +5,6 @@
 
 import { chromium, test as baseTest, mergeTests } from '@playwright/test';
 
-import * as boundaryCli from './helpers/boundary-cli';
 import { checkEnv } from './helpers/general.js';
 import { boundaryApiClientTest } from './helpers/boundary-api-client.js';
 import { LoginPage } from './admin/pages/login.js';
@@ -25,17 +24,6 @@ async function globalSetup() {
     'E2E_PASSWORD_AUTH_METHOD_ID',
   ]);
   await authenticateToBoundary();
-
-  // log in via CLI to ensure cache is running the correct version.
-  // when running locally, there's a chance that the cache could have an older
-  // version running. logging in via the CLI will update the cache to the latest version
-  await boundaryCli.checkBoundaryCli();
-  await boundaryCli.authenticateBoundary(
-    process.env.BOUNDARY_ADDR,
-    process.env.E2E_PASSWORD_AUTH_METHOD_ID,
-    process.env.E2E_PASSWORD_ADMIN_LOGIN_NAME,
-    process.env.E2E_PASSWORD_ADMIN_PASSWORD,
-  );
 }
 
 const authenticateToBoundary = async () => {

--- a/e2e-tests/helpers/boundary-cli.js
+++ b/e2e-tests/helpers/boundary-cli.js
@@ -9,6 +9,7 @@ export * from './boundary-cli/accounts.js';
 export * from './boundary-cli/aliases.js';
 export * from './boundary-cli/auth-methods.js';
 export * from './boundary-cli/authenticate.js';
+export * from './boundary-cli/cache.js';
 export * from './boundary-cli/connect.js';
 export * from './boundary-cli/credential-stores.js';
 export * from './boundary-cli/credentials.js';

--- a/e2e-tests/helpers/boundary-cli/cache.js
+++ b/e2e-tests/helpers/boundary-cli/cache.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright IBM Corp. 2021, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { execSync } from 'node:child_process';
+
+/**
+ * Stops the boundary cache used by the desktop client
+ */
+export async function stopCache() {
+  try {
+    execSync('boundary cache stop');
+  } catch (e) {
+    console.log(`${e.stderr}`);
+  }
+}

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -24,7 +24,8 @@
     "admin:dev:chrome": "pnpm run admin --project=chromium --headed",
     "admin:dev:firefox": "pnpm run admin --project=firefox --headed",
     "admin:dev:safari": "pnpm run admin --project=webkit --headed",
-    "desktop": "pnpm run --filter desktop build && pnpm run desktop:dev",
+    "desktop:local": "SETUP_CLI=true pnpm run --filter desktop build && pnpm run desktop:dev",
+    "desktop:ci": "pnpm run --filter desktop build && pnpm run desktop:dev",
     "desktop:dev": "pnpm playwright test --config desktop/playwright.config.js --reporter=html"
   },
   "devDependencies": {

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -24,8 +24,8 @@
     "admin:dev:chrome": "pnpm run admin --project=chromium --headed",
     "admin:dev:firefox": "pnpm run admin --project=firefox --headed",
     "admin:dev:safari": "pnpm run admin --project=webkit --headed",
-    "desktop:local": "SETUP_CLI=true pnpm run --filter desktop build && pnpm run desktop:dev",
-    "desktop:ci": "pnpm run --filter desktop build && pnpm run desktop:dev",
+    "desktop": "pnpm run --filter desktop build && pnpm run desktop:dev",
+    "desktop:local": "SETUP_CLI=true pnpm run desktop",
     "desktop:dev": "pnpm playwright test --config desktop/playwright.config.js --reporter=html"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description
This PR makes a slight adjustment to the e2e test setup. In the global setup, a step was added to log in to Boundary via the CLI. This will ensure that the Boundary cache is updated to the current version before starting desktop e2e tests (there is a cache check on authentication). 

This avoids a problem when running tests locally where someone may update their CLI before running e2e tests, but the desktop client behavior depends on updated cache functionality. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
