### PR TITLE
fix: 🐛 check for error string when initializating session

### DIFF
--- a/ui/desktop/electron-app/src/models/session.js
+++ b/ui/desktop/electron-app/src/models/session.js
@@ -115,7 +115,9 @@ class Session {
       const errorResponse = jsonify(stderr);
       const error = errorResponse.api_error || errorResponse.error;
       throw new Error(
-        error?.message ?? 'Unknown error occurred while starting session',
+        error?.message ??
+          error ??
+          'Unknown error occurred while starting session',
       );
     }
 


### PR DESCRIPTION
Currently when an error is returned from the connect command, we check if the error 's message is null, and throw a new error with 'Unknown error occurred while starting session'. However, the error may be a string, meaning it won't have the error.message field. This change modifies the thrown error so that the error string is returned once we determine that the error.message is null.

✅ Closes: ICU-18307

# Description
<!-- Add a brief description of changes here -->

<!-- Uncomment line below to manually add link to JIRA ticket -->
<!-- :tickets: [Jira ticket](https://hashicorp.atlassian.net/browse/JIRA_TICKET_NUMBER) -->

## Screenshots (if appropriate)

## How to Test
<!-- Add steps to test this change. Include any other necessary relevant links -->

## Checklist
<!-- strikethrough the checklist item that is not relevant to your change -->

<!-- If you are merging a long lived branch, major feature, or UI altering changes,
please add the a11y-tests label. Other cases, like a dependency change or
translation update likely does not need an a11y audit -->

- [X] I have added before and after screenshots for UI changes
- [ ] I have added JSON response output for API changes
- [ ] I have added steps to reproduce and test for bug fixes in the description
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added `a11y-tests` label to run a11y audit tests if needed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [X
<img width="1275" height="740" alt="Screenshot 2026-09-01 at 12 37 45 PM" src="https://github.com/user-attachments/assets/ec576ebe-bb20-4f16-948c-23d3b8f14296" />
<img width="1399" height="808" alt="Screenshot 2026-09-01 at 12 55 17 PM" src="https://github.com/user-attachments/assets/81b62ba6-53f7-47d4-83a7-c2d14b2528c3" />
] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
