### PR TITLE
ci: declare least-privilege permissions on the 10 remaining workflows

### DIFF
--- a/.github/workflows/a11y-tests.yaml
+++ b/.github/workflows/a11y-tests.yaml
@@ -5,6 +5,9 @@ on:
     types: [labeled, opened, synchronize, reopened]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   a11y-test:

--- a/.github/workflows/build-admin-ui.yaml
+++ b/.github/workflows/build-admin-ui.yaml
@@ -6,6 +6,9 @@ on:
       - "release/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   dependencies:
     name: Install dependencies

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,11 @@ on:
   schedule:
     - cron: '0 19 * * 4'
 
+permissions:
+  contents: read
+  actions: read
+  security-events: write   # CodeQL upload
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,11 @@ name: "Pull Request Labeler"
 on:
 - pull_request_target
 
+# actions/labeler reads .github/labeler.yml and applies labels in pull_request_target context.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   triage:
     runs-on: ${{ fromJSON(vars.RUNNER) }}

--- a/.github/workflows/monorepo-validate.yaml
+++ b/.github/workflows/monorepo-validate.yaml
@@ -1,5 +1,8 @@
 name: Validate Monorepo
 on: pull_request
+permissions:
+  contents: read
+
 jobs:
 
   dependencies:

--- a/.github/workflows/oss-ent-merge-trigger.yml
+++ b/.github/workflows/oss-ent-merge-trigger.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+# curl uses ELEVATED_GITHUB_TOKEN to repository_dispatch the enterprise repo;
+# default GITHUB_TOKEN is unused.
+permissions: {}
+
 jobs:
   trigger-oss-merge:
     # Run this only on merge events in OSS repo

--- a/.github/workflows/oss-merge.yml
+++ b/.github/workflows/oss-merge.yml
@@ -2,6 +2,9 @@ name: OSS → ENT Merge
 on:
   repository_dispatch:
     types: [ oss-merge ]
+# Checkout and merge run via ELEVATED_GITHUB_TOKEN; default token is unused.
+permissions: {}
+
 jobs:
   oss-merge:
     runs-on: ${{ fromJSON(vars.RUNNER) }}

--- a/.github/workflows/test-e2e-admin-ui.yaml
+++ b/.github/workflows/test-e2e-admin-ui.yaml
@@ -16,6 +16,9 @@ on:
         default: 'main'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test

--- a/.github/workflows/test-e2e-desktop.yaml
+++ b/.github/workflows/test-e2e-desktop.yaml
@@ -16,6 +16,9 @@ on:
         default: 'main'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test

--- a/.github/workflows/ui-release-trigger.yml
+++ b/.github/workflows/ui-release-trigger.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+# gh workflow run uses ELEVATED_GITHUB_TOKEN; default token is unused.
+permissions: {}
+
 jobs:
   trigger-gha-release:
     runs-on: ${{ fromJSON(vars.RUNNER) }}


### PR DESCRIPTION
Adds explicit `permissions:` blocks to the ten workflows still inheriting org defaults.

Read-only CI (`contents: read`):
- `a11y-tests.yaml`
- `build-admin-ui.yaml`
- `monorepo-validate.yaml`
- `test-e2e-admin-ui.yaml`
- `test-e2e-desktop.yaml`

Specific scopes:
- `codeql-analysis.yml` — `contents: read` + `actions: read` + `security-events: write` (the standard CodeQL set).
- `labeler.yml` — `contents: read` + `pull-requests: write`. `actions/labeler` applies labels in `pull_request_target` context.

`permissions: {}` (default token unused):
- `oss-ent-merge-trigger.yml` — `curl` to `repository_dispatch` uses `ELEVATED_GITHUB_TOKEN`.
- `oss-merge.yml` — checkout + merge script + `git push` all use `ELEVATED_GITHUB_TOKEN`.
- `ui-release-trigger.yml` — `gh workflow run` against `hashicorp/boundary-desktop-releases` uses `ELEVATED_GITHUB_TOKEN`.

YAML validated locally with `yaml.safe_load` for each edited file.