### PR TITLE
feat: 🎸 Fix contrast issue with count badge in dropdown

### DIFF
--- a/addons/rose/addon/styles/hds/themes/dark-mode/index.scss
+++ b/addons/rose/addon/styles/hds/themes/dark-mode/index.scss
@@ -121,6 +121,15 @@
   }
 }
 
+@mixin dark-mode-badge-count-override {
+  // Override the neutral badge count to fix contrast in dark mode.
+  /* stylelint-disable selector-class-pattern */
+  .hds-badge-count--color-neutral.hds-badge-count--type-inverted {
+    color: var(--token-color-palette-neutral-0);
+  }
+  /* stylelint-enable selector-class-pattern */
+}
+
 @mixin dark-mode-ember-dropdown-override {
   .ember-basic-dropdown-content {
     background-color: var(--token-color-palette-neutral-0);
@@ -251,6 +260,7 @@
   .ember-application:not(.rose-theme-light) {
     @include dark-mode;
     @include dark-mode-modal-override;
+    @include dark-mode-badge-count-override;
     @include dark-mode-ember-dropdown-override;
     @include dark-mode-app-header-override;
     @include dark-mode-app-side-nav-override;
@@ -267,6 +277,7 @@ html:has(.ember-application.rose-theme-dark) {
 .ember-application.rose-theme-dark {
   @include dark-mode;
   @include dark-mode-modal-override;
+  @include dark-mode-badge-count-override;
   @include dark-mode-ember-dropdown-override;
   @include dark-mode-app-header-override;
   @include dark-mode-app-side-nav-override;


### PR DESCRIPTION
✅ Closes: https://hashicorp.atlassian.net/browse/ICU-19106

# Description
We have a contrast issue with the count badge in our filter dropdowns. Added an override to alleviate it. 

## Screenshots (if appropriate)
Before:
<img width="590" height="412" alt="image" src="https://github.com/user-attachments/assets/5d6a6b5b-d941-40c1-87dd-b6beb935a2ed" />

After:
<img width="583" height="359" alt="image" src="https://github.com/user-attachments/assets/acb84999-6902-459c-bf64-fc06bf7c215e" />

## How to Test
Make sure the filters in both admin and desktop are readable in dark mode.  

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
