### PR TITLE
fix: 🐛 updates node and pnpm setup order

### DIFF
--- a/.github/workflows/a11y-tests.yaml
+++ b/.github/workflows/a11y-tests.yaml
@@ -17,14 +17,14 @@ jobs:
         with:
           install-dependencies: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
-        with:
-          run_install: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
+        with:
+          cache: true
           cache-dependency-path: '**/pnpm-lock.yaml'
+          run_install: false
       - run: pnpm install
       - name: Run a11y tests
         env:

--- a/.github/workflows/build-admin-ui.yaml
+++ b/.github/workflows/build-admin-ui.yaml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
-        with:
-          run_install: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
+        with:
+          cache: true
           cache-dependency-path: '**/pnpm-lock.yaml'
+          run_install: false
       - run: pnpm install --frozen-lockfile
   build-admin-ui-oss:
     name: Build Admin UI OSS
@@ -27,14 +27,14 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
-        with:
-          run_install: false
       - name: Build
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
+        with:
+          run_install: false
+          cache: true
           cache-dependency-path: '**/pnpm-lock.yaml'
       - run: pnpm install --offline
       - run: pnpm run build:ui:admin:oss
@@ -54,14 +54,14 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
-        with:
-          run_install: false
       - name: Build
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
+        with:
+          run_install: false
+          cache: true
           cache-dependency-path: '**/pnpm-lock.yaml'
       - run: pnpm install --offline
       - run: pnpm run build:ui:admin:enterprise
@@ -76,14 +76,14 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
-        with:
-          run_install: false
       - name: Build
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
+        with:
+          run_install: false
+          cache: true
           cache-dependency-path: '**/pnpm-lock.yaml'
       - run: pnpm install --offline
       - run: pnpm run build:ui:admin:hcp

--- a/.github/workflows/monorepo-validate.yaml
+++ b/.github/workflows/monorepo-validate.yaml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
-        with:
-          run_install: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
+        with:
+          cache: true
           cache-dependency-path: '**/pnpm-lock.yaml'
+          run_install: false
       - run: pnpm install --frozen-lockfile
 
   compliance:
@@ -23,13 +23,13 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
-        with:
-          run_install: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
+        with:
+          run_install: false
+          cache: true
           cache-dependency-path: '**/pnpm-lock.yaml'
       - run: pnpm install --offline
       - run: pnpm run compliance:licenses
@@ -41,13 +41,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
-        with:
-          run_install: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
+        with:
+          run_install: false
+          cache: true
           cache-dependency-path: '**/pnpm-lock.yaml'
       - run: pnpm install --offline
       - run: pnpm lint
@@ -62,13 +62,13 @@ jobs:
         with:
           install-dependencies: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
-        with:
-          run_install: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
+        with:
+          run_install: false
+          cache: true
           cache-dependency-path: '**/pnpm-lock.yaml'
       - run: pnpm install --offline
       - run: pnpm test

--- a/.github/workflows/test-e2e-admin-ui.yaml
+++ b/.github/workflows/test-e2e-admin-ui.yaml
@@ -56,19 +56,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
-        with:
-          run_install: false
-
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: "pnpm"
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
+        with:
+          cache: true
           cache-dependency-path: |
             pnpm-lock.yaml
             ui/desktop/electron-app/pnpm-lock.yaml
+          run_install: false
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85

--- a/.github/workflows/test-e2e-desktop.yaml
+++ b/.github/workflows/test-e2e-desktop.yaml
@@ -32,19 +32,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
-        with:
-          run_install: false
-
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: "pnpm"
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 #v6.0.8
+        with:
+          cache: true
           cache-dependency-path: |
             pnpm-lock.yaml
             ui/desktop/electron-app/pnpm-lock.yaml
+          run_install: false
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85


### PR DESCRIPTION
# Description
Updates the workflow to set up node first and then pnpm to ensure pnpm uses the correct Node version and lets pnpm handle caching. This is mainly to avoid errors on self hosted runners with older Node versions in boundary-ui-enterprise

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
