### PR TITLE
feat: 🎸 Add discard modal for edit grants page

### DIFF
--- a/ui/admin/app/components/form/role/edit-grants/index.hbs
+++ b/ui/admin/app/components/form/role/edit-grants/index.hbs
@@ -44,7 +44,7 @@
               @color='secondary'
               {{on 'click' @cancel}}
             />
-            {{#if this.grantStringsText}}
+            {{#if this.grantStrings.length}}
               <Hds::Button
                 @text={{t 'actions.export'}}
                 @color='tertiary'

--- a/ui/admin/app/components/form/role/edit-grants/index.js
+++ b/ui/admin/app/components/form/role/edit-grants/index.js
@@ -36,7 +36,6 @@ export default class FormRoleEditGrantsComponent extends Component {
   exportOptionsMap = { terraform: 'terraform', nativeHCL: 'native-hcl' };
   exportOptions = Object.values(this.exportOptionsMap);
 
-  @tracked grantStringsText = (this.args.model?.grant_strings ?? []).join('\n');
   @tracked currentLineText = this.args.model?.grant_strings?.[0] ?? '';
   @tracked showExportOptionsFlyout = false;
   @tracked selectedExportOption = this.exportOptions[0];
@@ -179,7 +178,11 @@ export default class FormRoleEditGrantsComponent extends Component {
         const line = update.state.doc.lineAt(update.state.selection.main.head);
         this.currentLineText = line.text;
         if (update.docChanged) {
-          this.grantStringsText = update.state.doc.toString();
+          const text = update.state.doc.toString();
+          this.args.model.grant_strings = text
+            .split('\n')
+            .map((s) => s.trim())
+            .filter(Boolean);
         }
         // Trigger autocomplete when we're on an empty line
         if (line.text === '') {
@@ -197,11 +200,12 @@ export default class FormRoleEditGrantsComponent extends Component {
     this.#editorView?.destroy();
   }
 
+  get grantStringsText() {
+    return this.grantStrings.join('\n');
+  }
+
   get grantStrings() {
-    return this.grantStringsText
-      .split('\n')
-      .map((grantString) => grantString.trim())
-      .filter(Boolean);
+    return this.args.model?.grant_strings ?? [];
   }
 
   /**
@@ -221,7 +225,7 @@ export default class FormRoleEditGrantsComponent extends Component {
    */
   get terraformFormattedExport() {
     let formatted = `grant_strings = [ \n`;
-    this.grantStringsText.split('\n').forEach((line) => {
+    this.grantStrings.forEach((line) => {
       formatted += `  "${line}",\n`;
     });
     formatted += `]\n`;
@@ -234,7 +238,7 @@ export default class FormRoleEditGrantsComponent extends Component {
    */
   get nativeHclFormattedExport() {
     let formatted = `[ \n`;
-    this.grantStringsText.split('\n').forEach((line) => {
+    this.grantStrings.forEach((line) => {
       formatted += `  "${line}",\n`;
     });
     formatted += `]\n`;

--- a/ui/admin/app/routes/scopes/scope/roles/role/edit-grants.js
+++ b/ui/admin/app/routes/scopes/scope/roles/role/edit-grants.js
@@ -4,6 +4,7 @@
  */
 
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
 import { modelMapping } from 'api/services/sqlite';
@@ -59,5 +60,16 @@ export default class ScopesScopeRolesRoleEditGrantsRoute extends Route {
     }
 
     return response.json();
+  }
+
+  /**
+   * Stores the role model in the transition data property so that the application level hook
+   * can check for dirty attributes and trigger the confirm service.
+   * @param {object} transition
+   */
+  @action
+  async willTransition(transition) {
+    const { role } = transition.from.attributes;
+    transition.data = { model: role };
   }
 }

--- a/ui/admin/tests/acceptance/roles/edit-grants-test.js
+++ b/ui/admin/tests/acceptance/roles/edit-grants-test.js
@@ -348,4 +348,83 @@ module('Acceptance | roles/edit grants', function (hooks) {
 
     assert.dom(selectors.AUTOCOMPLETE_TOOLTIP).isVisible();
   });
+
+  test('can discard unsaved grant changes via dialog', async function (assert) {
+    setRunOptions({
+      rules: {
+        'color-contrast': {
+          // [ember-a11y-ignore]: axe rule "color-contrast" automatically ignored on 2026-06-17
+          enabled: false,
+        },
+      },
+    });
+
+    assert.expect(3);
+    const confirmService = this.owner.lookup('service:confirm');
+    confirmService.enabled = true;
+
+    await visit(urls.editGrants);
+    await waitFor(commonSelectors.CODE_EDITOR_CM);
+
+    const newGrantString = 'ids=*;type=session;actions=list';
+    const editorElement = find(commonSelectors.CODE_EDITOR_CODE);
+    const editorView = editorElement.editor;
+    editorView.dispatch({
+      changes: {
+        from: editorView.state.doc.length,
+        insert: `\n${newGrantString}`,
+      },
+    });
+    await click(commonSelectors.HREF(urls.role));
+
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
+
+    await click(commonSelectors.MODAL_WARNING_CONFIRM_BTN);
+
+    assert.strictEqual(currentURL(), urls.role);
+    console.log(this.server.schema.roles.find(instances.role.id));
+    assert.false(
+      this.server.schema.roles
+        .find(instances.role.id)
+        .grant_strings.includes(newGrantString),
+    );
+  });
+
+  test('can cancel discard grant changes via dialog', async function (assert) {
+    setRunOptions({
+      rules: {
+        'color-contrast': {
+          // [ember-a11y-ignore]: axe rule "color-contrast" automatically ignored on 2026-06-17
+          enabled: false,
+        },
+      },
+    });
+
+    assert.expect(3);
+    const confirmService = this.owner.lookup('service:confirm');
+    confirmService.enabled = true;
+
+    await visit(urls.editGrants);
+    await waitFor(commonSelectors.CODE_EDITOR_CM);
+
+    const newGrantString = 'ids=*;type=session;actions=list';
+    const editorElement = find(commonSelectors.CODE_EDITOR_CODE);
+    const editorView = editorElement.editor;
+    editorView.dispatch({
+      changes: {
+        from: editorView.state.doc.length,
+        insert: `\n${newGrantString}`,
+      },
+    });
+    await click(commonSelectors.HREF(urls.role));
+
+    assert.dom(commonSelectors.MODAL_WARNING).isVisible();
+
+    await click(commonSelectors.MODAL_WARNING_CANCEL_BTN);
+
+    assert.strictEqual(currentURL(), urls.editGrants);
+    assert
+      .dom(commonSelectors.CODE_EDITOR_CONTENT)
+      .includesText(newGrantString);
+  });
 });


### PR DESCRIPTION
# Description
The edit grants page didn't have any sort of discard modal that we normally use when we modify a model and it's considered dirty. I added the logic to properly handle it by making the model the source of truth for grant strings and to use the established pattern for checking dirty models when the model route returns a POJO. 

## Screenshots (if appropriate)
<img width="1475" height="920" alt="image" src="https://github.com/user-attachments/assets/54bd8fc2-ecdb-4e8b-8bf3-1d9afca87e11" />

## How to Test
Goto edit grants page and make changes and try to navigate away

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [x] I have added before and after screenshots for UI changes
- ~[ ] I have added JSON response output for API changes~
- ~[ ] I have added steps to reproduce and test for bug fixes in the description~
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- ~[ ] I have added `a11y-tests` label to run a11y audit tests if needed~

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
