### PR TITLE
fix: 🐛 Add extra check for SQLite errors

### DIFF
--- a/addons/api/addon/workers/sqlite-worker.js
+++ b/addons/api/addon/workers/sqlite-worker.js
@@ -97,15 +97,25 @@ import {
             if (poolUtil.getCapacity() > 20) {
               await poolUtil.removeVfs();
             }
-          } else {
+          } else if (
+            err?.resultCode === SQLITE_CORRUPT ||
+            err instanceof WebAssembly.RuntimeError
+          ) {
+            // We might have gotten ourselves into a bad state which corrupted the DB so clear it out and retry.
             console.error('SQLite initialization error:', err);
-
-            // We might have gotten ourselves into a bad state which corrupted the DB so clear it out and retry
-            if (err?.resultCode === SQLITE_CORRUPT) {
+            try {
+              if (db) {
+                db.close();
+                db = null;
+              }
               poolUtil.unlink(`/${dbName}`);
-            } else {
-              throw err;
+            } catch (cleanupErr) {
+              // If cleanup fails, wipe the entire VFS and reinstall to start fresh
+              console.error('SQLite cleanup error:', cleanupErr);
+              await poolUtil.removeVfs();
             }
+          } else {
+            throw err;
           }
         }
       }


### PR DESCRIPTION
# Description
We're getting some flaky e2e test failures in webkit which seem to originate from an error in sqlite. I'm adding some extra guards to the initialization of the sqlite in the worker to see if that helps. 

https://hashicorp.atlassian.net/browse/ICU-19002

## Screenshots (if appropriate)

## How to Test
Run e2e tests and they should pass.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
