### PR TITLE
Use codemirror tooltip extension to set parent to fix positioning bug

### DIFF
--- a/addons/rose/addon/styles/hds/themes/dark-mode/index.scss
+++ b/addons/rose/addon/styles/hds/themes/dark-mode/index.scss
@@ -203,30 +203,30 @@
 // Overrides for CodeMirror 6 autocomplete and lint tooltips/panels.
 @mixin dark-mode-codemirror-override {
   /* stylelint-disable selector-class-pattern */
+  // Autocomplete dropdown and lint hover tooltips
+  .cm-tooltip {
+    background-color: var(--token-color-palette-neutral-50);
+    border: 1px solid var(--token-color-palette-neutral-100);
+    color: var(--token-color-palette-neutral-400);
+  }
+
+  // Arrow pointer for tooltips shown above the cursor
+  .cm-tooltip-above::before {
+    border-top-color: var(--token-color-palette-neutral-50);
+  }
+
+  // Arrow pointer for tooltips shown below the cursor
+  .cm-tooltip-below::before {
+    border-bottom-color: var(--token-color-palette-neutral-50);
+  }
+
+  // Autocomplete list > selected item highlight
+  .cm-tooltip-autocomplete > ul > li[aria-selected] {
+    background-color: var(--token-color-palette-blue-300);
+    color: var(--token-color-palette-neutral-700);
+  }
+
   .cm-editor {
-    // Autocomplete dropdown and lint hover tooltips
-    .cm-tooltip {
-      background-color: var(--token-color-palette-neutral-50);
-      border: 1px solid var(--token-color-palette-neutral-100);
-      color: var(--token-color-palette-neutral-400);
-    }
-
-    // Arrow pointer for tooltips shown above the cursor
-    .cm-tooltip-above::before {
-      border-top-color: var(--token-color-palette-neutral-50);
-    }
-
-    // Arrow pointer for tooltips shown below the cursor
-    .cm-tooltip-below::before {
-      border-bottom-color: var(--token-color-palette-neutral-50);
-    }
-
-    // Autocomplete list > selected item highlight
-    .cm-tooltip-autocomplete > ul > li[aria-selected] {
-      background-color: var(--token-color-palette-blue-300);
-      color: var(--token-color-palette-neutral-700);
-    }
-
     // Content/gutter border
     .cm-content {
       border-left: 1px solid var(--token-color-palette-neutral-100);

--- a/ui/admin/app/components/form/role/edit-grants/index.js
+++ b/ui/admin/app/components/form/role/edit-grants/index.js
@@ -170,8 +170,8 @@ export default class FormRoleEditGrantsComponent extends Component {
   );
 
   customExtensions = [
-    // Configure tooltips to render in the body to avoid overflow issues within the editor container.
-    tooltips({ parent: document.body }),
+    // Configure tooltips to render in page layout to avoid overflow issues within the editor container.
+    tooltips({ parent: document.querySelector('.rose-layout-page') }),
     autocompletion({
       override: [this.completionSource],
       // Trigger autocompletion when the user completes a grant field (which we labeled as keywords)

--- a/ui/admin/app/components/form/role/edit-grants/index.js
+++ b/ui/admin/app/components/form/role/edit-grants/index.js
@@ -170,6 +170,7 @@ export default class FormRoleEditGrantsComponent extends Component {
   );
 
   customExtensions = [
+    // Configure tooltips to render in the body to avoid overflow issues within the editor container.
     tooltips({ parent: document.body }),
     autocompletion({
       override: [this.completionSource],

--- a/ui/admin/app/components/form/role/edit-grants/index.js
+++ b/ui/admin/app/components/form/role/edit-grants/index.js
@@ -8,6 +8,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import {
+  tooltips,
   autocompletion,
   completionKeymap,
   startCompletion,
@@ -169,6 +170,7 @@ export default class FormRoleEditGrantsComponent extends Component {
   );
 
   customExtensions = [
+    tooltips({ parent: document.body }),
     autocompletion({
       override: [this.completionSource],
       // Trigger autocompletion when the user completes a grant field (which we labeled as keywords)

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -1043,7 +1043,8 @@
   overflow-y: auto;
 }
 
-// Grants editor autocomplete tooltip
+// Prevent grants editor autocomplete tooltip from
+// being hidden by code editor in fullscreen mode.
 .rose-layout-page div .cm-tooltip-autocomplete {
   z-index: 1000;
 }

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -1042,3 +1042,8 @@
   max-height: 50vh;
   overflow-y: auto;
 }
+
+// Grants editor autocomplete tooltip
+.rose-layout-page div .cm-tooltip-autocomplete {
+  z-index: 1000;
+}


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
In firefox only (works normally in Safari and Chrome), the autocomplete suggestions tooltip position gets set to `absolute` as a fallback. Usually this happens due to an ancestor of the tooltip element having a transform applied. After inspecting elements that does not seem to be the case so it seems to be an issue with firefox browser itself. To avoid positioning issue a [workaround](https://discuss.codemirror.net/t/tooltip-position-as-fixed-as-absolute/8776) is to set tooltip parent to `document.body`
<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
Before:
<img width="1556" height="984" alt="image" src="https://github.com/user-attachments/assets/4fc3d530-7fcf-4ef4-96e9-885d4fd1b89e" />

After:
<img width="1846" height="1026" alt="image" src="https://github.com/user-attachments/assets/c157ee76-7e0c-4a3b-b0d9-48a14a5199a6" />

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
1. Check in all major browsers (Firefox, Chrome, Safari) that autocomplete tooltip is not hidden and overlaps code editor instead.
2. Make sure tooltip is still visible in dark mode
3. Make sure tooltip is still visible when editor is in full screen mode

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [X] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [X] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
