### PR TITLE
fix: 🐛 code mirror lint tooltip format issues

### DIFF
--- a/ui/admin/app/components/form/role/edit-grants/index.js
+++ b/ui/admin/app/components/form/role/edit-grants/index.js
@@ -7,6 +7,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { getOwner } from '@ember/application';
 import {
   tooltips,
   autocompletion,
@@ -168,11 +169,14 @@ export default class FormRoleEditGrantsComponent extends Component {
     this.translateLintingError,
   );
 
+  rootElementSelector = getOwner(this).rootElement;
+  rootElement = getOwner(this)
+    .lookup('service:-document')
+    .querySelector(this.rootElementSelector);
+
   customExtensions = [
     // Configure tooltips to render in app root to avoid overflow issues within the editor container.
-    tooltips({
-      parent: document.querySelector('.ember-application') ?? document.body,
-    }),
+    tooltips({ parent: this.rootElement }),
     autocompletion({
       override: [this.completionSource],
       // Trigger autocompletion when the user completes a grant field (which we labeled as keywords)

--- a/ui/admin/app/components/form/role/edit-grants/index.js
+++ b/ui/admin/app/components/form/role/edit-grants/index.js
@@ -169,8 +169,8 @@ export default class FormRoleEditGrantsComponent extends Component {
   );
 
   customExtensions = [
-    // Configure tooltips to render in page layout to avoid overflow issues within the editor container.
-    tooltips({ parent: document.querySelector('.rose-layout-page') }),
+    // Configure tooltips to render in body to avoid overflow issues within the editor container.
+    tooltips({ parent: document.querySelector('.ember-application') }),
     autocompletion({
       override: [this.completionSource],
       // Trigger autocompletion when the user completes a grant field (which we labeled as keywords)

--- a/ui/admin/app/components/form/role/edit-grants/index.js
+++ b/ui/admin/app/components/form/role/edit-grants/index.js
@@ -169,8 +169,10 @@ export default class FormRoleEditGrantsComponent extends Component {
   );
 
   customExtensions = [
-    // Configure tooltips to render in body to avoid overflow issues within the editor container.
-    tooltips({ parent: document.querySelector('.ember-application') }),
+    // Configure tooltips to render in app root to avoid overflow issues within the editor container.
+    tooltips({
+      parent: document.querySelector('.ember-application') ?? document.body,
+    }),
     autocompletion({
       override: [this.completionSource],
       // Trigger autocompletion when the user completes a grant field (which we labeled as keywords)

--- a/ui/admin/app/styles/app.scss
+++ b/ui/admin/app/styles/app.scss
@@ -1043,8 +1043,8 @@
   overflow-y: auto;
 }
 
-// Prevent grants editor autocomplete tooltip from
-// being hidden by code editor in fullscreen mode.
-.rose-layout-page div .cm-tooltip-autocomplete {
+// Prevent grants editor tooltip from being
+// hidden by code editor in fullscreen mode.
+.ember-application div .cm-tooltip {
   z-index: 1000;
 }


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
Fix format issue tooltips with a single long line of text in grants editor. 

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
Before:
<img width="1724" height="1184" alt="image" src="https://github.com/user-attachments/assets/8953c42c-d88e-433b-b13e-d2703eb87dbd" />
After:
<img width="1866" height="966" alt="image" src="https://github.com/user-attachments/assets/2401b851-a15d-4140-8ec5-95a0f36b5961" />

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->
Validate in firefox & chrome that both lint and autocomplete tooltips don't have wonky positioning issues for grants editor. Also validate in code editor fullscreen mode.
## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [x] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
