### PR TITLE
Display session playback error

### DIFF
--- a/addons/api/addon/generated/models/session-recording.js
+++ b/addons/api/addon/generated/models/session-recording.js
@@ -96,19 +96,19 @@ export default class GeneratedSessionRecordingModel extends BaseModel {
   })
   duration;
 
-  @attr('string', {
+  @attr({
     description:
-      'The current state of the session recording. One of "started", "available" and "unknown".',
+      'The detailed state of the session recording. This contains storage_state, syncing_error_details, and verification_error_details.',
     readOnly: true,
   })
-  state;
+  recording_state;
 
   @attr('string', {
     description:
-      'Any error seen during the closing of the session recording. Currently only set if state is "unknown".',
+      'The availability of the session recording. One of "available" or "not available".',
     readOnly: true,
   })
-  error_details;
+  availability;
 
   @attr('date', {
     description: 'The time until a session recording is required to be stored.',
@@ -122,4 +122,19 @@ export default class GeneratedSessionRecordingModel extends BaseModel {
     readOnly: true,
   })
   delete_after;
+
+  // Deprecated: These two fields should be removed once support for RDP is added.
+  @attr('string', {
+    description:
+      'The current state of the session recording. One of "started", "available" and "unknown".',
+    readOnly: true,
+  })
+  state;
+
+  @attr('string', {
+    description:
+      'Any error seen during the closing of the session recording. Currently only set if state is "unknown".',
+    readOnly: true,
+  })
+  error_details;
 }

--- a/addons/api/app/mirage/factories/session-recording.js
+++ b/addons/api/app/mirage/factories/session-recording.js
@@ -37,9 +37,9 @@ export default factory.extend({
     const errorScenarios = [
       {
         syncing_error_details:
-          'sync errors in container "sr_jovU2XLzBP.bsr": file "sr_jovU2XLzBP.bsr/session-recording.meta": storage.(syncingFile).sync: storage.parseStoragePluginError: plugin error, external system issue: error #3001: rpc error: code = Internal desc = failed to put object into minio: Get "http://minio:9000/my-special-storage-bucket/?location=": dial tcp: lookup minio on 10.89.0.1:53: no such host',
+          'sync errors in container "sr_jovU2XLzBP.bsr": file "sr_jovU2XLzBP.bsr/session-recording.meta": storage.(syncingFile).sync: storage.parseStoragePluginError: plugin error, external system issue: error #3001: rpc error: \ncode = Internal desc = failed to put object into minio: Get "http://minio:9000/my-special-storage-bucket/?location=": dial tcp: lookup minio on 10.89.0.1:53: no such host',
         verification_error_details:
-          'integrity check failed for session recording file "sr_jovU2XLzBP.bsr/channels/connection-1/channel-recording-data.bin": expected SHA-256 checksum "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6" but computed checksum was "z6y5x4w3v2u1t0s9r8q7p6o5n4m3l2k1j0i9h8g7f6e5d4c3b2a1" indicating potential data corruption during transfer or storage',
+          'integrity check failed for session recording file "sr_jovU2XLzBP.bsr/channels/connection-1/channel-recording-data.bin": expected SHA-256 checksum "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6" but computed \nchecksum was "z6y5x4w3v2u1t0s9r8q7p6o5n4m3l2k1j0i9h8g7f6e5d4c3b2a1" indicating potential data corruption during transfer or storage',
       },
       {
         syncing_error_details:

--- a/addons/api/app/mirage/factories/session-recording.js
+++ b/addons/api/app/mirage/factories/session-recording.js
@@ -10,8 +10,8 @@ import { faker } from '@faker-js/faker';
 import { trait } from 'miragejs';
 import {
   TYPES_SESSION_RECORDING as types,
-  STATE_SESSION_RECORDING_STARTED,
   STATE_SESSION_RECORDING_AVAILABLE,
+  STATE_SESSION_RECORDING_STARTED,
   STATE_SESSION_RECORDING_UNKNOWN,
 } from 'api/models/session-recording';
 
@@ -27,6 +27,29 @@ export default factory.extend({
   // Cycle through available types
   type: (i) => types[i % types.length],
   state: (i) => states[i % states.length],
+
+  recording_state(i) {
+    // Only return error details if state is 'unknown' (failed)
+    if (this.state !== STATE_SESSION_RECORDING_UNKNOWN) {
+      return {};
+    }
+
+    const errorScenarios = [
+      {
+        syncing_error_details:
+          'sync errors in container "sr_jovU2XLzBP.bsr": file "sr_jovU2XLzBP.bsr/session-recording.meta": storage.(syncingFile).sync: storage.parseStoragePluginError: plugin error, external system issue: error #3001: rpc error: code = Internal desc = failed to put object into minio: Get "http://minio:9000/my-special-storage-bucket/?location=": dial tcp: lookup minio on 10.89.0.1:53: no such host',
+        verification_error_details:
+          'integrity check failed for session recording file "sr_jovU2XLzBP.bsr/channels/connection-1/channel-recording-data.bin": expected SHA-256 checksum "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6" but computed checksum was "z6y5x4w3v2u1t0s9r8q7p6o5n4m3l2k1j0i9h8g7f6e5d4c3b2a1" indicating potential data corruption during transfer or storage',
+      },
+      {
+        syncing_error_details:
+          'sync errors in container "sr_jovU2XLzBP.bsr": file "sr_jovU2XLzBP.bsr/session-recording.meta": storage.(syncingFile).sync: storage.parseStoragePluginError: plugin error, external system issue: error #3001: rpc error: code = Internal desc = failed to put object into minio: Get "http://minio:9000/my-special-storage-bucket/?location=": dial tcp: lookup minio on 10.89.0.1:53: no such host',
+        verification_error_details: null,
+      },
+    ];
+    return errorScenarios[i % 2];
+  },
+
   start_time() {
     return this.state === STATE_SESSION_RECORDING_AVAILABLE
       ? faker.date.recent({ days: 3, refDate: this.end_time })

--- a/addons/core/translations/actions/en-us.yaml
+++ b/addons/core/translations/actions/en-us.yaml
@@ -71,3 +71,4 @@ edit-worker-filter: Edit Worker Filter
 add-worker-filter: Add Worker Filter
 open: Open
 download: Download
+show-more: Show more

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -420,9 +420,14 @@ session-recording:
     title: Channels by connection
     messages:
       no-channels: There are no channels for this connection
+      flyout:
+        title: Session playback errors
       sync-error:
         title: This recording is not available
         copy: Copy error
+        flyout-section-title: Sync error
+      verification-error:
+        flyout-section-title: Verification error
       started-no-connections:
         title: Session Recording In Progress
         description: The Session has started but no connections have been made.

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -424,7 +424,6 @@ session-recording:
         title: Session playback errors
       sync-error:
         title: This recording is not available
-        copy: Copy error
         flyout-section-title: Sync error
       verification-error:
         flyout-section-title: Verification error

--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -420,6 +420,9 @@ session-recording:
     title: Channels by connection
     messages:
       no-channels: There are no channels for this connection
+      sync-error:
+        title: This recording is not available
+        copy: Copy error
       started-no-connections:
         title: Session Recording In Progress
         description: The Session has started but no connections have been made.

--- a/ui/admin/app/components/session-recording/error-flyout-alert.hbs
+++ b/ui/admin/app/components/session-recording/error-flyout-alert.hbs
@@ -27,11 +27,9 @@
           </li>
         </ul>
       {{else}}
-        <div class='playback-error-item'>
-          <Hds::Text::Body @tag='p' class='playback-error-message'>
-            {{or @syncError @verifyError}}
-          </Hds::Text::Body>
-        </div>
+        <Hds::Text::Body @tag='p' class='playback-error-message'>
+          {{or @syncError @verifyError}}
+        </Hds::Text::Body>
       {{/if}}
     </A.Description>
     <A.Button

--- a/ui/admin/app/components/session-recording/error-flyout-alert.hbs
+++ b/ui/admin/app/components/session-recording/error-flyout-alert.hbs
@@ -14,8 +14,8 @@
       }}</A.Title>
     <A.Description>
       {{#if (and @syncError @verifyError)}}
-        <ul class='playback-error-list'>
-          <li class='playback-error-item'>
+        <ul>
+          <li class='playback-error-item margin-bottom-s'>
             <Hds::Text::Body @tag='p' class='playback-error-message'>
               {{@syncError}}
             </Hds::Text::Body>

--- a/ui/admin/app/components/session-recording/error-flyout-alert.hbs
+++ b/ui/admin/app/components/session-recording/error-flyout-alert.hbs
@@ -65,7 +65,7 @@
                 @size='small'
                 @text={{t 'actions.copy'}}
                 @isIconOnly={{true}}
-                @textToCopy={{join @syncErrorLines '\n'}}
+                @textToCopy={{@syncError}}
               />
             </:toggle>
             <:content>
@@ -89,7 +89,7 @@
                 @size='small'
                 @text={{t 'actions.copy'}}
                 @isIconOnly={{true}}
-                @textToCopy={{join @verifyErrorLines '\n'}}
+                @textToCopy={{@verifyError}}
               />
             </:toggle>
             <:content>

--- a/ui/admin/app/components/session-recording/error-flyout-alert.hbs
+++ b/ui/admin/app/components/session-recording/error-flyout-alert.hbs
@@ -1,0 +1,109 @@
+{{!
+  Copyright IBM Corp. 2021, 2026
+  SPDX-License-Identifier: BUSL-1.1
+}}
+{{#if (or @syncError @verifyError)}}
+  <Hds::Alert
+    data-test-session-playback-alert
+    @type='inline'
+    @color='critical'
+    as |A|
+  >
+    <A.Title>{{t
+        'resources.session-recording.channels-by-connection.messages.sync-error.title'
+      }}</A.Title>
+    <A.Description>
+      {{#if (and @syncError @verifyError)}}
+        <ul class='playback-error-list'>
+          <li class='playback-error-item'>
+            <Hds::Text::Body @tag='p' class='playback-error-message'>
+              {{@syncError}}
+            </Hds::Text::Body>
+          </li>
+          <li class='playback-error-item'>
+            <Hds::Text::Body @tag='p' class='playback-error-message'>
+              {{@verifyError}}
+            </Hds::Text::Body>
+          </li>
+        </ul>
+      {{else}}
+        <div class='playback-error-item'>
+          <Hds::Text::Body @tag='p' class='playback-error-message'>
+            {{or @syncError @verifyError}}
+          </Hds::Text::Body>
+        </div>
+      {{/if}}
+    </A.Description>
+    <A.Button
+      @text={{t 'actions.show-more'}}
+      @color='secondary'
+      {{on 'click' @onShowFlyout}}
+    />
+  </Hds::Alert>
+{{/if}}
+
+{{#if @showFlyout}}
+  <Hds::Flyout
+    class='session-playback-error-flyout'
+    @size='large'
+    @onClose={{@onShowFlyout}}
+    data-test-error-flyout
+    as |F|
+  >
+    <F.Header>{{t
+        'resources.session-recording.channels-by-connection.messages.flyout.title'
+      }}</F.Header>
+    <F.Body>
+      <Hds::Accordion @size='large' as |A|>
+        {{#if @syncErrorLines.length}}
+          <A.Item @isOpen={{true}}>
+            <:toggle>
+              <Hds::Text::Body @tag='p' @size='300' @weight='medium'>
+                {{t
+                  'resources.session-recording.channels-by-connection.messages.sync-error.flyout-section-title'
+                }}
+              </Hds::Text::Body>
+              <Hds::Copy::Button
+                @size='small'
+                @text={{t 'actions.copy'}}
+                @isIconOnly={{true}}
+                @textToCopy={{join @syncErrorLines '\n'}}
+              />
+            </:toggle>
+            <:content>
+              {{#each @syncErrorLines as |error|}}
+                <Hds::Text::Body @tag='p' class='flyout-error-message'>
+                  {{error}}
+                </Hds::Text::Body>
+              {{/each}}
+            </:content>
+          </A.Item>
+        {{/if}}
+        {{#if @verifyErrorLines.length}}
+          <A.Item @isOpen={{true}}>
+            <:toggle>
+              <Hds::Text::Body @tag='p' @size='300' @weight='medium'>
+                {{t
+                  'resources.session-recording.channels-by-connection.messages.verification-error.flyout-section-title'
+                }}
+              </Hds::Text::Body>
+              <Hds::Copy::Button
+                @size='small'
+                @text={{t 'actions.copy'}}
+                @isIconOnly={{true}}
+                @textToCopy={{join @verifyErrorLines '\n'}}
+              />
+            </:toggle>
+            <:content>
+              {{#each @verifyErrorLines as |error|}}
+                <Hds::Text::Body @tag='p' class='flyout-error-message'>
+                  {{error}}
+                </Hds::Text::Body>
+              {{/each}}
+            </:content>
+          </A.Item>
+        {{/if}}
+      </Hds::Accordion>
+    </F.Body>
+  </Hds::Flyout>
+{{/if}}

--- a/ui/admin/app/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index.js
+++ b/ui/admin/app/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index.js
@@ -13,11 +13,18 @@ import {
   STATE_SESSION_RECORDING_STARTED,
   STATE_SESSION_RECORDING_UNKNOWN,
 } from 'api/models/session-recording';
+import { tracked } from '@glimmer/tracking';
 
 export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConnectionIndexController extends Controller {
   // =services
 
   @service router;
+
+  // =tracked
+
+  @tracked showErrorFlyout = false;
+  @tracked syncErrorLines = [];
+  @tracked verifyErrorLines = [];
 
   // =attributes
 
@@ -85,6 +92,26 @@ export default class ScopesScopeSessionRecordingsSessionRecordingChannelsByConne
     } catch (e) {
       sessionRecording.rollbackAttributes();
       throw new Error(e);
+    }
+  }
+
+  // =actions
+  /**
+   * Toggles the error flyout open and closed, and sets the error messages to be displayed when opening.
+   */
+  @action
+  toggleErrorFlyout() {
+    if (this.showErrorFlyout) {
+      this.showErrorFlyout = false;
+    } else {
+      const recordingState = this.model.sessionRecording?.recording_state || {};
+
+      const { syncing_error_details, verification_error_details } =
+        recordingState;
+
+      this.syncErrorLines = syncing_error_details?.split('\n') ?? [];
+      this.verifyErrorLines = verification_error_details?.split('\n') ?? [];
+      this.showErrorFlyout = true;
     }
   }
 }

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -751,10 +751,8 @@
 
   .playback-error-item {
     display: flex;
-    flex-direction: row;
     align-items: center;
     gap: 0.5rem;
-    position: relative;
   }
 
   .playback-error-list {
@@ -774,6 +772,19 @@
   /* stylelint-disable-next-line selector-class-pattern */
   .hds-alert__content {
     min-width: 0;
+  }
+}
+
+// Session playback error flyout
+.session-playback-error-flyout {
+  .flyout-error-message {
+    margin-bottom: 0.5rem;
+  }
+  /* stylelint-disable-next-line selector-class-pattern */
+  .hds-accordion-item__toggle-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
   }
 }
 

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -750,16 +750,7 @@
   }
 
   .playback-error-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .playback-error-list {
-    .playback-error-item::before {
-      content: '•';
-      font-size: 1.5em;
-    }
+    list-style: disc;
   }
 
   .playback-error-message {

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -757,7 +757,7 @@
 
   .playback-error-list {
     .playback-error-item::before {
-      content: '\2022';
+      content: '•';
       font-size: 1.5em;
     }
   }

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -748,6 +748,33 @@
   .no-channels-message {
     padding: 0 1rem;
   }
+
+  .playback-error-item {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    position: relative;
+  }
+
+  .playback-error-list {
+    .playback-error-item::before {
+      content: '\2022';
+      font-size: 1.5em;
+    }
+  }
+
+  .playback-error-message {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* stylelint-disable-next-line selector-class-pattern */
+  .hds-alert__content {
+    min-width: 0;
+  }
 }
 
 // Channel

--- a/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
@@ -46,6 +46,84 @@
     <div class='channels-by-connection'>
       <Rose::Layout::BodyContent as |bc|>
         <bc.Body>
+          {{#if
+            (or
+              @model.sessionRecording.recording_state.syncing_error_details
+              @model.sessionRecording.recording_state.verification_error_details
+            )
+          }}
+            <Hds::Alert
+              data-test-session-playback-alert
+              @type='inline'
+              @color='critical'
+              as |A|
+            >
+              <A.Title>{{t
+                  'resources.session-recording.channels-by-connection.messages.sync-error.title'
+                }}</A.Title>
+              <A.Description>
+                {{#if
+                  (and
+                    @model.sessionRecording.recording_state.syncing_error_details
+                    @model.sessionRecording.recording_state.verification_error_details
+                  )
+                }}
+                  {{! Both errors present - show as bullet list with inline copy buttons }}
+                  <ul class='playback-error-list'>
+                    <li class='playback-error-item margin-bottom-s'>
+                      <Hds::Text::Body
+                        @tag='span'
+                        class='playback-error-message'
+                      >
+                        {{@model.sessionRecording.recording_state.syncing_error_details}}
+                      </Hds::Text::Body>
+                      <Hds::Copy::Button
+                        @size='small'
+                        @text='Copy'
+                        @isIconOnly={{true}}
+                        @textToCopy={{@model.sessionRecording.recording_state.syncing_error_details}}
+                      />
+                    </li>
+                    <li class='playback-error-item'>
+                      <Hds::Text::Body
+                        @tag='span'
+                        class='playback-error-message'
+                      >
+                        {{@model.sessionRecording.recording_state.verification_error_details}}
+                      </Hds::Text::Body>
+                      <Hds::Copy::Button
+                        @size='small'
+                        @text='Copy'
+                        @isIconOnly={{true}}
+                        @textToCopy={{@model.sessionRecording.recording_state.verification_error_details}}
+                      />
+                    </li>
+                  </ul>
+                {{else}}
+                  {{! Only one error present - show as single message }}
+                  <div class='playback-error-item'>
+                    <Hds::Text::Body @tag='span' class='playback-error-message'>
+                      {{or
+                        @model.sessionRecording.recording_state.syncing_error_details
+                        @model.sessionRecording.recording_state.verification_error_details
+                      }}
+                    </Hds::Text::Body>
+                    <Hds::Copy::Button
+                      @size='small'
+                      @text={{t
+                        'resources.session-recording.channels-by-connection.messages.sync-error.copy'
+                      }}
+                      @isIconOnly={{true}}
+                      @textToCopy={{or
+                        @model.sessionRecording.recording_state.syncing_error_details
+                        @model.sessionRecording.recording_state.verification_error_details
+                      }}
+                    />
+                  </div>
+                {{/if}}
+              </A.Description>
+            </Hds::Alert>
+          {{/if}}
           {{#if this.isSessionInprogressWithNoConnections}}
             <Hds::ApplicationState as |A|>
               {{! Session recording in progress with no connections }}

--- a/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
@@ -46,84 +46,79 @@
     <div class='channels-by-connection'>
       <Rose::Layout::BodyContent as |bc|>
         <bc.Body>
-          {{#if
-            (or
-              @model.sessionRecording.recording_state.syncing_error_details
-              @model.sessionRecording.recording_state.verification_error_details
-            )
+          {{#let
+            @model.sessionRecording.recording_state.syncing_error_details
+            @model.sessionRecording.recording_state.verification_error_details
+            as |syncError verifyError|
           }}
-            <Hds::Alert
-              data-test-session-playback-alert
-              @type='inline'
-              @color='critical'
-              as |A|
-            >
-              <A.Title>{{t
-                  'resources.session-recording.channels-by-connection.messages.sync-error.title'
-                }}</A.Title>
-              <A.Description>
-                {{#if
-                  (and
-                    @model.sessionRecording.recording_state.syncing_error_details
-                    @model.sessionRecording.recording_state.verification_error_details
-                  )
-                }}
-                  {{! Both errors present - show as bullet list with inline copy buttons }}
-                  <ul class='playback-error-list'>
-                    <li class='playback-error-item margin-bottom-s'>
-                      <Hds::Text::Body
-                        @tag='span'
-                        class='playback-error-message'
-                      >
-                        {{@model.sessionRecording.recording_state.syncing_error_details}}
-                      </Hds::Text::Body>
-                      <Hds::Copy::Button
-                        @size='small'
-                        @text='Copy'
-                        @isIconOnly={{true}}
-                        @textToCopy={{@model.sessionRecording.recording_state.syncing_error_details}}
-                      />
-                    </li>
-                    <li class='playback-error-item'>
-                      <Hds::Text::Body
-                        @tag='span'
-                        class='playback-error-message'
-                      >
-                        {{@model.sessionRecording.recording_state.verification_error_details}}
-                      </Hds::Text::Body>
-                      <Hds::Copy::Button
-                        @size='small'
-                        @text='Copy'
-                        @isIconOnly={{true}}
-                        @textToCopy={{@model.sessionRecording.recording_state.verification_error_details}}
-                      />
-                    </li>
-                  </ul>
-                {{else}}
-                  {{! Only one error present - show as single message }}
-                  <div class='playback-error-item'>
-                    <Hds::Text::Body @tag='span' class='playback-error-message'>
-                      {{or
-                        @model.sessionRecording.recording_state.syncing_error_details
-                        @model.sessionRecording.recording_state.verification_error_details
-                      }}
-                    </Hds::Text::Body>
-                    <Hds::Copy::Button
-                      @size='small'
-                      @text={{t
-                        'resources.session-recording.channels-by-connection.messages.sync-error.copy'
-                      }}
-                      @isIconOnly={{true}}
-                      @textToCopy={{or
-                        @model.sessionRecording.recording_state.syncing_error_details
-                        @model.sessionRecording.recording_state.verification_error_details
-                      }}
-                    />
-                  </div>
-                {{/if}}
-              </A.Description>
-            </Hds::Alert>
-          {{/if}}
+            {{#if (or syncError verifyError)}}
+              <Hds::Alert
+                data-test-session-playback-alert
+                @type='inline'
+                @color='critical'
+                as |A|
+              >
+                <A.Title>{{t
+                    'resources.session-recording.channels-by-connection.messages.sync-error.title'
+                  }}</A.Title>
+                <A.Description>
+                  {{#if (and syncError verifyError)}}
+                    <ul class='playback-error-list'>
+                      <li class='playback-error-item margin-bottom-s'>
+                        <Hds::Text::Body
+                          @tag='span'
+                          class='playback-error-message'
+                        >
+                          {{syncError}}
+                        </Hds::Text::Body>
+                        <Hds::Copy::Button
+                          @size='small'
+                          @text='Copy'
+                          @isIconOnly={{true}}
+                          @textToCopy={{syncError}}
+                        />
+                      </li>
+                      <li class='playback-error-item'>
+                        <Hds::Text::Body
+                          @tag='span'
+                          class='playback-error-message'
+                        >
+                          {{verifyError}}
+                        </Hds::Text::Body>
+                        <Hds::Copy::Button
+                          @size='small'
+                          @text={{t
+                            'resources.session-recording.channels-by-connection.messages.sync-error.copy'
+                          }}
+                          @isIconOnly={{true}}
+                          @textToCopy={{verifyError}}
+                        />
+                      </li>
+                    </ul>
+                  {{else}}
+                    {{#let (or syncError verifyError) as |error|}}
+                      <div class='playback-error-item'>
+                        <Hds::Text::Body
+                          @tag='span'
+                          class='playback-error-message'
+                        >
+                          {{error}}
+                        </Hds::Text::Body>
+                        <Hds::Copy::Button
+                          @size='small'
+                          @text={{t
+                            'resources.session-recording.channels-by-connection.messages.sync-error.copy'
+                          }}
+                          @isIconOnly={{true}}
+                          @textToCopy={{error}}
+                        />
+                      </div>
+                    {{/let}}
+                  {{/if}}
+                </A.Description>
+              </Hds::Alert>
+            {{/if}}
+          {{/let}}
           {{#if this.isSessionInprogressWithNoConnections}}
             <Hds::ApplicationState as |A|>
               {{! Session recording in progress with no connections }}

--- a/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
+++ b/ui/admin/app/templates/scopes/scope/session-recordings/session-recording/channels-by-connection/index.hbs
@@ -46,79 +46,14 @@
     <div class='channels-by-connection'>
       <Rose::Layout::BodyContent as |bc|>
         <bc.Body>
-          {{#let
-            @model.sessionRecording.recording_state.syncing_error_details
-            @model.sessionRecording.recording_state.verification_error_details
-            as |syncError verifyError|
-          }}
-            {{#if (or syncError verifyError)}}
-              <Hds::Alert
-                data-test-session-playback-alert
-                @type='inline'
-                @color='critical'
-                as |A|
-              >
-                <A.Title>{{t
-                    'resources.session-recording.channels-by-connection.messages.sync-error.title'
-                  }}</A.Title>
-                <A.Description>
-                  {{#if (and syncError verifyError)}}
-                    <ul class='playback-error-list'>
-                      <li class='playback-error-item margin-bottom-s'>
-                        <Hds::Text::Body
-                          @tag='span'
-                          class='playback-error-message'
-                        >
-                          {{syncError}}
-                        </Hds::Text::Body>
-                        <Hds::Copy::Button
-                          @size='small'
-                          @text='Copy'
-                          @isIconOnly={{true}}
-                          @textToCopy={{syncError}}
-                        />
-                      </li>
-                      <li class='playback-error-item'>
-                        <Hds::Text::Body
-                          @tag='span'
-                          class='playback-error-message'
-                        >
-                          {{verifyError}}
-                        </Hds::Text::Body>
-                        <Hds::Copy::Button
-                          @size='small'
-                          @text={{t
-                            'resources.session-recording.channels-by-connection.messages.sync-error.copy'
-                          }}
-                          @isIconOnly={{true}}
-                          @textToCopy={{verifyError}}
-                        />
-                      </li>
-                    </ul>
-                  {{else}}
-                    {{#let (or syncError verifyError) as |error|}}
-                      <div class='playback-error-item'>
-                        <Hds::Text::Body
-                          @tag='span'
-                          class='playback-error-message'
-                        >
-                          {{error}}
-                        </Hds::Text::Body>
-                        <Hds::Copy::Button
-                          @size='small'
-                          @text={{t
-                            'resources.session-recording.channels-by-connection.messages.sync-error.copy'
-                          }}
-                          @isIconOnly={{true}}
-                          @textToCopy={{error}}
-                        />
-                      </div>
-                    {{/let}}
-                  {{/if}}
-                </A.Description>
-              </Hds::Alert>
-            {{/if}}
-          {{/let}}
+          <SessionRecording::ErrorFlyoutAlert
+            @syncError={{@model.sessionRecording.recording_state.syncing_error_details}}
+            @verifyError={{@model.sessionRecording.recording_state.verification_error_details}}
+            @syncErrorLines={{this.syncErrorLines}}
+            @verifyErrorLines={{this.verifyErrorLines}}
+            @showFlyout={{this.showErrorFlyout}}
+            @onShowFlyout={{this.toggleErrorFlyout}}
+          />
           {{#if this.isSessionInprogressWithNoConnections}}
             <Hds::ApplicationState as |A|>
               {{! Session recording in progress with no connections }}

--- a/ui/admin/tests/acceptance/session-recordings/read-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/read-test.js
@@ -224,13 +224,13 @@ module('Acceptance | session-recordings | read', function (hooks) {
     await visit(urls.sessionRecordings);
     await click(commonSelectors.HREF(urls.sessionRecording));
 
-    assert.dom(selectors.SESSION_PLAYBACK_ALERT).isVisible();
+    assert.dom(selectors.SESSION_PLAYBACK_ERROR_ALERT).isVisible();
     assert
-      .dom(`${selectors.SESSION_PLAYBACK_ALERT} button`)
+      .dom(`${selectors.SESSION_PLAYBACK_ERROR_ALERT} button`)
       .hasTextContaining('Show more');
 
     // Open the flyout
-    await click(`${selectors.SESSION_PLAYBACK_ALERT} button`);
+    await click(`${selectors.SESSION_PLAYBACK_ERROR_ALERT} button`);
     assert.dom(selectors.SESSION_ERROR_FLYOUT).isVisible();
 
     // Check for sync error section and copy button

--- a/ui/admin/tests/acceptance/session-recordings/read-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/read-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { visit, currentURL, click } from '@ember/test-helpers';
+import { visit, currentURL, click, findAll } from '@ember/test-helpers';
 import { setupApplicationTest } from 'admin/tests/helpers';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupSqlite } from 'api/test-support/helpers/sqlite';
@@ -174,5 +174,39 @@ module('Acceptance | session-recordings | read', function (hooks) {
 
     assert.notEqual(currentURL(), incorrectUrl);
     assert.strictEqual(currentURL(), urls.sessionRecording);
+  });
+
+  test('it displays error messages for session recording', async function (assert) {
+    setRunOptions({
+      rules: {
+        // [ember-a11y-ignore]: axe rule "color-contrast" automatically ignored on 2026-05-22
+        'color-contrast': {
+          enabled: false,
+        },
+      },
+    });
+
+    instances.sessionRecording.recording_state = {
+      syncing_error_details: 'sync errors in container',
+      verification_error_details: 'verification error',
+    };
+
+    featuresService.enable('ssh-session-recording');
+
+    await visit(urls.sessionRecordings);
+
+    await click(commonSelectors.HREF(urls.sessionRecording));
+
+    assert.dom(selectors.SESSION_PLAYBACK_ERROR_ALERT).isVisible();
+
+    let errorMessages = findAll(selectors.SESSION_PLAYBACK_ERROR_MESSAGE).map(
+      (err) => err.textContent.trim(),
+    );
+
+    assert.ok(errorMessages[0].includes('sync errors in container'));
+    assert.ok(errorMessages[1].includes('verification error'));
+    assert
+      .dom(selectors.SESSION_PLAYBACK_ERROR_COPY_BUTTON)
+      .exists({ count: 2 });
   });
 });

--- a/ui/admin/tests/acceptance/session-recordings/read-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/read-test.js
@@ -205,8 +205,40 @@ module('Acceptance | session-recordings | read', function (hooks) {
 
     assert.ok(errorMessages[0].includes('sync errors in container'));
     assert.ok(errorMessages[1].includes('verification error'));
+  });
+
+  test('flyout opens, displays errors, and can be closed', async function (assert) {
+    setRunOptions({
+      rules: {
+        // [ember-a11y-ignore]: axe rule "color-contrast" automatically ignored on 2026-05-27
+        'color-contrast': { enabled: false },
+      },
+    });
+
+    instances.sessionRecording.recording_state = {
+      syncing_error_details: 'Test sync error line 1\nTest sync error line 2',
+      verification_error_details: 'Test verification error',
+    };
+    featuresService.enable('ssh-session-recording');
+
+    await visit(urls.sessionRecordings);
+    await click(commonSelectors.HREF(urls.sessionRecording));
+
+    assert.dom(selectors.SESSION_PLAYBACK_ALERT).isVisible();
     assert
-      .dom(selectors.SESSION_PLAYBACK_ERROR_COPY_BUTTON)
-      .exists({ count: 2 });
+      .dom(`${selectors.SESSION_PLAYBACK_ALERT} button`)
+      .hasTextContaining('Show more');
+
+    // Open the flyout
+    await click(`${selectors.SESSION_PLAYBACK_ALERT} button`);
+    assert.dom(selectors.SESSION_ERROR_FLYOUT).isVisible();
+
+    // Check for sync error section and copy button
+    assert.dom(selectors.SESSION_ERROR_FLYOUT_ACCORDION_ITEM).isVisible();
+    assert.dom(selectors.SESSION_ERROR_FLYOUT_COPY_BUTTON).isVisible();
+    // Close the flyout
+    await click(selectors.SESSION_ERROR_FLYOUT_CLOSE);
+
+    assert.dom(selectors.SESSION_ERROR_FLYOUT).isNotVisible();
   });
 });

--- a/ui/admin/tests/acceptance/session-recordings/read-test.js
+++ b/ui/admin/tests/acceptance/session-recordings/read-test.js
@@ -199,7 +199,7 @@ module('Acceptance | session-recordings | read', function (hooks) {
 
     assert.dom(selectors.SESSION_PLAYBACK_ERROR_ALERT).isVisible();
 
-    let errorMessages = findAll(selectors.SESSION_PLAYBACK_ERROR_MESSAGE).map(
+    const errorMessages = findAll(selectors.SESSION_PLAYBACK_ERROR_MESSAGE).map(
       (err) => err.textContent.trim(),
     );
 

--- a/ui/admin/tests/acceptance/session-recordings/selectors.js
+++ b/ui/admin/tests/acceptance/session-recordings/selectors.js
@@ -22,3 +22,10 @@ export const MANAGE_DROPDOWN =
   '[data-test-manage-channels-dropdown] button:first-child';
 export const DELETE_ACTION =
   '[data-test-manage-channels-dropdown] ul li:last-child button';
+
+// Playback error selectors
+export const SESSION_PLAYBACK_ERROR_ALERT =
+  '[data-test-session-playback-alert]';
+export const SESSION_PLAYBACK_ERROR_MESSAGE = '.playback-error-message';
+export const SESSION_PLAYBACK_ERROR_COPY_BUTTON =
+  '.playback-error-item .hds-copy-button';

--- a/ui/admin/tests/acceptance/session-recordings/selectors.js
+++ b/ui/admin/tests/acceptance/session-recordings/selectors.js
@@ -31,7 +31,6 @@ export const SESSION_PLAYBACK_ERROR_COPY_BUTTON =
   '.playback-error-item .hds-copy-button';
 
 // Flyout and alert selectors
-export const SESSION_PLAYBACK_ALERT = '[data-test-session-playback-alert]';
 export const SESSION_ERROR_FLYOUT = '[data-test-error-flyout]';
 export const SESSION_ERROR_FLYOUT_COPY_BUTTON =
   '[data-test-error-flyout] .hds-copy-button';

--- a/ui/admin/tests/acceptance/session-recordings/selectors.js
+++ b/ui/admin/tests/acceptance/session-recordings/selectors.js
@@ -29,3 +29,12 @@ export const SESSION_PLAYBACK_ERROR_ALERT =
 export const SESSION_PLAYBACK_ERROR_MESSAGE = '.playback-error-message';
 export const SESSION_PLAYBACK_ERROR_COPY_BUTTON =
   '.playback-error-item .hds-copy-button';
+
+// Flyout and alert selectors
+export const SESSION_PLAYBACK_ALERT = '[data-test-session-playback-alert]';
+export const SESSION_ERROR_FLYOUT = '[data-test-error-flyout]';
+export const SESSION_ERROR_FLYOUT_COPY_BUTTON =
+  '[data-test-error-flyout] .hds-copy-button';
+export const SESSION_ERROR_FLYOUT_ACCORDION_ITEM =
+  '[data-test-error-flyout] .hds-accordion-item';
+export const SESSION_ERROR_FLYOUT_CLOSE = '[data-test-error-flyout] button';

--- a/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index-test.js
+++ b/ui/admin/tests/unit/controllers/scopes/scope/session-recordings/session-recording/channels-by-connection/index-test.js
@@ -135,5 +135,132 @@ module(
 
       assert.notEqual(sessionRecording.delete_after, deleteAfter);
     });
+
+    test('isSessionInprogressWithNoConnections handles session with syncing_error_details', function (assert) {
+      const sessionRecording = store.createRecord('session-recording', {
+        state: STATE_SESSION_RECORDING_STARTED,
+        connection_recordings: [],
+        recording_state: {
+          syncing_error_details: 'sync error occurred',
+          verification_error_details: null,
+        },
+      });
+      controller.set('model', { sessionRecording });
+
+      assert.true(controller.isSessionInprogressWithNoConnections);
+    });
+
+    test('isSessionUnknownWithNoConnections handles session with verification_error_details', function (assert) {
+      const sessionRecording = store.createRecord('session-recording', {
+        state: STATE_SESSION_RECORDING_UNKNOWN,
+        connection_recordings: [],
+        recording_state: {
+          syncing_error_details: null,
+          verification_error_details: 'verification failed',
+        },
+      });
+      controller.set('model', { sessionRecording });
+
+      assert.true(controller.isSessionUnknownWithNoConnections);
+    });
+
+    test('isSessionUnknownWithNoConnections handles session with both error types', function (assert) {
+      const sessionRecording = store.createRecord('session-recording', {
+        state: STATE_SESSION_RECORDING_UNKNOWN,
+        connection_recordings: [],
+        recording_state: {
+          syncing_error_details: 'sync error occurred',
+          verification_error_details: 'verification failed',
+        },
+      });
+      controller.set('model', { sessionRecording });
+
+      assert.true(controller.isSessionUnknownWithNoConnections);
+    });
+
+    test('model handles recording_state with only syncing_error_details', function (assert) {
+      const sessionRecording = store.createRecord('session-recording', {
+        state: STATE_SESSION_RECORDING_UNKNOWN,
+        connection_recordings: [],
+        recording_state: {
+          syncing_error_details:
+            'sync errors in container "sr_jovU2XLzBP.bsr": storage error',
+          verification_error_details: null,
+        },
+      });
+      controller.set('model', { sessionRecording });
+
+      assert.strictEqual(
+        sessionRecording.recording_state.syncing_error_details,
+        'sync errors in container "sr_jovU2XLzBP.bsr": storage error',
+      );
+      assert.strictEqual(
+        sessionRecording.recording_state.verification_error_details,
+        null,
+      );
+    });
+
+    test('model handles recording_state with only verification_error_details', function (assert) {
+      const sessionRecording = store.createRecord('session-recording', {
+        state: STATE_SESSION_RECORDING_UNKNOWN,
+        connection_recordings: [],
+        recording_state: {
+          syncing_error_details: null,
+          verification_error_details:
+            'integrity check failed for session recording file',
+        },
+      });
+      controller.set('model', { sessionRecording });
+
+      assert.strictEqual(
+        sessionRecording.recording_state.syncing_error_details,
+        null,
+      );
+      assert.strictEqual(
+        sessionRecording.recording_state.verification_error_details,
+        'integrity check failed for session recording file',
+      );
+    });
+
+    test('model handles recording_state with both error details', function (assert) {
+      const syncError = 'sync errors in container';
+      const verifyError = 'integrity check failed';
+      const sessionRecording = store.createRecord('session-recording', {
+        state: STATE_SESSION_RECORDING_UNKNOWN,
+        connection_recordings: [],
+        recording_state: {
+          syncing_error_details: syncError,
+          verification_error_details: verifyError,
+        },
+      });
+      controller.set('model', { sessionRecording });
+
+      assert.strictEqual(
+        sessionRecording.recording_state.syncing_error_details,
+        syncError,
+      );
+      assert.strictEqual(
+        sessionRecording.recording_state.verification_error_details,
+        verifyError,
+      );
+    });
+
+    test('model handles empty recording_state object', function (assert) {
+      const sessionRecording = store.createRecord('session-recording', {
+        state: STATE_SESSION_RECORDING_UNKNOWN,
+        connection_recordings: [],
+        recording_state: {},
+      });
+      controller.set('model', { sessionRecording });
+
+      assert.strictEqual(
+        sessionRecording.recording_state.syncing_error_details,
+        undefined,
+      );
+      assert.strictEqual(
+        sessionRecording.recording_state.verification_error_details,
+        undefined,
+      );
+    });
   },
 );


### PR DESCRIPTION
# Description

This PR adds shows ssh recording playback error messages

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

<img width="1412" height="673" alt="Screenshot 2026-05-27 at 5 49 32 PM" src="https://github.com/user-attachments/assets/9f7e3e21-781c-48a0-8db4-6d4b16a303eb" />

<img width="1610" height="697" alt="Screenshot 2026-05-27 at 5 49 54 PM" src="https://github.com/user-attachments/assets/6187cf24-3a5a-4919-8d92-aeb39d7ad471" />


with mock data if there are multiple error messages: 

<img width="1538" height="911" alt="Screenshot 2026-05-27 at 6 42 09 PM" src="https://github.com/user-attachments/assets/2ebbbee7-4970-4d39-ab0c-0cddd14ae064" />

 
list view: (no changes)
<img width="1610" height="595" alt="Screenshot 2026-05-22 at 11 37 54 AM" src="https://github.com/user-attachments/assets/1ad62821-e02c-4fd7-9b7a-afffa34c325d" />





## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

- use [boundary-local-env](https://github.com/hashicorp/boundary-local-env/blob/27f217e8aeae76a9092171ddfed765f1c3dbad51/scenarios/session-recording.md#L1) with the Session Recording instructions from the build binary in main with [MinIO](https://github.com/hashicorp/boundary-local-env/blob/e0418df6635676c8f233dc40db959481f04118cb/scenarios/session-recording-minio.md#L1)
- Start a ssh session recording
- In a separate terminal issue docker compose stop minio (this should force sync failures)
- End the ssh session in the prior terminal
- refresh the browser, you should see `failed` state in the ui and navigating to that recording should show the error message and the copy button. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [x] I have added before and after screenshots for UI changes
- [x] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
