### PR TITLE
feat: 🎸 Use new path for grants schema

### DIFF
--- a/addons/api/app/mirage/config.js
+++ b/addons/api/app/mirage/config.js
@@ -211,7 +211,7 @@ function routes() {
     return metadata;
   });
 
-  this.get('/grants-schema.json', () => {
+  this.get('/internal/grants-schema.json', () => {
     return grantsSchemaData;
   });
 

--- a/ui/admin/app/routes/scopes/scope/roles/role/edit-grants.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/edit-grants.js
@@ -51,7 +51,7 @@ export default class ScopesScopeRolesRoleEditGrantsRoute extends Route {
   @notifyError(({ message }) => message, { catch: true })
   async fetchGrantsSchema() {
     const adapter = this.store.adapterFor('application');
-    const url = `${adapter.host ?? ''}/grants-schema.json`;
+    const url = `${adapter.host ?? ''}/internal/grants-schema.json`;
     const response = await fetch(url);
 
     if (!response.ok) {

--- a/ui/admin/tests/integration/components/grant-actions/index-test.js
+++ b/ui/admin/tests/integration/components/grant-actions/index-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | grant-actions/index', function (hooks) {
   setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(async function () {
-    const response = await fetch('/grants-schema.json');
+    const response = await fetch('/internal/grants-schema.json');
 
     if (!response.ok) {
       throw new Error(`Failed to fetch grants schema: ${response.status}`);

--- a/ui/admin/tests/unit/utils/grant-completions-test.js
+++ b/ui/admin/tests/unit/utils/grant-completions-test.js
@@ -48,7 +48,7 @@ module('Unit | Utils | grant-completions', function (hooks) {
     this.idLookup = async () => [];
     this.getIsLoading = () => false;
 
-    const response = await fetch('/grants-schema.json');
+    const response = await fetch('/internal/grants-schema.json');
 
     if (!response.ok) {
       throw new Error(`Failed to fetch grants schema: ${response.status}`);

--- a/ui/admin/tests/unit/utils/grant-linter-test.js
+++ b/ui/admin/tests/unit/utils/grant-linter-test.js
@@ -26,7 +26,7 @@ module('Unit | Utility | grant-linter', function (hooks) {
   setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(async function () {
-    const response = await fetch('/grants-schema.json');
+    const response = await fetch('/internal/grants-schema.json');
 
     if (!response.ok) {
       throw new Error(`Failed to fetch grants schema: ${response.status}`);


### PR DESCRIPTION
# Description
There was a discussion that the internal grants-schema route should be under `/internal` which was done in https://github.com/hashicorp/boundary/pull/6753. This PR changes the routes to follow that new path.

## How to Test
All the grants editor workflow should still properly work. E2E tests are failing until the route is updated in main.

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- ~[ ] I have added before and after screenshots for UI changes~
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- ~[ ] I have commented on my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] I have added `a11y-tests` label to run a11y audit tests if needed~

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
