### PR TITLE
feat: 🎸 Update scope dropdown in login to show current scope

### DIFF
--- a/addons/core/translations/actions/en-us.yaml
+++ b/addons/core/translations/actions/en-us.yaml
@@ -30,7 +30,6 @@ copy-error-detail-to-clipboard: Copy error detail to clipboard
 authenticate: Sign In
 deauthenticate: Sign Out
 choose-org: Choose Scope
-choose-different-org: Choose a different scope
 add-host-set: Create Host Set
 add-host: Create Host
 add-principals: Add Principals

--- a/e2e-tests/admin/tests/auth-method-ldap.spec.js
+++ b/e2e-tests/admin/tests/auth-method-ldap.spec.js
@@ -174,8 +174,8 @@ test(
       // Log in using ldap account
       await loginPage.logout(adminLoginName);
 
-      await page.getByText('Choose a different scope').click();
-      await page.getByRole('link', { name: orgName }).click();
+      await page.getByRole('button', { name: /global/i }).click();
+      await page.getByRole('option', { name: orgName }).click();
       await page.getByRole('link', { name: ldapAuthMethodName }).click();
       await loginPage.login(ldapUserName, ldapUserPassword);
       await expect(

--- a/e2e-tests/admin/tests/auth-method-oidc-vault.spec.js
+++ b/e2e-tests/admin/tests/auth-method-oidc-vault.spec.js
@@ -129,8 +129,8 @@ test(
 
       // Log in using oidc account
       await loginPage.logout(adminLoginName);
-      await page.getByText('Choose a different scope').click();
-      await page.getByRole('link', { name: orgName }).click();
+      await page.getByRole('button', { name: /global/i }).click();
+      await page.getByRole('option', { name: orgName }).click();
       await page.getByRole('link', { name: oidcAuthMethodName }).click();
       const pagePromise = context.waitForEvent('page');
       await page.getByRole('button', { name: 'Sign In' }).click();

--- a/e2e-tests/admin/tests/auth-method-password.spec.js
+++ b/e2e-tests/admin/tests/auth-method-password.spec.js
@@ -58,8 +58,8 @@ test(
 
       // Log in using new account
       await loginPage.logout(adminLoginName);
-      await page.getByText('Choose a different scope').click();
-      await page.getByRole('link', { name: orgName }).click();
+      await page.getByRole('button', { name: /global/i }).click();
+      await page.getByRole('option', { name: orgName }).click();
       await page.getByRole('link', { name: authMethodName }).click();
 
       await loginPage.login(username, password);
@@ -97,8 +97,8 @@ test(
       // Log in using new password
       await loginPage.logout(adminLoginName);
 
-      await page.getByText('Choose a different scope').click();
-      await page.getByRole('link', { name: orgName }).click();
+      await page.getByRole('button', { name: /global/i }).click();
+      await page.getByRole('option', { name: orgName }).click();
       await page.getByRole('link', { name: authMethodName }).click();
       await loginPage.login(username, newPassword);
       await expect(

--- a/e2e-tests/admin/tests/change-password.spec.js
+++ b/e2e-tests/admin/tests/change-password.spec.js
@@ -52,8 +52,8 @@ test(
 
       // Log in using new account
       await page.reload();
-      await page.getByText('Choose a different scope').click();
-      await page.getByRole('link', { name: org.name }).click();
+      await page.getByRole('button', { name: /global/i }).click();
+      await page.getByRole('option', { name: org.name }).click();
       await page.getByRole('link', { name: authMethod.name }).click();
       const loginPage = new LoginPage(page);
       await loginPage.login(username, password);
@@ -79,8 +79,8 @@ test(
 
       // Confirm user cannot log in with old password
       await loginPage.logout(username);
-      await page.getByText('Choose a different scope').click();
-      await page.getByRole('link', { name: org.name }).click();
+      await page.getByRole('button', { name: /global/i }).click();
+      await page.getByRole('option', { name: org.name }).click();
       await page.getByRole('link', { name: authMethod.name }).click();
       await page.getByLabel('Login Name').fill(username);
       await page.getByLabel('Password', { exact: true }).fill(password);

--- a/ui/admin/app/templates/scopes/scope/authenticate.hbs
+++ b/ui/admin/app/templates/scopes/scope/authenticate.hbs
@@ -28,23 +28,25 @@
 
             <Hds::Dropdown @listPosition='bottom-left' as |dd|>
               <dd.ToggleButton
-                @text={{t 'actions.choose-different-org'}}
-                @icon='org'
+                @text={{@model.scope.displayName}}
+                @icon={{if (eq @model.scope.id 'global') 'globe' 'org'}}
                 @color='secondary'
               />
-              <dd.Interactive
+              <dd.Checkmark
                 @route='scopes.scope.authenticate'
                 @model='global'
+                @selected={{eq @model.scope.id 'global'}}
               >
                 {{t 'titles.global'}}
-              </dd.Interactive>
+              </dd.Checkmark>
               {{#each this.sortedScopes as |scope|}}
-                <dd.Interactive
+                <dd.Checkmark
                   @route='scopes.scope.authenticate'
                   @model={{scope.id}}
+                  @selected={{eq @model.scope.id scope.id}}
                 >
                   {{scope.displayName}}
-                </dd.Interactive>
+                </dd.Checkmark>
               {{/each}}
             </Hds::Dropdown>
             <Hds::Separator />

--- a/ui/desktop/app/templates/scopes/scope/authenticate.hbs
+++ b/ui/desktop/app/templates/scopes/scope/authenticate.hbs
@@ -18,17 +18,23 @@
 
     <Hds::Dropdown @listPosition='bottom-left' as |dd|>
       <dd.ToggleButton
-        @text={{t 'actions.choose-different-org'}}
-        @icon='org'
+        @text={{@model.scope.displayName}}
+        @icon={{if (eq @model.scope.id 'global') 'globe' 'org'}}
         @color='secondary'
       />
-      <dd.Interactive {{on 'click' (fn this.selectScope 'global' dd.close)}}>
+      <dd.Checkmark
+        @selected={{eq @model.scope.id 'global'}}
+        {{on 'click' (fn this.selectScope 'global' dd.close)}}
+      >
         {{t 'titles.global'}}
-      </dd.Interactive>
+      </dd.Checkmark>
       {{#each this.sortedScopes as |scope|}}
-        <dd.Interactive {{on 'click' (fn this.selectScope scope.id dd.close)}}>
+        <dd.Checkmark
+          @selected={{eq @model.scope.id scope.id}}
+          {{on 'click' (fn this.selectScope scope.id dd.close)}}
+        >
           {{scope.displayName}}
-        </dd.Interactive>
+        </dd.Checkmark>
       {{/each}}
     </Hds::Dropdown>
 


### PR DESCRIPTION
# Description
We always show by default in the login scope selector "Choose a different scope". It seems like this was intentional but I'm not sure if it was because of something we did with our own custom dropdowns? 

## Screenshots (if appropriate)
Before:
<img width="649" height="746" alt="image" src="https://github.com/user-attachments/assets/472ed726-5313-4296-86bb-f70648b38893" />


After:
<img width="649" height="748" alt="image" src="https://github.com/user-attachments/assets/726f9089-0b4c-436c-a90f-d6bcf8919845" />

## How to Test
Should be able to switch scopes in both admin and desktop logins.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
