### PR TITLE
test(e2e): Address flake when loading project page

### DIFF
--- a/e2e-tests/admin/tests/auth-method-ldap.spec.js
+++ b/e2e-tests/admin/tests/auth-method-ldap.spec.js
@@ -193,6 +193,9 @@ test(
 
       // View the LDAP account and verify account attributes
       await page.getByRole('link', { name: orgName }).click();
+      await expect(
+        page.getByRole('heading', { name: 'Projects' }),
+      ).toBeVisible();
       await page
         .getByRole('navigation', { name: 'Primary' })
         .getByRole('link', { name: 'Auth Methods' })


### PR DESCRIPTION
# Description
There was an e2e test failure that failed the following reason
```
Error: locator.click: Test timeout of 90000ms exceeded.
Call log:
  - waiting for getByRole('link', { name: 'LDAP a8IRTZ08JSdvxRI0rWdGc' })


  198 |         .getByRole('link', { name: 'Auth Methods' })
  199 |         .click();
> 200 |       await page.getByRole('link', { name: ldapAuthMethodName }).click();
      |                                                                  ^
  201 |       await page.getByRole('link', { name: 'Accounts' }).click();
  202 |       await expect(
  203 |         page
    at /home/runner/work/boundary-ui/boundary-ui/e2e-tests/admin/tests/auth-method-ldap.spec.js:200:66
```
<img width="782" height="466" alt="Screenshot 2026-06-09 at 6 44 17 PM" src="https://github.com/user-attachments/assets/04791b6b-984c-431c-89d2-016a5b84112b" />


On the UI, the test was waiting on the project list page trying to find the LDAP auth method link. It seems like the test clicked the `Auth Methods` link before the `Project` page fully loaded, and once if fully loaded, override the navigation to the `Auth Methods` page. 

```
await page.getByRole('link', { name: orgName }).click();  # Click the Org Name Link
await page  # Click on the Auth Methods link
  .getByRole('navigation', { name: 'Primary' })
  .getByRole('link', { name: 'Auth Methods' })
  .click();
await page.getByRole('link', { name: ldapAuthMethodName }).click();  # <-- timed out here
```

This PR adds a wait to ensure that the project page fully loads before proceeding with the click to the Auth Methods page.

## Screenshots (if appropriate)

## How to Test
e2e tests pass

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
