### PR TITLE
fix: 🐛 cannot modify credential library without credential_type

### DIFF
--- a/addons/api/addon/serializers/credential-library.js
+++ b/addons/api/addon/serializers/credential-library.js
@@ -72,7 +72,7 @@ export default class CredentialLibrarySerializer extends ApplicationSerializer {
       serialized.credential_mapping_overrides = null;
     }
     // API expects to send null to fields if it is undefined or deleted
-    if (credential_mapping_overrides && !isNew) {
+    if (credential_type && credential_mapping_overrides && !isNew) {
       serialized.credential_mapping_overrides = options.mapping_overrides[
         credential_type
       ].reduce((obj, key) => {


### PR DESCRIPTION
# Description
Fix error when modifying credential library without credential_type

## Screenshots (if appropriate)
The credential library created without setting Credential Type
<img width="1050" height="602" alt="image" src="https://github.com/user-attachments/assets/033d65aa-ec66-40a6-95af-3023bb7b471b" />

Try to modify the credential library
Before:
<img width="1590" height="460" alt="image" src="https://github.com/user-attachments/assets/1fc4ddec-4a57-4e8c-9d1f-ee7d0e4d9e8d" />
After:
<img width="1051" height="379" alt="image" src="https://github.com/user-attachments/assets/694a5837-7a9f-4cbb-91bd-6792c7080633" />

## How to Test
Validate in Chrome, can successfully modify credential library without credential_type

## Checklist

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
