### PR TITLE
fix: 🐛 credential library update

### DIFF
--- a/addons/api/addon/serializers/credential-library.js
+++ b/addons/api/addon/serializers/credential-library.js
@@ -68,21 +68,25 @@ export default class CredentialLibrarySerializer extends ApplicationSerializer {
    */
   handleCredentialMappingOverrides(serialized, isNew) {
     const { credential_type, credential_mapping_overrides } = serialized;
+
     if (Object.keys(credential_mapping_overrides).length === 0) {
       serialized.credential_mapping_overrides = null;
     }
-    // API expects to send null to fields if it is undefined or deleted
-    if (credential_mapping_overrides && !isNew) {
-      serialized.credential_mapping_overrides = options.mapping_overrides[
-        credential_type
-      ].reduce((obj, key) => {
-        if (credential_mapping_overrides[key]) {
-          obj[key] = credential_mapping_overrides[key];
-        } else {
-          obj[key] = null;
-        }
-        return obj;
-      }, {});
+
+    if (!credential_mapping_overrides || isNew || !credential_type) {
+      return;
     }
+
+    // API expects to send null to fields if it is undefined or deleted
+    serialized.credential_mapping_overrides = options.mapping_overrides[
+      credential_type
+    ].reduce((obj, key) => {
+      if (credential_mapping_overrides[key]) {
+        obj[key] = credential_mapping_overrides[key];
+      } else {
+        obj[key] = null;
+      }
+      return obj;
+    }, {});
   }
 }

--- a/addons/api/tests/unit/serializers/credential-library-test.js
+++ b/addons/api/tests/unit/serializers/credential-library-test.js
@@ -138,6 +138,45 @@ module('Unit | Serializer | credential library', function (hooks) {
     });
   });
 
