### PR TITLE
fix: 🐛 hides preferred clients section for linux

### DIFF
--- a/ui/desktop/app/routes/scopes/scope/projects/settings/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/settings/index.js
@@ -23,6 +23,7 @@ export default class ScopesScopeProjectsSettingsIndexRoute extends Route {
     const logLevel = await window.desktop.logging.getLogLevel();
     const logPath = await window.desktop.logging.getLogPath();
     const serverInformation = this.clusterUrl.rendererClusterUrl;
+    const { isLinux } = await window.desktop.system.checkOS();
 
     return {
       desktopVersion: `v${desktopVersion}`,
@@ -32,6 +33,7 @@ export default class ScopesScopeProjectsSettingsIndexRoute extends Route {
       logLevel,
       logPath,
       serverInformation,
+      isLinux,
     };
   }
 

--- a/ui/desktop/app/templates/scopes/scope/projects/settings/index.hbs
+++ b/ui/desktop/app/templates/scopes/scope/projects/settings/index.hbs
@@ -8,4 +8,6 @@
 <SettingsCard::Application @model={{@model}} @toggle={{this.toggleTheme}} />
 <SettingsCard::ClientAgent @model={{@model}} />
 <SettingsCard::Logs @model={{@model}} />
-<SettingsCard::PreferredClients />
+{{#unless @model.isLinux}}
+  <SettingsCard::PreferredClients />
+{{/unless}}

--- a/ui/desktop/tests/acceptance/projects/settings/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/settings/index-test.js
@@ -336,4 +336,17 @@ module('Acceptance | projects | settings | index', function (hooks) {
     );
     assert.strictEqual(rdpService.preferredRdpClient, RDP_CLIENT_NONE);
   });
+
+  test('preferred clients is hidden for Linux', async function (assert) {
+    window.desktop.system.checkOS.resolves({
+      isWindows: false,
+      isMac: false,
+      isLinux: true,
+    });
+
+    await visit(urls.settings);
+
+    assert.dom(RDP_PREFERRED_CLIENT).doesNotExist();
+    assert.dom(RDP_RECOMMENDED_CLIENT).doesNotExist();
+  });
 });


### PR DESCRIPTION
# Description
Currently, we only support RDP client launch in DC for Windows and Mac OS. We need to ensure the Preferred clients section is hidden for Linux. This PR addresses that bug.

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
Before:
<img width="1288" height="762" alt="Screenshot 2026-04-20 at 12 19 08 PM" src="https://github.com/user-attachments/assets/1b1eb6fa-119c-4714-8df8-a75e34327488" />

After:
<img width="1352" height="970" alt="Screenshot 2026-04-20 at 12 15 26 PM" src="https://github.com/user-attachments/assets/3882d1c3-d7bf-4e6f-a89f-25023d677bff" />



## How to Test
DC build for Linux: https://github.com/hashicorp/boundary-desktop-releases/actions/runs/24684358854

Navigate to Settings page and verify Preferred clients section is not displayed.
## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
