### PR TITLE
refactor: 💡 Update string formats to use select + add options

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -719,22 +719,33 @@ role:
       title: Grant Editor
       description: Add each new grant string on a different line
     string-formats:
-      title: String format
       title_plural: String formats
+      syntax: Syntax
+      syntax-format: Syntax format
+      more-info: More info
       resource-type:
         label: Singular resource type
-        help: Applies actions to a specific resource type
+        help: Applies actions to a specific resource type in a single grant.
       resource:
         label: Specific resource(s)
-        help: Applies actions to one or more individual resources
+        help: Applies actions to one or more individual resources in a single grant.
       pinned-id:
         label: Pinned ID
-        help: '"Pins" actions to a non-top-level type within a specific resource ID. Only available for certain resource types. '
-        link: More info
+        help: '"Pins" actions to a non-top-level type within a specific ID in a single grant.'
+      output-fields:
+        label: Output fields
+        help: Defines which fields from a request are returned to the user.
+      account-template:
+        label: Account template
+        help: Substitutes the account ID from the token used to perform the request.
+      user-template:
+        label: User template
+        help: Substitutes the user ID from the token used to perform the request.
       insert-actions: insert actions
       insert-resource-types: insert resource types
       insert-id: insert id
       insert-resource-ids: insert resource ids
+      insert-output-fields: insert output fields
     export:
       format: Format
       formatted-export-aria-label: Formatted export

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -726,10 +726,10 @@ role:
       more-info: More info
       resource-type:
         label: Singular resource type
-        help: Applies actions to a specific resource type in a single grant.
+        help: Applies collection actions to a specific resource type in a single grant.
       resource:
         label: Specific resource(s)
-        help: Applies actions to one or more individual resources in a single grant.
+        help: Applies ID actions to one or more individual resources in a single grant.
       pinned-id:
         label: Pinned ID
         help: '"Pins" actions to a non-top-level type within a specific ID in a single grant.'

--- a/ui/admin/app/components/grant-string-formats/index.hbs
+++ b/ui/admin/app/components/grant-string-formats/index.hbs
@@ -39,11 +39,9 @@
   <F.Label>{{t 'resources.role.edit-grants.string-formats.syntax'}}</F.Label>
 </Hds::Form::Textarea::Field>
 
-{{#if this.stringFormat.link}}
-  <Hds::Link::Standalone
-    @icon='docs-link'
-    @iconPosition='trailing'
-    @text={{t 'resources.role.edit-grants.string-formats.more-info'}}
-    @href={{doc-url this.stringFormat.link}}
-  />
-{{/if}}
+<Hds::Link::Standalone
+  @icon='docs-link'
+  @iconPosition='trailing'
+  @text={{t 'resources.role.edit-grants.string-formats.more-info'}}
+  @href={{doc-url this.stringFormat.link}}
+/>

--- a/ui/admin/app/components/grant-string-formats/index.hbs
+++ b/ui/admin/app/components/grant-string-formats/index.hbs
@@ -3,61 +3,47 @@
   SPDX-License-Identifier: BUSL-1.1
 }}
 
-<Hds::Form::Radio::Group
-  @name='string-formats'
-  {{on 'change' (set-from-event this 'selectedFormatType')}}
-  as |G|
+<Hds::Form::SuperSelect::Single::Field
+  name='string-formats'
+  @onChange={{this.changeSelectedFormatType}}
+  @selected={{this.selectedFormatType}}
+  @options={{this.stringFormatTypesList}}
+  as |F|
 >