+  test('it serializes credential library updates without credential_type', function (assert) {
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('credential-library');
+    store.push({
+      data: {
+        id: '1',
+        type: 'credential-library',
+        attributes: {
+          type: TYPE_CREDENTIAL_LIBRARY_VAULT_GENERIC,
+          name: 'Name',
+          description: 'Description',
+          path: '/vault/path',
+          http_method: 'GET',
+          version: 1,
+          credential_type: null,
+          credential_mapping_overrides: {},
+        },
+      },
+    });
+    const record = store.peekRecord('credential-library', '1');
+    const snapshot = record._createSnapshot();
+    const serializedRecord = serializer.serialize(snapshot);
+
+    assert.deepEqual(serializedRecord, {
+      type: TYPE_CREDENTIAL_LIBRARY_VAULT_GENERIC,
+      credential_store_id: null,
+      name: 'Name',
+      description: 'Description',
+      credential_type: null,
+      credential_mapping_overrides: null,
+      attributes: {
+        path: '/vault/path',
+        http_method: 'GET',
+        http_request_body: null,
+      },
+      version: 1,
+    });
+  });
+
   test('it does not serialize http_request_body unless http_method is set to POST', function (assert) {
     const store = this.owner.lookup('service:store');
     const record = store.createRecord('credential-library', {

--- a/ui/admin/tests/acceptance/credential-library/update-test.js
+++ b/ui/admin/tests/acceptance/credential-library/update-test.js
@@ -496,9 +496,10 @@ module('Acceptance | credential-libraries | update', function (hooks) {
 
     await click(commonSelectors.SAVE_BTN);
 
-    const credentialLibrary = this.server.schema.credentialLibraries.findBy({
-      id: credentialLibraryWithoutType.id,
-    });
+    const credentialLibrary = this.server.schema.credentialLibraries.find(
+      credentialLibraryWithoutType.id,
+    );
+
     assert.strictEqual(
       credentialLibrary.name,
       commonSelectors.FIELD_NAME_VALUE,

--- a/ui/admin/tests/acceptance/credential-library/update-test.js
+++ b/ui/admin/tests/acceptance/credential-library/update-test.js
@@ -462,6 +462,15 @@ module('Acceptance | credential-libraries | update', function (hooks) {
   });
 
   test('can update a vault generic credential library without credential_type and save changes without error', async function (assert) {
+    setRunOptions({
+      rules: {
+        'color-contrast': {
+          // [ember-a11y-ignore]: axe rule "color-contrast" automatically ignored on 2026-07-07
+          enabled: false,
+        },
+      },
+    });
+
     const credentialLibraryWithoutType = this.server.create(
       'credential-library',
       {

--- a/ui/admin/tests/acceptance/credential-library/update-test.js
+++ b/ui/admin/tests/acceptance/credential-library/update-test.js
@@ -460,4 +460,48 @@ module('Acceptance | credential-libraries | update', function (hooks) {
       selectors.FIELD_VAULT_PATH_VALUE,
     );
   });
+
+  test('can update a vault generic credential library without credential_type and save changes without error', async function (assert) {
+    const credentialLibraryWithoutType = this.server.create(
+      'credential-library',
+      {
+        scope: instances.scopes.project,
+        credentialStore: instances.credentialStore,
+        type: TYPE_CREDENTIAL_LIBRARY_VAULT_GENERIC,
+        credential_type: null,
+        credentialMappingOverrides: null,
+      },
+    );
+
+    await visit(
+      `${urls.credentialLibraries}/${credentialLibraryWithoutType.id}`,
+    );
+
+    await click(commonSelectors.EDIT_BTN, 'Activate edit mode');
+    await fillIn(commonSelectors.FIELD_NAME, commonSelectors.FIELD_NAME_VALUE);
+    await fillIn(
+      commonSelectors.FIELD_DESCRIPTION,
+      commonSelectors.FIELD_DESCRIPTION_VALUE,
+    );
+    await fillIn(selectors.FIELD_VAULT_PATH, selectors.FIELD_VAULT_PATH_VALUE);
+
+    await click(commonSelectors.SAVE_BTN);
+
+    const credentialLibrary = this.server.schema.credentialLibraries.findBy({
+      id: instances.credentialLibraryWithoutType.id,
+    });
+    assert.strictEqual(
+      credentialLibrary.name,
+      commonSelectors.FIELD_NAME_VALUE,
+    );
+    assert.strictEqual(
+      credentialLibrary.description,
+      commonSelectors.FIELD_DESCRIPTION_VALUE,
+    );
+    assert.strictEqual(
+      credentialLibrary.attributes.path,
+      selectors.FIELD_VAULT_PATH_VALUE,
+    );
+    assert.strictEqual(credentialLibrary.credentialType, null);
+  });
 });

--- a/ui/admin/tests/acceptance/credential-library/update-test.js
+++ b/ui/admin/tests/acceptance/credential-library/update-test.js
@@ -487,8 +487,11 @@ module('Acceptance | credential-libraries | update', function (hooks) {
 
     await click(commonSelectors.SAVE_BTN);
 
+    // Verify the save succeeded: no error toast should appear
+    assert.dom(commonSelectors.ALERT_TOAST).doesNotExist();
+
     const credentialLibrary = this.server.schema.credentialLibraries.findBy({
-      id: instances.credentialLibraryWithoutType.id,
+      id: credentialLibraryWithoutType.id,
     });
     assert.strictEqual(
       credentialLibrary.name,

--- a/ui/admin/tests/acceptance/credential-library/update-test.js
+++ b/ui/admin/tests/acceptance/credential-library/update-test.js
@@ -487,9 +487,6 @@ module('Acceptance | credential-libraries | update', function (hooks) {
 
     await click(commonSelectors.SAVE_BTN);
 
-    // Verify the save succeeded: no error toast should appear
-    assert.dom(commonSelectors.ALERT_TOAST).doesNotExist();
-
     const credentialLibrary = this.server.schema.credentialLibraries.findBy({
       id: credentialLibraryWithoutType.id,
     });


### PR DESCRIPTION
# Description
<!-- Add a brief description of changes here -->
This PR addresses the issue reported [here](https://github.com/hashicorp/boundary-ui/pull/3327).

Fix serializer error for updating credential library with no `credential_type`  

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)
Before:

<img width="1778" height="1162" alt="Screenshot 2026-06-26 at 2 06 50 PM" src="https://github.com/user-attachments/assets/8113fd7d-df0c-4942-b0b6-1c34baeeed86" />


After:

<img width="1799" height="1238" alt="Screenshot 2026-06-26 at 2 07 46 PM" src="https://github.com/user-attachments/assets/120ac164-ada0-49f9-948c-0cf14f0f5a86" />

## How to Test

1. Create a Vault Credential store.
2. Add credential library without any credential type
3. Edit that credential library and it should update successfully without any errors

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [ ] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
