### PR TITLE
fix: 🐛 actions not displaying for templates in grants editor

### DIFF
--- a/addons/core/translations/resources/en-us.yaml
+++ b/addons/core/translations/resources/en-us.yaml
@@ -758,8 +758,8 @@ role:
         label: User template
         help: Substitutes the user ID from the token used to perform the request.
       insert-actions: insert actions
-      insert-resource-types: insert resource types
-      insert-id: insert id
+      insert-resource-type: insert resource type
+      insert-ids: insert ids
       insert-resource-ids: insert resource ids
       insert-output-fields: insert output fields
     export:

--- a/ui/admin/app/components/grant-string-formats/index.js
+++ b/ui/admin/app/components/grant-string-formats/index.js
@@ -28,7 +28,7 @@ export default class GrantStringFormatsIndex extends Component {
 
   stringFormats = {
     [this.stringFormatTypes.resourceType]: {
-      text: `type=<${this.intl.t('resources.role.edit-grants.string-formats.insert-resource-types')}>;actions=<${this.intl.t('resources.role.edit-grants.string-formats.insert-actions')}>`,
+      text: `type=<${this.intl.t('resources.role.edit-grants.string-formats.insert-resource-type')}>;actions=<${this.intl.t('resources.role.edit-grants.string-formats.insert-actions')}>`,
       link: 'role.grant-string-format.resource-type',
     },
     [this.stringFormatTypes.resource]: {
@@ -36,7 +36,7 @@ export default class GrantStringFormatsIndex extends Component {
       link: 'role.grant-string-format.resource',
     },
     [this.stringFormatTypes.pinnedId]: {
-      text: `ids=<${this.intl.t('resources.role.edit-grants.string-formats.insert-id')}>;type=<${this.intl.t('resources.role.edit-grants.string-formats.insert-resource-types')}>;actions=<${this.intl.t('resources.role.edit-grants.string-formats.insert-actions')}>`,
+      text: `ids=<${this.intl.t('resources.role.edit-grants.string-formats.insert-ids')}>;type=<${this.intl.t('resources.role.edit-grants.string-formats.insert-resource-type')}>;actions=<${this.intl.t('resources.role.edit-grants.string-formats.insert-actions')}>`,
       link: 'role.grant-string-format.pinned-id',
     },
     [this.stringFormatTypes.outputFields]: {

--- a/ui/admin/app/utils/grant-completions.js
+++ b/ui/admin/app/utils/grant-completions.js
@@ -107,7 +107,7 @@ export const analyzeGrantString = (grantsSchema, grantString = '') => {
   );
 
   const hasInvalidType = hasExplicitType && !schema.resourcesByType[typeValue];
-  const hasInvalidIds = !compatibleIdsResourceType;
+  const hasInvalidIds = hasSpecificIds && !compatibleIdsResourceType;
 
   const hasInvalidPinnedIdTypeCombination =
     hasSpecificIds &&

--- a/ui/admin/app/utils/grant-completions.js
+++ b/ui/admin/app/utils/grant-completions.js
@@ -101,18 +101,13 @@ export const analyzeGrantString = (grantsSchema, grantString = '') => {
   const hasSpecificIds = Boolean(idsValue) && !idsValue.includes('*');
   const hasExplicitType = Boolean(typeValue) && typeValue !== '*';
 
-  const hasTemplateIds =
-    hasSpecificIds &&
-    parseIds(idsValue).some((id) => id.startsWith('{{') && id.endsWith('}}'));
-
-  const hasLiteralIds = hasSpecificIds && !hasTemplateIds;
-
-  const compatibleIdsResourceType = hasLiteralIds
-    ? getCompatibleResourceTypeForIds(schema, idsValue)
-    : null;
+  const compatibleIdsResourceType = getCompatibleResourceTypeForIds(
+    schema,
+    idsValue,
+  );
 
   const hasInvalidType = hasExplicitType && !schema.resourcesByType[typeValue];
-  const hasInvalidIds = hasLiteralIds && !compatibleIdsResourceType;
+  const hasInvalidIds = !compatibleIdsResourceType;
 
   const hasInvalidPinnedIdTypeCombination =
     hasSpecificIds &&

--- a/ui/admin/app/utils/grant-completions.js
+++ b/ui/admin/app/utils/grant-completions.js
@@ -101,10 +101,9 @@ export const analyzeGrantString = (grantsSchema, grantString = '') => {
   const hasSpecificIds = Boolean(idsValue) && !idsValue.includes('*');
   const hasExplicitType = Boolean(typeValue) && typeValue !== '*';
 
-  const compatibleIdsResourceType = getCompatibleResourceTypeForIds(
-    schema,
-    idsValue,
-  );
+  const compatibleIdsResourceType = hasSpecificIds
+    ? getCompatibleResourceTypeForIds(schema, idsValue)
+    : null;
 
   const hasInvalidType = hasExplicitType && !schema.resourcesByType[typeValue];
   const hasInvalidIds = hasSpecificIds && !compatibleIdsResourceType;

--- a/ui/admin/tests/integration/components/grant-actions/index-test.js
+++ b/ui/admin/tests/integration/components/grant-actions/index-test.js
@@ -32,7 +32,6 @@ module('Integration | Component | grant-actions/index', function (hooks) {
 
     const grantsSchemaData = await response.json();
     this.grantsSchema = grantsSchemaData;
-    console.log('grantsSchemaData', this.grantSchema);
   });
 
   test('it renders the actions relevant to the current grant line', async function (assert) {

--- a/ui/admin/tests/integration/components/grant-actions/index-test.js
+++ b/ui/admin/tests/integration/components/grant-actions/index-test.js
@@ -6,6 +6,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'admin/tests/helpers';
 import { setupIntl } from 'ember-intl/test-support';
+import { setupMirage } from 'admin/tests/helpers/mirage';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import * as commonSelectors from 'admin/tests/helpers/selectors';
@@ -19,40 +20,19 @@ const GRANT_ACTIONS_INVALID_ID_OR_TYPE =
 
 module('Integration | Component | grant-actions/index', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
   setupIntl(hooks, 'en-us');
 
-  hooks.beforeEach(function () {
-    this.grantsSchema = {
-      resource_types: [
-        {
-          type: 'host-catalog',
-          collection_actions: ['create', 'list'],
-          id_actions: ['read', 'update', 'delete'],
-          id_prefixes: ['hcst'],
-        },
-        {
-          type: 'host',
-          parent_type: 'host-catalog',
-          collection_actions: ['create', 'list'],
-          id_actions: ['read', 'update', 'delete'],
-          id_prefixes: ['h'],
-        },
-        {
-          type: 'host-set',
-          parent_type: 'host-catalog',
-          collection_actions: ['create', 'list'],
-          id_actions: [
-            'delete',
-            'add-hosts',
-            'set-hosts',
-            'remove-hosts',
-            'read',
-            'update',
-          ],
-          id_prefixes: ['hs'],
-        },
-      ],
-    };
+  hooks.beforeEach(async function () {
+    const response = await fetch('/grants-schema.json');
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch grants schema: ${response.status}`);
+    }
+
+    const grantsSchemaData = await response.json();
+    this.grantsSchema = grantsSchemaData;
+    console.log('grantsSchemaData', this.grantSchema);
   });
 
   test('it renders the actions relevant to the current grant line', async function (assert) {
@@ -68,16 +48,13 @@ module('Integration | Component | grant-actions/index', function (hooks) {
     assert.dom(GRANT_ACTIONS_TABLE).isVisible();
     assert.dom(commonSelectors.TABLE_ROWS).isVisible({ count: 8 });
 
-    const rows = [...this.element.querySelectorAll(commonSelectors.TABLE_ROWS)];
-    const rowData = rows.map((row) => {
-      const cells = [...row.querySelectorAll('td')].map((cell) =>
+    const rowData = [
+      ...this.element.querySelectorAll(commonSelectors.TABLE_ROWS),
+    ].map((row) => {
+      const [name, description] = [...row.querySelectorAll('td')].map((cell) =>
         cell.textContent.trim(),
       );
-
-      return {
-        name: cells[0],
-        description: cells[1],
-      };
+      return { name, description };
     });
 
     assert.deepEqual(
@@ -98,15 +75,65 @@ module('Integration | Component | grant-actions/index', function (hooks) {
       name: 'add-hosts',
       description: 'Add hosts to a host set',
     });
-
     assert.deepEqual(rowData[1], {
       name: 'create',
       description: 'Create a new host-set',
     });
-
     assert.deepEqual(rowData.at(-1), {
       name: 'update',
       description: 'Update a host-set',
+    });
+
+    assert.dom(GRANT_ACTIONS_EMPTY_STATE).doesNotExist();
+    assert.dom(GRANT_ACTIONS_NO_TYPE_DETECTED).doesNotExist();
+  });
+
+  test('it renders relevant actions for template IDs', async function (assert) {
+    this.grantString = 'ids={{.User.Id}}';
+
+    await render(hbs`
+      <GrantActions
+        @grantsSchema={{this.grantsSchema}}
+        @grantString={{this.grantString}}
+      />
+    `);
+
+    assert.dom(GRANT_ACTIONS_TABLE).isVisible();
+    assert.dom(commonSelectors.TABLE_ROWS).isVisible({ count: 7 });
+
+    const rowData = [
+      ...this.element.querySelectorAll(commonSelectors.TABLE_ROWS),
+    ].map((row) => {
+      const [name, description] = [...row.querySelectorAll('td')].map((cell) =>
+        cell.textContent.trim(),
+      );
+      return { name, description };
+    });
+
+    assert.deepEqual(
+      rowData.map(({ name }) => name),
+      [
+        'add-accounts',
+        'delete',
+        'list-resolvable-aliases',
+        'read',
+        'remove-accounts',
+        'set-accounts',
+        'update',
+      ],
+    );
+
+    assert.deepEqual(rowData[0], {
+      name: 'add-accounts',
+      description: 'Add accounts to a user',
+    });
+    assert.deepEqual(rowData[1], {
+      name: 'delete',
+      description: 'Delete a user',
+    });
+    assert.deepEqual(rowData.at(-1), {
+      name: 'update',
+      description: 'Update a user',
     });
 
     assert.dom(GRANT_ACTIONS_EMPTY_STATE).doesNotExist();
@@ -185,24 +212,6 @@ module('Integration | Component | grant-actions/index', function (hooks) {
 
   test('it renders the no-type-detected state for an empty grant string', async function (assert) {
     this.grantString = '';
-
-    await render(hbs`
-      <GrantActions
-        @grantsSchema={{this.grantsSchema}}
-        @grantString={{this.grantString}}
-      />
-    `);
-
-    assert.dom(GRANT_ACTIONS_TABLE).doesNotExist();
-    assert.dom(GRANT_ACTIONS_INVALID_ID_OR_TYPE).doesNotExist();
-    assert
-      .dom(GRANT_ACTIONS_NO_TYPE_DETECTED)
-      .hasText('No resource type detected.');
-    assert.dom(GRANT_ACTIONS_EMPTY_STATE).doesNotExist();
-  });
-
-  test('it renders the no-type-detected state for template IDs', async function (assert) {
-    this.grantString = 'ids={{.User.Id}}';
 
     await render(hbs`
       <GrantActions

--- a/ui/admin/tests/integration/components/grant-string-formats/index-test.js
+++ b/ui/admin/tests/integration/components/grant-string-formats/index-test.js
@@ -39,8 +39,7 @@ module(
       [
         {
           selectedOption: 'resourceType',
-          expectedValue:
-            'type=<insert resource types>;actions=<insert actions>',
+          expectedValue: 'type=<insert resource type>;actions=<insert actions>',
         },
         {
           optionToClick: RESOURCE_OPTION,
@@ -51,7 +50,7 @@ module(
           optionToClick: PINNED_ID_OPTION,
           selectedOption: 'pinnedId',
           expectedValue:
-            'ids=<insert id>;type=<insert resource types>;actions=<insert actions>',
+            'ids=<insert ids>;type=<insert resource type>;actions=<insert actions>',
         },
         {
           optionToClick: OUTPUT_FIELDS_OPTION,


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
This [refactor](https://github.com/hashicorp/boundary-ui/pull/3279) caused a bug where actions were not properly displaying for template types. This fix show show actions for `{{.User.Id}}` `{{user.id}}` `{{.Account.Id}}` and `{{account.id}}`

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
before:
<img width="2840" height="1026" alt="image" src="https://github.com/user-attachments/assets/e4be61a3-d512-4379-9965-d08cc6b01a6a" />
after:
<img width="2810" height="1410" alt="image" src="https://github.com/user-attachments/assets/52772c2d-0cf9-4db3-91bb-45b615492f86" />

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
1. Go to "Edit Grants" test out that correct actions are shown for template ids
2. 
## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [x] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [x] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
