### PR TITLE
ci: 🎡 Update when e2e tests run

### DIFF
--- a/.github/workflows/test-e2e-admin-ui.yaml
+++ b/.github/workflows/test-e2e-admin-ui.yaml
@@ -331,7 +331,7 @@ jobs:
 
       - name: Send Slack message on failure
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-        if: ${{ failure() && github.repository == 'hashicorp/boundary-ui' }}
+        if: ${{ failure() && github.repository == 'hashicorp/boundary-ui-enterprise' }}
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/test-e2e-admin-ui.yaml
+++ b/.github/workflows/test-e2e-admin-ui.yaml
@@ -17,32 +17,57 @@ on:
         type: string
 
 jobs:
-  test:
-    name: test
+  setup:
+    name: setup matrix
     # don't need to run e2e tests on ce -> ent merges since tests were already
     # run in the ce branch, and there are currently no code diffferences between
     # the two repos
     if: github.actor != 'hc-github-team-secure-boundary'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set matrix
+        id: set-matrix
+        run: |
+          BOUNDARY_BRANCH="${{ github.event.inputs.boundary-branch || 'main' }}"
+          ENT_BRANCH="${{ github.event.inputs.boundary-enterprise-branch || 'main' }}"
+
+          if [[ "${{ github.repository }}" == "hashicorp/boundary-ui" ]]; then
+            matrix=$(jq -cn --arg branch "$BOUNDARY_BRANCH" '{
+              browser: ["chromium", "firefox", "webkit"],
+              include: [{
+                boundary_edition: "community",
+                github_repo: "hashicorp/boundary",
+                folder_name: "boundary",
+                boundary_edition_short: "oss",
+                enos_scenario: "e2e_ui_docker",
+                test_command: "admin:ce:docker",
+                boundary_branch: $branch
+              }]
+            }')
+          else
+            matrix=$(jq -cn --arg branch "$ENT_BRANCH" '{
+              browser: ["chromium", "firefox", "webkit"],
+              include: [{
+                boundary_edition: "enterprise",
+                github_repo: "hashicorp/boundary-enterprise",
+                folder_name: "boundary-enterprise",
+                boundary_edition_short: "ent",
+                enos_scenario: "e2e_ui_docker_ent",
+                test_command: "admin:ent:docker",
+                boundary_branch: $branch
+              }]
+            }')
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  test:
+    name: test
+    needs: setup
     runs-on: ${{ fromJSON(vars.RUNNER_UBUNTU_22) }}
     strategy:
-      matrix:
-        boundary_edition: [community, enterprise]
-        browser: [chromium, firefox, webkit]
-        include:
-          - boundary_edition: community
-            github_repo: hashicorp/boundary
-            folder_name: boundary
-            boundary_edition_short: oss
-            enos_scenario: e2e_ui_docker
-            test_command: admin:ce:docker
-            boundary_branch: ${{ github.event.inputs.boundary-branch || 'main' }}
-          - boundary_edition: enterprise
-            github_repo: hashicorp/boundary-enterprise
-            folder_name: boundary-enterprise
-            boundary_edition_short: ent
-            enos_scenario: e2e_ui_docker_ent
-            test_command: admin:ent:docker
-            boundary_branch: ${{ github.event.inputs.boundary-enterprise-branch || 'main' }}
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
       fail-fast: false
     env:
       ENOS_VAR_e2e_debug_no_run: true

--- a/.github/workflows/test-e2e-admin-ui.yaml
+++ b/.github/workflows/test-e2e-admin-ui.yaml
@@ -20,7 +20,7 @@ jobs:
   setup:
     name: setup matrix
     # don't need to run e2e tests on ce -> ent merges since tests were already
-    # run in the ce branch, and there are currently no code diffferences between
+    # run in the ce branch, and there are currently no code differences between
     # the two repos
     if: github.actor != 'hc-github-team-secure-boundary'
     runs-on: ubuntu-latest

--- a/.github/workflows/test-e2e-desktop.yaml
+++ b/.github/workflows/test-e2e-desktop.yaml
@@ -20,7 +20,7 @@ jobs:
   test:
     name: test
     # don't need to run e2e tests on ce -> ent merges since tests were already
-    # run in the ce branch, and there are currently no code diffferences between
+    # run in the ce branch, and there are currently no code differences between
     # the two repos
     # desktop client e2e tests only run enterprise tests, so only run in boundary-ui-enterprise
     if: github.actor != 'hc-github-team-secure-boundary' && github.repository == 'hashicorp/boundary-ui-enterprise'

--- a/.github/workflows/test-e2e-desktop.yaml
+++ b/.github/workflows/test-e2e-desktop.yaml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Send Slack message on failure
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-        if: ${{ failure() && github.repository == 'hashicorp/boundary-ui' }}
+        if: ${{ failure() && github.repository == 'hashicorp/boundary-ui-enterprise' }}
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/test-e2e-desktop.yaml
+++ b/.github/workflows/test-e2e-desktop.yaml
@@ -22,7 +22,8 @@ jobs:
     # don't need to run e2e tests on ce -> ent merges since tests were already
     # run in the ce branch, and there are currently no code diffferences between
     # the two repos
-    if: github.actor != 'hc-github-team-secure-boundary'
+    # desktop client e2e tests only run enterprise tests, so only run in boundary-ui-enterprise
+    if: github.actor != 'hc-github-team-secure-boundary' && github.repository == 'hashicorp/boundary-ui-enterprise'
     runs-on: ${{ fromJSON(vars.RUNNER_UBUNTU_22) }}
     env:
       ENOS_VAR_boundary_edition: "ent"


### PR DESCRIPTION
# Description
Update e2e tests to only run in their respective repos. I still kept it in the same file as I didn't want to use two separate workflow files for the two repos

## How to Test
e2e tests should run. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
