### PR TITLE
fix: targets pagination shows wrong counts and empty pages

### DIFF
--- a/addons/api/addon/handlers/cache-daemon-handler.js
+++ b/addons/api/addon/handlers/cache-daemon-handler.js
@@ -147,7 +147,20 @@ export default class CacheDaemonHandler {
           }
         }
 
-        const results = cacheDaemonResults[underscore(resourceName)];
+        // The cache daemon may return multiple raw rows for the same
+        // underlying resource (e.g. stale or duplicate entries in its local
+        // cache). Pagination must be computed from the unique set of
+        // resources, not the raw row count, otherwise a single resource can
+        // be repeated or fragmented across many pages.
+        const rawResults = cacheDaemonResults[underscore(resourceName)];
+        const seenIds = new Set();
+        const results = rawResults?.filter((result) => {
+          if (seenIds.has(result.id)) {
+            return false;
+          }
+          seenIds.add(result.id);
+          return true;
+        });
         const payload = { items: paginateResults(results, page, pageSize) };
 
         const schema = store.modelFor(type);

--- a/addons/api/addon/utils/paginate-results.js
+++ b/addons/api/addon/utils/paginate-results.js
@@ -22,7 +22,7 @@ export const paginateResults = (array, page, pageSize) => {
   }
 
   const offset = (page - 1) * pageSize;
-  const start = Math.min(length - 1, offset);
+  const start = Math.min(length, offset);
   const end = Math.min(length, offset + pageSize);
 
   return array.slice(start, end);

--- a/addons/api/tests/unit/utils/paginate-results-test.js
+++ b/addons/api/tests/unit/utils/paginate-results-test.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright IBM Corp. 2021, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { paginateResults } from 'api/utils/paginate-results';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | paginate-results', function () {
+  test('it returns the full array when no page or pageSize is given', function (assert) {
+    const array = ['a', 'b', 'c'];
+    assert.deepEqual(paginateResults(array, undefined, undefined), array);
+  });
+
+  test('it returns an empty array when given an empty array', function (assert) {
+    assert.deepEqual(paginateResults([], 1, 10), []);
+  });
+
+  test('it returns all items on the first page when they all fit within pageSize', function (assert) {
+    const array = ['a', 'b', 'c', 'd', 'e'];
+    assert.deepEqual(paginateResults(array, 1, 10), array);
+    assert.deepEqual(paginateResults(array, 1, 50), array);
+  });
+
+  test('it returns the correct slice for a page in the middle of the results', function (assert) {
+    const array = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+    assert.deepEqual(paginateResults(array, 2, 3), ['d', 'e', 'f']);
+  });
+
+  test('it returns an empty array, not a duplicate of the last item, for a page beyond the available results', function (assert) {
+    const array = ['a', 'b', 'c', 'd', 'e'];
+
+    // With only 5 items and a pageSize of 10, there is only one page of
+    // results. Requesting page 2 or beyond must not return any items.
+    assert.deepEqual(paginateResults(array, 2, 10), []);
+    assert.deepEqual(paginateResults(array, 3, 10), []);
+  });
+});

--- a/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
+++ b/ui/desktop/app/routes/scopes/scope/projects/targets/index.js
@@ -11,6 +11,7 @@ import {
 } from 'api/models/session';
 import { action } from '@ember/object';
 import { restartableTask, timeout } from 'ember-concurrency';
+import { paginateResults } from 'api/utils/paginate-results';
 
 const { __electronLog } = globalThis;
 
@@ -136,19 +137,26 @@ export default class ScopesScopeProjectsTargetsIndexRoute extends Route {
         recursive: true,
         scope_id: orgScope.id,
         query: { search, filters, sort },
-        page,
-        pageSize,
         force_refresh: true,
       };
       if (orgScope.isOrg && scopes.length === 0) {
         query.filter = orgFilter;
       }
-      let targets = await this.store.query('target', query);
-      const { totalItems, isLoadIncomplete, isCacheRefreshing } = targets.meta;
+      // Intentionally don't send page/pageSize here: the "connect" ability
+      // can only be evaluated client-side once records are loaded, so we
+      // have to filter out targets the user can't connect to *before*
+      // paginating. Paginating the raw (unfiltered) result set first would
+      // compute page counts against targets the user may not even be able
+      // to see, and could scatter the targets they can connect to sparsely
+      // (or not at all) across pages.
+      const allTargets = await this.store.query('target', query);
+      const { isLoadIncomplete, isCacheRefreshing } = allTargets.meta;
       // Filter out targets to which users do not have the connect ability
