### PR TITLE
feat: 🎸 No-op linting errors should be warnings

### DIFF
--- a/ui/admin/app/utils/grant-linter.js
+++ b/ui/admin/app/utils/grant-linter.js
@@ -617,7 +617,7 @@ const validateActionsField = (
         diagnostics.push({
           from: pos.valueStart,
           to: pos.valueEnd,
-          severity: 'error',
+          severity: 'warning',
           message: translate('actions.noop-requires-list'),
         });
         return;
@@ -637,7 +637,7 @@ const validateActionsField = (
         diagnostics.push({
           from: pos.valueStart,
           to: pos.valueEnd,
-          severity: 'error',
+          severity: 'warning',
           message: translate('actions.list-requires-noop'),
           actions: [createAddTextAction(translate('editor.add-noop'))],
         });


### PR DESCRIPTION
# Description
Changed two `no-op` related errors as warnings since they never cause any actual errors and may be valid depending on other grants users might have. 

## Screenshots (if appropriate)
<img width="593" height="470" alt="image" src="https://github.com/user-attachments/assets/ed775b95-d4eb-47a2-ad1f-693bb8b1c5e1" />

## How to Test
Test the no-op cases. 

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
