### PR TITLE
test(e2e): Fix flakiness in host catalog navigation

### DIFF
--- a/e2e-tests/admin/tests/target.spec.js
+++ b/e2e-tests/admin/tests/target.spec.js
@@ -52,6 +52,9 @@ test(
         .getByRole('navigation', { name: 'Primary' })
         .getByRole('link', { name: 'Host Catalogs' })
         .click();
+      await expect(
+        page.getByRole('heading', { name: 'Host Catalogs' }),
+      ).toBeVisible();
       await page.getByRole('link', { name: hostCatalogName }).click();
       const hostSetName2 = await hostCatalogsPage.createHostSet();
 


### PR DESCRIPTION
# Description
Observed a flaky Admin UI e2e test here: https://github.com/hashicorp/boundary-ui/actions/runs/26655044447/job/78562916448
```
1) [firefox] › admin/tests/target.spec.js:21:1 › Verify session created to target with host, then cancel the session @ce @aws @docker 

    Test timeout of 90000ms exceeded.

    Error: locator.click: Test timeout of 90000ms exceeded.
    Call log:
      - waiting for getByRole('link', { name: 'Host Sets' })

       at pages/host-catalogs.js:60

      58 |   async createHostSet() {
      59 |     const hostSetName = 'Host Set ' + nanoid();
    > 60 |     await this.page.getByRole('link', { name: 'Host Sets' }).click();
         |                                                              ^
      61 |     await expect(
      62 |       this.page
      63 |         .getByRole('navigation', { name: 'breadcrumbs' })
        at HostCatalogsPage.createHostSet (/home/runner/work/boundary-ui/boundary-ui/e2e-tests/admin/pages/host-catalogs.js:60:62)
        at /home/runner/work/boundary-ui/boundary-ui/e2e-tests/admin/tests/target.spec.js:56:51
```

Looking at the trace, the test was supposed to have navigated to the host catalog details page to be able to add host sets to it. Instead, it went to the host catalog list page.

<img width="803" height="504" alt="Screenshot 2026-05-29 at 4 19 51 PM" src="https://github.com/user-attachments/assets/7fc2cf39-2f85-4df5-8590-5b91957045c2" />
<img width="799" height="505" alt="Screenshot 2026-05-29 at 4 21 03 PM" src="https://github.com/user-attachments/assets/d6a938ce-a605-4677-bc39-ae2dabfab1d7" />

The theory is that the second click to pick the `Host Catalog Name` occurred before the first click to go to the `Host Catalogs list` page finished processing (it's able to find it since it's also in the breadcrumbs). This PR adds a wait to ensure that the `Host Catalogs list` page has loaded (by waiting for the header) before it tries to click the `Host Catalog Name`. 

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