-      targets = targets.filter((target) =>
+      const connectableTargets = allTargets.filter((target) =>
         this.abilities.can('connect target', target),
       );
+      const totalItems = connectableTargets.length;
+      const targets = paginateResults(connectableTargets, page, pageSize);
 
       const aliasPromise = this.store.query('alias', {
         scope_id: 'global',

--- a/ui/desktop/tests/acceptance/projects/targets/index-test.js
+++ b/ui/desktop/tests/acceptance/projects/targets/index-test.js
@@ -55,6 +55,7 @@ module('Acceptance | projects | targets | index', function (hooks) {
     'thead tr th:nth-child(1) button .hds-icon-arrow-up';
   const TABLE_SORT_BTN_ARROW_DOWN =
     'thead tr th:nth-child(1) button .hds-icon-arrow-down';
+  const PAGINATION_INFO = '[data-test-pagination] .hds-pagination-info';
 
   const instances = {
     scopes: {
@@ -229,6 +230,108 @@ module('Acceptance | projects | targets | index', function (hooks) {
     await click(`[href="${urls.targets}"]`);
 
     assert.dom(APP_STATE_TITLE).hasText('No Targets Available');
+  });
+
+  test('pagination reflects unique targets when the cache daemon returns duplicate rows for the same target', async function (assert) {
+    setRunOptions({
+      rules: {
+        'color-contrast': {
+          // [ember-a11y-ignore]: axe rule "color-contrast" automatically ignored on 2025-08-01
+          enabled: false,
+        },
+      },
+    });
+
+    this.server.schema.targets.all().destroy();
+    this.server.schema.sessions.all().destroy();
+
+    const targets = this.server.createList('target', 5, {
+      scope: instances.scopes.project,
+      address: '127.0.0.1',
+    });
+
+    // The cache daemon is known to sometimes return multiple raw rows for
+    // the same underlying target (e.g. stale/duplicate entries in its local
+    // cache). These collapse into a single record per unique id once
+    // normalized and pushed into the Ember Data store, but pagination must
+    // still be computed from the unique target count, not the raw
+    // (duplicated) row count returned by the daemon.
+    const duplicatedRows = targets.flatMap((target) => Array(20).fill(target));
+
+    this.stubCacheDaemonSearch(
+      'sessions',
+      { resource: 'targets', func: () => duplicatedRows },
+      'aliases',
+      'sessions',
+    );
+
+    await visit(urls.targets);
+
+    assert
+      .dom('[data-test-visit-target]')
+      .exists(
+        { count: 5 },
+        'all 5 unique targets are shown on a single page despite the duplicate raw rows',
+      );
+    assert
+      .dom(PAGINATION_INFO)
+      .includesText(
+        'of 5',
+        'pagination totals reflect the unique target count, not the raw duplicated row count',
+      );
+  });
+
+  test('pagination reflects only targets the user can connect to, computed before pagination', async function (assert) {
+    setRunOptions({
+      rules: {
+        'color-contrast': {
+          // [ember-a11y-ignore]: axe rule "color-contrast" automatically ignored on 2025-08-01
+          enabled: false,
+        },
+      },
+    });
+
+    this.server.schema.targets.all().destroy();
+    this.server.schema.sessions.all().destroy();
+
+    // Simulate a scope with many targets, most of which the current user
+    // is not authorized to connect to (a common real-world shape). The
+    // "connect" ability can only be evaluated after records are loaded,
+    // so it must be applied before pagination: only the 5 connectable
+    // targets should ever be counted or paginated, and all 5 should fit
+    // on a single page regardless of the requested page size.
+    const nonConnectableTargets = this.server.createList('target', 70, {
+      scope: instances.scopes.project,
+      address: '127.0.0.1',
+    });
+    nonConnectableTargets.forEach((target) => {
+      target.update({
+        authorized_actions: target.authorized_actions.filter(
+          (action) => action !== 'authorize-session',
+        ),
+      });
+    });
+    this.server.createList('target', 5, {
+      scope: instances.scopes.project,
+      address: '127.0.0.1',
+    });
+
+    this.stubCacheDaemonSearch('sessions', 'targets', 'aliases', 'sessions');
+
+    await visit(urls.targets);
+
+    assert
+      .dom('[data-test-visit-target]')
+      .exists(
+        { count: 5 },
+        'all 5 connectable targets are shown on a single page',
+      );
+    assert
+      .dom(PAGINATION_INFO)
+      .includesText(
+        'of 5',
+        'pagination totals reflect only the connectable targets, not the full raw match count',
+      );
   });
 
   test('user cannot navigate to a target without proper authorization', async function (assert) {


### PR DESCRIPTION
## Summary

Fixes #3338. Two bugs combined to break pagination in the desktop client's Targets view:

- The "connect" ability filter (`this.abilities.can('connect target', target)`) was applied **after** the target list was already paginated. With permissions scattered unevenly across a larger raw target set, a given page could end up showing far fewer connectable targets than fit (or none at all), while the pagination total was computed from the raw, permission-unaware count. The filter is now applied before pagination, and totals are computed from the filtered set.
- The local cache daemon can return multiple raw rows for the same underlying target (e.g. stale/duplicate entries in its cache). These are now deduplicated by id before totals are computed and pages are sliced.
- `paginateResults` returned a duplicate of the last item instead of an empty array when asked for a page beyond the available results; fixed to return `[]`.

## Test plan

- [x] Added a unit test for `paginateResults` covering the out-of-range page case
- [x] Added an acceptance test reproducing the duplicate-cache-daemon-row scenario
- [x] Added an acceptance test reproducing the ability-filter-before-pagination scenario (many targets, only a few connectable)
- [x] `pnpm test` passes in `addons/api` and `ui/desktop`
- [x] Verified manually against a real cluster and running cache daemon