-  <G.RadioField
-    @value={{this.stringFormatTypes.resourceType}}
-    checked={{eq this.selectedFormatType this.stringFormatTypes.resourceType}}
-    as |F|
-  >
-    <F.Label>{{t
-        'resources.role.edit-grants.string-formats.resource-type.label'
-      }}</F.Label>
-    <F.HelperText>{{t
-        'resources.role.edit-grants.string-formats.resource-type.help'
-      }}</F.HelperText>
-  </G.RadioField>
-  <G.RadioField
-    @value={{this.stringFormatTypes.resource}}
-    checked={{eq this.selectedFormatType this.stringFormatTypes.resource}}
-    as |F|
-  >
-    <F.Label>{{t
-        'resources.role.edit-grants.string-formats.resource.label'
-      }}</F.Label>
-    <F.HelperText>{{t
-        'resources.role.edit-grants.string-formats.resource.help'
-      }}</F.HelperText>
-  </G.RadioField>
-  <G.RadioField
-    @value={{this.stringFormatTypes.pinnedId}}
-    checked={{eq this.selectedFormatType this.stringFormatTypes.pinnedId}}
-    as |F|
-  >
-    <F.Label>{{t
-        'resources.role.edit-grants.string-formats.pinned-id.label'
-      }}</F.Label>
-    <F.HelperText>
-      {{t 'resources.role.edit-grants.string-formats.pinned-id.help'}}
-      <Hds::Link::Inline
-        @color='secondary'
-        @href={{doc-url 'role.grant-string-format.pinned-id'}}
-      >
-        {{t 'resources.role.edit-grants.string-formats.pinned-id.link'}}
-      </Hds::Link::Inline>
-    </F.HelperText>
-  </G.RadioField>
-</Hds::Form::Radio::Group>
+  <F.Label>{{t
+      'resources.role.edit-grants.string-formats.syntax-format'
+    }}</F.Label>
+  <F.Options>
+    {{#let F.options as |formatType|}}
+      <Hds::Text::Body @tag='p' @weight='semibold'>{{t
+          (concat
+            'resources.role.edit-grants.string-formats.' formatType '.label'
+          )
+        }}</Hds::Text::Body>
+      <Hds::Text::Body @tag='p' @color='faint' @size='100'>{{t
+          (concat
+            'resources.role.edit-grants.string-formats.' formatType '.help'
+          )
+        }}</Hds::Text::Body>
+    {{/let}}
+  </F.Options>
+</Hds::Form::SuperSelect::Single::Field>
 
 <Hds::Form::Textarea::Field
   name='string-format'
   readonly
-  @value={{this.stringFormat}}
+  @value={{this.stringFormat.text}}
   @height='3.5rem'
   as |F|
 >
-  <F.Label>{{t 'resources.role.edit-grants.string-formats.title'}}</F.Label>
+  <F.Label>{{t 'resources.role.edit-grants.string-formats.syntax'}}</F.Label>
 </Hds::Form::Textarea::Field>
+
+{{#if this.stringFormat.link}}
+  <Hds::Link::Standalone
+    @icon='docs-link'
+    @iconPosition='trailing'
+    @text={{t 'resources.role.edit-grants.string-formats.more-info'}}
+    @href={{doc-url this.stringFormat.link}}
+  />
+{{/if}}

--- a/ui/admin/app/components/grant-string-formats/index.js
+++ b/ui/admin/app/components/grant-string-formats/index.js
@@ -6,6 +6,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class GrantStringFormatsIndex extends Component {
   // =services
@@ -18,15 +19,36 @@ export default class GrantStringFormatsIndex extends Component {
     resourceType: 'resource-type',
     resource: 'resource',
     pinnedId: 'pinned-id',
+    outputFields: 'output-fields',
+    accountTemplate: 'account-template',
+    userTemplate: 'user-template',
   };
 
+  stringFormatTypesList = Object.values(this.stringFormatTypes);
+
   stringFormats = {
-    [this.stringFormatTypes.resourceType]:
-      `type=<${this.intl.t('resources.role.edit-grants.string-formats.insert-resource-types')}>;actions=<${this.intl.t('resources.role.edit-grants.string-formats.insert-actions')}>`,
-    [this.stringFormatTypes.resource]:
-      `ids=<${this.intl.t('resources.role.edit-grants.string-formats.insert-resource-ids')}>;actions=<${this.intl.t('resources.role.edit-grants.string-formats.insert-actions')}>`,
-    [this.stringFormatTypes.pinnedId]:
-      `ids=<${this.intl.t('resources.role.edit-grants.string-formats.insert-id')}>;type=<${this.intl.t('resources.role.edit-grants.string-formats.insert-resource-types')}>;actions=<${this.intl.t('resources.role.edit-grants.string-formats.insert-actions')}>`,
+    [this.stringFormatTypes.resourceType]: {
+      text: `type=<${this.intl.t('resources.role.edit-grants.string-formats.insert-resource-types')}>;actions=<${this.intl.t('resources.role.edit-grants.string-formats.insert-actions')}>`,
+    },
+    [this.stringFormatTypes.resource]: {
+      text: `ids=<${this.intl.t('resources.role.edit-grants.string-formats.insert-resource-ids')}>;actions=<${this.intl.t('resources.role.edit-grants.string-formats.insert-actions')}>`,
+    },
+    [this.stringFormatTypes.pinnedId]: {
+      text: `ids=<${this.intl.t('resources.role.edit-grants.string-formats.insert-id')}>;type=<${this.intl.t('resources.role.edit-grants.string-formats.insert-resource-types')}>;actions=<${this.intl.t('resources.role.edit-grants.string-formats.insert-actions')}>`,
+      link: 'role.grant-string-format.pinned-id',
+    },
+    [this.stringFormatTypes.outputFields]: {
+      text: `output_fields=<${this.intl.t('resources.role.edit-grants.string-formats.insert-output-fields')}>`,
+      link: 'role.grant-string-format.output-fields',
+    },
+    [this.stringFormatTypes.accountTemplate]: {
+      text: 'ids={{.Account.Id}}',
+      link: 'role.grant-string-format.account-template',
+    },
+    [this.stringFormatTypes.userTemplate]: {
+      text: 'ids={{.User.Id}}',
+      link: 'role.grant-string-format.user-template',
+    },
   };
 
   @tracked selectedFormatType = this.stringFormatTypes.resourceType;
@@ -37,5 +59,12 @@ export default class GrantStringFormatsIndex extends Component {
    */
   get stringFormat() {
     return this.stringFormats[this.selectedFormatType];
+  }
+
+  // =actions
+
+  @action
+  changeSelectedFormatType(type) {
+    this.selectedFormatType = type;
   }
 }

--- a/ui/admin/app/components/grant-string-formats/index.js
+++ b/ui/admin/app/components/grant-string-formats/index.js
@@ -29,9 +29,11 @@ export default class GrantStringFormatsIndex extends Component {
   stringFormats = {
     [this.stringFormatTypes.resourceType]: {
       text: `type=<${this.intl.t('resources.role.edit-grants.string-formats.insert-resource-types')}>;actions=<${this.intl.t('resources.role.edit-grants.string-formats.insert-actions')}>`,
+      link: 'role.grant-string-format.resource-type',
     },
     [this.stringFormatTypes.resource]: {
       text: `ids=<${this.intl.t('resources.role.edit-grants.string-formats.insert-resource-ids')}>;actions=<${this.intl.t('resources.role.edit-grants.string-formats.insert-actions')}>`,
+      link: 'role.grant-string-format.resource',
     },
     [this.stringFormatTypes.pinnedId]: {
       text: `ids=<${this.intl.t('resources.role.edit-grants.string-formats.insert-id')}>;type=<${this.intl.t('resources.role.edit-grants.string-formats.insert-resource-types')}>;actions=<${this.intl.t('resources.role.edit-grants.string-formats.insert-actions')}>`,

--- a/ui/admin/config/environment.js
+++ b/ui/admin/config/environment.js
@@ -97,6 +97,10 @@ module.exports = function (environment) {
         'role.add-principals':
           '/tutorials/oss-administration/oss-manage-roles#create-a-role',
         'role.add-grant-scopes': '/docs/commands/roles/add-grant-scopes',
+        'role.grant-string-format.resource-type':
+          '/docs/rbac/permission-grant-formats#type-only',
+        'role.grant-string-format.resource':
+          '/docs/rbac/permission-grant-formats#id-only',
         'role.grant-string-format.pinned-id':
           '/docs/rbac/permission-grant-formats#pinned-id',
         'role.grant-string-format.output-fields':

--- a/ui/admin/config/environment.js
+++ b/ui/admin/config/environment.js
@@ -99,6 +99,12 @@ module.exports = function (environment) {
         'role.add-grant-scopes': '/docs/commands/roles/add-grant-scopes',
         'role.grant-string-format.pinned-id':
           '/docs/rbac/permission-grant-formats#pinned-id',
+        'role.grant-string-format.output-fields':
+          '/docs/rbac/assignable-permissions#output-fields',
+        'role.grant-string-format.account-template':
+          '/docs/rbac/permission-grant-formats#account-id',
+        'role.grant-string-format.user-template':
+          '/docs/rbac/permission-grant-formats#user-id',
         session: '/docs/concepts/domain-model/sessions',
         target: '/docs/concepts/domain-model/targets',
         'target.new': '/docs/common-workflows/manage-targets',

--- a/ui/admin/tests/integration/components/grant-string-formats/index-test.js
+++ b/ui/admin/tests/integration/components/grant-string-formats/index-test.js
@@ -41,43 +41,37 @@ module(
           selectedOption: 'resourceType',
           expectedValue:
             'type=<insert resource types>;actions=<insert actions>',
-          showsMoreInfoLink: false,
         },
         {
           optionToClick: RESOURCE_OPTION,
           selectedOption: 'resource',
           expectedValue: 'ids=<insert resource ids>;actions=<insert actions>',
-          showsMoreInfoLink: false,
         },
         {
           optionToClick: PINNED_ID_OPTION,
           selectedOption: 'pinnedId',
           expectedValue:
             'ids=<insert id>;type=<insert resource types>;actions=<insert actions>',
-          showsMoreInfoLink: true,
         },
         {
           optionToClick: OUTPUT_FIELDS_OPTION,
           selectedOption: 'outputFields',
           expectedValue: 'output_fields=<insert output fields>',
-          showsMoreInfoLink: true,
         },
         {
           optionToClick: ACCOUNT_TEMPLATE_OPTION,
           selectedOption: 'accountTemplate',
           expectedValue: 'ids={{.Account.Id}}',
-          showsMoreInfoLink: true,
         },
         {
           optionToClick: USER_TEMPLATE_OPTION,
           selectedOption: 'userTemplate',
           expectedValue: 'ids={{.User.Id}}',
-          showsMoreInfoLink: true,
         },
       ],
       async function (
         assert,
-        { optionToClick, selectedOption, expectedValue, showsMoreInfoLink },
+        { optionToClick, selectedOption, expectedValue },
       ) {
         await render(hbs`<GrantStringFormats />`);
 
@@ -98,12 +92,7 @@ module(
         }
 
         assert.dom(STRING_FORMAT_FIELD).hasValue(expectedValue);
-
-        if (showsMoreInfoLink) {
-          assert.dom(MORE_INFO_LINK).isVisible();
-        } else {
-          assert.dom(MORE_INFO_LINK).doesNotExist();
-        }
+        assert.dom(MORE_INFO_LINK).isVisible();
       },
     );
   },

--- a/ui/admin/tests/integration/components/grant-string-formats/index-test.js
+++ b/ui/admin/tests/integration/components/grant-string-formats/index-test.js
@@ -15,48 +15,96 @@ module(
     setupRenderingTest(hooks);
     setupIntl(hooks, 'en-us');
 
-    const RESOURCE_TYPE_OPTION = '[value="resource-type"]';
-    const RESOURCE_OPTION = '[value="resource"]';
-    const PINNED_ID_OPTION = '[value="pinned-id"]';
+    const STRING_FORMATS_SELECT = '[name="string-formats"]';
+    const RESOURCE_TYPE_OPTION = '[data-option-index="0"]';
+    const RESOURCE_OPTION = '[data-option-index="1"]';
+    const PINNED_ID_OPTION = '[data-option-index="2"]';
+    const OUTPUT_FIELDS_OPTION = '[data-option-index="3"]';
+    const ACCOUNT_TEMPLATE_OPTION = '[data-option-index="4"]';
+    const USER_TEMPLATE_OPTION = '[data-option-index="5"]';
     const STRING_FORMAT_FIELD = '[name="string-format"]';
+    const MORE_INFO_LINK = '.hds-link-standalone';
 
-    test('it renders string format with resource type by default', async function (assert) {
-      await render(hbs`<GrantStringFormats />`);
+    const options = {
+      resourceType: RESOURCE_TYPE_OPTION,
+      resource: RESOURCE_OPTION,
+      pinnedId: PINNED_ID_OPTION,
+      outputFields: OUTPUT_FIELDS_OPTION,
+      accountTemplate: ACCOUNT_TEMPLATE_OPTION,
+      userTemplate: USER_TEMPLATE_OPTION,
+    };
 
-      assert.dom(RESOURCE_TYPE_OPTION).isChecked();
-      assert.dom(RESOURCE_OPTION).isNotChecked();
-      assert.dom(PINNED_ID_OPTION).isNotChecked();
-      assert
-        .dom(STRING_FORMAT_FIELD)
-        .hasValue('type=<insert resource types>;actions=<insert actions>');
-    });
+    test.each(
+      'it renders the expected string format for each option',
+      [
+        {
+          selectedOption: 'resourceType',
+          expectedValue:
+            'type=<insert resource types>;actions=<insert actions>',
+          showsMoreInfoLink: false,
+        },
+        {
+          optionToClick: RESOURCE_OPTION,
+          selectedOption: 'resource',
+          expectedValue: 'ids=<insert resource ids>;actions=<insert actions>',
+          showsMoreInfoLink: false,
+        },
+        {
+          optionToClick: PINNED_ID_OPTION,
+          selectedOption: 'pinnedId',
+          expectedValue:
+            'ids=<insert id>;type=<insert resource types>;actions=<insert actions>',
+          showsMoreInfoLink: true,
+        },
+        {
+          optionToClick: OUTPUT_FIELDS_OPTION,
+          selectedOption: 'outputFields',
+          expectedValue: 'output_fields=<insert output fields>',
+          showsMoreInfoLink: true,
+        },
+        {
+          optionToClick: ACCOUNT_TEMPLATE_OPTION,
+          selectedOption: 'accountTemplate',
+          expectedValue: 'ids={{.Account.Id}}',
+          showsMoreInfoLink: true,
+        },
+        {
+          optionToClick: USER_TEMPLATE_OPTION,
+          selectedOption: 'userTemplate',
+          expectedValue: 'ids={{.User.Id}}',
+          showsMoreInfoLink: true,
+        },
+      ],
+      async function (
+        assert,
+        { optionToClick, selectedOption, expectedValue, showsMoreInfoLink },
+      ) {
+        await render(hbs`<GrantStringFormats />`);
 
-    test('it renders string format when type is changed to specific resource', async function (assert) {
-      await render(hbs`<GrantStringFormats />`);
+        await click(STRING_FORMATS_SELECT);
 
-      await click(RESOURCE_OPTION);
+        if (optionToClick) {
+          await click(optionToClick);
+          await click(STRING_FORMATS_SELECT);
+        }
 
-      assert.dom(RESOURCE_OPTION).isChecked();
-      assert.dom(RESOURCE_TYPE_OPTION).isNotChecked();
-      assert.dom(PINNED_ID_OPTION).isNotChecked();
-      assert
-        .dom(STRING_FORMAT_FIELD)
-        .hasValue('ids=<insert resource ids>;actions=<insert actions>');
-    });
+        for (const [optionName, selector] of Object.entries(options)) {
+          assert
+            .dom(selector)
+            .hasAria(
+              'selected',
+              optionName === selectedOption ? 'true' : 'false',
+            );
+        }
 
-    test('it renders string format when type is changed to pinned id', async function (assert) {
-      await render(hbs`<GrantStringFormats />`);
+        assert.dom(STRING_FORMAT_FIELD).hasValue(expectedValue);
 
-      await click(PINNED_ID_OPTION);
-
-      assert.dom(PINNED_ID_OPTION).isChecked();
-      assert.dom(RESOURCE_TYPE_OPTION).isNotChecked();
-      assert.dom(RESOURCE_OPTION).isNotChecked();
-      assert
-        .dom(STRING_FORMAT_FIELD)
-        .hasValue(
-          'ids=<insert id>;type=<insert resource types>;actions=<insert actions>',
-        );
-    });
+        if (showsMoreInfoLink) {
+          assert.dom(MORE_INFO_LINK).isVisible();
+        } else {
+          assert.dom(MORE_INFO_LINK).doesNotExist();
+        }
+      },
+    );
   },
 );


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-18983

# Description
<!-- Add a brief description of changes here -->
Refactor string formats field to use super select instead of radio select. Update to add more format options as well.
<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
Before:
<img width="422" height="582" alt="image" src="https://github.com/user-attachments/assets/91eb0d24-d3ac-43e0-af4a-cebc54288b2d" />

After:
<img width="448" height="418" alt="image" src="https://github.com/user-attachments/assets/2bd2b901-5fa4-41b6-ba15-1d1d33f114a1" />

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
Go to Edit Grants page and validate switching between options works
## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [X] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [X] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
