### PR TITLE
fix: 🐛 Fix race condition from sqlite initialization

### DIFF
--- a/addons/api/addon/workers/utils/shared-service.js
+++ b/addons/api/addon/workers/utils/shared-service.js
@@ -169,6 +169,12 @@ const onBecomeProvider = async ({
   target,
   status,
 }) => {
+  // Create a gate that prevents request handling until the provider is fully initialized.
+  // This prevents a race condition where a client registers and sends requests before
+  // the provider has finished initialization.
+  const { promise: providerReady, resolve: providerReadyResolve } =
+    Promise.withResolvers();
+
   // Set an event listener for other tabs to register with the provider tab
   commonChannel.addEventListener('message', async (event) => {
     const { clientId, type } = event.data;
@@ -193,6 +199,9 @@ const onBecomeProvider = async ({
         return;
       }
       const { method, args, id } = data;
+
+      // Wait for the provider to finish initialization before handling requests
+      await providerReady;
 
       let result, error;
       try {
@@ -221,6 +230,7 @@ const onBecomeProvider = async ({
   });
 
   await onProviderChange?.(status.isServiceProvider);
+  providerReadyResolve();
   commonChannel.postMessage({ type: 'providerChange', serviceName });
 
   // If we became the new provider and there were requests in flight, request it directly again.


### PR DESCRIPTION
# Description
We have a flaky test for `Set up OIDC auth method` that seems to only happen in firefox. It's possible firefox has timing differences in how it handles microtasks which is why we only see it in one browser.

I added another gate to try and prevent any requests from firing before initialization occurs.

Related tickets: 
https://hashicorp.atlassian.net/browse/ICU-18773
https://hashicorp.atlassian.net/browse/ICU-18808

## How to Test
Run the e2e tests and they should pass. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
